### PR TITLE
BIT-854 Add Account Navigates to Login

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -1,9 +1,22 @@
 import BitwardenSdk
+import Foundation
 
 /// A protocol for an `AuthRepository` which manages access to the data needed by the UI layer.
 ///
 protocol AuthRepository: AnyObject {
     // MARK: Methods
+
+    /// Gets all accounts.
+    ///
+    /// - Returns: The known user accounts as `[ProfileSwitcherItem]`.
+    ///
+    func getAccounts() async throws -> [ProfileSwitcherItem]
+
+    /// Gets the active account.
+    ///
+    /// - Returns: The active user account as a `ProfileSwitcherItem`.
+    ///
+    func getActiveAccount() async throws -> ProfileSwitcherItem
 
     /// Logs the user out of the active account.
     ///
@@ -49,6 +62,20 @@ class DefaultAuthRepository {
 // MARK: - AuthRepository
 
 extension DefaultAuthRepository: AuthRepository {
+    func getAccounts() async throws -> [ProfileSwitcherItem] {
+        // TODO: BIT-1132 - Profile Switcher UI on Auth
+        let accounts = try await stateService.getAccounts()
+        return accounts.map { account in
+            profileItem(from: account)
+        }
+    }
+
+    func getActiveAccount() async throws -> ProfileSwitcherItem {
+        // TODO: BIT-1132 - Profile Switcher UI on Auth
+        let active = try await stateService.getActiveAccount()
+        return profileItem(from: active)
+    }
+
     func logout() async throws {
         try await stateService.logoutAccount()
     }
@@ -65,6 +92,19 @@ extension DefaultAuthRepository: AuthRepository {
                 privateKey: encryptionKeys.encryptedPrivateKey,
                 organizationKeys: [:]
             )
+        )
+    }
+
+    /// A function to convert an `Account` to a `ProfileSwitcherItem`
+    ///   - Parameter account: The account to convert
+    ///   - Returns: The `ProfileSwitcherItem` representing the account
+    ///
+    func profileItem(from account: Account) -> ProfileSwitcherItem {
+        ProfileSwitcherItem(
+            email: account.profile.email,
+            userId: account.profile.userId,
+            userInitials: account.initials()
+                ?? "  "
         )
     }
 }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -3,12 +3,152 @@ import XCTest
 
 @testable import BitwardenShared
 
