### PR TITLE
BIT-386: Add ServiceContainer for managing dependencies

### DIFF
--- a/Bitwarden/Application/AppDelegate.swift
+++ b/Bitwarden/Application/AppDelegate.swift
@@ -1,4 +1,31 @@
 import BitwardenShared
 import UIKit
 
-class AppDelegate: UIResponder, UIApplicationDelegate {}
+/// A protocol for an `AppDelegate` that can be used by the `SceneDelegate` to look up the
+/// `AppDelegate` when the app is running (`AppDelegate`) or testing (`TestingAppDelegate`).
+///
+protocol AppDelegateType: AnyObject {
+    /// The processor that manages application level logic.
+    var appProcessor: AppProcessor? { get }
+}
+
+/// The app's `UIApplicationDelegate` which serves as the entry point into the app.
+///
+class AppDelegate: UIResponder, UIApplicationDelegate, AppDelegateType {
+    // MARK: Properties
+
+    /// The processor that manages application level logic.
+    var appProcessor: AppProcessor?
+
+    // MARK: Methods
+
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+    ) -> Bool {
+        let services = ServiceContainer()
+        let appModule = DefaultAppModule(services: services)
+        appProcessor = AppProcessor(appModule: appModule, services: services)
+        return true
+    }
+}

--- a/Bitwarden/Application/SceneDelegate.swift
+++ b/Bitwarden/Application/SceneDelegate.swift
@@ -4,12 +4,6 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     // MARK: Properties
 
-    /// The root module to use to create sub-coordinators.
-    var appModule: AppModule = DefaultAppModule()
-
-    /// The root coordinator of this scene.
-    var appCoordinator: AnyCoordinator<AppRoute>?
-
     /// The main window for this scene.
     var window: UIWindow?
 
@@ -20,18 +14,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         willConnectTo session: UISceneSession,
         options connectionOptions: UIScene.ConnectionOptions
     ) {
-        guard let windowScene = (scene as? UIWindowScene) else {
+        guard let appProcessor = (UIApplication.shared.delegate as? AppDelegateType)?.appProcessor,
+              let windowScene = scene as? UIWindowScene
+        else {
             return
         }
 
         let appWindow = UIWindow(windowScene: windowScene)
         let rootViewController = RootViewController()
-        let coordinator = appModule.makeAppCoordinator(navigator: rootViewController)
-        coordinator.start()
+        appProcessor.start(navigator: rootViewController)
 
         appWindow.rootViewController = rootViewController
         appWindow.makeKeyAndVisible()
-        appCoordinator = coordinator
         window = appWindow
     }
 }

--- a/Bitwarden/Application/SceneDelegateTests.swift
+++ b/Bitwarden/Application/SceneDelegateTests.swift
@@ -1,7 +1,7 @@
-import BitwardenShared
 import XCTest
 
 @testable import Bitwarden
+@testable import BitwardenShared
 
 // MARK: - SceneDelegateTests
 
