### PR TITLE
BIT-1220: Display empty vault list message if no ciphers exist

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -164,6 +164,8 @@ class DefaultVaultRepository {
             .decryptList(folders: response.folders.map(Folder.init))
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
 
+        guard !ciphers.isEmpty else { return [] }
+
         let activeCiphers = ciphers.filter { $0.deletedDate == nil }
 
         let ciphersFavorites = activeCiphers.filter(\.favorite).compactMap(VaultListItem.init)

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -248,6 +248,22 @@ class VaultRepositoryTests: BitwardenTestCase {
         }
     }
 
+    /// `vaultListPublisher()` returns a publisher which publishes an empty array if the user's
+    /// vault contains no ciphers.
+    func test_vaultListPublisher_empty() async throws {
+        client.result = .httpSuccess(testData: .syncWithProfile)
+
+        var iterator = subject.vaultListPublisher().makeAsyncIterator()
+
+        Task {
+            try await subject.fetchSync()
+        }
+
+        let sections = await iterator.next()
+
+        try XCTAssertTrue(XCTUnwrap(sections).isEmpty)
+    }
+
     /// `vaultListPublisher(group:)` returns a publisher for a group of items within the vault list.
     func test_vaultListPublisher_forGroup() async throws {
         client.result = .httpSuccess(testData: .syncWithCiphers)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1220](https://livefront.atlassian.net/browse/BIT-1220)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes an issue where the empty vault list view wasn't being displayed if there were no ciphers in the user's vault.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **VaultRepository.swift:** Adds a check to return an empty list of sections if the vault has no ciphers.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <img width="559" alt="Screenshot 2023-12-11 at 12 33 40 PM" src="https://github.com/bitwarden/ios/assets/126492398/a901c996-5599-405e-83f4-9766a45d09a0"> | <img width="559" alt="Screenshot 2023-12-11 at 12 38 51 PM" src="https://github.com/bitwarden/ios/assets/126492398/717f711c-fcc8-44c2-8fea-4663eb79b2e7"> |

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
