### PR TITLE
BIT-880: Update dark mode colors

### DIFF
--- a/Bitwarden/Application/Support/Assets.xcassets/BackgroundColors/backgroundSplash.colorset/Contents.json
+++ b/Bitwarden/Application/Support/Assets.xcassets/BackgroundColors/backgroundSplash.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xFF",
-          "green" : "0xFF",
-          "red" : "0xFE"
+          "blue" : "0xF7",
+          "green" : "0xF2",
+          "red" : "0xF2"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x00",
-          "green" : "0x00",
-          "red" : "0x00"
+          "blue" : "0x1E",
+          "green" : "0x1C",
+          "red" : "0x1C"
         }
       },
       "idiom" : "universal"

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -128,7 +128,7 @@ struct BitwardenTextField: View {
         .tint(Asset.Colors.primaryBitwarden.swiftUIColor)
         .padding(.horizontal, 16)
         .padding(.vertical, 8)
-        .background(Asset.Colors.backgroundPrimary.swiftUIColor)
+        .background(Asset.Colors.backgroundElevatedTertiary.swiftUIColor)
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -19,7 +19,7 @@ struct SettingsView: View {
                         .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding()
-                        .background(Asset.Colors.backgroundPrimary.swiftUIColor)
+                        .background(Asset.Colors.backgroundElevatedTertiary.swiftUIColor)
                         .cornerRadius(10)
                 }
             }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-880](https://livefront.atlassian.net/browse/BIT-880)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the splash screen and text field background colors to match the designs for dark mode.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **BitwardenTextField.swift:** Updates the text field background color to match the designs.
- **backgroundSplash.colorset:** Updates the background color of the splash screen to match the designs (background secondary).
- **SettingsView.swift:** Updates the background color of the logout button.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| -- | -- |
| <img width="565" alt="Screenshot 2023-10-24 at 11 21 17 AM" src="https://github.com/bitwarden/ios/assets/126492398/02592b1f-afb1-4a1b-b0c9-608909a866e6"> | <img width="565" alt="Screenshot 2023-10-24 at 11 19 52 AM" src="https://github.com/bitwarden/ios/assets/126492398/21aef2b0-5e1f-4714-a3fa-7f07ca242861"> |


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
