### PR TITLE
BIT-271: Terms of service/Privacy policy links

### DIFF
--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -1,0 +1,13 @@
+// MARK: - ExternalLinksConstants
+
+/// Links that are used throughout the app.
+///
+enum ExternalLinksConstants {
+    // MARK: Properties
+
+    /// A markdown link to Bitwarden's privacy policy.
+    static let privacyPolicy = "[\(Localizations.privacyPolicy)](https://bitwarden.com/privacy/)"
+
+    /// A markdown link to Bitwarden's terms of service.
+    static let termsOfService = "[\(Localizations.termsOfService)](https://bitwarden.com/terms/)"
+}

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -18,7 +18,7 @@ protocol AuthCoordinatorDelegate: AnyObject {
 ///
 internal final class AuthCoordinator: Coordinator {
     // MARK: Types
-    
+
     typealias Services = HasAccountAPIService
         & HasAuthAPIService
 

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -12,12 +12,12 @@ struct CreateAccountView: View {
 
     /// The privacy policy attributed string used in navigating to Bitwarden's Privacy Policy website.
     let privacyPolicyString: AttributedString? = try? AttributedString(
-        markdown: "[Privacy Policy](https://bitwarden.com/privacy/)"
+        markdown: ExternalLinksConstants.privacyPolicy
     )
 
     /// The terms of service attributed string used in navigating to Bitwarden's Terms of Service website.
     let termsOfServiceString: AttributedString? = try? AttributedString(
-        markdown: "[Terms of Service](https://bitwarden.com/terms/)"
+        markdown: ExternalLinksConstants.termsOfService
     )
 
     // MARK: View


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-271](https://livefront.atlassian.net/browse/BIT-271?atlOrigin=eyJpIjoiZmZhODQ3YjIzOGJjNGQyNWJkMjBlZWI0OTE4YWM4YjQiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
This PR adds functionality to the **Terms of Service** and **Privacy Policy** buttons on the create account screen. When tapped, each button will redirect the user to its respective website in the Safari browser.

## 📋 Code changes
-   **CreateAccountView.swift:** Adds functionality to the **Terms of Service** and **Privacy Policy** buttons through the use of Markdowns.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
