### PR TITLE
BIT-1224: Add TextFieldConfiguration to apply common text field properties based on content type

### DIFF
--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -84,10 +84,7 @@ struct CreateAccountView: View {
                     send: CreateAccountAction.emailTextChanged
                 )
             )
-            .textContentType(.emailAddress)
-            .keyboardType(.emailAddress)
-            .textInputAutocapitalization(.never)
-            .autocorrectionDisabled()
+            .textFieldConfiguration(.email)
 
             BitwardenTextField(
                 accessibilityIdentifier: "MasterPasswordEntry",
@@ -102,9 +99,7 @@ struct CreateAccountView: View {
                     send: CreateAccountAction.passwordTextChanged
                 )
             )
-            .textContentType(.password)
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
+            .textFieldConfiguration(.password)
         }
     }
 
@@ -141,8 +136,7 @@ struct CreateAccountView: View {
                 send: CreateAccountAction.retypePasswordTextChanged
             )
         )
-        .textContentType(.password)
-        .textInputAutocapitalization(.never)
+        .textFieldConfiguration(.password)
     }
 
     /// The button pressed when the user attempts to create the account.

--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -90,10 +90,7 @@ struct LandingView: View {
                         send: LandingAction.emailChanged
                     )
                 )
-                .textContentType(.emailAddress)
-                .keyboardType(.emailAddress)
-                .autocorrectionDisabled()
-                .textInputAutocapitalization(.never)
+                .textFieldConfiguration(.email)
 
                 Button {
                     store.send(.regionPressed)

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
@@ -18,6 +18,7 @@ struct SelfHostedView: View {
             customEnvironment
             saveButton
         }
+        .textFieldConfiguration(.url)
         .navigationBar(title: Localizations.settings, titleDisplayMode: .inline)
         .scrollView()
         .toolbar {
@@ -43,10 +44,6 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.webVaultUrlChanged
                     )
                 )
-                .autocorrectionDisabled()
-                .keyboardType(.URL)
-                .textContentType(.URL)
-                .textInputAutocapitalization(.never)
 
                 BitwardenTextField(
                     title: Localizations.apiUrl,
@@ -55,10 +52,6 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.apiUrlChanged
                     )
                 )
-                .autocorrectionDisabled()
-                .keyboardType(.URL)
-                .textContentType(.URL)
-                .textInputAutocapitalization(.never)
 
                 BitwardenTextField(
                     title: Localizations.identityUrl,
@@ -67,10 +60,6 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.identityUrlChanged
                     )
                 )
-                .autocorrectionDisabled()
-                .keyboardType(.URL)
-                .textContentType(.URL)
-                .textInputAutocapitalization(.never)
 
                 BitwardenTextField(
                     title: Localizations.iconsUrl,
@@ -79,10 +68,6 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.iconsUrlChanged
                     )
                 )
-                .autocorrectionDisabled()
-                .keyboardType(.URL)
-                .textContentType(.URL)
-                .textInputAutocapitalization(.never)
             }
         }
         .padding(.top, 8)

--- a/BitwardenShared/UI/Auth/Login/LoginView.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginView.swift
@@ -57,8 +57,7 @@ struct LoginView: View {
                     send: LoginAction.masterPasswordChanged
                 )
             )
-            .textContentType(.password)
-            .textInputAutocapitalization(.never)
+            .textFieldConfiguration(.password)
 
             Button(Localizations.getMasterPasswordwordHint) {
                 store.send(.getMasterPasswordHintPressed)

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -32,8 +32,7 @@ struct VaultUnlockView: View {
                         send: VaultUnlockAction.masterPasswordChanged
                     )
                 )
