### PR TITLE
BIT-855: Update Profile Switcher Accessibility Label

### DIFF
--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
@@ -36,6 +36,7 @@ struct ProfileSwitcherToolbarView: View {
                 EmptyView()
             }
         }
+        .accessibilityLabel(Localizations.account)
     }
 }
 

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarViewTests.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarViewTests.swift
@@ -31,7 +31,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
 
     /// Tapping the view dispatches the `.requestedProfileSwitcher` action.
     func test_tap_currentAccount() throws {
-        let view = try subject.inspect().find(button: "AA")
+        let view = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.account)
         try view.tap()
 
         XCTAssertEqual(


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-855](https://livefront.atlassian.net/browse/BIT-855)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

1. Match the voiceover from the Xamarin app

## 📋 Code changes

Sets the accessibility label to "Account"

## 📸 Screenshots

https://github.com/bitwarden/ios/assets/148839008/8c9932bb-6c4f-49d8-b6b6-a9d850eddbe7

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
