### PR TITLE
BIT-915: Persist username generation options

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -33,6 +33,13 @@ protocol StateService: AnyObject {
     ///
     func getPasswordGenerationOptions(userId: String?) async throws -> PasswordGenerationOptions?
 
+    /// Gets the username generation options for a user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the username generation options.
+    /// - Returns: The username generation options for the user ID.
+    ///
+    func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions?
+
     /// Logs the user out of an account.
     ///
     /// - Parameter userId: The user ID of the account to log out of. Defaults to the active
@@ -64,6 +71,14 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setTokens(accessToken: String, refreshToken: String, userId: String?) async throws
+
+    /// Sets the username generation options for a user ID.
+    ///
+    /// - Parameters:
+    ///   - options: The user's username generation options.
+    ///   - userId: The user ID associated with the username generation options.
+    ///
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?, userId: String?) async throws
 }
 
 extension StateService {
@@ -81,6 +96,14 @@ extension StateService {
     ///
     func getPasswordGenerationOptions() async throws -> PasswordGenerationOptions? {
         try await getPasswordGenerationOptions(userId: nil)
+    }
+
+    /// Gets the username generation options for the active account.
+    ///
+    /// - Returns: The username generation options for the user ID.
+    ///
+    func getUsernameGenerationOptions() async throws -> UsernameGenerationOptions? {
+        try await getUsernameGenerationOptions(userId: nil)
     }
 
     /// Logs the user out of the active account.
@@ -114,6 +137,14 @@ extension StateService {
     ///
     func setTokens(accessToken: String, refreshToken: String) async throws {
         try await setTokens(accessToken: accessToken, refreshToken: refreshToken, userId: nil)
+    }
+
+    /// Sets the username generation options for the active account.
+    ///
+    /// - Parameters options: The user's username generation options.
+    ///
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?) async throws {
+        try await setUsernameGenerationOptions(options, userId: nil)
     }
 }
 
@@ -190,6 +221,11 @@ actor DefaultStateService: StateService {
         return appSettingsStore.passwordGenerationOptions(userId: userId)
     }
 
+    func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.usernameGenerationOptions(userId: userId)
+    }
+
     func logoutAccount(userId: String?) async throws {
         guard var state = appSettingsStore.state else { return }
         defer { appSettingsStore.state = state }
@@ -229,6 +265,11 @@ actor DefaultStateService: StateService {
             refreshToken: refreshToken
         )
         appSettingsStore.state = state
+    }
+
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setUsernameGenerationOptions(options, userId: userId)
     }
 
     // MARK: Private

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -32,6 +32,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions?
 
+    /// Gets the username generation options for a user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the username generation options.
+    /// - Returns: The username generation options for the user ID.
+    ///
+    func usernameGenerationOptions(userId: String) -> UsernameGenerationOptions?
+
     /// Sets the encrypted private key for a user ID.
     ///
     /// - Parameters:
@@ -55,6 +62,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the password generation options.
     ///
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String)
+
+    /// Sets the username generation options for a user ID.
+    ///
+    /// - Parameters:
+    ///   - options: The user's username generation options.
+    ///   - userId: The user ID associated with the username generation options.
+    ///
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?, userId: String)
 }
 
 // MARK: - DefaultAppSettingsStore
@@ -152,6 +167,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case passwordGenerationOptions(userId: String)
         case rememberedEmail
         case state
+        case usernameGenerationOptions(userId: String)
 
         /// Returns the key used to store the data under for retrieving it later.
         var storageKey: String {
@@ -169,6 +185,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "rememberedEmail"
             case .state:
                 key = "state"
+            case let .usernameGenerationOptions(userId):
+                key = "usernameGenerationOptions_\(userId)"
             }
             return "bwPreferencesStorage:\(key)"
         }
@@ -201,6 +219,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .passwordGenerationOptions(userId: userId))
     }
 
+    func usernameGenerationOptions(userId: String) -> UsernameGenerationOptions? {
+        fetch(for: .usernameGenerationOptions(userId: userId))
+    }
+
     func setEncryptedPrivateKey(key: String?, userId: String) {
         store(key, for: .encryptedPrivateKey(userId: userId))
     }
@@ -211,5 +233,9 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String) {
         store(options, for: .passwordGenerationOptions(userId: userId))
+    }
+
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?, userId: String) {
+        store(options, for: .usernameGenerationOptions(userId: userId))
     }
 }

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -168,6 +168,46 @@ class AppSettingsStoreTests: BitwardenTestCase {
         XCTAssertEqual(subject.passwordGenerationOptions(userId: "2"), options2)
     }
 
