### PR TITLE
BIT-895: Fixes email field keyboard type

### DIFF
--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -94,19 +94,18 @@ struct CreateAccountView: View {
         VStack(spacing: 16) {
             BitwardenTextField(
                 title: Localizations.emailAddress,
-                contentType: .emailAddress,
-                autoCapitalizationType: .never,
-                keyboardType: .emailAddress,
                 text: store.binding(
                     get: \.emailText,
                     send: CreateAccountAction.emailTextChanged
                 )
             )
+            .textContentType(.emailAddress)
+            .keyboardType(.emailAddress)
+            .textInputAutocapitalization(.never)
+            .autocorrectionDisabled()
 
             BitwardenTextField(
                 title: Localizations.masterPassword,
-                contentType: .password,
-                autoCapitalizationType: .never,
                 isPasswordVisible: store.binding(
                     get: \.arePasswordsVisible,
                     send: CreateAccountAction.togglePasswordVisibility
@@ -116,6 +115,9 @@ struct CreateAccountView: View {
                     send: CreateAccountAction.passwordTextChanged
                 )
             )
+            .textContentType(.password)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
         }
     }
 
@@ -124,7 +126,6 @@ struct CreateAccountView: View {
         VStack(alignment: .leading) {
             BitwardenTextField(
                 title: Localizations.masterPasswordHint,
-                contentType: .name,
                 text: store.binding(
                     get: \.passwordHintText,
                     send: CreateAccountAction.passwordHintTextChanged
@@ -141,8 +142,6 @@ struct CreateAccountView: View {
     private var retypePassword: some View {
         BitwardenTextField(
             title: Localizations.retypeMasterPassword,
-            contentType: .password,
-            autoCapitalizationType: .never,
             isPasswordVisible: store.binding(
                 get: \.arePasswordsVisible,
                 send: CreateAccountAction.togglePasswordVisibility
@@ -152,6 +151,8 @@ struct CreateAccountView: View {
                 send: CreateAccountAction.retypePasswordTextChanged
             )
         )
+        .textContentType(.password)
+        .textInputAutocapitalization(.never)
     }
 
     /// The button pressed when the user attempts to create the account.

--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -27,14 +27,14 @@ struct LandingView: View {
 
                 BitwardenTextField(
                     title: Localizations.emailAddress,
-                    contentType: .emailAddress,
-                    autoCapitalizationType: .never,
-                    keyboardType: .emailAddress,
                     text: store.binding(
                         get: \.email,
                         send: LandingAction.emailChanged
                     )
                 )
+                .textContentType(.emailAddress)
+                .keyboardType(.emailAddress)
+                .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
 
                 Button {

--- a/BitwardenShared/UI/Auth/Login/LoginView.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginView.swift
@@ -53,8 +53,6 @@ struct LoginView: View {
         VStack(alignment: .leading, spacing: 8) {
             BitwardenTextField(
                 title: Localizations.masterPassword,
-                contentType: .password,
-                autoCapitalizationType: .never,
                 isPasswordVisible: store.binding(
                     get: \.isMasterPasswordRevealed,
                     send: LoginAction.revealMasterPasswordFieldPressed
@@ -64,6 +62,8 @@ struct LoginView: View {
                     send: LoginAction.masterPasswordChanged
                 )
             )
+            .textContentType(.password)
+            .textInputAutocapitalization(.never)
 
             Button(Localizations.getMasterPasswordwordHint) {
                 store.send(.getMasterPasswordHintPressed)

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -24,20 +24,11 @@ struct BitwardenTextField: View {
 
     // MARK: Properties
 
-    /// The auto-capitalization type for the text field.
-    let autoCaptializationType: TextInputAutocapitalization
-
     /// A list of additional buttons that appear on the trailing edge of a textfield.
     let buttons: [AccessoryButton]
 
-    /// The text content type used for the text field.
-    let contentType: UITextContentType
-
     /// Whether a password in this text field is visible.
     let isPasswordVisible: Binding<Bool>?
-
-    /// The type of keyboard to use.
-    let keyboardType: UIKeyboardType
 
     /// The placeholder that is displayed in the textfield.
     let placeholder: String
@@ -67,16 +58,13 @@ struct BitwardenTextField: View {
     private var textField: some View {
         HStack(spacing: 8) {
             ZStack {
-                let isPassword = contentType == .password
+                let isPassword = isPasswordVisible != nil
                 let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
 
                 TextField(placeholder, text: $text)
                     .font(.styleGuide(isPassword ? .bodyMonospaced : .body))
-                    .hidden(!isPasswordVisible && contentType == .password)
+                    .hidden(!isPasswordVisible && isPassword)
                     .id(title)
-                    .keyboardType(keyboardType)
-                    .textContentType(contentType)
-                    .textInputAutocapitalization(autoCaptializationType)
                 if isPassword, !isPasswordVisible {
                     SecureField(placeholder, text: $text)
                         .id(title)
@@ -142,9 +130,6 @@ struct BitwardenTextField: View {
     /// - Parameters:
     ///   - title: The title of the text field.
     ///   - buttons: A list of additional buttons that appear on the trailing edge of a textfield.
-    ///   - contentType: The text content type used for the text field.
-    ///   - autoCaptializationType: The auto-capitalization type for the text field.
-    ///   - keyboardType: The type of keyboard to use.
     ///   - isPasswordVisible: Whether or not the password in the text field is visible.
     ///   - placeholder: An optional placeholder to display in the text field.
     ///   - text: The text entered into the text field.
@@ -152,18 +137,12 @@ struct BitwardenTextField: View {
     init(
         title: String? = nil,
         buttons: [AccessoryButton] = [],
-        contentType: UITextContentType,
-        autoCapitalizationType: TextInputAutocapitalization = .sentences,
-        keyboardType: UIKeyboardType = .default,
         isPasswordVisible: Binding<Bool>? = nil,
         placeholder: String? = nil,
         text: Binding<String>
     ) {
-        autoCaptializationType = autoCapitalizationType
         self.buttons = buttons
-        self.contentType = contentType
         self.isPasswordVisible = isPasswordVisible
-        self.keyboardType = keyboardType
         self.placeholder = placeholder ?? ""
         _text = text
         self.title = title
@@ -199,9 +178,9 @@ struct BitwardenTextField_Previews: PreviewProvider {
         VStack {
             BitwardenTextField(
                 title: "Title",
-                contentType: .emailAddress,
                 text: .constant("Text field text")
             )
+            .textContentType(.emailAddress)
             .padding()
         }
         .background(Color(.systemGroupedBackground))
@@ -210,10 +189,10 @@ struct BitwardenTextField_Previews: PreviewProvider {
         VStack {
             BitwardenTextField(
                 title: "Title",
-                contentType: .password,
                 isPasswordVisible: .constant(false),
                 text: .constant("Text field text")
             )
+            .textContentType(.password)
             .padding()
         }
         .background(Color(.systemGroupedBackground))
@@ -222,10 +201,10 @@ struct BitwardenTextField_Previews: PreviewProvider {
         VStack {
             BitwardenTextField(
                 title: "Title",
-                contentType: .password,
                 isPasswordVisible: .constant(true),
                 text: .constant("Password")
             )
+            .textContentType(.password)
             .padding()
         }
         .background(Color(.systemGroupedBackground))
@@ -241,8 +220,6 @@ struct BitwardenTextField_Previews: PreviewProvider {
                         icon: Asset.Images.cog
                     ),
                 ],
-                contentType: .password,
-                isPasswordVisible: .constant(false),
                 text: .constant("Text field text")
             )
             .padding()


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-895](https://livefront.atlassian.net/browse/BIT-895)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

This PR fixes a small issue with the keyboard type on the email field in the Landing screen being incorrect.

## 📋 Code changes

- **LandingView.swift:** Updated the text field's configuration to use the email address keyboard.

## 📸 Screenshots

<img src="https://github.com/bitwarden/ios/assets/125909022/c2b101b1-c57b-4c3f-aa90-6b7bec576d38" width=300>

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes