### PR TITLE
BIT-401: Add support for persisting folders

### DIFF
--- a/BitwardenShared/Core/Platform/Extensions/NSManagedObjectContext+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/NSManagedObjectContext+Extensions.swift
@@ -1,21 +1,47 @@
 import CoreData
 
 extension NSManagedObjectContext {
-    /// Executes the batch delete request and merges any changes into the current context plus any
-    /// additional contexts.
+    /// Executes the batch delete request and/or batch insert request and merges any changes into
+    /// the current context plus any additional contexts.
     ///
     /// - Parameters:
     ///   - batchDeleteRequest: The batch delete request to execute.
+    ///   - batchInsertRequest: The batch insert request to execute.
     ///   - additionalContexts: Any additional contexts other than the current to merge the changes into.
     ///
     func executeAndMergeChanges(
-        _ batchDeleteRequest: NSBatchDeleteRequest,
+        batchDeleteRequest: NSBatchDeleteRequest? = nil,
+        batchInsertRequest: NSBatchInsertRequest? = nil,
         additionalContexts: [NSManagedObjectContext] = []
     ) throws {
-        batchDeleteRequest.resultType = .resultTypeObjectIDs
-        guard let result = try execute(batchDeleteRequest) as? NSBatchDeleteResult else { return }
-        let changes: [AnyHashable: Any] = [NSDeletedObjectsKey: result.result as? [NSManagedObjectID] ?? []]
+        var changes: [AnyHashable: Any] = [:]
+
+        if let batchDeleteRequest {
+            batchDeleteRequest.resultType = .resultTypeObjectIDs
+            if let deleteResult = try execute(batchDeleteRequest) as? NSBatchDeleteResult {
+                changes[NSDeletedObjectsKey] = deleteResult.result as? [NSManagedObjectID] ?? []
+            }
+        }
+
+        if let batchInsertRequest {
+            batchInsertRequest.resultType = .objectIDs
+            if let insertResult = try execute(batchInsertRequest) as? NSBatchInsertResult {
+                changes[NSInsertedObjectsKey] = insertResult.result as? [NSManagedObjectID] ?? []
+            }
+        }
+
         NSManagedObjectContext.mergeChanges(fromRemoteContextSave: changes, into: [self] + additionalContexts)
+    }
+
+    /// Performs the closure on the context's queue and saves the context if there are any changes.
+    ///
+    /// - Parameter closure: The closure to perform.
+    ///
+    func performAndSave(closure: @escaping () throws -> Void) async throws {
+        try await perform {
+            try closure()
+            try self.saveIfChanged()
+        }
     }
 
     /// Saves the context if there are changes.

--- a/BitwardenShared/Core/Platform/Models/Data/CodableModelData.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/CodableModelData.swift
@@ -1,0 +1,40 @@
+import CoreData
+import OSLog
+
+/// A protocol for a `NSManagedObject` which persists a data model as JSON encoded data. The model
+/// can be set via the `model` property which encodes the model to the data property, which should
+/// be a `@NSManaged` property of the `NSManagedObject`. When the managed object is populated from
+/// the database, the `model` property can be read to decode the data.
+///
+protocol CodableModelData: AnyObject, NSManagedObject {
+    associatedtype Model: Codable
+
+    /// A `@NSManaged` property of the manage object for storing the encoded model as data.
+    var modelData: Data? { get set }
+}
+
+extension CodableModelData {
+    /// Encodes or decodes the model to/from the data instance.
+    var model: Model? {
+        get {
+            guard let modelData else { return nil }
+            do {
+                return try JSONDecoder().decode(Model.self, from: modelData)
+            } catch {
+                Logger.application.error("Error decoding \(String(describing: Model.self)): \(error)")
+                return nil
+            }
+        }
+        set {
+            guard let newValue else {
+                modelData = nil
+                return
+            }
+            do {
+                modelData = try JSONEncoder().encode(newValue)
+            } catch {
+                Logger.application.error("Error encoding \(String(describing: Model.self)): \(error)")
+            }
+        }
+    }
+}

--- a/BitwardenShared/Core/Platform/Models/Data/ManagedObject.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/ManagedObject.swift
@@ -13,21 +13,49 @@ extension ManagedObject where Self: NSManagedObject {
         String(describing: self)
     }
 
+    /// Returns a `NSBatchInsertRequest` for batch inserting an array of objects.
+    ///
+    /// - Parameters:
+    ///   - objects: The objects (or objects that can be converted to managed objects) to insert.
+    ///   - handler: A handler that is called for each object to set the properties on the
+    ///     `NSManagedObject` to insert.
+    /// - Returns: A `NSBatchInsertRequest` for batch inserting an array of objects.
+    ///
+    static func batchInsertRequest<T>(objects: [T], handler: @escaping (Self, T) -> Void) -> NSBatchInsertRequest {
+        var index = 0
+        return NSBatchInsertRequest(entityName: entityName) { (managedObject: NSManagedObject) -> Bool in
+            guard index < objects.count else { return true }
+            defer { index += 1 }
+
+            if let managedObject = (managedObject as? Self) {
+                handler(managedObject, objects[index])
+            }
+
+            return false
+        }
+    }
+
     /// Returns a `NSFetchRequest` for fetching instances of the managed object.
     ///
+    /// - Parameter predicate: An optional predicate to apply to the fetch request.
     /// - Returns: A `NSFetchRequest` used to fetch instances of the managed object.
     ///
-    static func fetchRequest() -> NSFetchRequest<Self> {
-        NSFetchRequest<Self>(entityName: entityName)
+    static func fetchRequest(predicate: NSPredicate? = nil) -> NSFetchRequest<Self> {
+        let fetchRequest = NSFetchRequest<Self>(entityName: entityName)
+        fetchRequest.predicate = predicate
+        return fetchRequest
     }
 
     /// Returns a `NSFetchRequest` for fetching a generic `NSFetchRequestResult` instances of the
     /// managed object.
     ///
+    /// - Parameter predicate: An optional predicate to apply to the fetch request.
     /// - Returns: A `NSFetchRequest` used to fetch generic `NSFetchRequestResult` instances of the
     ///     managed object.
     ///
-    static func fetchResultRequest() -> NSFetchRequest<NSFetchRequestResult> {
-        NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+    static func fetchResultRequest(predicate: NSPredicate? = nil) -> NSFetchRequest<NSFetchRequestResult> {
+        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entityName)
+        fetchRequest.predicate = predicate
+        return fetchRequest
     }
 }

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -314,6 +314,13 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
             userId: "1",
             passwordHistory: PasswordHistory(password: "PASSWORD", lastUsedDate: Date())
         )
