### PR TITLE
BIT-392: Add passphrase generation

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepository.swift
@@ -3,6 +3,13 @@ import BitwardenSdk
 /// A protocol for a `GeneratorRepository` which manages access to the data needed by the UI layer.
 ///
 protocol GeneratorRepository: AnyObject {
+    /// Generates a passphrase based on the passphrase settings.
+    ///
+    /// - Parameter settings: The settings used to generate the passphrase.
+    /// - Returns: The generated passphrase.
+    ///
+    func generatePassphrase(settings: PassphraseGeneratorRequest) async throws -> String
+
     /// Generates a password based on the password settings.
     ///
     /// - Parameter settings: The settings used to generate the password.
@@ -35,6 +42,10 @@ class DefaultGeneratorRepository {
 // MARK: GeneratorRepository
 
 extension DefaultGeneratorRepository: GeneratorRepository {
+    func generatePassphrase(settings: PassphraseGeneratorRequest) async throws -> String {
+        try await clientGenerators.passphrase(settings: settings)
+    }
+
     func generatePassword(settings: PasswordGeneratorRequest) async throws -> String {
         try await clientGenerators.password(settings: settings)
     }

--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
@@ -28,6 +28,38 @@ class GeneratorRepositoryTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `generatePassphrase` returns the generated passphrase.
+    func test_generatePassphrase() async throws {
+        let passphrase = try await subject.generatePassphrase(
+            settings: PassphraseGeneratorRequest(
+                numWords: 3,
+                wordSeparator: "-",
+                capitalize: false,
+                includeNumber: false
+            )
+        )
+
+        XCTAssertEqual(passphrase, "PASSPHRASE")
+    }
+
+    /// `generatePassphrase` throws an error if generating a passphrase fails.
+    func test_generatePassphrase_error() async {
+        struct GeneratePassphraseError: Error, Equatable {}
+
+        clientGenerators.passphraseResult = .failure(GeneratePassphraseError())
+
+        await assertAsyncThrows(error: GeneratePassphraseError()) {
+            _ = try await subject.generatePassphrase(
+                settings: PassphraseGeneratorRequest(
+                    numWords: 3,
+                    wordSeparator: "-",
+                    capitalize: false,
+                    includeNumber: false
+                )
+            )
+        }
+    }
+
     /// `generatePassword` returns the generated password.
     func test_generatePassword() async throws {
         let password = try await subject.generatePassword(

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockGeneratorRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockGeneratorRepository.swift
@@ -3,8 +3,16 @@ import BitwardenSdk
 @testable import BitwardenShared
 
 class MockGeneratorRepository: GeneratorRepository {
+    var passphraseGeneratorRequest: PassphraseGeneratorRequest?
+    var passphraseResult: Result<String, Error> = .success("PASSPHRASE")
+
     var passwordGeneratorRequest: PasswordGeneratorRequest?
     var passwordResult: Result<String, Error> = .success("PASSWORD")
+
+    func generatePassphrase(settings: PassphraseGeneratorRequest) async throws -> String {
+        passphraseGeneratorRequest = settings
+        return try passphraseResult.get()
+    }
 
     func generatePassword(settings: PasswordGeneratorRequest) async throws -> String {
         passwordGeneratorRequest = settings

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -77,6 +77,20 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
 
     // MARK: Private
 
+    /// Generates a new passphrase.
+    ///
+    func generatePassphrase() async {
+        do {
+            let passphrase = try await services.generatorRepository.generatePassphrase(
+                settings: state.passwordState.passphraseGeneratorRequest
+            )
+            try Task.checkCancellation()
+            state.generatedValue = passphrase
+        } catch {
+            Logger.application.error("Generator: error generating passphrase: \(error)")
+        }
+    }
+
     /// Generates a new password.
     ///
     func generatePassword() async {
@@ -98,7 +112,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
         case .password:
             switch state.passwordState.passwordGeneratorType {
             case .passphrase:
-                break
+                await generatePassphrase()
             case .password:
                 await generatePassword()
             }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -57,6 +57,26 @@ class GeneratorProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.generatorType, .username)
     }
 
+    /// `receive(_:)` with `.refreshGeneratedValue` generates a new passphrase.
+    func test_receive_refreshGeneratedValue_passphrase() {
+        subject.state.generatorType = .password
+        subject.state.passwordState.passwordGeneratorType = .passphrase
+
+        subject.receive(.refreshGeneratedValue)
+
+        waitFor { generatorRepository.passphraseGeneratorRequest != nil }
+
+        XCTAssertEqual(
+            generatorRepository.passphraseGeneratorRequest,
+            PassphraseGeneratorRequest(
+                numWords: 3,
+                wordSeparator: "-",
+                capitalize: false,
+                includeNumber: false
+            )
+        )
+    }
+
     /// `receive(_:)` with `.refreshGeneratedValue` generates a new password.
     func test_receive_refreshGeneratedValue_password() {
         subject.state.generatorType = .password

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+PasswordState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+PasswordState.swift
@@ -83,6 +83,17 @@ extension GeneratorState {
 }
 
 extension GeneratorState.PasswordState {
+    /// Returns a `PassphraseGeneratorRequest` containing the user selected settings for generating
+    /// a passphrase.
+    var passphraseGeneratorRequest: PassphraseGeneratorRequest {
+        PassphraseGeneratorRequest(
+            numWords: UInt8(numberOfWords),
+            wordSeparator: wordSeparator,
+            capitalize: capitalize,
+            includeNumber: includeNumber
+        )
+    }
+
     /// Returns a `PasswordGeneratorRequest` containing the user selected settings for generating a
     /// password.
     var passwordGeneratorRequest: PasswordGeneratorRequest {

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -51,6 +51,36 @@ class GeneratorStateTests: XCTestCase {
         }
     }
 
+    /// `passwordState.passphraseGeneratorRequest` returns the passphrase generator request.
+    func test_passwordState_passphraseGeneratorRequest() {
+        var subject = GeneratorState().passwordState
+
+        XCTAssertEqual(
+            subject.passphraseGeneratorRequest,
+            PassphraseGeneratorRequest(
+                numWords: 3,
+                wordSeparator: "-",
+                capitalize: false,
+                includeNumber: false
+            )
+        )
+
+        subject.numberOfWords = 6
+        subject.wordSeparator = "*"
+        subject.capitalize = true
+        subject.includeNumber = true
+
+        XCTAssertEqual(
+            subject.passphraseGeneratorRequest,
+            PassphraseGeneratorRequest(
+                numWords: 6,
+                wordSeparator: "*",
+                capitalize: true,
+                includeNumber: true
+            )
+        )
+    }
+
     /// `passwordState.passwordGeneratorRequest` returns the password generator request.
     func test_passwordState_passwordGeneratorRequest() {
         var subject = GeneratorState().passwordState


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-392](https://livefront.atlassian.net/browse/BIT-392)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This implements generating passphrases using the SDK. New passphrases are generated when the view appears, any inputs are changed, or if the refresh button is tapped. The SDK only returns a single hardcoded passphrases, so it's hard to tell that or if it's changing though.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **GeneratorRepository.swift:** Adds a method to the repository to generate passphrases.
- **GeneratorProcessor.swift:** Generates a new passphrase when the password generator type is passphrase or the refresh button is tapped.
- **GeneratorState+PasswordState.swift:** Creates the generate passphrase request to send to the SDK to generate a new passphrase.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/4faedf2c-2877-406d-a447-02f9ea42e914

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
