### PR TITLE
BIT-1052: Adds a check for using the correct simulator when running unit tests

### DIFF
--- a/GlobalTestHelpers/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers/Support/BitwardenTestCase.swift
@@ -8,6 +8,17 @@ open class BitwardenTestCase: XCTestCase {
     /// The window being used for testing. Defaults to a new window with the same size as `UIScreen.main.bounds`.
     public var window: UIWindow!
 
+    @MainActor
+    override open class func setUp() {
+        if UIDevice.current.name != "iPhone 14 Pro" {
+            assertionFailure(
+                """
+                Tests must be run using the iPhone 14 Pro simulator. Snapshot tests depend on using the correct device.
+                """
+            )
+        }
+    }
+
     /// Executes any logic that should be applied before each test runs.
     ///
     @MainActor


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1052](https://livefront.atlassian.net/browse/BIT-1052)

## 🚧 Type of change

-   🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

This PR keeps us from accidentally running unit tests on the wrong simulator. If we use an incorrect simulator, that can throw off our snapshot tests, and to keep us from pushing up broken snapshots, we should only be running tests on one type of simulator (currently the iPhone 14 Pro simulator).

## 📋 Code changes

- **BitwardenTestCase.swift:** Added a class setup method override that performs a check to ensure we're running our test suite with the correct simulator.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