-                .textContentType(.password)
-                .textInputAutocapitalization(.never)
+                .textFieldConfiguration(.password)
 
                 Button {
                     Task { await store.perform(.unlockVault) }

--- a/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+// MARK: - TextFieldConfiguration
+
+/// A struct containing several `TextField` configuration properties that are commonly set on text
+/// fields in the app.
+///
+struct TextFieldConfiguration {
+    // MARK: Properties
+
+    /// Whether autocorrect is disabled in the text field.
+    let isAutocorrectionDisabled: Bool
+
+    /// The type of keyboard to display.
+    let keyboardType: UIKeyboardType?
+
+    /// The expected type of content input in the text field.
+    let textContentType: UITextContentType?
+
+    /// The behavior for when the input should be automatically capitalized.
+    let textInputAutocapitalization: TextInputAutocapitalization?
+}
+
+extension TextFieldConfiguration {
+    /// A `TextFieldConfiguration` for applying common properties to email text fields.
+    static let email = TextFieldConfiguration(
+        isAutocorrectionDisabled: true,
+        keyboardType: .emailAddress,
+        textContentType: .emailAddress,
+        textInputAutocapitalization: .never
+    )
+
+    /// A `TextFieldConfiguration` for applying common properties to password text fields.
+    static let password = TextFieldConfiguration(
+        isAutocorrectionDisabled: true,
+        keyboardType: .default,
+        textContentType: .password,
+        textInputAutocapitalization: .never
+    )
+
+    /// A `TextFieldConfiguration` for applying common properties to URL text fields.
+    static let url = TextFieldConfiguration(
+        isAutocorrectionDisabled: true,
+        keyboardType: .URL,
+        textContentType: .URL,
+        textInputAutocapitalization: .never
+    )
+
+    /// A `TextFieldConfiguration` for applying common properties to username text fields.
+    static let username = TextFieldConfiguration(
+        isAutocorrectionDisabled: true,
+        keyboardType: .default,
+        textContentType: .username,
+        textInputAutocapitalization: .never
+    )
+}
+
+// MARK: - View
+
+extension View {
+    /// A view extension that applies common text field properties based on a configuration.
+    ///
+    /// - Parameter configuration: The configuration used to set common text field properties.
+    /// - Returns: The wrapped view modified with the common text field modifiers applied.
+    ///
+    func textFieldConfiguration(_ configuration: TextFieldConfiguration) -> some View {
+        autocorrectionDisabled(configuration.isAutocorrectionDisabled)
+            .keyboardType(configuration.keyboardType ?? .default)
+            .textContentType(configuration.textContentType)
+            .textInputAutocapitalization(configuration.textInputAutocapitalization)
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/AddItem/AddLoginItem/AddLoginItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddItem/AddLoginItem/AddLoginItemView.swift
@@ -26,9 +26,7 @@ struct AddLoginItemView: View {
                     send: AddItemAction.usernameChanged
                 )
             )
-            .textContentType(.username)
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
+            .textFieldConfiguration(.username)
         }
 
         BitwardenTextField(
@@ -56,8 +54,7 @@ struct AddLoginItemView: View {
                 send: AddItemAction.passwordChanged
             )
         )
-        .textContentType(.password)
-        .textInputAutocapitalization(.never)
+        .textFieldConfiguration(.password)
 
         VStack(alignment: .leading, spacing: 8) {
             Text(Localizations.authenticatorKey)
@@ -91,9 +88,7 @@ struct AddLoginItemView: View {
                     send: AddItemAction.uriChanged
                 )
             )
-            .keyboardType(.URL)
-            .textInputAutocapitalization(.never)
-            .textContentType(.URL)
+            .textFieldConfiguration(.url)
 
             Button(Localizations.newUri) {
                 store.send(.newUriPressed)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1224](https://livefront.atlassian.net/browse/BIT-1224)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a `TextFieldConfiguration` struct and modifier to apply common text field properties based on the intended input or content type of the field.

This stemmed from: https://github.com/bitwarden/ios/pull/173#discussion_r1416146924

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **TextFieldConfiguration.swift:** Adds configuration container and view extension to apply common text field properties.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
