### PR TITLE
BIT-992: Add self-hosting error alert

### DIFF
--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessor.swift
@@ -28,8 +28,7 @@ final class SelfHostedProcessor: StateProcessor<SelfHostedState, SelfHostedActio
     override func perform(_ effect: SelfHostedEffect) async {
         switch effect {
         case .saveEnvironment:
-            // TODO: BIT-1062
-            break
+            saveEnvironment()
         }
     }
 
@@ -48,5 +47,38 @@ final class SelfHostedProcessor: StateProcessor<SelfHostedState, SelfHostedActio
         case let .webVaultUrlChanged(url):
             state.webVaultServerUrl = url
         }
+    }
+
+    // MARK: Private
+
+    /// Returns whether all of the entered URLs are valid URLs.
+    ///
+    private func areURLsValid() -> Bool {
+        let urls = [
+            state.apiServerUrl,
+            state.iconsServerUrl,
+            state.identityServerUrl,
+            state.serverUrl,
+            state.webVaultServerUrl,
+        ]
+
+        return urls
+            .filter { !$0.isEmpty }
+            .allSatisfy(\.isValidURL)
+    }
+
+    /// Saves the environment URLs if they are valid or presents an alert if any are invalid.
+    private func saveEnvironment() {
+        guard areURLsValid() else {
+            coordinator.showAlert(Alert.defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.environmentPageUrlsError
+            ))
+            return
+        }
+
+        // TODO: BIT-1062 Save and apply environment
+
+        coordinator.navigate(to: .dismiss)
     }
 }

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
@@ -29,6 +29,22 @@ class SelfHostedProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `perform(_:)` with `.saveEnvironment` displays an alert if any of the URLs are invalid.
+    func test_perform_saveEnvironment_invalidURLs() async throws {
+        subject.state.serverUrl = "a<b>c"
+
+        await subject.perform(.saveEnvironment)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.first)
+        XCTAssertEqual(
+            alert,
+            Alert.defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.environmentPageUrlsError
+            )
+        )
+    }
+
     /// Receiving `.apiUrlChanged` updates the state.
     func test_receive_apiUrlChanged() {
         subject.receive(.apiUrlChanged("api url"))

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
@@ -113,6 +113,10 @@ struct SelfHostedView: View {
                     send: SelfHostedAction.serverUrlChanged
                 )
             )
+            .autocorrectionDisabled()
+            .keyboardType(.URL)
+            .textContentType(.URL)
+            .textInputAutocapitalization(.never)
         }
     }
 

--- a/BitwardenShared/UI/Platform/Application/Extensions/String.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/String.swift
@@ -33,6 +33,24 @@ extension String {
         contains("@")
     }
 
+    /// Returns `true` if the URL is valid.
+    var isValidURL: Bool {
+        guard rangeOfCharacter(from: .whitespaces) == nil else { return false }
+
+        let urlString: String
+        if starts(with: "https://") || starts(with: "http://") {
+            urlString = self
+        } else {
+            urlString = "https://" + self
+        }
+
+        if #available(iOS 16, *) {
+            return (try? URL(urlString, strategy: .url)) != nil
+        } else {
+            return URL(string: urlString) != nil
+        }
+    }
+
     /// Returns the string or `nil` if it is empty.
     var nilIfEmpty: String? {
         isEmpty ? nil : self

--- a/BitwardenShared/UI/Platform/Application/Extensions/StringTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/StringTests.swift
@@ -41,6 +41,21 @@ class StringTests: BitwardenTestCase {
         XCTAssertTrue(subjects.allSatisfy(\.isValidEmail))
     }
 
+    /// `isValidURL` returns `true` for a valid URL.
+    func test_isValidURL_withValidURL() {
+        XCTAssertTrue("http://bitwarden.com".isValidURL)
+        XCTAssertTrue("https://bitwarden.com".isValidURL)
+        XCTAssertTrue("bitwarden.com".isValidURL)
+    }
+
+    /// `isValidURL` returns `true` for an invalid URL.
+    func test_isValidURL_withInvalidURL() {
+        XCTAssertFalse(" ".isValidURL)
+        XCTAssertFalse("a b c".isValidURL)
+        XCTAssertFalse("a<b>c".isValidURL)
+        XCTAssertFalse("a[b]c".isValidURL)
+    }
+
     /// `nilIfEmpty` returns the string if it's not empty or `nil` if it's empty.
     func test_nilIfEmpty() {
         XCTAssertEqual("abc".nilIfEmpty, "abc")


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-992](https://livefront.atlassian.net/browse/BIT-992)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the self-hosted view to display an error alert if the user tries to save the self-hosted URLs but one or more of the URLs are invalid.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SelfHostedProcessor.swift:** Validates the URLs and displays an error alert if any of the URLs are invalid.
- **String.swift:** Adds an extension method to check if a string contains a valid URL.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/d52cb642-05bb-44a5-9a7e-402e46f53561




## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
