### PR TITLE
BIT-270: Add assertion failure if logout fails

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -1,3 +1,5 @@
+import OSLog
+
 /// The processor used to manage state and handle actions for the settings screen.
 ///
 final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Void> {
@@ -47,7 +49,13 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Voi
     ///
     private func showLogoutConfirmation() {
         let alert = Alert.logoutConfirmation {
-            try? await self.services.settingsRepository.logout()
+            do {
+                try await self.services.settingsRepository.logout()
+            } catch {
+                // TODO: BIT-941 Log error to Crashlytics.
+                Logger.processor.error("Error logging out: \(error)")
+                assertionFailure("Error logging out: \(error)")
+            }
             self.coordinator.navigate(to: .logout)
         }
         coordinator.navigate(to: .alert(alert))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-270](https://livefront.atlassian.net/browse/BIT-270)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds an assertion failure and error logging if logging out produces an error. We don't want to prevent the user from logging out in this case since they aren't able to recover from this, but this should allow us to catch any potential issues during development (and eventually in production when we log to Crashlytics).

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SettingsProcessor.swift:** Adds an assertion failure and error logging if logout throws an error.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