@@ -17,7 +17,6 @@ class SceneDelegateTests: BitwardenTestCase {
         super.setUp()
         appModule = MockAppModule()
         subject = SceneDelegate()
-        subject.appModule = appModule
     }
 
     override func tearDown() {
@@ -30,6 +29,9 @@ class SceneDelegateTests: BitwardenTestCase {
 
     /// `scene(_:willConnectTo:options:)` with a `UIWindowScene` creates the app's UI.
     func test_sceneWillConnectTo_withWindowScene() throws {
+        let appProcessor = AppProcessor(appModule: appModule, services: ServiceContainer())
+        (UIApplication.shared.delegate as? TestingAppDelegate)?.appProcessor = appProcessor
+
         let session = TestInstanceFactory.create(UISceneSession.self)
         let scene = TestInstanceFactory.create(UIWindowScene.self, properties: [
             "session": session,
@@ -37,13 +39,16 @@ class SceneDelegateTests: BitwardenTestCase {
         let options = TestInstanceFactory.create(UIScene.ConnectionOptions.self)
         subject.scene(scene, willConnectTo: session, options: options)
 
-        XCTAssertNotNil(subject.appCoordinator)
+        XCTAssertNotNil(appProcessor.coordinator)
         XCTAssertNotNil(subject.window)
         XCTAssertTrue(appModule.appCoordinator.isStarted)
     }
 
     /// `scene(_:willConnectTo:options:)` without a `UIWindowScene` fails to create the app's UI.
     func test_sceneWillConnectTo_withNonWindowScene() throws {
+        let appProcessor = AppProcessor(appModule: appModule, services: ServiceContainer())
+        (UIApplication.shared.delegate as? TestingAppDelegate)?.appProcessor = appProcessor
+
         let session = TestInstanceFactory.create(UISceneSession.self)
         let scene = TestInstanceFactory.create(UIScene.self, properties: [
             "session": session,
@@ -51,7 +56,7 @@ class SceneDelegateTests: BitwardenTestCase {
         let options = TestInstanceFactory.create(UIScene.ConnectionOptions.self)
         subject.scene(scene, willConnectTo: session, options: options)
 
-        XCTAssertNil(subject.appCoordinator)
+        XCTAssertNil(appProcessor.coordinator)
         XCTAssertNil(subject.window)
         XCTAssertFalse(appModule.appCoordinator.isStarted)
     }

--- a/Bitwarden/Application/TestHelpers/Support/TestingAppDelegate.swift
+++ b/Bitwarden/Application/TestHelpers/Support/TestingAppDelegate.swift
@@ -1,3 +1,4 @@
+import BitwardenShared
 import UIKit
 
 @testable import Bitwarden
@@ -5,4 +6,6 @@ import UIKit
 /// A replacement for `AppDelegate` that allows for checking that certain app delegate methods get called at the
 /// appropriate times during unit tests.
 ///
-class TestingAppDelegate: NSObject, UIApplicationDelegate {}
+class TestingAppDelegate: NSObject, UIApplicationDelegate, AppDelegateType {
+    var appProcessor: AppProcessor?
+}

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// The `ServiceContainer` contains the list of services used by the app. This can be injected into
+/// `Coordinator`s throughout the app which build processors. A `Processor` can define which
+/// services it needs access to by defining a typealias containing a list of services.
+///
+/// For example:
+///
+///     class ExampleProcessor: StateProcessor<ExampleState, ExampleAction, Void> {
+///         typealias Services = HasExampleService
+///             & HasExampleRepository
+///     }
+///
+public class ServiceContainer: Services {
+    // MARK: Properties
+
+    /// The service used by the application to make API requests.
+    let apiService: APIService
+
+    /// The service used by the application to manage the app's ID.
+    let appIdService: AppIdService
+
+    /// The service used by the application to persist app setting values.
+    let appSettingsStore: AppSettingsStore
+
+    // MARK: Initialization
+
+    /// Initialize a `ServiceContainer`.
+    ///
+    /// - Parameters:
+    ///   - apiService: The service used by the application to make API requests.
+    ///   - appSettingsStore: The service used by the application to persist app setting values.
+    ///
+    init(
+        apiService: APIService,
+        appSettingsStore: AppSettingsStore
+    ) {
+        self.apiService = apiService
+        self.appSettingsStore = appSettingsStore
+
+        appIdService = AppIdService(appSettingStore: appSettingsStore)
+    }
+
+    /// A convenience initializer to initialize the `ServiceContainer` with the default services.
+    ///
+    public convenience init() {
+        self.init(
+            apiService: APIService(),
+            appSettingsStore: DefaultAppSettingsStore(userDefaults: UserDefaults.standard)
+        )
+    }
+}
+
+extension ServiceContainer {
+    var authAPIService: AuthAPIService {
+        apiService
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/Services.swift
+++ b/BitwardenShared/Core/Platform/Services/Services.swift
@@ -1,0 +1,33 @@
+/// The services provided by the `ServiceContainer`.
+typealias Services = HasAPIService
+    & HasAppIdService
+    & HasAppSettingsStore
+    & HasAuthAPIService
+
+/// Protocol for an object that provides an `APIService`.
+///
+protocol HasAPIService {
+    /// The service used by the application to make API requests.
+    var apiService: APIService { get }
+}
+
+/// Protocol for an object that provides an `AppIdService`.
+///
+protocol HasAppIdService {
+    /// The service used by the application to manage the app's ID.
+    var appIdService: AppIdService { get }
+}
+
+/// Protocol for an object that provides an `AppSettingsStore`.
+///
+protocol HasAppSettingsStore {
+    /// The service used by the application to persist app setting values.
+    var appSettingsStore: AppSettingsStore { get }
+}
+
+/// Protocol for an object that provides an `AuthAPIService`.
+///
+protocol HasAuthAPIService {
+    /// The service used by the application to make auth-related API requests.
+    var authAPIService: AuthAPIService { get }
+}

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
@@ -1,0 +1,15 @@
+import Networking
+
+@testable import BitwardenShared
+
+extension ServiceContainer {
+    static func withMocks(
+        appSettingsStore: AppSettingsStore = MockAppSettingsStore(),
+        httpClient: HTTPClient = MockHTTPClient()
+    ) -> ServiceContainer {
+        ServiceContainer(
+            apiService: APIService(client: httpClient),
+            appSettingsStore: appSettingsStore
+        )
+    }
+}

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -17,6 +17,8 @@ protocol AuthCoordinatorDelegate: AnyObject {
 /// A coordinator that manages navigation in the authentication flow.
 ///
 internal final class AuthCoordinator: Coordinator {
+    typealias Services = HasAuthAPIService
+
     // MARK: Properties
 
     /// The delegate for this coordinator. Used to signal when auth has been completed.
@@ -24,6 +26,9 @@ internal final class AuthCoordinator: Coordinator {
 
     /// The root navigator used to display this coordinator's interface.
     weak var rootNavigator: (any RootNavigator)?
+
+    /// The services used by this coordinator.
+    let services: Services
 
     /// The stack navigator that is managed by this coordinator.
     var stackNavigator: StackNavigator
@@ -35,15 +40,18 @@ internal final class AuthCoordinator: Coordinator {
     /// - Parameters:
     ///   - delegate: The delegate for this coordinator. Used to signal when auth has been completed.
     ///   - rootNavigator: The root navigator used to display this coordinator's interface.
+    ///   - services: The services used by this coordinator.
     ///   - stackNavigator: The stack navigator that is managed by this coordinator.
     ///
     init(
         delegate: AuthCoordinatorDelegate,
         rootNavigator: RootNavigator,
+        services: Services,
         stackNavigator: StackNavigator
     ) {
         self.delegate = delegate
         self.rootNavigator = rootNavigator
+        self.services = services
         self.stackNavigator = stackNavigator
     }
 

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -23,6 +23,7 @@ class AuthCoordinatorTests: BitwardenTestCase {
         subject = AuthCoordinator(
             delegate: authDelegate,
             rootNavigator: rootNavigator,
+            services: ServiceContainer.withMocks(),
             stackNavigator: stackNavigator
         )
     }
@@ -122,6 +123,7 @@ class AuthCoordinatorTests: BitwardenTestCase {
         subject = AuthCoordinator(
             delegate: authDelegate,
             rootNavigator: rootNavigator!,
+            services: ServiceContainer.withMocks(),
             stackNavigator: stackNavigator
         )
         XCTAssertNotNil(subject.rootNavigator)

--- a/BitwardenShared/UI/Auth/AuthModule.swift
+++ b/BitwardenShared/UI/Auth/AuthModule.swift
@@ -31,6 +31,7 @@ extension DefaultAppModule: AuthModule {
         AuthCoordinator(
             delegate: delegate,
             rootNavigator: rootNavigator,
+            services: services,
             stackNavigator: stackNavigator
         ).asAnyCoordinator()
     }

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -49,7 +49,8 @@ class AppCoordinator: Coordinator {
     }
 
     func start() {
-        showAuth(route: .landing)
+        // Nothing to do here - the initial route is specified by `AppProcessor` and this
+        // coordinator doesn't need to navigate within the `Navigator` since it's the root.
     }
 
     // MARK: Private Methods

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -71,10 +71,10 @@ class AppCoordinatorTests: BitwardenTestCase {
         XCTAssertEqual(module.tabCoordinator.routes, [.vault, .vault])
     }
 
-    /// `start()` initializes the interface correctly.
+    /// `start()` doesn't navigate anywhere (first route is managed by AppProcessor).
     func test_start() {
         subject.start()
 
-        XCTAssertTrue(module.authCoordinator.isStarted)
+        XCTAssertFalse(module.authCoordinator.isStarted)
     }
 }

--- a/BitwardenShared/UI/Platform/Application/AppModule.swift
+++ b/BitwardenShared/UI/Platform/Application/AppModule.swift
@@ -6,7 +6,7 @@ public protocol AppModule: AnyObject {
     /// Initializes a coordinator for navigating between `Route`s.
     ///
     /// - Parameter navigator: The object that will be used to navigate between routes.
-    /// - Returns: A coordinator that can navigate to `Route`s.
+    /// - Returns: A coordinator that can navigate to `AppRoute`s.
     ///
     func makeAppCoordinator(navigator: RootNavigator) -> AnyCoordinator<AppRoute>
 }
@@ -16,8 +16,20 @@ public protocol AppModule: AnyObject {
 /// The default app module that can be used to build coordinators.
 @MainActor
 public class DefaultAppModule {
+    // MARK: Properties
+
+    /// The services used by the app.
+    let services: Services
+
+    // MARK: Initialization
+
     /// Creates a new `DefaultAppModule`.
-    public init() {}
+    ///
+    /// - Parameter services: The services used by the app.
+    ///
+    public init(services: ServiceContainer) {
+        self.services = services
+    }
 }
 
 extension DefaultAppModule: AppModule {

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// The `AppProcessor` processes actions received at the application level and contains the logic
+/// to control the top-level flow through the app.
+///
+@MainActor
+public class AppProcessor {
+    // MARK: Properties
+
+    /// The root module to use to create sub-coordinators.
+    let appModule: AppModule
+
+    /// The root coordinator of the app.
+    var coordinator: AnyCoordinator<AppRoute>?
+
+    /// The services used by the app.
+    let services: ServiceContainer
+
+    // MARK: Initialization
+
+    /// Initializes an `AppProcessor`.
+    ///
+    /// - Parameters:
+    ///   - appModule: The root module to use to create sub-coordinators.
+    ///   - services: The services used by the app.
+    ///
+    public init(
+        appModule: AppModule,
+        services: ServiceContainer
+    ) {
+        self.appModule = appModule
+        self.services = services
+    }
+
+    // MARK: Methods
+
+    /// Starts the application flow by navigating the user to the first flow.
+    ///
+    /// - Parameter navigator: The object that will be used to navigate between routes.
+    ///
+    public func start(navigator: RootNavigator) {
+        let coordinator = appModule.makeAppCoordinator(navigator: navigator)
+        coordinator.start()
+        coordinator.navigate(to: .auth(.landing))
+        self.coordinator = coordinator
+    }
+}

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class AppProcessorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var appModule: MockAppModule!
+    var subject: AppProcessor!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        appModule = MockAppModule()
+        subject = AppProcessor(appModule: appModule, services: ServiceContainer.withMocks())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        appModule = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `start(navigator:)` builds the AppCoordinator and navigates to the initial route.
+    func test_start() {
+        let rootNavigator = MockRootNavigator()
+
+        subject.start(navigator: rootNavigator)
+
+        XCTAssertTrue(appModule.appCoordinator.isStarted)
+        XCTAssertEqual(appModule.appCoordinator.routes, [.auth(.landing)])
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-386](https://livefront.atlassian.net/browse/BIT-386)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AppDelegate.swift:** Builds the service container with default services and injects it into the `AppModule` and `AppProcessor`.
- **AppProcessor.swift:** An app-level processor that handles things like determining the first screen to show and the entry point for push notifications, startup tasks, etc in the future.
- **ServiceContainer.swift:** A container to wrap our services to allow for easier injection into coordinators and processors in the app.
- **ServiceContainer+Mocks.swift:** Provides a convenience method to build a `ServiceContainer` which uses mocked services for tests.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
