### PR TITLE
BIT-1112: Fixes an issue with the Send search bar

### DIFF
--- a/BitwardenShared/UI/Tools/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendList/SendListView.swift
@@ -19,6 +19,7 @@ struct SendListView: View {
                     get: \.searchText,
                     send: SendListAction.searchTextChanged
                 ),
+                placement: .navigationBarDrawer(displayMode: .always),
                 prompt: Localizations.search
             )
             .navigationTitle(Localizations.send)


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1112](https://livefront.atlassian.net/browse/BIT-1112)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

This PR fixes a bug with the Send List screen's search bar in landscape, where it would be pushed over to the side in a wonky way.

## 📋 Code changes

- **SendListView.swift:** Updated the `.searchable` modifier usage to explicitly keep the search bar in the navigation bar, just like on the vault list screen.

## 📸 Screenshots

https://github.com/bitwarden/ios/assets/125909022/68c5e3fe-e321-4fda-9a4f-18d5f1033dac

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