+        try await dataStore.persistentContainer.viewContext.performAndSave {
+            _ = FolderData(
+                context: self.dataStore.persistentContainer.viewContext,
+                userId: "1",
+                folder: Folder(id: "1", name: "FOLDER1", revisionDate: Date())
+            )
+        }
 
         try await subject.logoutAccount()
 
@@ -324,6 +331,10 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try XCTAssertEqual(
             dataStore.persistentContainer.viewContext
                 .count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")),
+            0
+        )
+        try XCTAssertEqual(
+            dataStore.persistentContainer.viewContext.count(for: FolderData.fetchByUserIdRequest(userId: "1")),
             0
         )
     }

--- a/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
+++ b/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="FolderData" representedClassName=".FolderData" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="modelData" optional="YES" attributeType="Binary"/>
+        <attribute name="userId" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userId"/>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="PasswordHistoryData" representedClassName=".PasswordHistoryData" syncable="YES">
         <attribute name="lastUsedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="password" attributeType="String"/>

--- a/BitwardenShared/Core/Tools/Services/GeneratorDataStore.swift
+++ b/BitwardenShared/Core/Tools/Services/GeneratorDataStore.swift
@@ -44,24 +44,14 @@ protocol GeneratorDataStore: AnyObject {
 
 extension DataStore: GeneratorDataStore {
     func deleteAllPasswordHistory(userId: String) async throws {
-        try await backgroundContext.perform {
-            try self.backgroundContext.executeAndMergeChanges(
-                PasswordHistoryData.deleteByUserIdRequest(userId: userId),
-                additionalContexts: [self.persistentContainer.viewContext]
-            )
-        }
+        try await executeBatchDelete(PasswordHistoryData.deleteByUserIdRequest(userId: userId))
     }
 
     func deletePasswordHistoryPastLimit(userId: String, limit: Int) async throws {
-        try await backgroundContext.perform {
-            let fetchRequest = PasswordHistoryData.fetchResultRequest()
-            fetchRequest.sortDescriptors = [PasswordHistoryData.sortByLastUsedDateDescending]
-            fetchRequest.fetchOffset = limit
-            try self.backgroundContext.executeAndMergeChanges(
-                NSBatchDeleteRequest(fetchRequest: fetchRequest),
-                additionalContexts: [self.persistentContainer.viewContext]
-            )
-        }
+        let fetchRequest = PasswordHistoryData.fetchResultRequest()
+        fetchRequest.sortDescriptors = [PasswordHistoryData.sortByLastUsedDateDescending]
+        fetchRequest.fetchOffset = limit
+        try await executeBatchDelete(NSBatchDeleteRequest(fetchRequest: fetchRequest))
     }
 
     func fetchPasswordHistoryMostRecent(userId: String) async throws -> PasswordHistory? {

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -423,6 +423,19 @@ extension BitwardenSdk.Folder {
             revisionDate: model.revisionDate
         )
     }
+
+    init(folderData: FolderData) throws {
+        guard let id = folderData.id,
+              let name = folderData.model?.name,
+              let revisionDate = folderData.model?.revisionDate else {
+            throw DataMappingError.invalidData
+        }
+        self.init(
+            id: id,
+            name: name,
+            revisionDate: revisionDate
+        )
+    }
 }
 
 // MARK: - Sends (BitwardenSdk)

--- a/BitwardenShared/Core/Vault/Models/Data/FolderData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/FolderData.swift
@@ -1,0 +1,143 @@
+import BitwardenSdk
+import CoreData
+import Foundation
+
+/// A data model for persisting folders.
+///
+class FolderData: NSManagedObject, ManagedObject, CodableModelData {
+    typealias Model = FolderModelData
+
+    // MARK: Properties
+
+    /// The folder's identifier.
+    @NSManaged var id: String?
+
+    /// The data model encoded as JSON data.
+    @NSManaged var modelData: Data?
+
+    /// The ID of the user who owns the folder.
+    @NSManaged var userId: String?
+
+    // MARK: Initialization
+
+    /// Initialize a `FolderData` object for insertion into the managed object context.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context to insert the initialized object.
+    ///   - userId: The user ID associated with the folder.
+    ///   - folder: The `Folder` object used to create the object.
+    ///
+    convenience init(
+        context: NSManagedObjectContext,
+        userId: String,
+        folder: Folder
+    ) {
+        self.init(context: context)
+        id = folder.id
+        model = FolderModelData(folder: folder)
+        self.userId = userId
+    }
+
+    // MARK: Methods
+
+    /// Updates the `FolderData` object from a `Folder` and user ID.
+    ///
+    /// - Parameters:
+    ///   - folder: The `Folder` object used to update the `FolderData` instance.
+    ///   - userId: The user ID associated with the folder.
+    ///
+    func update(with folder: Folder, userId: String) {
+        id = folder.id
+        model = FolderModelData(folder: folder)
+        self.userId = userId
+    }
+}
+
+extension FolderData {
+    /// A `Codable` struct for encoding the folder's properties as JSON encoded data.
+    struct FolderModelData: Codable {
+        // MARK: Properties
+
+        /// The folder's identifier.
+        let id: String?
+
+        /// The folder's name.
+        let name: String?
+
+        /// The date of the folder's last revision.
+        let revisionDate: Date?
+
+        /// Initialize a `FolderModelData` from a `Folder`.
+        ///
+        /// - Parameter folder: The `Folder` used to initialize the `FolderModelData`.
+        ///
+        init(folder: Folder) {
+            id = folder.id
+            name = folder.name
+            revisionDate = folder.revisionDate
+        }
+    }
+}
+
+extension FolderData {
+    /// Returns a `NSPredicate` used for filtering by a user's ID.
+    ///
+    /// - Parameter userId: The user ID associated with the folder.
+    ///
+    static func userIdPredicate(userId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(FolderData.userId), userId)
+    }
+
+    /// Returns a `NSPredicate` used for filtering by a user and folder ID.
+    ///
+    /// - Parameter userId: The user ID associated with the folder.
+    ///
+    static func userIdAndIdPredicate(userId: String, id: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@ AND %K == %@", #keyPath(FolderData.userId), userId, #keyPath(FolderData.id), id)
+    }
+}
+
+extension FolderData {
+    /// A `NSBatchInsertRequest` that inserts `FolderData` objects for the specified user.
+    ///
+    /// - Parameters:
+    ///   - folders: The list of `FolderData` objects to insert.
+    ///   - userId: The user associated with the `FolderData` objects to insert.
+    /// - Returns: A `NSBatchInsertRequest` that inserts `FolderData` objects for the user.
+    ///
+    static func batchInsertRequest(folders: [Folder], userId: String) -> NSBatchInsertRequest {
+        batchInsertRequest(objects: folders) { folderData, folder in
+            folderData.update(with: folder, userId: userId)
+        }
+    }
+
+    /// A `NSBatchDeleteRequest` that deletes all `FolderData` objects for the specified user.
+    ///
+    /// - Parameter userId: The user associated with the `FolderData` objects to delete.
+    /// - Returns: A `NSBatchDeleteRequest` that deletes all `FolderData` objects for the user.
+    ///
+    static func deleteByUserIdRequest(userId: String) -> NSBatchDeleteRequest {
+        let fetchRequest = fetchResultRequest(predicate: userIdPredicate(userId: userId))
+        return NSBatchDeleteRequest(fetchRequest: fetchRequest)
+    }
+
+    /// A `NSFetchRequest` that fetches `FolderData` objects for the specified user matching an ID.
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the `FolderData` object to fetch.
+    ///   - userId: The user associated with the `FolderData` objects to delete.
+    /// - Returns: A `NSFetchRequest` that fetches all `FolderData` objects for the user.
+    ///
+    static func fetchByIdRequest(id: String, userId: String) -> NSFetchRequest<FolderData> {
+        fetchRequest(predicate: userIdAndIdPredicate(userId: userId, id: id))
+    }
+
+    /// A `NSFetchRequest` that fetches all `FolderData` objects for the specified user.
+    ///
+    /// - Parameter userId: The user associated with the `FolderData` objects to delete.
+    /// - Returns: A `NSFetchRequest` that fetches all `FolderData` objects for the user.
+    ///
+    static func fetchByUserIdRequest(userId: String) -> NSFetchRequest<FolderData> {
+        fetchRequest(predicate: userIdPredicate(userId: userId))
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/FolderDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/FolderDataStore.swift
@@ -1,0 +1,88 @@
+import BitwardenSdk
+import Combine
+import CoreData
+
+// MARK: - FolderDataStore
+
+/// A protocol for a data store that handles performing data requests for folders.
+///
+protocol FolderDataStore: AnyObject {
+    /// Deletes all `Folder` objects for a specific user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the objects to delete.
+    ///
+    func deleteAllFolders(userId: String) async throws
+
+    /// Deletes a `Folder` by ID for a user.
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the `Folder` to delete.
+    ///   - userId: The user ID of the user associated with the object to delete.
+    ///
+    func deleteFolder(id: String, userId: String) async throws
+
+    /// A publisher for a user's folder objects.
+    ///
+    /// - Parameter userId: The user ID of the user to associated with the objects to fetch.
+    /// - Returns: A publisher for the user's folders.
+    ///
+    func folderPublisher(userId: String) -> AnyPublisher<[Folder], Error>
+
+    /// Replaces a list of `Folder` objects for a user.
+    ///
+    /// - Parameters:
+    ///   - folders: The list of folders to replace any existing folders.
+    ///   - userId: The user ID of the user associated with the folders.
+    ///
+    func replaceFolders(_ folders: [Folder], userId: String) async throws
+
+    /// Inserts or updates a folder for a user.
+    ///
+    /// - Parameters:
+    ///   - folder: The folder to insert or update.
+    ///   - userId: The user ID of the user associated with the folder.
+    ///
+    func upsertFolder(_ folder: Folder, userId: String) async throws
+}
+
+extension DataStore: FolderDataStore {
+    func deleteAllFolders(userId: String) async throws {
+        try await executeBatchDelete(FolderData.deleteByUserIdRequest(userId: userId))
+    }
+
+    func deleteFolder(id: String, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            let results = try self.backgroundContext.fetch(FolderData.fetchByIdRequest(id: id, userId: userId))
+            for result in results {
+                self.backgroundContext.delete(result)
+            }
+        }
+    }
+
+    func folderPublisher(userId: String) -> AnyPublisher<[Folder], Error> {
+        let fetchRequest = FolderData.fetchByUserIdRequest(userId: userId)
+        // A sort descriptor is needed by `NSFetchedResultsController`.
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \FolderData.id, ascending: true)]
+        return FetchedResultsPublisher(
+            context: persistentContainer.viewContext,
+            request: fetchRequest
+        )
+        .tryMap { try $0.map(Folder.init) }
+        .eraseToAnyPublisher()
+    }
+
+    func replaceFolders(_ folders: [Folder], userId: String) async throws {
+        let deleteRequest = FolderData.deleteByUserIdRequest(userId: userId)
+        let insertRequest = FolderData.batchInsertRequest(folders: folders, userId: userId)
+        try await executeBatchReplace(
+            deleteRequest: deleteRequest,
+            insertRequest: insertRequest
+        )
+    }
+
+    func upsertFolder(_ folder: Folder, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            _ = FolderData(context: self.backgroundContext, userId: userId, folder: folder)
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/FolderDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/FolderDataStoreTests.swift
@@ -1,0 +1,133 @@
+import BitwardenSdk
+import CoreData
+import XCTest
+
+@testable import BitwardenShared
+
+class FolderDataStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DataStore!
+
+    let folders = [
+        Folder(id: "1", name: "FOLDER1", revisionDate: Date()),
+        Folder(id: "2", name: "FOLDER2", revisionDate: Date()),
+        Folder(id: "3", name: "FOLDER3", revisionDate: Date()),
+    ]
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `deleteAllFolders(user:)` removes all objects for the user.
+    func test_deleteAllFolders() async throws {
+        try await insertFolders(folders, userId: "1")
+        try await insertFolders(folders, userId: "2")
+
+        try await subject.deleteAllFolders(userId: "1")
+
+        try XCTAssertTrue(fetchFolders(userId: "1").isEmpty)
+        try XCTAssertEqual(fetchFolders(userId: "2").count, 3)
+    }
+
+    /// `deleteFolder(id:userId:)` removes the folder with the given ID for the user.
+    func test_deleteFolder() async throws {
+        try await insertFolders(folders, userId: "1")
+
+        try await subject.deleteFolder(id: "2", userId: "1")
+
+        try XCTAssertEqual(
+            fetchFolders(userId: "1"),
+            folders.filter { $0.id != "2" }
+        )
+    }
+
+    /// `folderPublisher(userId:)` returns a publisher for a user's folder objects.
+    func test_folderPublisher() async throws {
+        var publishedValues = [[Folder]]()
+        let publisher = subject.folderPublisher(userId: "1")
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { values in
+                    publishedValues.append(values)
+                }
+            )
+        defer { publisher.cancel() }
+
+        try await subject.replaceFolders(folders, userId: "1")
+
+        waitFor { publishedValues.count == 2 }
+        XCTAssertTrue(publishedValues[0].isEmpty)
+        XCTAssertEqual(publishedValues[1], folders)
+    }
+
+    /// `replaceFolders(_:userId)` replaces the list of folders for the user.
+    func test_replaceFolders() async throws {
+        try await insertFolders(folders, userId: "1")
+
+        let newFolders = [
+            Folder(id: "3", name: "FOLDER3", revisionDate: Date()),
+            Folder(id: "4", name: "FOLDER4", revisionDate: Date()),
+            Folder(id: "5", name: "FOLDER5", revisionDate: Date()),
+        ]
+        try await subject.replaceFolders(newFolders, userId: "1")
+
+        XCTAssertEqual(try fetchFolders(userId: "1"), newFolders)
+    }
+
+    /// `upsertFolder(_:userId:)` inserts a folder for a user.
+    func test_upsertFolder_insert() async throws {
+        let folder = Folder(id: "1", name: "FOLDER1", revisionDate: Date())
+        try await subject.upsertFolder(folder, userId: "1")
+
+        try XCTAssertEqual(fetchFolders(userId: "1"), [folder])
+
+        let folder2 = Folder(id: "2", name: "FOLDER2", revisionDate: Date())
+        try await subject.upsertFolder(folder2, userId: "1")
+
+        try XCTAssertEqual(fetchFolders(userId: "1"), [folder, folder2])
+    }
+
+    /// `upsertFolder(_:userId:)` updates an existing folder for a user.
+    func test_upsertFolder_update() async throws {
+        try await insertFolders(folders, userId: "1")
+
+        let updatedFolder = Folder(id: "2", name: "UPDATED FOLDER2", revisionDate: Date())
+        try await subject.upsertFolder(updatedFolder, userId: "1")
+
+        var expectedFolders = folders
+        expectedFolders[1] = updatedFolder
+
+        try XCTAssertEqual(fetchFolders(userId: "1"), expectedFolders)
+    }
+
+    // MARK: Test Helpers
+
+    /// A test helper to fetch all folder's for a user.
+    private func fetchFolders(userId: String) throws -> [Folder] {
+        let fetchRequest = FolderData.fetchByUserIdRequest(userId: userId)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \FolderData.id, ascending: true)]
+        return try subject.backgroundContext.fetch(fetchRequest).map(Folder.init)
+    }
+
+    /// A test helper for inserting a list of folders for a user.
+    private func insertFolders(_ folders: [Folder], userId: String) async throws {
+        try await subject.backgroundContext.performAndSave {
+            for folder in folders {
+                _ = FolderData(context: self.subject.backgroundContext, userId: userId, folder: folder)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-401](https://livefront.atlassian.net/browse/BIT-401)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the `FolderDataStore` used to persist folders to the database along with the main operations for delete, delete all, replace and insert/update. This doesn't yet include the work of having the sync process insert the data into the database, which will be done as a separate PR. 

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **NSManagedObjectContext+Extensions.swift:** Updates the execute and merge changes method to support batch insert and delete requests.
- **CodableModelData.swift:** A protocol helper used to persist a model object as JSON encoded data as an attribute of the Core Data entity.
- **ManagedObject.swift:** Adds a helper for batch insert requests.
- **DataStore.swift:** Adds helpers for batch delete and replace.
- **FolderData.swift:** The managed object for persisting folders.
- **FolderDataStore.swift:** The data store for persisting folders.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
