### PR TITLE
BIT-404: Add support for persisting collections

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Data/ManagedUserObject.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/ManagedUserObject.swift
@@ -1,0 +1,74 @@
+import CoreData
+
+/// A protocol for a `ManagedObject` data model associated with a user that adds some convenience
+/// methods for building `NSPersistentStoreRequest` for common CRUD operations.
+///
+protocol ManagedUserObject: ManagedObject {
+    /// The value type (struct) associated with the managed object that is persisted in the database.
+    associatedtype ValueType
+
+    /// Returns a `NSPredicate` used for filtering by a user's ID.
+    ///
+    /// - Parameter userId: The user ID associated with the managed object.
+    ///
+    static func userIdPredicate(userId: String) -> NSPredicate
+
+    /// Returns a `NSPredicate` used for filtering by a user and managed object ID.
+    ///
+    /// - Parameter userId: The user ID associated with the managed object.
+    ///
+    static func userIdAndIdPredicate(userId: String, id: String) -> NSPredicate
+
+    /// Updates the managed object from its associated value type object and user ID.
+    ///
+    /// - Parameters:
+    ///   - value: The value type object used to update the managed object.
+    ///   - userId: The user ID associated with the object.
+    ///
+    func update(with value: ValueType, userId: String)
+}
+
+extension ManagedUserObject where Self: NSManagedObject {
+    /// A `NSBatchInsertRequest` that inserts objects for the specified user.
+    ///
+    /// - Parameters:
+    ///   - objects: The list of objects to insert.
+    ///   - userId: The user associated with the objects to insert.
+    /// - Returns: A `NSBatchInsertRequest` that inserts the objects for the user.
+    ///
+    static func batchInsertRequest(objects: [ValueType], userId: String) -> NSBatchInsertRequest {
+        batchInsertRequest(objects: objects) { object, value in
+            object.update(with: value, userId: userId)
+        }
+    }
+
+    /// A `NSBatchDeleteRequest` that deletes all objects for the specified user.
+    ///
+    /// - Parameter userId: The user associated with the objects to delete.
+    /// - Returns: A `NSBatchDeleteRequest` that deletes all objects for the user.
+    ///
+    static func deleteByUserIdRequest(userId: String) -> NSBatchDeleteRequest {
+        let fetchRequest = fetchResultRequest(predicate: userIdPredicate(userId: userId))
+        return NSBatchDeleteRequest(fetchRequest: fetchRequest)
+    }
+
+    /// A `NSFetchRequest` that fetches objects for the specified user matching an ID.
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the object to fetch.
+    ///   - userId: The user associated with the object to fetch.
+    /// - Returns: A `NSFetchRequest` that fetches all objects for the user.
+    ///
+    static func fetchByIdRequest(id: String, userId: String) -> NSFetchRequest<Self> {
+        fetchRequest(predicate: userIdAndIdPredicate(userId: userId, id: id))
+    }
+
+    /// A `NSFetchRequest` that fetches all objects for the specified user.
+    ///
+    /// - Parameter userId: The user associated with the objects to delete.
+    /// - Returns: A `NSFetchRequest` that fetches all objects for the user.
+    ///
+    static func fetchByUserIdRequest(userId: String) -> NSFetchRequest<Self> {
+        fetchRequest(predicate: userIdPredicate(userId: userId))
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -159,11 +159,13 @@ public class ServiceContainer: Services {
         let dataStore = DataStore(errorReporter: errorReporter)
         let stateService = DefaultStateService(appSettingsStore: appSettingsStore, dataStore: dataStore)
         let environmentService = DefaultEnvironmentService(stateService: stateService)
+        let collectionService = DefaultCollectionService(collectionDataStore: dataStore, stateService: stateService)
         let folderService = DefaultFolderService(folderDataStore: dataStore, stateService: stateService)
         let tokenService = DefaultTokenService(stateService: stateService)
         let apiService = APIService(environmentService: environmentService, tokenService: tokenService)
         let syncService = DefaultSyncService(
             clientCrypto: clientService.clientCrypto(),
+            collectionService: collectionService,
             errorReporter: errorReporter,
             folderService: folderService,
             stateService: stateService,

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -315,8 +315,10 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
             passwordHistory: PasswordHistory(password: "PASSWORD", lastUsedDate: Date())
         )
         try await dataStore.persistentContainer.viewContext.performAndSave {
+            let context = self.dataStore.persistentContainer.viewContext
+            _ = CollectionData(context: context, userId: "1", collection: .fixture())
             _ = FolderData(
-                context: self.dataStore.persistentContainer.viewContext,
+                context: context,
                 userId: "1",
                 folder: Folder(id: "1", name: "FOLDER1", revisionDate: Date())
             )
@@ -328,15 +330,10 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, [:])
         XCTAssertEqual(appSettingsStore.passwordGenerationOptions, [:])
 
-        try XCTAssertEqual(
-            dataStore.persistentContainer.viewContext
-                .count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")),
-            0
-        )
-        try XCTAssertEqual(
-            dataStore.persistentContainer.viewContext.count(for: FolderData.fetchByUserIdRequest(userId: "1")),
-            0
-        )
+        let context = dataStore.persistentContainer.viewContext
+        try XCTAssertEqual(context.count(for: CollectionData.fetchByUserIdRequest(userId: "1")), 0)
+        try XCTAssertEqual(context.count(for: FolderData.fetchByUserIdRequest(userId: "1")), 0)
+        try XCTAssertEqual(context.count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")), 0)
     }
 
     /// `logoutAccount(_:)` removes the account from the account list and sets the active account to

--- a/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
+++ b/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CollectionData" representedClassName=".CollectionData" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="modelData" attributeType="Binary"/>
+        <attribute name="userId" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userId"/>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="FolderData" representedClassName=".FolderData" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="modelData" optional="YES" attributeType="Binary"/>

--- a/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
@@ -75,6 +75,7 @@ class DataStore {
     /// - Parameter userId: The ID of the user associated with the data to delete.
     ///
     func deleteDataForUser(userId: String) async throws {
+        try await deleteAllCollections(userId: userId)
         try await deleteAllFolders(userId: userId)
         try await deleteAllPasswordHistory(userId: userId)
     }

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -398,9 +398,31 @@ extension BitwardenSdk.UriMatchType {
     }
 }
 
+// MARK: Collections
+
+extension CollectionDetailsResponseModel {
+    init(collection: Collection) {
+        self.init(
+            externalId: collection.externalId,
+            hidePasswords: collection.hidePasswords,
+            id: collection.id,
+            name: collection.name,
+            organizationId: collection.organizationId,
+            readOnly: collection.readOnly
+        )
+    }
+}
+
 // MARK: Collections (BitwardenSdk)
 
 extension BitwardenSdk.Collection {
+    init(collectionData: CollectionData) throws {
+        guard let model = collectionData.model else {
+            throw DataMappingError.invalidData
+        }
+        self.init(collectionDetailsResponseModel: model)
+    }
+
     init(collectionDetailsResponseModel model: CollectionDetailsResponseModel) {
         self.init(
             id: model.id,

--- a/BitwardenShared/Core/Vault/Extensions/TestHelpers/BitwardenSdk+VaultFixtures.swift
+++ b/BitwardenShared/Core/Vault/Extensions/TestHelpers/BitwardenSdk+VaultFixtures.swift
@@ -171,6 +171,26 @@ extension CipherView {
     }
 }
 
+extension Collection {
+    static func fixture(
+        id: String = "",
+        organizationId: String = "",
+        name: String = "",
+        externalId: String = "",
+        hidePasswords: Bool = false,
+        readOnly: Bool = false
+    ) -> Collection {
+        Collection(
+            id: id,
+            organizationId: organizationId,
+            name: name,
+            externalId: externalId,
+            hidePasswords: hidePasswords,
+            readOnly: readOnly
+        )
+    }
+}
+
 extension BitwardenSdk.LoginView {
     static func fixture(
         password: String? = nil,

--- a/BitwardenShared/Core/Vault/Models/Data/CollectionData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/CollectionData.swift
@@ -1,0 +1,70 @@
+import BitwardenSdk
+import CoreData
+import Foundation
+
+/// A data model for persisting collections.
+///
+class CollectionData: NSManagedObject, ManagedUserObject, CodableModelData {
+    typealias Model = CollectionDetailsResponseModel
+
+    // MARK: Properties
+
+    /// The collection's identifier.
+    @NSManaged var id: String?
+
+    /// The data model encoded as JSON data.
+    @NSManaged var modelData: Data?
+
+    /// The ID of the user who owns the collection.
+    @NSManaged var userId: String?
+
+    // MARK: Initialization
+
+    /// Initialize a `CollectionData` object for insertion into the managed object context.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context to insert the initialized object.
+    ///   - userId: The user ID associated with the collection.
+    ///   - collection: The `Collection` object used to create the object.
+    ///
+    convenience init(
+        context: NSManagedObjectContext,
+        userId: String,
+        collection: Collection
+    ) {
+        self.init(context: context)
+        id = collection.id
+        model = CollectionDetailsResponseModel(collection: collection)
+        self.userId = userId
+    }
+
+    // MARK: Methods
+
+    /// Updates the `CollectionData` object from a `Collection` and user ID.
+    ///
+    /// - Parameters:
+    ///   - collection: The `Collection` object used to update the `CollectionData` instance.
+    ///   - userId: The user ID associated with the collection.
+    ///
+    func update(with collection: Collection, userId: String) {
+        id = collection.id
+        model = CollectionDetailsResponseModel(collection: collection)
+        self.userId = userId
+    }
+}
+
+extension CollectionData {
+    static func userIdPredicate(userId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(CollectionData.userId), userId)
+    }
+
+    static func userIdAndIdPredicate(userId: String, id: String) -> NSPredicate {
+        NSPredicate(
+            format: "%K == %@ AND %K == %@",
+            #keyPath(CollectionData.userId),
+            userId,
+            #keyPath(CollectionData.id),
+            id
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Response/Fixtures/CollectionDetailsResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/Fixtures/CollectionDetailsResponseModel+Fixtures.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+@testable import BitwardenShared
+
+extension CollectionDetailsResponseModel {
+    static func fixture(
+        externalId: String? = nil,
+        hidePasswords: Bool = false,
+        id: String = UUID().uuidString,
+        name: String = "",
+        organizationId: String = UUID().uuidString,
+        readOnly: Bool = false
+    ) -> CollectionDetailsResponseModel {
+        self.init(
+            externalId: externalId,
+            hidePasswords: hidePasswords,
+            id: id,
+            name: name,
+            organizationId: organizationId,
+            readOnly: readOnly
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/CollectionService.swift
+++ b/BitwardenShared/Core/Vault/Services/CollectionService.swift
@@ -1,0 +1,46 @@
+import BitwardenSdk
+
+// MARK: - CollectionService
+
+/// A protocol for a `CollectionService` which manages syncing and updates to the user's collections.
+///
+protocol CollectionService {
+    /// Replaces the persisted list of collections for the user.
+    ///
+    /// - Parameters:
+    ///   - collections: The updated list of collections for the user.
+    ///   - userId: The user ID associated with the collections.
+    ///
+    func replaceCollections(_ collections: [CollectionDetailsResponseModel], userId: String) async throws
+}
+
+// MARK: - DefaultCollectionService
+
+class DefaultCollectionService: CollectionService {
+    // MARK: Properties
+
+    /// The data store for managing the persisted collections for the user.
+    let collectionDataStore: CollectionDataStore
+
+    /// The service used by the application to manage account state.
+    let stateService: StateService
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultCollectionService`.
+    ///
+    /// - Parameters:
+    ///   - collectionDataStore: The data store for managing the persisted collections for the user.
+    ///   - stateService: The service used by the application to manage account state.
+    ///
+    init(collectionDataStore: CollectionDataStore, stateService: StateService) {
+        self.collectionDataStore = collectionDataStore
+        self.stateService = stateService
+    }
+}
+
+extension DefaultCollectionService {
+    func replaceCollections(_ collections: [CollectionDetailsResponseModel], userId: String) async throws {
+        try await collectionDataStore.replaceCollections(collections.map(Collection.init), userId: userId)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/CollectionServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CollectionServiceTests.swift
@@ -1,0 +1,46 @@
+import BitwardenSdk
+import XCTest
+
+@testable import BitwardenShared
+
+class CollectionServiceTests: XCTestCase {
+    // MARK: Properties
+
+    var collectionDataStore: MockCollectionDataStore!
+    var subject: CollectionService!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        collectionDataStore = MockCollectionDataStore()
+
+        subject = DefaultCollectionService(
+            collectionDataStore: collectionDataStore,
+            stateService: MockStateService()
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        collectionDataStore = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `replaceCollections(_:userId:)` replaces the persisted collections in the data store.
+    func test_replaceCollections() async throws {
+        let collections: [CollectionDetailsResponseModel] = [
+            CollectionDetailsResponseModel.fixture(id: "1", name: "Collection 1"),
+            CollectionDetailsResponseModel.fixture(id: "2", name: "Collection 2"),
+        ]
+
+        try await subject.replaceCollections(collections, userId: "1")
+
+        XCTAssertEqual(collectionDataStore.replaceCollectionsValue, collections.map(Collection.init))
+        XCTAssertEqual(collectionDataStore.replaceCollectionsUserId, "1")
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStore.swift
@@ -1,0 +1,88 @@
+import BitwardenSdk
+import Combine
+import CoreData
+
+// MARK: - CollectionDataStore
+
+/// A protocol for a data store that handles performing data requests for collections.
+///
+protocol CollectionDataStore: AnyObject {
+    /// Deletes all `Collection` objects for a specific user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the objects to delete.
+    ///
+    func deleteAllCollections(userId: String) async throws
+
+    /// Deletes a `Collection` by ID for a user.
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the `Collection` to delete.
+    ///   - userId: The user ID of the user associated with the object to delete.
+    ///
+    func deleteCollection(id: String, userId: String) async throws
+
+    /// A publisher for a user's collection objects.
+    ///
+    /// - Parameter userId: The user ID of the user to associated with the objects to fetch.
+    /// - Returns: A publisher for the user's collections.
+    ///
+    func collectionPublisher(userId: String) -> AnyPublisher<[Collection], Error>
+
+    /// Replaces a list of `Collection` objects for a user.
+    ///
+    /// - Parameters:
+    ///   - collections: The list of collections to replace any existing collections.
+    ///   - userId: The user ID of the user associated with the collections.
+    ///
+    func replaceCollections(_ collections: [Collection], userId: String) async throws
+
+    /// Inserts or updates a collection for a user.
+    ///
+    /// - Parameters:
+    ///   - collection: The collection to insert or update.
+    ///   - userId: The user ID of the user associated with the collection.
+    ///
+    func upsertCollection(_ collection: Collection, userId: String) async throws
+}
+
+extension DataStore: CollectionDataStore {
+    func deleteAllCollections(userId: String) async throws {
+        try await executeBatchDelete(CollectionData.deleteByUserIdRequest(userId: userId))
+    }
+
+    func deleteCollection(id: String, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            let results = try self.backgroundContext.fetch(CollectionData.fetchByIdRequest(id: id, userId: userId))
+            for result in results {
+                self.backgroundContext.delete(result)
+            }
+        }
+    }
+
+    func collectionPublisher(userId: String) -> AnyPublisher<[Collection], Error> {
+        let fetchRequest = CollectionData.fetchByUserIdRequest(userId: userId)
+        // A sort descriptor is needed by `NSFetchedResultsController`.
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \CollectionData.id, ascending: true)]
+        return FetchedResultsPublisher(
+            context: persistentContainer.viewContext,
+            request: fetchRequest
+        )
+        .tryMap { try $0.map(Collection.init) }
+        .eraseToAnyPublisher()
+    }
+
+    func replaceCollections(_ collections: [Collection], userId: String) async throws {
+        let deleteRequest = CollectionData.deleteByUserIdRequest(userId: userId)
+        let insertRequest = CollectionData.batchInsertRequest(objects: collections, userId: userId)
+        try await executeBatchReplace(
+            deleteRequest: deleteRequest,
+            insertRequest: insertRequest
+        )
+    }
+
+    func upsertCollection(_ collection: Collection, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            _ = CollectionData(context: self.backgroundContext, userId: userId, collection: collection)
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStoreTests.swift
@@ -1,0 +1,133 @@
+import BitwardenSdk
+import CoreData
+import XCTest
+
+@testable import BitwardenShared
+
+class CollectionDataStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DataStore!
+
+    let collections = [
+        Collection.fixture(id: "1", name: "COLLECTION1"),
+        Collection.fixture(id: "2", name: "COLLECTION2"),
+        Collection.fixture(id: "3", name: "COLLECTION3"),
+    ]
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `deleteAllCollections(user:)` removes all objects for the user.
+    func test_deleteAllCollections() async throws {
+        try await insertCollections(collections, userId: "1")
+        try await insertCollections(collections, userId: "2")
+
+        try await subject.deleteAllCollections(userId: "1")
+
+        try XCTAssertTrue(fetchCollections(userId: "1").isEmpty)
+        try XCTAssertEqual(fetchCollections(userId: "2").count, 3)
+    }
+
+    /// `deleteCollection(id:userId:)` removes the collection with the given ID for the user.
+    func test_deleteCollection() async throws {
+        try await insertCollections(collections, userId: "1")
+
+        try await subject.deleteCollection(id: "2", userId: "1")
+
+        try XCTAssertEqual(
+            fetchCollections(userId: "1"),
+            collections.filter { $0.id != "2" }
+        )
+    }
+
+    /// `collectionPublisher(userId:)` returns a publisher for a user's collection objects.
+    func test_collectionPublisher() async throws {
+        var publishedValues = [[Collection]]()
+        let publisher = subject.collectionPublisher(userId: "1")
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { values in
+                    publishedValues.append(values)
+                }
+            )
+        defer { publisher.cancel() }
+
+        try await subject.replaceCollections(collections, userId: "1")
+
+        waitFor { publishedValues.count == 2 }
+        XCTAssertTrue(publishedValues[0].isEmpty)
+        XCTAssertEqual(publishedValues[1], collections)
+    }
+
+    /// `replaceCollections(_:userId)` replaces the list of collections for the user.
+    func test_replaceCollections() async throws {
+        try await insertCollections(collections, userId: "1")
+
+        let newCollections = [
+            Collection.fixture(id: "3", name: "COLLECTION3"),
+            Collection.fixture(id: "4", name: "COLLECTION4"),
+            Collection.fixture(id: "5", name: "COLLECTION5"),
+        ]
+        try await subject.replaceCollections(newCollections, userId: "1")
+
+        XCTAssertEqual(try fetchCollections(userId: "1"), newCollections)
+    }
+
+    /// `upsertCollection(_:userId:)` inserts a collection for a user.
+    func test_upsertCollection_insert() async throws {
+        let collection = Collection.fixture(id: "1")
+        try await subject.upsertCollection(collection, userId: "1")
+
+        try XCTAssertEqual(fetchCollections(userId: "1"), [collection])
+
+        let collection2 = Collection.fixture(id: "2")
+        try await subject.upsertCollection(collection2, userId: "1")
+
+        try XCTAssertEqual(fetchCollections(userId: "1"), [collection, collection2])
+    }
+
+    /// `upsertCollection(_:userId:)` updates an existing collection for a user.
+    func test_upsertCollection_update() async throws {
+        try await insertCollections(collections, userId: "1")
+
+        let updatedCollection = Collection.fixture(id: "2", name: "UPDATED COLLECTION2")
+        try await subject.upsertCollection(updatedCollection, userId: "1")
+
+        var expectedCollections = collections
+        expectedCollections[1] = updatedCollection
+
+        try XCTAssertEqual(fetchCollections(userId: "1"), expectedCollections)
+    }
+
+    // MARK: Test Helpers
+
+    /// A test helper to fetch all collection's for a user.
+    private func fetchCollections(userId: String) throws -> [Collection] {
+        let fetchRequest = CollectionData.fetchByUserIdRequest(userId: userId)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \CollectionData.id, ascending: true)]
+        return try subject.backgroundContext.fetch(fetchRequest).map(Collection.init)
+    }
+
+    /// A test helper for inserting a list of collections for a user.
+    private func insertCollections(_ collections: [Collection], userId: String) async throws {
+        try await subject.backgroundContext.performAndSave {
+            for collection in collections {
+                _ = CollectionData(context: self.subject.backgroundContext, userId: userId, collection: collection)
+            }
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCollectionDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCollectionDataStore.swift
@@ -1,0 +1,42 @@
+import BitwardenSdk
+import Combine
+
+@testable import BitwardenShared
+
+class MockCollectionDataStore: CollectionDataStore {
+    var deleteAllCollectionsUserId: String?
+
+    var deleteCollectionId: String?
+    var deleteCollectionUserId: String?
+
+    var collectionSubject = CurrentValueSubject<[Collection], Error>([])
+
+    var replaceCollectionsValue: [Collection]?
+    var replaceCollectionsUserId: String?
+
+    var upsertCollectionValue: Collection?
+    var upsertCollectionUserId: String?
+
+    func deleteAllCollections(userId: String) async throws {
+        deleteAllCollectionsUserId = userId
+    }
+
+    func deleteCollection(id: String, userId: String) async throws {
+        deleteCollectionId = id
+        deleteCollectionUserId = userId
+    }
+
+    func collectionPublisher(userId: String) -> AnyPublisher<[Collection], Error> {
+        collectionSubject.eraseToAnyPublisher()
+    }
+
+    func replaceCollections(_ collections: [Collection], userId: String) async throws {
+        replaceCollectionsValue = collections
+        replaceCollectionsUserId = userId
+    }
+
+    func upsertCollection(_ collection: Collection, userId: String) async throws {
+        upsertCollectionValue = collection
+        upsertCollectionUserId = userId
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -33,6 +33,9 @@ class DefaultSyncService: SyncService {
     /// The client used by the application to handle encryption and decryption setup tasks.
     let clientCrypto: ClientCryptoProtocol
 
+    /// The service for managing the collections for the user.
+    let collectionService: CollectionService
+
     /// The service used by the application to report non-fatal errors.
     let errorReporter: ErrorReporter
 
@@ -54,6 +57,7 @@ class DefaultSyncService: SyncService {
     ///
     /// - Parameters:
     ///   - clientCrypto: The client used by the application to handle encryption and decryption setup tasks.
+    ///   - collectionService: The service for managing the collections for the user.
     ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - folderService: The service for managing the folders for the user.
     ///   - stateService: The service used by the application to manage account state.
@@ -61,12 +65,14 @@ class DefaultSyncService: SyncService {
     ///
     init(
         clientCrypto: ClientCryptoProtocol,
+        collectionService: CollectionService,
         errorReporter: ErrorReporter,
         folderService: FolderService,
         stateService: StateService,
         syncAPIService: SyncAPIService
     ) {
         self.clientCrypto = clientCrypto
+        self.collectionService = collectionService
         self.errorReporter = errorReporter
         self.folderService = folderService
         self.stateService = stateService
@@ -106,6 +112,7 @@ extension DefaultSyncService {
         let response = try await syncAPIService.getSync()
         await initializeOrganizationCrypto(syncResponse: response)
 
+        try await collectionService.replaceCollections(response.collections, userId: userId)
         try await folderService.replaceFolders(response.folders, userId: userId)
 
         syncResponseSubject.value = response

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockCollectionService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockCollectionService.swift
@@ -1,0 +1,11 @@
+@testable import BitwardenShared
+
+class MockCollectionService: CollectionService {
+    var replaceCollectionsCollections: [CollectionDetailsResponseModel]?
+    var replaceCollectionsUserId: String?
+
+    func replaceCollections(_ collections: [CollectionDetailsResponseModel], userId: String) async throws {
+        replaceCollectionsCollections = collections
+        replaceCollectionsUserId = userId
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-404](https://livefront.atlassian.net/browse/BIT-404)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the `CollectionDataStore` used to persist collections to the database along with the main operations for delete, delete all, replace and insert/update.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **ManagedUserObject.swift:** A protocol for a managed object containing user data which adds some convenience methods for building fetch and batch requests.
- **DataStore.swift:** Clears collection data for the user on logout.
- **CollectionData.swift:** The data model for persisting collections.
- **CollectionService.swift:** The service for managing syncing and updating the user's collections.
- **CollectionDataService.swift:** The data store for persisting collections.
- **SyncService.swift:** Updates collections after receiving a sync response.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
