### PR TITLE
BIT-421: Implement the identity token refresh request

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRefreshRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRefreshRequestModel.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Networking
+
+/// API request model for refreshing an identity token.
+///
+struct IdentityTokenRefreshRequestModel {
+    // MARK: Properties
+
+    /// The refresh token used to get a new access token.
+    let refreshToken: String
+}
+
+// MARK: - FormURLEncodedRequestBody
+
+extension IdentityTokenRefreshRequestModel: FormURLEncodedRequestBody {
+    var values: [URLQueryItem] {
+        [
+            URLQueryItem(name: "client_id", value: Constants.clientType),
+            URLQueryItem(name: "grant_type", value: "refresh_token"),
+            URLQueryItem(name: "refresh_token", value: refreshToken),
+        ]
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRefreshRequestModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRefreshRequestModelTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class IdentityTokenRefreshRequestModelTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: IdentityTokenRefreshRequestModel!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = IdentityTokenRefreshRequestModel(
+            refreshToken: "REFRESH_TOKEN"
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `values` returns the form values to be encoded in the body of the request.
+    func test_values() {
+        XCTAssertEqual(
+            subject.values,
+            [
+                URLQueryItem(name: "client_id", value: "mobile"),
+                URLQueryItem(name: "grant_type", value: "refresh_token"),
+                URLQueryItem(name: "refresh_token", value: "REFRESH_TOKEN"),
+            ]
+        )
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenRefreshResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenRefreshResponseModel.swift
@@ -1,0 +1,22 @@
+import Foundation
+import Networking
+
+/// API response model for the identity token refresh request.
+///
+struct IdentityTokenRefreshResponseModel: JSONResponse, Equatable {
+    static var decoder = JSONDecoder.snakeCaseDecoder
+
+    // MARK: Properties
+
+    /// The user's access token.
+    let accessToken: String
+
+    /// The number of seconds before the access token expires.
+    let expiresIn: Int
+
+    /// The type of token.
+    let tokenType: String
+
+    /// The user's refresh token.
+    let refreshToken: String
+}

--- a/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIService.swift
@@ -3,14 +3,25 @@
 protocol AuthAPIService {
     /// Performs the identity token request and returns the response.
     ///
-    /// - Parameter request: The access token to authenticate the user.
-    /// - Returns: The identity token response.
+    /// - Parameter request: The user's authentication details.
+    /// - Returns: The identity token response containing an access token.
     ///
     func getIdentityToken(_ request: IdentityTokenRequestModel) async throws -> IdentityTokenResponseModel
+
+    /// Performs the identity token refresh request to get a new access token.
+    ///
+    /// - Parameter request: The user's refresh token used to get a new access token.
+    /// - Returns: The identity token refresh response containing a new access token.
+    ///
+    func refreshIdentityToken(refreshToken: String) async throws -> IdentityTokenRefreshResponseModel
 }
 
 extension APIService: AuthAPIService {
     func getIdentityToken(_ request: IdentityTokenRequestModel) async throws -> IdentityTokenResponseModel {
         try await identityService.send(IdentityTokenRequest(requestModel: request))
+    }
+
+    func refreshIdentityToken(refreshToken: String) async throws -> IdentityTokenRefreshResponseModel {
+        try await identityService.send(IdentityTokenRefreshRequest(refreshToken: refreshToken))
     }
 }

--- a/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIServiceTests.swift
@@ -82,4 +82,21 @@ class AuthAPIServiceTests: BitwardenTestCase {
             )
         }
     }
+
+    /// `refreshIdentityToken()` successfully decodes the identity token refresh response.
+    func test_refreshIdentityToken() async throws {
+        client.result = .httpSuccess(testData: .identityTokenRefresh)
+
+        let response = try await subject.refreshIdentityToken(refreshToken: "REFRESH_TOKEN")
+
+        XCTAssertEqual(
+            response,
+            IdentityTokenRefreshResponseModel(
+                accessToken: "ACCESS_TOKEN",
+                expiresIn: 3600,
+                tokenType: "Bearer",
+                refreshToken: "REFRESH_TOKEN"
+            )
+        )
+    }
 }

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/APITestData+Auth.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/APITestData+Auth.swift
@@ -3,4 +3,5 @@ extension APITestData {
 
     static let identityToken = loadFromJsonBundle(resource: "IdentityTokenSuccess")
     static let identityTokenCaptchaError = loadFromJsonBundle(resource: "IdentityTokenCaptchaFailure")
+    static let identityTokenRefresh = loadFromJsonBundle(resource: "identityTokenRefresh")
 }

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/identityTokenRefresh.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/identityTokenRefresh.json
@@ -1,0 +1,7 @@
+{
+  "access_token": "ACCESS_TOKEN",
+  "expires_in": 3600,
+  "token_type": "Bearer",
+  "refresh_token": "REFRESH_TOKEN",
+  "scope": "api offline_access"
+}

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRefreshRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRefreshRequest.swift
@@ -1,0 +1,33 @@
+import Networking
+
+/// Data model for performing a identity token refresh request.
+///
+struct IdentityTokenRefreshRequest: Request {
+    typealias Response = IdentityTokenRefreshResponseModel
+
+    // MARK: Properties
+
+    /// The body of the request.
+    var body: IdentityTokenRefreshRequestModel? {
+        requestModel
+    }
+
+    /// The HTTP method for this request.
+    let method = HTTPMethod.post
+
+    /// The URL path for this request.
+    let path = "/connect/token"
+
+    /// The request details to include in the body of the request.
+    let requestModel: IdentityTokenRefreshRequestModel
+
+    // MARK: Initialization
+
+    /// Initialize an `IdentityTokenRefreshRequest`.
+    ///
+    /// - Parameter refreshToken: The refresh token used to get a new access token.
+    ///
+    init(refreshToken: String) {
+        requestModel = IdentityTokenRefreshRequestModel(refreshToken: refreshToken)
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRefreshRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRefreshRequestTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class IdentityTokenRefreshRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: IdentityTokenRefreshRequest!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = IdentityTokenRefreshRequest(refreshToken: "REFRESH_TOKEN")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `body` returns the URL encoded form data for the request.
+    func test_body() throws {
+        let bodyData = try XCTUnwrap(subject.body?.encode())
+        XCTAssertEqual(
+            String(data: bodyData, encoding: .utf8),
+            "client%5Fid=mobile&grant%5Ftype=refresh%5Ftoken&refresh%5Ftoken=REFRESH%5FTOKEN"
+        )
+    }
+
+    /// `query` returns no headers.
+    func test_headers() {
+        XCTAssertTrue(subject.headers.isEmpty)
+    }
+
+    /// `method` returns the method of the request.
+    func test_method() {
+        XCTAssertEqual(subject.method, .post)
+    }
+
+    /// `path` returns the path of the request.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/connect/token")
+    }
+
+    /// `query` returns no query parameters.
+    func test_query() {
+        XCTAssertTrue(subject.query.isEmpty)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoder+Bitwarden.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoder+Bitwarden.swift
@@ -74,4 +74,11 @@ extension JSONDecoder {
         }
         return decoder
     }()
+
+    /// A `JSONDecoder` instance that handles decoding JSON with snake_case keys.
+    static let snakeCaseDecoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }()
 }

