### PR TITLE
BIT-58: Add Github Actions workflow for caching dependencies

### DIFF
--- a/.github/workflows/cache-dependencies.yml
+++ b/.github/workflows/cache-dependencies.yml
@@ -1,0 +1,54 @@
+---
+name: Cache Dependencies
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DEVELOPER_DIR: /Applications/Xcode_14.3.1.app/Contents/Developer
+  MINT_LINK_PATH: .mint/bin
+  MINT_PATH: .mint/lib
+
+jobs:
+  cache-dependencies:
+    name: Cache Dependencies
+    runs-on: macos-13
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # v1.152.0
+        with:
+          bundler-cache: true
+          ruby-version: 3.2.2
+
+      - name: Cache Mint Packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: .mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
+
+      - name: Cache SPM Packages
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: build/DerivedData/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
+      - name: Setup
+        run: |
+          brew install mint xcbeautify
+          ./Scripts/bootstrap.sh
+
+      - name: Update Xcode Dependencies
+        run: |
+          set -o pipefail && \
+            xcodebuild -resolvePackageDependencies \
+            -project Bitwarden.xcodeproj \
+            -clonedSourcePackagesDirPath build/DerivedData/SourcePackages


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-58](https://livefront.atlassian.net/browse/BIT-58)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🤖 Build/deploy pipeline (DevOps)

## 📔 Objective

[Previously](https://github.com/bitwarden/ios/pull/13) I added a Github Actions workflow for building and testing PRs. This workflow is setup to use cached dependencies, but since we don't yet have a build that runs on the base branch (`main`) the cache is empty for any initial PR builds.

Adding this workflow will cache dependencies on pushes to main. This cache will then be available for PRs and should improve the run time when testing PRs.

Eventually, we may have some CI automation that runs on `main` which would likely replace this, but this should help in the meantime.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **cache-dependencies.yml:** A Github Actions workflow that runs on pushes to main which caches build dependencies to improve PR build times.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
