### PR TITLE
BIT-1109: Add accessibility identifiers to Create Account

### DIFF
--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -85,6 +85,7 @@ struct CreateAccountView: View {
                 .foregroundColor(Color(asset: Asset.Colors.textPrimary))
                 .font(.styleGuide(.footnote))
         }
+        .accessibilityIdentifier("CheckExposedMasterPasswordToggle")
         .toggleStyle(.bitwarden)
         .id(ViewIdentifier.CreateAccount.checkBreaches)
     }
@@ -93,6 +94,7 @@ struct CreateAccountView: View {
     private var emailAndPassword: some View {
         VStack(spacing: 16) {
             BitwardenTextField(
+                accessibilityIdentifier: "EmailAddressEntry",
                 title: Localizations.emailAddress,
                 text: store.binding(
                     get: \.emailText,
@@ -105,11 +107,13 @@ struct CreateAccountView: View {
             .autocorrectionDisabled()
 
             BitwardenTextField(
+                accessibilityIdentifier: "MasterPasswordEntry",
                 title: Localizations.masterPassword,
                 isPasswordVisible: store.binding(
                     get: \.arePasswordsVisible,
                     send: CreateAccountAction.togglePasswordVisibility
                 ),
+                passwordVisibilityAccessibilityId: "PasswordVisibilityToggle",
                 text: store.binding(
                     get: \.passwordText,
                     send: CreateAccountAction.passwordTextChanged
@@ -125,6 +129,7 @@ struct CreateAccountView: View {
     private var passwordHint: some View {
         VStack(alignment: .leading) {
             BitwardenTextField(
+                accessibilityIdentifier: "MasterPasswordHintLabel",
                 title: Localizations.masterPasswordHint,
                 text: store.binding(
                     get: \.passwordHintText,
@@ -141,11 +146,13 @@ struct CreateAccountView: View {
     /// The text field for re-typing the master password.
     private var retypePassword: some View {
         BitwardenTextField(
+            accessibilityIdentifier: "ConfirmMasterPasswordEntry",
             title: Localizations.retypeMasterPassword,
             isPasswordVisible: store.binding(
                 get: \.arePasswordsVisible,
                 send: CreateAccountAction.togglePasswordVisibility
             ),
+            passwordVisibilityAccessibilityId: "ConfirmPasswordVisibilityToggle",
             text: store.binding(
                 get: \.retypePasswordText,
                 send: CreateAccountAction.retypePasswordTextChanged
@@ -190,6 +197,7 @@ struct CreateAccountView: View {
         .accessibilityAction(named: Localizations.privacyPolicy) {
             openURL(ExternalLinksConstants.privacyPolicy)
         }
+        .accessibilityIdentifier("AcceptPoliciesToggle")
         .foregroundColor(Color(asset: Asset.Colors.textPrimary))
         .font(.styleGuide(.footnote))
         .toggleStyle(.bitwarden)

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -21,6 +21,9 @@ struct BitwardenTextField: View {
             case async(() async -> Void)
         }
 
+        /// The accessibility identifier for the button.
+        var accessibilityIdentifier: String?
+
         /// The accessibility label for this button.
         var accessibilityLabel: String
 
@@ -33,11 +36,18 @@ struct BitwardenTextField: View {
         /// Creates a new `AccessoryButton`.
         ///
         /// - Parameters:
+        ///   - accessibilityIdentifier: The accessibility identifier for the button.
         ///   - accessibilityLabel: The accessibility label for this button.
         ///   - action: The synchronous action that is executed when this button is tapped.
         ///   - icon: The icon to display in this button.
         ///
-        init(accessibilityLabel: String, action: @escaping () -> Void, icon: ImageAsset) {
+        init(
+            accessibilityIdentifier: String? = nil,
+            accessibilityLabel: String,
+            action: @escaping () -> Void,
+            icon: ImageAsset
+        ) {
+            self.accessibilityIdentifier = accessibilityIdentifier
             self.accessibilityLabel = accessibilityLabel
             self.action = .sync(action)
             self.icon = icon
@@ -46,11 +56,18 @@ struct BitwardenTextField: View {
         /// Creates a new `AccessoryButton`.
         ///
         /// - Parameters:
+        ///   - accessibilityIdentifier: The accessibility identifier for the button.
         ///   - accessibilityLabel: The accessibility label for this button.
         ///   - action: The asynchronous action that is executed when this button is tapped.
         ///   - icon: The icon to display in this button.
         ///
-        init(accessibilityLabel: String, action: @escaping () async -> Void, icon: ImageAsset) {
+        init(
+            accessibilityIdentifier: String? = nil,
+            accessibilityLabel: String,
+            action: @escaping () async -> Void,
+            icon: ImageAsset
+        ) {
+            self.accessibilityIdentifier = accessibilityIdentifier
             self.accessibilityLabel = accessibilityLabel
             self.action = .async(action)
             self.icon = icon
@@ -58,6 +75,9 @@ struct BitwardenTextField: View {
     }
 
     // MARK: Properties
+
+    /// The accessibility identifier for the text field.
+    let accessibilityIdentifier: String?
 
     /// A list of additional buttons that appear on the trailing edge of a textfield.
     let buttons: [AccessoryButton]
@@ -67,6 +87,9 @@ struct BitwardenTextField: View {
 
     /// Whether a password in this text field is visible.
     let isPasswordVisible: Binding<Bool>?
+
+    /// The accessibility identifier for the button to toggle password visibility.
+    let passwordVisibilityAccessibilityId: String?
 
     /// The placeholder that is displayed in the textfield.
     let placeholder: String
@@ -116,6 +139,7 @@ struct BitwardenTextField: View {
                         .id(title)
                 }
             }
+            .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
 
             Button {
                 text = ""
@@ -139,6 +163,7 @@ struct BitwardenTextField: View {
                 if let isPasswordVisible {
                     accessoryButton(
                         AccessoryButton(
+                            accessibilityIdentifier: passwordVisibilityAccessibilityId ?? "PasswordVisibilityToggle",
                             accessibilityLabel: isPasswordVisible.wrappedValue
                                 ? Localizations.passwordIsVisibleTapToHide
                                 : Localizations.passwordIsNotVisibleTapToShow,
@@ -174,24 +199,31 @@ struct BitwardenTextField: View {
     /// Initializes a new `BitwardenTextField`.
     ///
     /// - Parameters:
+    ///   - accessibilityIdentifier: The accessibility identifier for the text field.
     ///   - title: The title of the text field.
     ///   - buttons: A list of additional buttons that appear on the trailing edge of a textfield.
     ///   - footer: The footer text displayed below the text field.
     ///   - isPasswordVisible: Whether or not the password in the text field is visible.
+    ///   - passwordVisibilityAccessibilityId: The accessibility identifier for the
+    ///     button to toggle password visibility.
     ///   - placeholder: An optional placeholder to display in the text field.
     ///   - text: The text entered into the text field.
     ///
     init(
+        accessibilityIdentifier: String? = nil,
         title: String? = nil,
         buttons: [AccessoryButton] = [],
         footer: String? = nil,
         isPasswordVisible: Binding<Bool>? = nil,
+        passwordVisibilityAccessibilityId: String? = nil,
         placeholder: String? = nil,
         text: Binding<String>
     ) {
+        self.accessibilityIdentifier = accessibilityIdentifier
         self.buttons = buttons
         self.footer = footer
         self.isPasswordVisible = isPasswordVisible
+        self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
         self.placeholder = placeholder ?? ""
         _text = text
         self.title = title
@@ -212,10 +244,12 @@ struct BitwardenTextField: View {
         switch button.action {
         case let .async(action):
             AsyncButton(role: nil, action: action, label: { label })
+                .accessibilityIdentifier(button.accessibilityIdentifier ?? "")
                 .accessibilityLabel(button.accessibilityLabel)
                 .buttonStyle(.accessory)
         case let .sync(action):
             Button(action: action, label: { label })
+                .accessibilityIdentifier(button.accessibilityIdentifier ?? "")
                 .accessibilityLabel(button.accessibilityLabel)
                 .buttonStyle(.accessory)
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1109](https://livefront.atlassian.net/browse/BIT-1109)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds accessibility identifiers for automated testing to the create account screen.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **CreateAccountView.swift:** Adds accessibility identifiers.
- **BitwardenTextField.swift:** Adds support for setting the text field and accessory button accessibility identifiers.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
