### PR TITLE
BIT-220: Unlock the user's vault on login

### DIFF
--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -28,6 +28,7 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
     typealias Services = HasAccountAPIService
         & HasAppIdService
         & HasAuthAPIService
+        & HasAuthRepository
         & HasCaptchaService
         & HasClientAuth
         & HasDeviceAPIService
@@ -158,6 +159,8 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
             await services.stateService.addAccount(account)
             let encryptionKeys = AccountEncryptionKeys(identityTokenResponseModel: identityToken)
             try await services.stateService.setAccountEncryptionKeys(encryptionKeys)
+
+            try await services.authRepository.unlockVault(password: state.masterPassword)
 
             coordinator.hideLoadingOverlay()
             coordinator.navigate(to: .complete)

--- a/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
@@ -9,6 +9,7 @@ class LoginProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var appSettingsStore: MockAppSettingsStore!
+    var authRepository: MockAuthRepository!
     var captchaService: MockCaptchaService!
     var client: MockHTTPClient!
     var clientAuth: MockClientAuth!
@@ -22,6 +23,7 @@ class LoginProcessorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
         appSettingsStore = MockAppSettingsStore()
+        authRepository = MockAuthRepository()
         captchaService = MockCaptchaService()
         client = MockHTTPClient()
         clientAuth = MockClientAuth()
@@ -32,6 +34,7 @@ class LoginProcessorTests: BitwardenTestCase {
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 appSettingsStore: appSettingsStore,
+                authRepository: authRepository,
                 captchaService: captchaService,
                 clientService: MockClientService(clientAuth: clientAuth),
                 httpClient: client,
@@ -97,6 +100,7 @@ class LoginProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(coordinator.routes.last, .complete)
 
+        XCTAssertEqual(authRepository.unlockVaultPassword, "Password1234!")
         XCTAssertEqual(stateService.accountsAdded, [Account.fixtureAccountLogin()])
         XCTAssertEqual(
             stateService.accountEncryptionKeys,
@@ -203,6 +207,7 @@ class LoginProcessorTests: BitwardenTestCase {
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.loggingIn)])
 
+        XCTAssertEqual(authRepository.unlockVaultPassword, "Password1234!")
         XCTAssertEqual(stateService.accountsAdded, [Account.fixtureAccountLogin()])
         XCTAssertEqual(
             stateService.accountEncryptionKeys,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-220](https://livefront.atlassian.net/browse/BIT-220)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When the user logs in, we need to unlock their vault / initialize the SDK so that encryption/decryption works when we load their vault data or they add a new vault item.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **LoginProcessor.swift:** Unlocks the user's vault after logging in.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
