### PR TITLE
BIT-844: Updates the value for the `primaryBitwarden` dark mode color

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Support/Colors.xcassets/BrandColors/primaryBitwarden.colorset/Contents.json
+++ b/BitwardenShared/UI/Platform/Application/Support/Colors.xcassets/BrandColors/primaryBitwarden.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "245",
-          "green" : "186",
-          "red" : "111"
+          "blue" : "255",
+          "green" : "197",
+          "red" : "178"
         }
       },
       "idiom" : "universal"


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-884](https://livefront.atlassian.net/browse/BIT-884)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

This PR adjusts the dark mode value of the `primaryBitwarden` color to match design. Since we don't have any dark mode snapshots for any views using this color, none of our snapshot tests had to be updated.

## 📋 Code changes

- **Colors.xcassets:** Updated the value of `primaryBitwarden`'s dark mode variant.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes