### PR TITLE
BIT-437: Enable syncing from settings

### DIFF
--- a/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
@@ -1,10 +1,17 @@
 @testable import BitwardenShared
 
 class MockSettingsRepository: SettingsRepository {
+    var fetchSyncCalled = false
+    var fetchSyncResult: Result<Void, Error> = .success(())
     var isLockedResult: Result<Bool, VaultTimeoutServiceError> = .failure(.noAccountFound)
     var lockVaultCalls = [String?]()
     var unlockVaultCalls = [String?]()
     var logoutResult: Result<Void, StateServiceError> = .failure(.noActiveAccount)
+
+    func fetchSync() async throws {
+        fetchSyncCalled = true
+        try fetchSyncResult.get()
+    }
 
     func isLocked(userId: String) throws -> Bool {
         try isLockedResult.get()

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -190,6 +190,7 @@ public class ServiceContainer: Services {
 
         let settingsRepository = DefaultSettingsRepository(
             stateService: stateService,
+            syncService: syncService,
             vaultTimeoutService: vaultTimeoutService
         )
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
@@ -4,7 +4,10 @@ import Combine
 
 class MockSyncService: SyncService {
     var didClearCachedData = false
+
     var didFetchSync = false
+    var fetchSyncResult: Result<Void, Error> = .success(())
+
     var syncSubject = CurrentValueSubject<SyncResponseModel?, Never>(nil)
 
     func clearCachedData() {
@@ -13,6 +16,7 @@ class MockSyncService: SyncService {
 
     func fetchSync() async throws {
         didFetchSync = true
+        try fetchSyncResult.get()
     }
 
     func syncResponsePublisher() -> AnyPublisher<BitwardenShared.SyncResponseModel?, Never> {

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsAction.swift
@@ -3,6 +3,9 @@
 /// Actions handled by the `OtherSettingsProcessor`.
 ///
 enum OtherSettingsAction {
+    /// The toast was shown or hidden.
+    case toastShown(Toast?)
+
     /// The allow sync on refresh toggle value changed.
     case toggleAllowSyncOnRefresh(Bool)
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsEffect.swift
@@ -1,0 +1,8 @@
+// MARK: - OtherSettingsEffect
+
+/// Effects handled by the `OtherSettingsProcessor`.
+///
+enum OtherSettingsEffect {
+    /// The sync button was tapped.
+    case syncNow
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessor.swift
@@ -2,11 +2,18 @@
 
 /// The processor used to manage state and handle actions for the `OtherSettingsView`.
 ///
-final class OtherSettingsProcessor: StateProcessor<OtherSettingsState, OtherSettingsAction, Void> {
+final class OtherSettingsProcessor: StateProcessor<OtherSettingsState, OtherSettingsAction, OtherSettingsEffect> {
+    // MARK: Types
+
+    typealias Services = HasSettingsRepository
+
     // MARK: Properties
 
     /// The coordinator used to manage navigation.
     private let coordinator: AnyCoordinator<SettingsRoute>
+
+    /// The services used by this processor.
+    private let services: Services
 
     // MARK: Initialization
 
@@ -14,23 +21,53 @@ final class OtherSettingsProcessor: StateProcessor<OtherSettingsState, OtherSett
     ///
     /// - Parameters:
     ///   - coordinator: The coordinator used to manage navigation.
+    ///   - services: The services used by this processor.
     ///   - state: The initial state of the processor.
     init(
         coordinator: AnyCoordinator<SettingsRoute>,
+        services: Services,
         state: OtherSettingsState
     ) {
         self.coordinator = coordinator
+        self.services = services
         super.init(state: state)
     }
 
     // MARK: Methods
 
+    override func perform(_ effect: OtherSettingsEffect) async {
+        switch effect {
+        case .syncNow:
+            await syncVault()
+        }
+    }
+
     override func receive(_ action: OtherSettingsAction) {
         switch action {
+        case let .toastShown(newValue):
+            state.toast = newValue
         case let .toggleAllowSyncOnRefresh(isOn):
             state.isAllowSyncOnRefreshToggleOn = isOn
         case let .toggleConnectToWatch(isOn):
             state.isConnectToWatchToggleOn = isOn
+        }
+    }
+
+    // MARK: Private
+
+    /// Syncs the user's vault with the API.
+    ///
+    private func syncVault() async {
+        coordinator.showLoadingOverlay(title: Localizations.syncing)
+        defer { coordinator.hideLoadingOverlay() }
+
+        do {
+            try await services.settingsRepository.fetchSync()
+            state.toast = Toast(text: Localizations.syncingComplete)
+        } catch {
+            coordinator.showAlert(.networkResponseError(error) {
+                await self.syncVault()
+            })
         }
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessorTests.swift
@@ -6,6 +6,7 @@ class OtherSettingsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<SettingsRoute>!
+    var settingsRepository: MockSettingsRepository!
     var subject: OtherSettingsProcessor!
 
     // MARK: Setup and Teardown
@@ -14,17 +15,62 @@ class OtherSettingsProcessorTests: BitwardenTestCase {
         super.setUp()
 
         coordinator = MockCoordinator<SettingsRoute>()
-        subject = OtherSettingsProcessor(coordinator: coordinator.asAnyCoordinator(), state: OtherSettingsState())
+        settingsRepository = MockSettingsRepository()
+        subject = OtherSettingsProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                settingsRepository: settingsRepository
+            ),
+            state: OtherSettingsState()
+        )
     }
 
     override func tearDown() {
         super.tearDown()
 
         coordinator = nil
+        settingsRepository = nil
         subject = nil
     }
 
     // MARK: Tests
+
+    /// `perform(_:)` with `.syncNow` shows the loading overlay while syncing and then a toast if
+    /// it completes successfully.
+    func test_perform_syncNow() async {
+        await subject.perform(.syncNow)
+
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.syncing)])
+        XCTAssertTrue(settingsRepository.fetchSyncCalled)
+        XCTAssertEqual(subject.state.toast?.text, Localizations.syncingComplete)
+    }
+
+    /// `perform(_:)` with `.syncNow` shows the loading overlay while syncing and then an alert if
+    /// syncing fails.
+    func test_perform_syncNow_error() async throws {
+        struct SyncError: Error, Equatable {}
+        settingsRepository.fetchSyncResult = .failure(SyncError())
+
+        await subject.perform(.syncNow)
+
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.syncing)])
+        XCTAssertTrue(settingsRepository.fetchSyncCalled)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.first)
+        XCTAssertEqual(alert, .defaultAlert(title: Localizations.anErrorHasOccurred))
+    }
+
+    /// `receive(_:)` with `.toastShown` updates the state's toast value.
+    func test_receive_toastShown() {
+        let toast = Toast(text: "toast!")
+        subject.receive(.toastShown(toast))
+        XCTAssertEqual(subject.state.toast, toast)
+
+        subject.receive(.toastShown(nil))
+        XCTAssertNil(subject.state.toast)
+    }
 
     /// Toggling allow sync on refresh is reflected in the state.
     func test_toggleAllowSyncOnRefresh() {

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsState.swift
@@ -8,4 +8,7 @@ struct OtherSettingsState {
 
     /// Whether the connect to watch toggle is on.
     var isConnectToWatchToggleOn: Bool = false
+
+    /// A toast message to show in the view.
+    var toast: Toast?
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 struct OtherSettingsView: View {
     // MARK: Properties
 
-    @ObservedObject var store: Store<OtherSettingsState, OtherSettingsAction, Void>
+    @ObservedObject var store: Store<OtherSettingsState, OtherSettingsAction, OtherSettingsEffect>
 
     // MARK: View
 
@@ -23,6 +23,10 @@ struct OtherSettingsView: View {
         }
         .scrollView()
         .navigationBar(title: Localizations.other, titleDisplayMode: .inline)
+        .toast(store.binding(
+            get: \.toast,
+            send: OtherSettingsAction.toastShown
+        ))
     }
 
     // MARK: Private views
@@ -80,7 +84,9 @@ struct OtherSettingsView: View {
     /// The sync now button and last synced description.
     private var syncNow: some View {
         VStack(alignment: .leading, spacing: 5) {
-            Button {} label: {
+            AsyncButton {
+                await store.perform(.syncNow)
+            } label: {
                 Text(Localizations.syncNow)
             }
             .buttonStyle(.tertiary())

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsViewTests.swift
@@ -6,9 +6,34 @@ import XCTest
 class OtherSettingsViewTests: BitwardenTestCase {
     // MARK: Properties
 
-    let subject = OtherSettingsView(store: Store(processor: StateProcessor(state: OtherSettingsState())))
+    // MARK: Properties
+
+    var processor: MockProcessor<OtherSettingsState, OtherSettingsAction, OtherSettingsEffect>!
+    var subject: OtherSettingsView!
+
+    override func setUp() {
+        super.setUp()
+
+        processor = MockProcessor(state: OtherSettingsState())
+
+        subject = OtherSettingsView(store: Store(processor: processor))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        processor = nil
+        subject = nil
+    }
 
     // MARK: Tests
+
+    /// Tapping the sync now button performs the `.syncNow` effect.
+    func test_syncNow_tapped() async throws {
+        let button = try subject.inspect().find(asyncButton: Localizations.syncNow)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .syncNow)
+    }
 
     /// The view renders correctly.
     func test_view_render() {

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -168,6 +168,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
     private func showOtherScreen() {
         let processor = OtherSettingsProcessor(
             coordinator: asAnyCoordinator(),
+            services: services,
             state: OtherSettingsState()
         )
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-437](https://livefront.atlassian.net/browse/BIT-437)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables the ability to trigger a vault sync from the other settings view.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SettingsRepository.swift:** Adds a method to trigger a sync.
- **OtherSettingsProcessor.swift:** Adds support for syncing and showing a toast or alert depending on the result.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/698efc27-b24c-4e7c-83de-303c7e1eb46b



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