+// swiftlint:disable:next type_body_length
 class AuthRepositoryTests: BitwardenTestCase {
     // MARK: Properties
 
     var clientCrypto: MockClientCrypto!
     var subject: DefaultAuthRepository!
     var stateService: MockStateService!
+
+    let anneAccount = Account(
+        profile: .init(
+            avatarColor: nil,
+            email: "Anne.Account@bitwarden.com",
+            emailVerified: nil,
+            forcePasswordResetReason: nil,
+            hasPremiumPersonally: nil,
+            kdfIterations: nil,
+            kdfMemory: nil,
+            kdfParallelism: nil,
+            kdfType: nil,
+            name: "Anne Account",
+            orgIdentifier: nil,
+            stamp: nil,
+            userDecryptionOptions: nil,
+            userId: UUID().uuidString
+        ),
+        settings: .init(environmentUrls: nil),
+        tokens: .init(
+            accessToken: "",
+            refreshToken: ""
+        )
+    )
+    let beeAccount = Account(
+        profile: .init(
+            avatarColor: nil,
+            email: "bee.account@bitwarden.com",
+            emailVerified: nil,
+            forcePasswordResetReason: nil,
+            hasPremiumPersonally: nil,
+            kdfIterations: nil,
+            kdfMemory: nil,
+            kdfParallelism: nil,
+            kdfType: nil,
+            name: nil,
+            orgIdentifier: nil,
+            stamp: nil,
+            userDecryptionOptions: nil,
+            userId: UUID().uuidString
+        ),
+        settings: .init(environmentUrls: nil),
+        tokens: .init(
+            accessToken: "",
+            refreshToken: ""
+        )
+    )
+    let claimedAccount = Account(
+        profile: .init(
+            avatarColor: nil,
+            email: "claims@bitwarden.com",
+            emailVerified: nil,
+            forcePasswordResetReason: nil,
+            hasPremiumPersonally: nil,
+            kdfIterations: nil,
+            kdfMemory: nil,
+            kdfParallelism: nil,
+            kdfType: nil,
+            name: nil,
+            orgIdentifier: nil,
+            stamp: nil,
+            userDecryptionOptions: nil,
+            userId: UUID().uuidString
+        ),
+        settings: .init(environmentUrls: nil),
+        tokens: .init(
+            accessToken: "",
+            refreshToken: ""
+        )
+    )
+    let empty = Account(
+        profile: .init(
+            avatarColor: nil,
+            email: "",
+            emailVerified: nil,
+            forcePasswordResetReason: nil,
+            hasPremiumPersonally: nil,
+            kdfIterations: nil,
+            kdfMemory: nil,
+            kdfParallelism: nil,
+            kdfType: nil,
+            name: nil,
+            orgIdentifier: nil,
+            stamp: nil,
+            userDecryptionOptions: nil,
+            userId: ""
+        ),
+        settings: .init(environmentUrls: nil),
+        tokens: .init(
+            accessToken: "",
+            refreshToken: ""
+        )
+    )
+    let shortEmail = Account(
+        profile: .init(
+            avatarColor: nil,
+            email: "a@gmail.com",
+            emailVerified: nil,
+            forcePasswordResetReason: nil,
+            hasPremiumPersonally: nil,
+            kdfIterations: nil,
+            kdfMemory: nil,
+            kdfParallelism: nil,
+            kdfType: nil,
+            name: nil,
+            orgIdentifier: nil,
+            stamp: nil,
+            userDecryptionOptions: nil,
+            userId: UUID().uuidString
+        ),
+        settings: .init(environmentUrls: nil),
+        tokens: .init(
+            accessToken: "",
+            refreshToken: ""
+        )
+    )
+    let shortName = Account(
+        profile: .init(
+            avatarColor: nil,
+            email: "aj@gmail.com",
+            emailVerified: nil,
+            forcePasswordResetReason: nil,
+            hasPremiumPersonally: nil,
+            kdfIterations: nil,
+            kdfMemory: nil,
+            kdfParallelism: nil,
+            kdfType: nil,
+            name: "AJ",
+            orgIdentifier: nil,
+            stamp: nil,
+            userDecryptionOptions: nil,
+            userId: UUID().uuidString
+        ),
+        settings: .init(environmentUrls: nil),
+        tokens: .init(
+            accessToken: "",
+            refreshToken: ""
+        )
+    )
 
     // MARK: Setup & Teardown
 
@@ -33,6 +173,105 @@ class AuthRepositoryTests: BitwardenTestCase {
     }
 
     // MARK: Tests
+
+    /// `getAccounts()` throws an error when the accounts are nil
+    func test_getAccounts_empty() async throws {
+        await assertAsyncThrows(error: StateServiceError.noAccounts) {
+            _ = try await subject.getAccounts()
+        }
+    }
+
+    /// `getAccounts()` returns all known accounts
+    ///
+    func test_getAccounts_valid() async throws { // swiftlint:disable:this function_body_length
+        stateService.accounts = [
+            anneAccount,
+            beeAccount,
+            claimedAccount,
+            empty,
+            shortEmail,
+            shortName,
+        ]
+
+        let accounts = try await subject.getAccounts()
+        XCTAssertEqual(
+            accounts.first,
+            ProfileSwitcherItem(
+                email: anneAccount.profile.email,
+                userId: anneAccount.profile.userId,
+                userInitials: "AA"
+            )
+        )
+        XCTAssertEqual(
+            accounts[1],
+            ProfileSwitcherItem(
+                email: beeAccount.profile.email,
+                userId: beeAccount.profile.userId,
+                userInitials: "BA"
+            )
+        )
+        XCTAssertEqual(
+            accounts[2],
+            ProfileSwitcherItem(
+                email: claimedAccount.profile.email,
+                userId: claimedAccount.profile.userId,
+                userInitials: "CL"
+            )
+        )
+        XCTAssertEqual(
+            accounts[3],
+            ProfileSwitcherItem(
+                email: "",
+                userId: "",
+                userInitials: "  "
+            )
+        )
+        XCTAssertEqual(
+            accounts[4],
+            ProfileSwitcherItem(
+                email: shortEmail.profile.email,
+                userId: shortEmail.profile.userId,
+                userInitials: "A"
+            )
+        )
+        XCTAssertEqual(
+            accounts[5],
+            ProfileSwitcherItem(
+                email: shortName.profile.email,
+                userId: shortName.profile.userId,
+                userInitials: "AJ"
+            )
+        )
+    }
+
+    /// `getActiveAccount()` returns a profile switcher item
+    func test_getActiveAccount_empty() async throws {
+        stateService.accounts = [
+            anneAccount,
+        ]
+
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.getActiveAccount()
+        }
+    }
+
+    /// `getActiveAccount()` returns an error when the active account is nil
+    func test_getActiveAccount_valid() async throws {
+        stateService.accounts = [
+            anneAccount,
+        ]
+        stateService.activeAccount = anneAccount
+
+        let active = try await subject.getActiveAccount()
+        XCTAssertEqual(
+            active,
+            ProfileSwitcherItem(
+                email: anneAccount.profile.email,
+                userId: anneAccount.profile.userId,
+                userInitials: "AA"
+            )
+        )
+    }
 
     /// `unlockVault(password:)` unlocks the vault with the user's password.
     func test_unlockVault() async throws {

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -1,9 +1,21 @@
 @testable import BitwardenShared
 
 class MockAuthRepository: AuthRepository {
+    var accountsResult: Result<[ProfileSwitcherItem], Error> = .failure(StateServiceError.noAccounts)
+    var activeAccountResult: Result<ProfileSwitcherItem, Error> = .failure(StateServiceError.noActiveAccount)
     var logoutCalled = false
     var unlockVaultPassword: String?
     var unlockVaultResult: Result<Void, Error> = .success(())
+
+    func getAccounts() async throws -> [ProfileSwitcherItem] {
+        // TODO: BIT-1132 - Profile Switcher UI on Auth
+        try accountsResult.get()
+    }
+
+    func getActiveAccount() async throws -> ProfileSwitcherItem {
+        // TODO: BIT-1132 - Profile Switcher UI on Auth
+        try activeAccountResult.get()
+    }
 
     func logout() async throws {
         logoutCalled = true

--- a/BitwardenShared/Core/Platform/Extensions/Account+Initials.swift
+++ b/BitwardenShared/Core/Platform/Extensions/Account+Initials.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+extension Account {
+    /// A function to convert a name or user email to initials
+    ///   - Parameter profile: The profile to use for the initials
+    ///   - Returns: A `String?` representing user initials
+    ///
+    func initials() -> String? {
+        var initials: String?
+        if let name = profile.name,
+           !name.isEmpty {
+            initials = extractInitials(
+                from: name
+            )
+        } else {
+            // Create a separators set that includes punctuation characters and symbols
+            let separators = CharacterSet.punctuationCharacters
+                .union(.symbols)
+
+            // Extract initials from the part of the email before '@'
+            if let emailPrefix = profile.email.components(separatedBy: "@").first {
+                return extractInitials(
+                    from: emailPrefix,
+                    separators: separators
+                )
+            }
+        }
+        guard let initials else { return nil }
+        return initials
+    }
+
+    /// A function to convert a string to component initials
+    ///   - Parameters:
+    ///     - string: The string to be converted to initials
+    ///     - limit: The maximum number of initials
+    ///     - separators: The characters used to separate string components
+    ///   - Returns: A `String?` representing component initials
+    ///
+    private func extractInitials(
+        from string: String,
+        limit: Int = 2,
+        separators: CharacterSet = .whitespacesAndNewlines
+    ) -> String? {
+        var initials: String?
+        let components = string.components(separatedBy: separators)
+        if let firstComponent = components.first, components.count == 1 {
+            // If there's only one component, return up to the first two characters of it
+            initials = String(firstComponent.prefix(2)).uppercased()
+        } else {
+            // Otherwise, proceed with the usual logic to get the first character of each component
+            initials = components
+                .compactMap { component in
+                    component.first
+                }
+                .prefix(limit)
+                .map { String($0) }
+                .joined()
+        }
+        guard let initials,
+              !initials.isEmpty else { return nil }
+        return initials.uppercased()
+    }
+}

--- a/BitwardenShared/Core/Platform/Models/Domain/AccountTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/AccountTests.swift
@@ -61,4 +61,112 @@ class AccountTests: BitwardenTestCase {
             )
         )
     }
+
+    func test_initials_oneName_short() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "user@bitwarden.com",
+                name: "AJ"
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("AJ", initials)
+    }
+
+    func test_initials_oneName_long() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "user@bitwarden.com",
+                name: "User"
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("US", initials)
+    }
+
+    func test_initials_twoNames() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "user@bitwarden.com",
+                name: "Bitwarden User"
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("BU", initials)
+    }
+
+    func test_initials_threeNames() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "user@bitwarden.com",
+                name: "An Interesting User"
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("AI", initials)
+    }
+
+    func test_initials_email_oneName() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "user@bitwarden.com",
+                name: nil
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("US", initials)
+    }
+
+    func test_initials_email_oneName_short() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "a@bitwarden.com",
+                name: nil
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("A", initials)
+    }
+
+    func test_initials_email_oneNamePlus() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "user+1@bitwarden.com",
+                name: nil
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("U1", initials)
+    }
+
+    func test_initials_email_twoNamesDot() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "test.user@bitwarden.com",
+                name: nil
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertEqual("TU", initials)
+    }
+
+    func test_initials_empty() throws {
+        let subject = Account.fixture(
+            profile: .fixture(
+                email: "",
+                name: nil
+            )
+        )
+        let initials = subject.initials()
+
+        XCTAssertNil(initials)
+    }
 }

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -140,6 +140,7 @@ public class ServiceContainer: Services {
         let vaultRepository = DefaultVaultRepository(
             cipherAPIService: apiService,
             clientVault: clientService.clientVault(),
+            stateService: stateService,
             syncAPIService: apiService
         )
 

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -14,6 +14,12 @@ protocol StateService: AnyObject {
     ///
     func getAccountEncryptionKeys(userId: String?) async throws -> AccountEncryptionKeys
 
+    /// Gets all accounts.
+    ///
+    /// - Returns: The known user accounts.
+    ///
+    func getAccounts() async throws -> [Account]
+
     /// Gets the active account.
     ///
     /// - Returns: The active user account.
@@ -85,6 +91,8 @@ extension StateService {
 /// The errors thrown from a `StateService`.
 ///
 enum StateServiceError: Error {
+    /// There are no known accounts.
+    case noAccounts
     /// There isn't an active account.
     case noActiveAccount
 }
@@ -130,6 +138,13 @@ actor DefaultStateService: StateService {
             encryptedPrivateKey: encryptedPrivateKey,
             encryptedUserKey: encryptedUserKey
         )
+    }
+
+    func getAccounts() throws -> [Account] {
+        guard let accounts = appSettingsStore.state?.accounts else {
+            throw StateServiceError.noAccounts
+        }
+        return Array(accounts.values)
     }
 
     func getActiveAccount() throws -> Account {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -6,6 +6,7 @@ class MockStateService: StateService {
     var accountsAdded = [Account]()
     var accountsLoggedOut = [String]()
     var activeAccount: Account?
+    var accounts: [Account]?
 
     func addAccount(_ account: BitwardenShared.Account) async {
         accountsAdded.append(account)
@@ -19,6 +20,12 @@ class MockStateService: StateService {
             throw StateServiceError.noActiveAccount
         }
         return encryptionKeys
+    }
+
+    func getAccounts() async throws -> [BitwardenShared.Account] {
+        // TODO: BIT-1132 - Profile Switcher UI on Auth
+        guard let accounts else { throw StateServiceError.noAccounts }
+        return accounts
     }
 
     func getActiveAccount() throws -> Account {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -58,6 +58,9 @@ class DefaultVaultRepository {
     /// The client used by the application to handle vault encryption and decryption tasks.
     let clientVault: ClientVaultService
 
+    /// The service used by the application to manage account state.
+    let stateService: StateService
+
     /// The API service used to perform sync API requests.
     let syncAPIService: SyncAPIService
 
@@ -71,11 +74,18 @@ class DefaultVaultRepository {
     /// - Parameters:
     ///   - cipherAPIService: The API service used to perform API requests for the ciphers in a user's vault.
     ///   - clientVault: The client used by the application to handle vault encryption and decryption tasks.
+    ///   - stateService: The service used by the application to manage account state.
     ///   - syncAPIService: The API service used to perform sync API requests.
     ///
-    init(cipherAPIService: CipherAPIService, clientVault: ClientVaultService, syncAPIService: SyncAPIService) {
+    init(
+        cipherAPIService: CipherAPIService,
+        clientVault: ClientVaultService,
+        stateService: StateService,
+        syncAPIService: SyncAPIService
+    ) {
         self.cipherAPIService = cipherAPIService
         self.clientVault = clientVault
+        self.stateService = stateService
         self.syncAPIService = syncAPIService
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -10,6 +10,7 @@ class VaultRepositoryTests: BitwardenTestCase {
     var client: MockHTTPClient!
     var clientCiphers: MockClientCiphers!
     var clientVault: MockClientVaultService!
+    var stateService: MockStateService!
     var subject: DefaultVaultRepository!
 
     // MARK: Setup & Teardown
@@ -23,9 +24,12 @@ class VaultRepositoryTests: BitwardenTestCase {
 
         clientVault.clientCiphers = clientCiphers
 
+        stateService = MockStateService()
+
         subject = DefaultVaultRepository(
             cipherAPIService: APIService(client: client),
             clientVault: clientVault,
+            stateService: stateService,
             syncAPIService: APIService(client: client)
         )
     }
@@ -34,6 +38,7 @@ class VaultRepositoryTests: BitwardenTestCase {
         super.tearDown()
 
         client = nil
+        stateService = nil
         subject = nil
     }
 

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -35,7 +35,7 @@ internal final class AuthCoordinator: NSObject, Coordinator, HasStackNavigator {
     // MARK: Properties
 
     /// The delegate for this coordinator. Used to signal when auth has been completed.
-    weak var delegate: (any AuthCoordinatorDelegate)?
+    private weak var delegate: (any AuthCoordinatorDelegate)?
 
     /// The root navigator used to display this coordinator's interface.
     weak var rootNavigator: (any RootNavigator)?

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -87,7 +87,8 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             let coordinator = module.makeTabCoordinator(
                 rootNavigator: rootNavigator,
                 settingsDelegate: self,
-                tabNavigator: tabNavigator
+                tabNavigator: tabNavigator,
+                vaultDelegate: self
             )
             coordinator.start()
             coordinator.navigate(to: route)
@@ -108,6 +109,14 @@ extension AppCoordinator: AuthCoordinatorDelegate {
 
 extension AppCoordinator: SettingsCoordinatorDelegate {
     func didLogout() {
+        showAuth(route: .landing)
+    }
+}
+
+// MARK: - VaultCoordinatorDelegate
+
+extension AppCoordinator: VaultCoordinatorDelegate {
+    func didTapAddAccount() {
         showAuth(route: .landing)
     }
 }

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -47,6 +47,13 @@ class AppCoordinatorTests: BitwardenTestCase {
         XCTAssertEqual(module.authCoordinator.routes, [.landing])
     }
 
+    /// `didTapAddAccount()` triggers the login sequence from the llanding page
+    func test_didTapAddAccount() {
+        subject.didTapAddAccount()
+        XCTAssertTrue(module.authCoordinator.isStarted)
+        XCTAssertEqual(module.authCoordinator.routes, [.landing])
+    }
+
     /// `navigate(to:)` with `.onboarding` starts the auth coordinator and navigates to the proper auth route.
     func test_navigateTo_auth() throws {
         subject.navigate(to: .auth(.landing))

--- a/BitwardenShared/UI/Platform/Application/AppModuleTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppModuleTests.swift
@@ -74,10 +74,12 @@ class AppModuleTests: BitwardenTestCase {
         let rootViewController = RootViewController()
         let tabBarController = UITabBarController()
         let settingsDelegate = MockSettingsCoordinatorDelegate()
+        let vaultDelegate = MockVaultCoordinatorDelegate()
         let coordinator = subject.makeTabCoordinator(
             rootNavigator: rootViewController,
             settingsDelegate: settingsDelegate,
-            tabNavigator: tabBarController
+            tabNavigator: tabBarController,
+            vaultDelegate: vaultDelegate
         )
         coordinator.start()
         XCTAssertNotNil(rootViewController.childViewController)
@@ -88,6 +90,7 @@ class AppModuleTests: BitwardenTestCase {
     func test_makeVaultCoordinator() {
         let navigationController = UINavigationController()
         let coordinator = subject.makeVaultCoordinator(
+            delegate: MockVaultCoordinatorDelegate(),
             stackNavigator: navigationController
         )
         coordinator.navigate(to: .list)

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -22,7 +22,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
     // MARK: Properties
 
     /// The delegate for this coordinator, used to notify when the user logs out.
-    weak var delegate: SettingsCoordinatorDelegate?
+    private weak var delegate: SettingsCoordinatorDelegate?
 
     /// The services used by this coordinator.
     let services: Services

--- a/BitwardenShared/UI/Platform/Settings/SettingsModule.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsModule.swift
@@ -6,7 +6,9 @@
 protocol SettingsModule {
     /// Initializes a coordinator for navigating between `SettingsRoute`s.
     ///
-    /// - Parameter stackNavigator: The stack navigator that will be used to navigate between routes.
+    /// - Parameters:
+    ///   - delegate: A delegate of the `SettingsCoordinator`.
+    ///   - stackNavigator: The stack navigator that will be used to navigate between routes.
     /// - Returns: A coordinator that can navigate to `SettingsRoute`s.
     ///
     func makeSettingsCoordinator(

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -42,6 +42,9 @@ internal final class TabCoordinator: Coordinator, HasTabNavigator {
     /// The coordinator used to navigate to `VaultRoute`s.
     private var vaultCoordinator: AnyCoordinator<VaultRoute>?
 
+    /// A delegate of the `VaultCoordinator`.
+    private weak var vaultDelegate: VaultCoordinatorDelegate?
+
     // MARK: Initialization
 
     /// Creates a new `TabCoordinator`.
@@ -51,17 +54,20 @@ internal final class TabCoordinator: Coordinator, HasTabNavigator {
     ///   - rootNavigator: The root navigator used to display this coordinator's interface.
     ///   - settingsDelegate: A delegate of the `SettingsCoordinator`.
     ///   - tabNavigator: The tab navigator that is managed by this coordinator.
+    ///   - vaultDelegate: A delegate of the `VaultCoordinator`.
     ///
     init(
         module: Module,
         rootNavigator: RootNavigator,
         settingsDelegate: SettingsCoordinatorDelegate,
-        tabNavigator: TabNavigator
+        tabNavigator: TabNavigator,
+        vaultDelegate: VaultCoordinatorDelegate
     ) {
         self.module = module
         self.rootNavigator = rootNavigator
         self.settingsDelegate = settingsDelegate
         self.tabNavigator = tabNavigator
+        self.vaultDelegate = vaultDelegate
     }
 
     // MARK: Methods
@@ -87,13 +93,14 @@ internal final class TabCoordinator: Coordinator, HasTabNavigator {
     }
 
     func start() {
-        guard let rootNavigator, let settingsDelegate else { return }
+        guard let rootNavigator, let settingsDelegate, let vaultDelegate else { return }
 
         rootNavigator.show(child: tabNavigator)
 
         let vaultNavigator = UINavigationController()
         vaultNavigator.navigationBar.prefersLargeTitles = true
         vaultCoordinator = module.makeVaultCoordinator(
+            delegate: vaultDelegate,
             stackNavigator: vaultNavigator
         )
 

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -13,6 +13,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     var settingsDelegate: MockSettingsCoordinatorDelegate!
     var subject: TabCoordinator!
     var tabNavigator: MockTabNavigator!
+    var vaultDelegate: MockVaultCoordinatorDelegate!
 
     // MARK: Setup & Teardown
 
@@ -22,11 +23,13 @@ class TabCoordinatorTests: BitwardenTestCase {
         rootNavigator = MockRootNavigator()
         tabNavigator = MockTabNavigator()
         settingsDelegate = MockSettingsCoordinatorDelegate()
+        vaultDelegate = MockVaultCoordinatorDelegate()
         subject = TabCoordinator(
             module: module,
             rootNavigator: rootNavigator,
             settingsDelegate: settingsDelegate,
-            tabNavigator: tabNavigator
+            tabNavigator: tabNavigator,
+            vaultDelegate: vaultDelegate
         )
     }
 
@@ -36,6 +39,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         rootNavigator = nil
         subject = nil
         tabNavigator = nil
+        vaultDelegate = nil
     }
 
     // MARK: Tests
@@ -73,7 +77,8 @@ class TabCoordinatorTests: BitwardenTestCase {
             module: module,
             rootNavigator: rootNavigator!,
             settingsDelegate: MockSettingsCoordinatorDelegate(),
-            tabNavigator: tabNavigator
+            tabNavigator: tabNavigator,
+            vaultDelegate: MockVaultCoordinatorDelegate()
         )
         XCTAssertNotNil(subject.rootNavigator)
 

--- a/BitwardenShared/UI/Platform/Tabs/TabModule.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabModule.swift
@@ -11,12 +11,14 @@ public protocol TabModule: AnyObject {
     ///   - rootNavigator: The root navigator used to display this coordinator's interface.
     ///   - settingsDelegate: The delegate for the settings coordinator.
     ///   - tabNavigator: The navigator used by the coordinator to navigate between routes.
+    ///   - vaultDelegate: The delegate for the vault coordinator.
     /// - Returns: A new coordinator that can navigate to any `TabRoute`.
     ///
     func makeTabCoordinator(
         rootNavigator: RootNavigator,
         settingsDelegate: SettingsCoordinatorDelegate,
-        tabNavigator: TabNavigator
+        tabNavigator: TabNavigator,
+        vaultDelegate: VaultCoordinatorDelegate
     ) -> AnyCoordinator<TabRoute>
 }
 
@@ -26,13 +28,15 @@ extension DefaultAppModule: TabModule {
     public func makeTabCoordinator(
         rootNavigator: RootNavigator,
         settingsDelegate: SettingsCoordinatorDelegate,
-        tabNavigator: TabNavigator
+        tabNavigator: TabNavigator,
+        vaultDelegate: VaultCoordinatorDelegate
     ) -> AnyCoordinator<TabRoute> {
         TabCoordinator(
             module: self,
             rootNavigator: rootNavigator,
             settingsDelegate: settingsDelegate,
-            tabNavigator: tabNavigator
+            tabNavigator: tabNavigator,
+            vaultDelegate: vaultDelegate
         ).asAnyCoordinator()
     }
 }

--- a/BitwardenShared/UI/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultCoordinator.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+// MARK: - VaultCoordinatorDelegate
+
+/// An object that is signaled when specific circumstances in the application flow have been encountered.
+///
+@MainActor
+public protocol VaultCoordinatorDelegate: AnyObject {
+    /// Called when the user taps add account.
+    ///
+    func didTapAddAccount()
+}
+
 // MARK: - VaultCoordinator
 
 /// A coordinator that manages navigation in the vault tab.
@@ -8,6 +19,11 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasVaultRepository
+
+    // MARK: Properties
+
+    /// The delegate for this coordinator, used to notify when the user logs out.
+    private weak var delegate: VaultCoordinatorDelegate?
 
     // MARK: - Private Properties
 
@@ -22,18 +38,26 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
     /// Creates a new `VaultCoordinator`.
     ///
     /// - Parameters:
+    ///   - delegate: The delegate for this coordinator, relays user interactions with the profile switcher.
     ///   - services: The services used by this coordinator.
     ///   - stackNavigator: The stack navigator that is managed by this coordinator.
     ///
-    init(services: Services, stackNavigator: StackNavigator) {
+    init(
+        delegate: VaultCoordinatorDelegate,
+        services: Services,
+        stackNavigator: StackNavigator
+    ) {
         self.services = services
         self.stackNavigator = stackNavigator
+        self.delegate = delegate
     }
 
     // MARK: Methods
 
     func navigate(to route: VaultRoute, context: AnyObject?) {
         switch route {
+        case .addAccount:
+            delegate?.didTapAddAccount()
         case let .addItem(group):
             showAddItem(for: group.flatMap(CipherType.init))
         case let .alert(alert):

--- a/BitwardenShared/UI/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultCoordinatorTests.swift
@@ -8,6 +8,7 @@ import XCTest
 class VaultCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
+    var delegate: MockVaultCoordinatorDelegate!
     var stackNavigator: MockStackNavigator!
     var subject: VaultCoordinator!
 
@@ -16,8 +17,10 @@ class VaultCoordinatorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        delegate = MockVaultCoordinatorDelegate()
         stackNavigator = MockStackNavigator()
         subject = VaultCoordinator(
+            delegate: delegate,
             services: ServiceContainer.withMocks(),
             stackNavigator: stackNavigator
         )
@@ -26,11 +29,19 @@ class VaultCoordinatorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        delegate = nil
         stackNavigator = nil
         subject = nil
     }
 
     // MARK: Tests
+
+    /// `navigate(to:)` with `. addAccount ` informs the delegate that the user wants to add an account.
+    func test_navigateTo_addAccount() throws {
+        subject.navigate(to: .addAccount)
+
+        XCTAssertTrue(delegate.addAccountTapped)
+    }
 
     /// `navigate(to:)` with `.addItem` pushes the add item view onto the stack navigator.
     func test_navigateTo_addItem() throws {
@@ -127,5 +138,13 @@ class VaultCoordinatorTests: BitwardenTestCase {
         subject.start()
 
         XCTAssertTrue(stackNavigator.actions.isEmpty)
+    }
+}
+
+class MockVaultCoordinatorDelegate: VaultCoordinatorDelegate {
+    var addAccountTapped = false
+
+    func didTapAddAccount() {
+        addAccountTapped = true
     }
 }

--- a/BitwardenShared/UI/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultList/VaultListProcessor.swift
@@ -80,8 +80,7 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
                 // TODO: BIT-124 Switch account
                 state.profileSwitcherState.isVisible = false
             case .addAccountPressed:
-                // TODO: BIT-124 Switch account
-                state.profileSwitcherState.isVisible = false
+                addAccount()
             case .backgroundPressed:
                 state.profileSwitcherState.isVisible = false
             case let .scrollOffsetChanged(newOffset):
@@ -99,6 +98,12 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
     }
 
     // MARK: - Private Methods
+
+    /// Navigates to login to initiate the add account flow.
+    ///
+    private func addAccount() {
+        coordinator.navigate(to: .addAccount)
+    }
 
     /// Refreshes the vault's contents.
     ///

--- a/BitwardenShared/UI/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultList/VaultListProcessorTests.swift
@@ -81,7 +81,7 @@ class VaultListProcessorTests: BitwardenTestCase {
         subject.state.profileSwitcherState.isVisible = true
         subject.receive(.profileSwitcherAction(.addAccountPressed))
 
-        XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
+        XCTAssertEqual(coordinator.routes.last, .addAccount)
     }
 
     /// `receive(_:)` with `.addItemPressed` navigates to the `.addItem` route.

--- a/BitwardenShared/UI/Vault/VaultModule.swift
+++ b/BitwardenShared/UI/Vault/VaultModule.swift
@@ -7,19 +7,24 @@ import Foundation
 protocol VaultModule {
     /// Initializes a coordinator for navigating between `VaultRoute`s.
     ///
-    /// - Parameter stackNavigator: The stack navigator that will be used to navigate between routes.
+    /// - Parameters:
+    ///   - delegate: A delegate of the `VaultCoordinator`.
+    ///   - stackNavigator: The stack navigator that will be used to navigate between routes.
     /// - Returns: A coordinator that can navigate to `VaultRoute`s.
     ///
     func makeVaultCoordinator(
+        delegate: VaultCoordinatorDelegate,
         stackNavigator: StackNavigator
     ) -> AnyCoordinator<VaultRoute>
 }
 
 extension DefaultAppModule: VaultModule {
     func makeVaultCoordinator(
+        delegate: VaultCoordinatorDelegate,
         stackNavigator: StackNavigator
     ) -> AnyCoordinator<VaultRoute> {
         VaultCoordinator(
+            delegate: delegate,
             services: services,
             stackNavigator: stackNavigator
         ).asAnyCoordinator()

--- a/BitwardenShared/UI/Vault/VaultRoute.swift
+++ b/BitwardenShared/UI/Vault/VaultRoute.swift
@@ -4,6 +4,9 @@ import Foundation
 
 /// A route to a specific screen in the vault tab.
 public enum VaultRoute: Equatable, Hashable {
+    /// A route to the add account flow.
+    case addAccount
+
     /// A route to the add item screen.
     ///
     /// - Parameter group: An optional `VaultListGroup` that the user wants to add an item for.

--- a/GlobalTestHelpers/MockAppModule.swift
+++ b/GlobalTestHelpers/MockAppModule.swift
@@ -45,16 +45,18 @@ class MockAppModule: AppModule, AuthModule, GeneratorModule, TabModule, SendModu
     }
 
     func makeTabCoordinator(
-        rootNavigator: RootNavigator,
-        settingsDelegate: SettingsCoordinatorDelegate,
-        tabNavigator: TabNavigator
-    ) -> AnyCoordinator<TabRoute> {
+        rootNavigator: BitwardenShared.RootNavigator,
+        settingsDelegate: BitwardenShared.SettingsCoordinatorDelegate,
+        tabNavigator: BitwardenShared.TabNavigator,
+        vaultDelegate: BitwardenShared.VaultCoordinatorDelegate
+    ) -> BitwardenShared.AnyCoordinator<BitwardenShared.TabRoute> {
         tabCoordinator.asAnyCoordinator()
     }
 
     func makeVaultCoordinator(
-        stackNavigator: StackNavigator
-    ) -> AnyCoordinator<VaultRoute> {
+        delegate: BitwardenShared.VaultCoordinatorDelegate,
+        stackNavigator: BitwardenShared.StackNavigator
+    ) -> BitwardenShared.AnyCoordinator<BitwardenShared.VaultRoute> {
         vaultCoordinator.asAnyCoordinator()
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-854](https://livefront.atlassian.net/browse/BIT-854)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

UI implementation to navigate from the Profile Switcher View on the Vault Tab to Login when tapping Add Account

## 📸 Screenshots

https://github.com/bitwarden/ios/assets/148839008/02db0cbf-c83a-4e0e-b1b7-c3d38e2986c0

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