+    /// `usernameGenerationOptions(userId:)` returns `nil` if there isn't a previously stored value.
+    func test_usernameGenerationOptions_isInitiallyNil() {
+        XCTAssertNil(subject.usernameGenerationOptions(userId: "-1"))
+    }
+
+    /// `usernameGenerationOptions(userId:)` can be used to get the username generation options for a user.
+    func test_usernameGenerationOptions_withValue() {
+        let options1 = UsernameGenerationOptions(plusAddressedEmail: "user@bitwarden.com")
+        let options2 = UsernameGenerationOptions(catchAllEmailDomain: "bitwarden.com")
+
+        subject.setUsernameGenerationOptions(options1, userId: "1")
+        subject.setUsernameGenerationOptions(options2, userId: "2")
+
+        try XCTAssertEqual(
+            JSONDecoder().decode(
+                UsernameGenerationOptions.self,
+                from: XCTUnwrap(
+                    userDefaults
+                        .string(forKey: "bwPreferencesStorage:usernameGenerationOptions_1")?
+                        .data(using: .utf8)
+                )
+            ),
+            options1
+        )
+        try XCTAssertEqual(
+            JSONDecoder().decode(
+                UsernameGenerationOptions.self,
+                from: XCTUnwrap(
+                    userDefaults
+                        .string(forKey: "bwPreferencesStorage:usernameGenerationOptions_2")?
+                        .data(using: .utf8)
+                )
+            ),
+            options2
+        )
+
+        XCTAssertEqual(subject.usernameGenerationOptions(userId: "1"), options1)
+        XCTAssertEqual(subject.usernameGenerationOptions(userId: "2"), options2)
+    }
+
     /// `rememberedEmail` returns `nil` if there isn't a previously stored value.
     func test_rememberedEmail_isInitiallyNil() {
         XCTAssertNil(subject.rememberedEmail)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -7,6 +7,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var rememberedEmail: String?
     var state: State?
+    var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
     func encryptedPrivateKey(userId: String) -> String? {
         encryptedPrivateKeys[userId]
@@ -18,6 +19,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions? {
         passwordGenerationOptions[userId]
+    }
+
+    func usernameGenerationOptions(userId: String) -> UsernameGenerationOptions? {
+        usernameGenerationOptions[userId]
     }
 
     func setEncryptedPrivateKey(key: String?, userId: String) {
@@ -42,5 +47,13 @@ class MockAppSettingsStore: AppSettingsStore {
             return
         }
         passwordGenerationOptions[userId] = options
+    }
+
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?, userId: String) {
+        guard let options else {
+            usernameGenerationOptions.removeValue(forKey: userId)
+            return
+        }
+        usernameGenerationOptions[userId] = options
     }
 }

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -8,6 +8,7 @@ class MockStateService: StateService {
     var activeAccount: Account?
     var accounts: [Account]?
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
+    var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
     func addAccount(_ account: BitwardenShared.Account) async {
         accountsAdded.append(account)
@@ -34,9 +35,14 @@ class MockStateService: StateService {
         return activeAccount
     }
 
-    func getPasswordGenerationOptions(userId: String?) async -> PasswordGenerationOptions? {
-        guard let userId = try? userId ?? getActiveAccount().profile.userId else { return nil }
+    func getPasswordGenerationOptions(userId: String?) async throws -> PasswordGenerationOptions? {
+        let userId = try userId ?? getActiveAccount().profile.userId
         return passwordGenerationOptions[userId]
+    }
+
+    func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        return usernameGenerationOptions[userId]
     }
 
     func logoutAccount(userId: String?) async throws {
@@ -56,5 +62,10 @@ class MockStateService: StateService {
 
     func setTokens(accessToken: String, refreshToken: String, userId: String?) async throws {
         accountTokens = Account.AccountTokens(accessToken: accessToken, refreshToken: refreshToken)
+    }
+
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        usernameGenerationOptions[userId] = options
     }
 }

--- a/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptions.swift
@@ -1,0 +1,48 @@
+/// A data model containing the options used to generate a username, which is persisted between app
+/// launches to maintain the user's selected options.
+///
+struct UsernameGenerationOptions: Codable, Equatable {
+    // MARK: Properties
+
+    /// The addy.io API access token to generate a forwarded email alias.
+    var anonAddyApiAccessToken: String?
+
+    /// The domain name used to generate a forwarded email alias with addy.io.
+    var anonAddyDomainName: String?
+
+    /// Whether to capitalize the random word.
+    var capitalizeRandomWordUsername: Bool?
+
+    /// The user's domain for generating catch all emails.
+    var catchAllEmailDomain: String?
+
+    /// The type of value to use when generating a catch-all email.
+    var catchAllEmailType: UsernameEmailType?
+
+    /// The DuckDuckGo API key used to generate a forwarded email alias.
+    var duckDuckGoApiKey: String?
+
+    /// The Fastmail API Key used to generate a forwarded email alias.
+    var fastMailApiKey: String?
+
+    /// The Firefox Relay API access token used to generate a forwarded email alias.
+    var firefoxRelayApiAccessToken: String?
+
+    /// Whether the random word should include numbers.
+    var includeNumberRandomWordUsername: Bool?
+
+    /// The user's email for generating plus addressed emails.
+    var plusAddressedEmail: String?
+
+    /// The type of value to use when generating a plus-addressed email.
+    var plusAddressedEmailType: UsernameEmailType?
+
+    /// The service used to generate a forwarded email alias.
+    var serviceType: ForwardedEmailServiceType?
+
+    /// The simple login API key used to generate a forwarded email alias.
+    var simpleLoginApiKey: String?
+
+    /// The type of username to generate.
+    var type: UsernameGeneratorType?
+}

--- a/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptionsTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class UsernameGenerationOptionsTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `PasswordGenerationOptions` can be decoded from a JSON with all values set.
+    func test_decode() throws {
+        let json = """
+        {
+          "anonAddyApiAccessToken": "ADDYIO_API_TOKEN",
+          "anonAddyDomainName": "bitwarden.com",
+          "capitalizeRandomWordUsername": true,
+          "catchAllEmailDomain": "bitwarden.com",
+          "catchAllEmailType": 0,
+          "duckDuckGoApiKey": "DUCKDUCKGO_API_KEY",
+          "fastMailApiKey": "FASTMAIL_API_KEY",
+          "firefoxRelayApiAccessToken": "FIREFOX_API_TOKEN",
+          "includeNumberRandomWordUsername": true,
+          "plusAddressedEmail": "user@bitwarden.com",
+          "plusAddressedEmailType": 0,
+          "serviceType": 2,
+          "simpleLoginApiKey": "SIMPLELOGIN_API_KEY",
+          "type": 2
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let subject = try JSONDecoder().decode(UsernameGenerationOptions.self, from: data)
+        XCTAssertEqual(
+            subject,
+            UsernameGenerationOptions(
+                anonAddyApiAccessToken: "ADDYIO_API_TOKEN",
+                anonAddyDomainName: "bitwarden.com",
+                capitalizeRandomWordUsername: true,
+                catchAllEmailDomain: "bitwarden.com",
+                catchAllEmailType: .random,
+                duckDuckGoApiKey: "DUCKDUCKGO_API_KEY",
+                fastMailApiKey: "FASTMAIL_API_KEY",
+                firefoxRelayApiAccessToken: "FIREFOX_API_TOKEN",
+                includeNumberRandomWordUsername: true,
+                plusAddressedEmail: "user@bitwarden.com",
+                plusAddressedEmailType: .random,
+                serviceType: .simpleLogin,
+                simpleLoginApiKey: "SIMPLELOGIN_API_KEY",
+                type: .forwardedEmail
+            )
+        )
+    }
+
+    /// `UsernameGenerationOptions` can be decoded from an empty JSON object.
+    func test_decode_empty() throws {
+        let data = try XCTUnwrap(#"{}"#.data(using: .utf8))
+        let subject = try JSONDecoder().decode(UsernameGenerationOptions.self, from: data)
+        XCTAssertEqual(subject, UsernameGenerationOptions())
+    }
+}

--- a/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
@@ -1,0 +1,36 @@
+/// The service used to generate a forwarded email alias.
+///
+enum ForwardedEmailServiceType: Int, CaseIterable, Codable, Equatable, Menuable {
+    /// Generate a forwarded email using addy.io.
+    case addyIO = 0
+
+    /// Generate a forwarded email using Firefox Relay.
+    case firefoxRelay = 1
+
+    /// Generate a forwarded email using SimpleLogin.
+    case simpleLogin = 2
+
+    /// Generate a forwarded email using DuckDuckGo.
+    case duckDuckGo = 3
+
+    /// Generate a forwarded email using Fastmail.
+    case fastmail = 4
+
+    /// All of the cases to show in the menu.
+    static let allCases: [Self] = [.addyIO, .duckDuckGo, .fastmail, .firefoxRelay, .simpleLogin]
+
+    var localizedName: String {
+        switch self {
+        case .addyIO:
+            return Localizations.addyIo
+        case .duckDuckGo:
+            return Localizations.duckDuckGo
+        case .fastmail:
+            return Localizations.fastmail
+        case .firefoxRelay:
+            return Localizations.firefoxRelay
+        case .simpleLogin:
+            return Localizations.simpleLogin
+        }
+    }
+}

--- a/BitwardenShared/Core/Tools/Models/Enum/UsernameEmailType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/UsernameEmailType.swift
@@ -1,0 +1,9 @@
+/// The value to use when generating a plus-addressed or catch-all email.
+///
+enum UsernameEmailType: Int, Codable {
+    /// Random values should be used to generate the email.
+    case random = 0
+
+    /// A website should be used to generate the email.
+    case website = 1
+}

--- a/BitwardenShared/Core/Tools/Models/Enum/UsernameGeneratorType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/UsernameGeneratorType.swift
@@ -1,0 +1,45 @@
+/// The type of username to generate.
+///
+enum UsernameGeneratorType: Int, CaseIterable, Codable, Equatable, Menuable {
+    /// Generate a plus addressed email.
+    case plusAddressedEmail = 0
+
+    /// Generate a catch all email.
+    case catchAllEmail = 1
+
+    /// Generate a forwarded email.
+    case forwardedEmail = 2
+
+    /// Generate a random word.
+    case randomWord = 3
+
+    /// All of the cases to show in the menu.
+    static let allCases: [Self] = [.plusAddressedEmail, .catchAllEmail, .forwardedEmail, .randomWord]
+
+    var localizedName: String {
+        switch self {
+        case .catchAllEmail:
+            return Localizations.catchAllEmail
+        case .forwardedEmail:
+            return Localizations.forwardedEmailAlias
+        case .plusAddressedEmail:
+            return Localizations.plusAddressedEmail
+        case .randomWord:
+            return Localizations.randomWord
+        }
+    }
+
+    /// A localized description of the field, used as the footer text below the menu value in the UI.
+    var localizedDescription: String? {
+        switch self {
+        case .catchAllEmail:
+            return Localizations.catchAllEmailDescription
+        case .forwardedEmail:
+            return Localizations.forwardedEmailDescription
+        case .plusAddressedEmail:
+            return Localizations.plusAddressedEmailDescription
+        case .randomWord:
+            return nil
+        }
+    }
+}

--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepository.swift
@@ -29,11 +29,23 @@ protocol GeneratorRepository: AnyObject {
     ///
     func getPasswordGenerationOptions() async throws -> PasswordGenerationOptions
 
+    /// Gets the username generation options for the active account.
+    ///
+    /// - Returns: The username generation options for the account.
+    ///
+    func getUsernameGenerationOptions() async throws -> UsernameGenerationOptions
+
     /// Sets the password generation options for the active account.
     ///
     /// - Parameter options: The user's password generation options.
     ///
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions) async throws
+
+    /// Sets the username generation options for the active account.
+    ///
+    /// - Parameter options: The user's username generation options.
+    ///
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions) async throws
 }
 
 // MARK: - DefaultGeneratorRepository
@@ -106,7 +118,15 @@ extension DefaultGeneratorRepository: GeneratorRepository {
         try await stateService.getPasswordGenerationOptions() ?? PasswordGenerationOptions()
     }
 
+    func getUsernameGenerationOptions() async throws -> UsernameGenerationOptions {
+        try await stateService.getUsernameGenerationOptions() ?? UsernameGenerationOptions()
+    }
+
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions) async throws {
         try await stateService.setPasswordGenerationOptions(options)
+    }
+
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions) async throws {
+        try await stateService.setUsernameGenerationOptions(options)
     }
 }

--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
@@ -193,6 +193,30 @@ class GeneratorRepositoryTests: BitwardenTestCase {
         XCTAssertEqual(fetchedOptions, PasswordGenerationOptions())
     }
 
+    /// `getUsernameGenerationOptions` returns the saved username generation options for the active account.
+    func test_getUsernameGenerationOptions() async throws {
+        let options = UsernameGenerationOptions(plusAddressedEmail: "user@bitwarden.com")
+
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.usernameGenerationOptions = [account.profile.userId: options]
+
+        let fetchedOptions = try await subject.getUsernameGenerationOptions()
+
+        XCTAssertEqual(fetchedOptions, options)
+    }
+
+    /// `getUsernameGenerationOptions` returns an empty set of options if they haven't previously
+    /// been saved for the active account.
+    func test_getUsernameGenerationOptions_notSet() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+
+        let fetchedOptions = try await subject.getUsernameGenerationOptions()
+
+        XCTAssertEqual(fetchedOptions, UsernameGenerationOptions())
+    }
+
     /// `setPasswordGenerationOptions` sets the password generation options for the active account.
     func test_setPasswordGenerationOptions() async throws {
         let account = Account.fixture()
@@ -203,5 +227,17 @@ class GeneratorRepositoryTests: BitwardenTestCase {
         try await subject.setPasswordGenerationOptions(options)
 
         XCTAssertEqual(stateService.passwordGenerationOptions, [account.profile.userId: options])
+    }
+
+    /// `setUsernameGenerationOptions` sets the username generation options for the active account.
+    func test_setUsernameGenerationOptions() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+
+        let options = UsernameGenerationOptions(plusAddressedEmail: "user@bitwarden.com")
+
+        try await subject.setUsernameGenerationOptions(options)
+
+        XCTAssertEqual(stateService.usernameGenerationOptions, [account.profile.userId: options])
     }
 }

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockGeneratorRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockGeneratorRepository.swift
@@ -9,7 +9,17 @@ class MockGeneratorRepository: GeneratorRepository {
     var passwordGeneratorRequest: PasswordGeneratorRequest?
     var passwordResult: Result<String, Error> = .success("PASSWORD")
 
+    var getPasswordGenerationOptionsCalled = false
+    var getPasswordGenerationOptionsResult: Result<PasswordGenerationOptions, Error> =
+        .success(PasswordGenerationOptions())
     var passwordGenerationOptions = PasswordGenerationOptions()
+    var setPasswordGenerationOptionsResult: Result<Void, Error> = .success(())
+
+    var getUsernameGenerationOptionsCalled = false
+    var getUsernameGenerationOptionsResult: Result<UsernameGenerationOptions, Error> =
+        .success(UsernameGenerationOptions())
+    var usernameGenerationOptions = UsernameGenerationOptions()
+    var setUsernameGenerationOptionsResult: Result<Void, Error> = .success(())
 
     var usernamePlusAddressEmail: String?
     var usernamePlusAddressEmailResult: Result<String, Error> = .success("user+abcd0123@bitwarden.com")
@@ -30,10 +40,22 @@ class MockGeneratorRepository: GeneratorRepository {
     }
 
     func getPasswordGenerationOptions() async throws -> PasswordGenerationOptions {
-        passwordGenerationOptions
+        defer { getPasswordGenerationOptionsCalled = true }
+        return try getPasswordGenerationOptionsResult.get()
+    }
+
+    func getUsernameGenerationOptions() async throws -> UsernameGenerationOptions {
+        defer { getUsernameGenerationOptionsCalled = true }
+        return try getUsernameGenerationOptionsResult.get()
     }
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions) async throws {
         passwordGenerationOptions = options
+        try setPasswordGenerationOptionsResult.get()
+    }
+
+    func setUsernameGenerationOptions(_ options: UsernameGenerationOptions) async throws {
+        usernameGenerationOptions = options
+        try setUsernameGenerationOptionsResult.get()
     }
 }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorAction.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorAction.swift
@@ -38,10 +38,10 @@ enum GeneratorAction: Equatable {
     case toggleValueChanged(field: ToggleField<GeneratorState>, isOn: Bool)
 
     /// The username forwarded email service was changed.
-    case usernameForwardedEmailServiceChanged(GeneratorState.UsernameState.ForwardedEmailService)
+    case usernameForwardedEmailServiceChanged(ForwardedEmailServiceType)
 
     /// The username generator type was changed.
-    case usernameGeneratorTypeChanged(GeneratorState.UsernameState.UsernameGeneratorType)
+    case usernameGeneratorTypeChanged(UsernameGeneratorType)
 }
 
 extension GeneratorAction {

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -198,6 +198,9 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
         do {
             let passwordOptions = try await services.generatorRepository.getPasswordGenerationOptions()
             state.passwordState.update(with: passwordOptions)
+
+            let usernameOptions = try await services.generatorRepository.getUsernameGenerationOptions()
+            state.usernameState.update(with: usernameOptions)
         } catch {
             services.errorReporter.log(error: BitwardenError.generatorOptionsError(error: error))
         }
@@ -207,9 +210,16 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     ///
     func saveGeneratorOptions() async {
         do {
-            try await services.generatorRepository.setPasswordGenerationOptions(
-                state.passwordState.passwordGenerationOptions
-            )
+            switch state.generatorType {
+            case .password:
+                try await services.generatorRepository.setPasswordGenerationOptions(
+                    state.passwordState.passwordGenerationOptions
+                )
+            case .username:
+                try await services.generatorRepository.setUsernameGenerationOptions(
+                    state.usernameState.usernameGenerationOptions
+                )
+            }
         } catch {
             services.errorReporter.log(error: BitwardenError.generatorOptionsError(error: error))
         }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -9,6 +9,7 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     // MARK: Properties
 
     var coordinator: MockCoordinator<GeneratorRoute>!
+    var errorReporter: MockErrorReporter!
     var generatorRepository: MockGeneratorRepository!
     var pasteboardService: MockPasteboardService!
     var subject: GeneratorProcessor!
@@ -19,56 +20,79 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         super.setUp()
 
         coordinator = MockCoordinator()
+        errorReporter = MockErrorReporter()
         generatorRepository = MockGeneratorRepository()
         pasteboardService = MockPasteboardService()
 
-        subject = GeneratorProcessor(
-            coordinator: coordinator.asAnyCoordinator(),
-            services: ServiceContainer.withMocks(
-                generatorRepository: generatorRepository,
-                pasteboardService: pasteboardService
-            ),
-            state: GeneratorState()
-        )
+        setUpSubject()
     }
 
     override func tearDown() {
         super.tearDown()
 
         coordinator = nil
+        errorReporter = nil
         generatorRepository = nil
         pasteboardService = nil
         subject = nil
     }
 
+    func setUpSubject(generatorRepository: MockGeneratorRepository? = nil) {
+        subject = GeneratorProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                errorReporter: errorReporter,
+                generatorRepository: generatorRepository ?? self.generatorRepository,
+                pasteboardService: pasteboardService
+            ),
+            state: GeneratorState()
+        )
+    }
+
     // MARK: Tests
 
-    /// `perform(_:)` with `.appeared` generates a new generated value.
-    func test_perform_appear_generatesValue() async {
-        subject.state.generatorType = .password
-        subject.state.passwordState.passwordGeneratorType = .password
+    /// `init` loads the password generation options and doesn't change the defaults if the options
+    /// are empty.
+    func test_init_loadsPasswordOptions_empty() {
+        waitFor { generatorRepository.getPasswordGenerationOptionsCalled }
+        XCTAssertTrue(generatorRepository.getPasswordGenerationOptionsCalled)
 
-        await subject.perform(.appeared)
-
-        XCTAssertNotNil(generatorRepository.passwordGeneratorRequest)
+        XCTAssertEqual(
+            subject.state.passwordState,
+            GeneratorState.PasswordState(
+                passwordGeneratorType: .password,
+                avoidAmbiguous: false,
+                containsLowercase: true,
+                containsNumbers: true,
+                containsSpecial: false,
+                containsUppercase: true,
+                length: 14,
+                minimumNumber: 1,
+                minimumSpecial: 1,
+                capitalize: false,
+                includeNumber: false,
+                numberOfWords: 3,
+                wordSeparator: "-"
+            )
+        )
     }
 
-    /// `perform(_:)` with `.appeared` loads the password generation options and doesn't change the
-    /// defaults if the options are empty.
-    func test_perform_appear_loadsPasswordOptions_empty() async {
-        generatorRepository.passwordGenerationOptions = PasswordGenerationOptions()
-
-        let passwordState = subject.state.passwordState
-
-        await subject.perform(.appeared)
-
-        XCTAssertEqual(subject.state.passwordState, passwordState)
+    /// `init` loads the password generation options and logs an error if one occurs.
+    func test_init_loadsPasswordOptions_error() {
+        generatorRepository.getPasswordGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
+        setUpSubject()
+        waitFor { !errorReporter.errors.isEmpty }
+        XCTAssertEqual(
+            errorReporter.errors[0] as NSError,
+            BitwardenError.generatorOptionsError(error: StateServiceError.noActiveAccount)
+        )
     }
 
-    /// `perform(_:)` with `.appeared` loads the password generation options and updates the state
+    /// `init` loads the password generation options and updates the state
     /// based on the previously selected options.
-    func test_perform_appear_loadsPasswordOptions_withValues() async {
-        generatorRepository.passwordGenerationOptions = PasswordGenerationOptions(
+    func test_init_loadsPasswordOptions_withValues() {
+        let generatorRepository = MockGeneratorRepository()
+        generatorRepository.getPasswordGenerationOptionsResult = .success(PasswordGenerationOptions(
             allowAmbiguousChar: false,
             capitalize: true,
             includeNumber: true,
@@ -84,9 +108,10 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
             type: .passphrase,
             uppercase: false,
             wordSeparator: "*"
-        )
+        ))
 
-        await subject.perform(.appeared)
+        setUpSubject(generatorRepository: generatorRepository)
+        waitFor { subject.state.passwordState.length == 30 }
 
         XCTAssertEqual(
             subject.state.passwordState,
@@ -106,6 +131,99 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
                 wordSeparator: "*"
             )
         )
+    }
+
+    /// `init` loads the username generation options and doesn't change the defaults if the options
+    /// are empty.
+    func test_init_loadsUsernameOptions_empty() {
+        waitFor { generatorRepository.getUsernameGenerationOptionsCalled }
+        XCTAssertTrue(generatorRepository.getUsernameGenerationOptionsCalled)
+
+        XCTAssertEqual(
+            subject.state.usernameState,
+            GeneratorState.UsernameState(
+                usernameGeneratorType: .plusAddressedEmail,
+                catchAllEmailType: .random,
+                domain: "",
+                addyIOAPIAccessToken: "",
+                addyIODomainName: "",
+                duckDuckGoAPIKey: "",
+                fastmailAPIKey: "",
+                firefoxRelayAPIAccessToken: "",
+                forwardedEmailService: .addyIO,
+                simpleLoginAPIKey: "",
+                email: "",
+                plusAddressedEmailType: .random,
+                capitalize: false,
+                includeNumber: false
+            )
+        )
+    }
+
+    /// `init` loads the username generation options and logs an error if one occurs.
+    func test_init_loadsUsernameOptions_error() {
+        generatorRepository.getUsernameGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
+        setUpSubject()
+        waitFor { !errorReporter.errors.isEmpty }
+        XCTAssertEqual(
+            errorReporter.errors[0] as NSError,
+            BitwardenError.generatorOptionsError(error: StateServiceError.noActiveAccount)
+        )
+    }
+
+    /// `perform(_:)` with `.appeared` loads the username generation options and updates the state
+    /// based on the previously selected options.
+    func test_init_loadsUsernameOptions_withValues() {
+        let generatorRepository = MockGeneratorRepository()
+        generatorRepository.getUsernameGenerationOptionsResult = .success(UsernameGenerationOptions(
+            anonAddyApiAccessToken: "ADDYIO_API_TOKEN",
+            anonAddyDomainName: "bitwarden.com",
+            capitalizeRandomWordUsername: true,
+            catchAllEmailDomain: "bitwarden.com",
+            catchAllEmailType: .random,
+            duckDuckGoApiKey: "DUCKDUCKGO_API_KEY",
+            fastMailApiKey: "FASTMAIL_API_KEY",
+            firefoxRelayApiAccessToken: "FIREFOX_API_TOKEN",
+            includeNumberRandomWordUsername: true,
+            plusAddressedEmail: "user@bitwarden.com",
+            plusAddressedEmailType: .website,
+            serviceType: .fastmail,
+            simpleLoginApiKey: "SIMPLELOGIN_API_KEY",
+            type: .randomWord
+        ))
+
+        setUpSubject(generatorRepository: generatorRepository)
+        waitFor { subject.state.usernameState.usernameGeneratorType == .randomWord }
+
+        XCTAssertEqual(
+            subject.state.usernameState,
+            GeneratorState.UsernameState(
+                usernameGeneratorType: .randomWord,
+                catchAllEmailType: .random,
+                domain: "bitwarden.com",
+                addyIOAPIAccessToken: "ADDYIO_API_TOKEN",
+                addyIODomainName: "bitwarden.com",
+                duckDuckGoAPIKey: "DUCKDUCKGO_API_KEY",
+                fastmailAPIKey: "FASTMAIL_API_KEY",
+                firefoxRelayAPIAccessToken: "FIREFOX_API_TOKEN",
+                forwardedEmailService: .fastmail,
+                simpleLoginAPIKey: "SIMPLELOGIN_API_KEY",
+                email: "user@bitwarden.com",
+                plusAddressedEmailType: .website,
+                capitalize: true,
+                includeNumber: true
+            )
+        )
+    }
+
+    /// `perform(_:)` with `.appeared` generates a new generated value.
+    func test_perform_appear_generatesValue() async {
+        subject.state.generatorType = .password
+        subject.state.passwordState.passwordGeneratorType = .password
+
+        await subject.perform(.appeared)
+
+        XCTAssertNotNil(generatorRepository.passwordGeneratorRequest)
     }
 
     /// `receive(_:)` with `.copyGeneratedValue` copies the generated password to the system
@@ -362,6 +480,9 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
 
     /// The user's password options are saved when any of the password options are changed.
     func test_saveGeneratorOptions_password() {
+        // Wait for the initial loading of the generation options to complete before making changes.
+        waitFor { generatorRepository.getPasswordGenerationOptionsCalled }
+
         subject.receive(.passwordGeneratorTypeChanged(.passphrase))
         waitFor { generatorRepository.passwordGenerationOptions.type == .passphrase }
         XCTAssertEqual(
@@ -403,6 +524,73 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         ))
         waitFor { generatorRepository.passwordGenerationOptions.lowercase == false }
         XCTAssertEqual(generatorRepository.passwordGenerationOptions.lowercase, false)
+    }
+
+    /// Saving the password generation options logs an error if one occurs.
+    func test_saveGeneratorOptions_password_error() {
+        generatorRepository.setPasswordGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
+
+        subject.receive(.passwordGeneratorTypeChanged(.passphrase))
+
+        waitFor { !errorReporter.errors.isEmpty }
+        XCTAssertEqual(
+            errorReporter.errors[0] as NSError,
+            BitwardenError.generatorOptionsError(error: StateServiceError.noActiveAccount)
+        )
+    }
+
+    /// The user's username options are saved when any of the username options are changed.
+    func test_saveGeneratorOptions_username() {
+        // Wait for the initial loading of the generation options to complete before making changes.
+        waitFor { generatorRepository.getUsernameGenerationOptionsCalled }
+
+        subject.state.generatorType = .username
+
+        subject.receive(.usernameGeneratorTypeChanged(.catchAllEmail))
+        waitFor { generatorRepository.usernameGenerationOptions.type == .catchAllEmail }
+        XCTAssertEqual(
+            generatorRepository.usernameGenerationOptions,
+            UsernameGenerationOptions(
+                capitalizeRandomWordUsername: false,
+                catchAllEmailType: .random,
+                includeNumberRandomWordUsername: false,
+                plusAddressedEmailType: .random,
+                serviceType: .addyIO,
+                type: .catchAllEmail
+            )
+        )
+
+        subject.receive(.usernameForwardedEmailServiceChanged(.duckDuckGo))
+        waitFor { generatorRepository.usernameGenerationOptions.serviceType == .duckDuckGo }
+        XCTAssertEqual(generatorRepository.usernameGenerationOptions.serviceType, .duckDuckGo)
+
+        subject.receive(.textValueChanged(
+            field: textField(keyPath: \.usernameState.duckDuckGoAPIKey),
+            value: "API_KEY"
+        ))
+        waitFor { generatorRepository.usernameGenerationOptions.duckDuckGoApiKey == "API_KEY" }
+        XCTAssertEqual(generatorRepository.usernameGenerationOptions.duckDuckGoApiKey, "API_KEY")
+
+        subject.receive(.toggleValueChanged(
+            field: toggleField(keyPath: \.usernameState.capitalize),
+            isOn: true
+        ))
+        waitFor { generatorRepository.usernameGenerationOptions.capitalizeRandomWordUsername == true }
+        XCTAssertEqual(generatorRepository.usernameGenerationOptions.capitalizeRandomWordUsername, true)
+    }
+
+    /// Saving the username generation options logs an error if one occurs.
+    func test_saveGeneratorOptions_username_error() {
+        generatorRepository.setUsernameGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
+
+        subject.state.generatorType = .username
+        subject.receive(.usernameGeneratorTypeChanged(.catchAllEmail))
+
+        waitFor { !errorReporter.errors.isEmpty }
+        XCTAssertEqual(
+            errorReporter.errors[0] as NSError,
+            BitwardenError.generatorOptionsError(error: StateServiceError.noActiveAccount)
+        )
     }
 
     // MARK: Private

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+FormSection.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+FormSection.swift
@@ -34,10 +34,10 @@ extension GeneratorState {
             case menuPasswordGeneratorType(FormMenuField<State, PasswordGeneratorType>)
 
             /// A menu field for the user generator type.
-            case menuUsernameGeneratorType(FormMenuField<State, UsernameState.UsernameGeneratorType>)
+            case menuUsernameGeneratorType(FormMenuField<State, UsernameGeneratorType>)
 
             /// A menu field for username forwarded email service.
-            case menuUsernameForwardedEmailService(FormMenuField<State, UsernameState.ForwardedEmailService>)
+            case menuUsernameForwardedEmailService(FormMenuField<State, ForwardedEmailServiceType>)
 
             /// A slider field.
             case slider(SliderField<State>)

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -2,94 +2,15 @@ extension GeneratorState {
     /// Data model for the values that can be set for generating a username.
     ///
     struct UsernameState: Equatable {
-        // MARK: Types
-
-        /// The type of username to generate.
-        ///
-        enum UsernameGeneratorType: CaseIterable, Equatable, Menuable { // swiftlint:disable:this nesting
-            /// Generate a catch all email.
-            case catchAllEmail
-
-            /// Generate a forwarded email.
-            case forwardedEmail
-
-            /// Generate a plus addressed email.
-            case plusAddressedEmail
-
-            /// Generate a random word.
-            case randomWord
-
-            /// All of the cases to show in the menu.
-            static let allCases: [Self] = [.plusAddressedEmail, .catchAllEmail, .forwardedEmail, .randomWord]
-
-            var localizedName: String {
-                switch self {
-                case .catchAllEmail:
-                    return Localizations.catchAllEmail
-                case .forwardedEmail:
-                    return Localizations.forwardedEmailAlias
-                case .plusAddressedEmail:
-                    return Localizations.plusAddressedEmail
-                case .randomWord:
-                    return Localizations.randomWord
-                }
-            }
-
-            /// A localized description of the field, used as the footer text below the menu value in the UI.
-            var localizedDescription: String? {
-                switch self {
-                case .catchAllEmail:
-                    return Localizations.catchAllEmailDescription
-                case .forwardedEmail:
-                    return Localizations.forwardedEmailDescription
-                case .plusAddressedEmail:
-                    return Localizations.plusAddressedEmailDescription
-                case .randomWord:
-                    return nil
-                }
-            }
-        }
-
-        /// The service used to generate a forwarded email alias.
-        ///
-        enum ForwardedEmailService: CaseIterable, Equatable, Menuable { // swiftlint:disable:this nesting
-            /// Generate a forwarded email using addy.io.
-            case addyIO
-
-            /// Generate a forwarded email using DuckDuckGo.
-            case duckDuckGo
-
-            /// Generate a forwarded email using Fastmail.
-            case fastmail
-
-            /// Generate a forwarded email using Firefox Relay.
-            case firefoxRelay
-
-            /// Generate a forwarded email using SimpleLogin.
-            case simpleLogin
-
-            var localizedName: String {
-                switch self {
-                case .addyIO:
-                    return Localizations.addyIo
-                case .duckDuckGo:
-                    return Localizations.duckDuckGo
-                case .fastmail:
-                    return Localizations.fastmail
-                case .firefoxRelay:
-                    return Localizations.firefoxRelay
-                case .simpleLogin:
-                    return Localizations.simpleLogin
-                }
-            }
-        }
-
         // MARK: Properties
 
         /// The type of username to generate.
         var usernameGeneratorType = UsernameGeneratorType.plusAddressedEmail
 
         // MARK: Catch All Email Properties
+
+        /// The type of value to use when generating a catch-all email.
+        var catchAllEmailType: UsernameEmailType = .random
 
         /// The user's domain for generating catch all emails.
         var domain: String = ""
@@ -105,25 +26,28 @@ extension GeneratorState {
         /// The DuckDuckGo API key used to generate a forwarded email alias.
         var duckDuckGoAPIKey: String = ""
 
-        /// The Fastmail API Key used to generate a forwarded email alias
+        /// The Fastmail API Key used to generate a forwarded email alias.
         var fastmailAPIKey: String = ""
 
-        /// The Firefox Relay API access token used to generate a forwarded email alias
+        /// The Firefox Relay API access token used to generate a forwarded email alias.
         var firefoxRelayAPIAccessToken: String = ""
 
         /// The service used to generate a forwarded email alias.
-        var forwardedEmailService = ForwardedEmailService.addyIO
+        var forwardedEmailService = ForwardedEmailServiceType.addyIO
 
         /// Whether the service's API key is visible or not.
         var isAPIKeyVisible = false
 
-        /// The simple login API key used to generate a forwarded email alias
+        /// The simple login API key used to generate a forwarded email alias.
         var simpleLoginAPIKey: String = ""
 
         // MARK: Plus Addressed Email Properties
 
         /// The user's email for generating plus addressed emails.
         var email: String = ""
+
+        /// The type of value to use when generating a plus-addressed email.
+        var plusAddressedEmailType: UsernameEmailType = .random
 
         // MARK: Random Word Properties
 
@@ -132,5 +56,59 @@ extension GeneratorState {
 
         /// Whether the random word should include numbers.
         var includeNumber: Bool = false
+
+        // MARK: Methods
+
+        /// Updates the state based on the user's persisted username generation options.
+        ///
+        /// - Parameter options: The user's saved options.
+        ///
+        mutating func update(with options: UsernameGenerationOptions) {
+            usernameGeneratorType = options.type ?? usernameGeneratorType
+
+            // Catch All Properties
+            catchAllEmailType = options.catchAllEmailType ?? catchAllEmailType
+            domain = options.catchAllEmailDomain ?? domain
+
+            // Forwarded Email Properties
+            addyIOAPIAccessToken = options.anonAddyApiAccessToken ?? addyIOAPIAccessToken
+            addyIODomainName = options.anonAddyDomainName ?? addyIODomainName
+            duckDuckGoAPIKey = options.duckDuckGoApiKey ?? duckDuckGoAPIKey
+            fastmailAPIKey = options.fastMailApiKey ?? fastmailAPIKey
+            firefoxRelayAPIAccessToken = options.firefoxRelayApiAccessToken ?? firefoxRelayAPIAccessToken
+            forwardedEmailService = options.serviceType ?? forwardedEmailService
+            simpleLoginAPIKey = options.simpleLoginApiKey ?? simpleLoginAPIKey
+
+            // Plus Address Email Properties
+            email = options.plusAddressedEmail ?? email
+            plusAddressedEmailType = options.plusAddressedEmailType ?? plusAddressedEmailType
+
+            // Random Word Properties
+            capitalize = options.capitalizeRandomWordUsername ?? capitalize
+            includeNumber = options.includeNumberRandomWordUsername ?? includeNumber
+        }
+    }
+}
+
+extension GeneratorState.UsernameState {
+    /// Returns a `UsernameGenerationOptions` containing the user selected settings for generating
+    /// a username used to persist the options between app launches.
+    var usernameGenerationOptions: UsernameGenerationOptions {
+        UsernameGenerationOptions(
+            anonAddyApiAccessToken: addyIOAPIAccessToken.nilIfEmpty,
+            anonAddyDomainName: addyIODomainName.nilIfEmpty,
+            capitalizeRandomWordUsername: capitalize,
+            catchAllEmailDomain: domain.nilIfEmpty,
+            catchAllEmailType: catchAllEmailType,
+            duckDuckGoApiKey: duckDuckGoAPIKey.nilIfEmpty,
+            fastMailApiKey: fastmailAPIKey.nilIfEmpty,
+            firefoxRelayApiAccessToken: firefoxRelayAPIAccessToken.nilIfEmpty,
+            includeNumberRandomWordUsername: includeNumber,
+            plusAddressedEmail: email.nilIfEmpty,
+            plusAddressedEmailType: plusAddressedEmailType,
+            serviceType: forwardedEmailService,
+            simpleLoginApiKey: simpleLoginAPIKey.nilIfEmpty,
+            type: usernameGeneratorType
+        )
     }
 }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -112,7 +112,7 @@ struct GeneratorState: Equatable {
                 FormField(fieldType: .menuUsernameGeneratorType(FormMenuField(
                     footer: usernameState.usernameGeneratorType.localizedDescription,
                     keyPath: \.usernameState.usernameGeneratorType,
-                    options: UsernameState.UsernameGeneratorType.allCases,
+                    options: UsernameGeneratorType.allCases,
                     selection: usernameState.usernameGeneratorType,
                     title: Localizations.usernameType
                 ))),
@@ -132,7 +132,7 @@ struct GeneratorState: Equatable {
                 optionFields.append(FormField(fieldType: .menuUsernameForwardedEmailService(
                     FormMenuField(
                         keyPath: \.usernameState.forwardedEmailService,
-                        options: UsernameState.ForwardedEmailService.allCases,
+                        options: ForwardedEmailServiceType.allCases,
                         selection: usernameState.forwardedEmailService,
                         title: Localizations.service
                     )

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
@@ -151,7 +151,7 @@ struct GeneratorView: View {
     /// - Parameter field: The data for displaying the menu field.
     ///
     func menuUsernameGeneratorTypeView(
-        field: FormMenuField<GeneratorState, GeneratorState.UsernameState.UsernameGeneratorType>
+        field: FormMenuField<GeneratorState, UsernameGeneratorType>
     ) -> some View {
         FormMenuFieldView(field: field) { newValue in
             store.send(.usernameGeneratorTypeChanged(newValue))

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorViewTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorViewTests.swift
@@ -67,7 +67,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.usernameState.usernameGeneratorType = .forwardedEmail
         processor.state.usernameState.forwardedEmailService = .addyIO
         let menuField = try subject.inspect().find(bitwardenMenuField: Localizations.service)
-        try menuField.select(newValue: GeneratorState.UsernameState.ForwardedEmailService.fastmail)
+        try menuField.select(newValue: ForwardedEmailServiceType.fastmail)
         XCTAssertEqual(processor.dispatchedActions.last, .usernameForwardedEmailServiceChanged(.fastmail))
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-915](https://livefront.atlassian.net/browse/BIT-915)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds support for persisting the username generation options between app launches. The options are stored to user defaults using the same key and format as the Xamarin app to support an easy migration.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **StateService.swift:** Adds methods for getting and setting username generation options for a user.
- **AppSettingsStore.swift:** Adds methods for getting and setting username generation options for a user.
- **UsernameGenerationOptions.swift:** Data model for persisting username generation options.
- **GeneratorRepository.swift:** Adds methods for getting and setting username generation options.
- **GeneratorProcessor.swift:** Loads username generation options when the processor is initialized and saves the options when any of the input fields change.
- **GeneratorState+UsernameState.swift:** Updates the state with the generation options and returns the options that should be persisted.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
