### PR TITLE
BIT-1088: Make MasterPasswordPolicyResponseModel.requireSpecial optional to fix a decoding error

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/MasterPasswordPolicyResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/MasterPasswordPolicyResponseModel.swift
@@ -19,7 +19,7 @@ struct MasterPasswordPolicyResponseModel: Codable, Equatable {
     let requireNumbers: Bool?
 
     /// Whether the password requires a special character.
-    let requireSpecial: Bool
+    let requireSpecial: Bool?
 
     /// Whether the password requires an uppercase character.
     let requireUpper: Bool?


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1088](https://livefront.atlassian.net/browse/BIT-1088)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates `MasterPasswordPolicyResponseModel.requireSpecial` to be optional to fix a decoding error when it isn't present.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **MasterPasswordPolicyResponseModel.swift:** Updates `requireSpecial` to be optional.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