--- a/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
@@ -92,4 +92,22 @@ class JSONDecoderBitwardenTests: BitwardenTestCase {
 
         XCTAssertEqual(casing, Casing(camelCase: "camel", pascalCase: "pascal", snakeCase: "snake"))
     }
+
+    /// `JSONDecoder.snakeCaseDecoder` handles decoding keys that use snake case.
+    func test_snakeCaseDecoder() throws {
+        let json = """
+        {
+            "snake_case": "snake"
+        }
+        """
+
+        struct Casing: Codable, Equatable {
+            let snakeCase: String
+        }
+
+        let subject = JSONDecoder.snakeCaseDecoder
+        let casing = try subject.decode(Casing.self, from: Data(json.utf8))
+
+        XCTAssertEqual(casing, Casing(snakeCase: "snake"))
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-421](https://livefront.atlassian.net/browse/BIT-421)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implements the API request `POST /identity/connect/token`  to refresh the user's access token.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

- **IdentityTokenRefreshRequest.swift:** The request used to refresh an access token.
- **IdentityTokenRefreshRequestModel.swift:** The form URL encoded body of the request.
- **IdentityTokenRefreshResponseModel.swift:** The response object.
- **JSONDecoder+Bitwarden.swift:** Adds a snake case JSON decoder.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
