### PR TITLE
BIT-453: Add support for persisting ciphers

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Data/ManagedUserObject.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/ManagedUserObject.swift
@@ -25,7 +25,7 @@ protocol ManagedUserObject: ManagedObject {
     ///   - value: The value type object used to update the managed object.
     ///   - userId: The user ID associated with the object.
     ///
-    func update(with value: ValueType, userId: String)
+    func update(with value: ValueType, userId: String) throws
 }
 
 extension ManagedUserObject where Self: NSManagedObject {
@@ -36,9 +36,9 @@ extension ManagedUserObject where Self: NSManagedObject {
     ///   - userId: The user associated with the objects to insert.
     /// - Returns: A `NSBatchInsertRequest` that inserts the objects for the user.
     ///
-    static func batchInsertRequest(objects: [ValueType], userId: String) -> NSBatchInsertRequest {
-        batchInsertRequest(objects: objects) { object, value in
-            object.update(with: value, userId: userId)
+    static func batchInsertRequest(objects: [ValueType], userId: String) throws -> NSBatchInsertRequest {
+        try batchInsertRequest(objects: objects) { object, value in
+            try object.update(with: value, userId: userId)
         }
     }
 

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -159,12 +159,14 @@ public class ServiceContainer: Services {
         let dataStore = DataStore(errorReporter: errorReporter)
         let stateService = DefaultStateService(appSettingsStore: appSettingsStore, dataStore: dataStore)
         let environmentService = DefaultEnvironmentService(stateService: stateService)
+        let cipherService = DefaultCipherService(cipherDataStore: dataStore, stateService: stateService)
         let collectionService = DefaultCollectionService(collectionDataStore: dataStore, stateService: stateService)
         let folderService = DefaultFolderService(folderDataStore: dataStore, stateService: stateService)
         let sendService = DefaultSendService(sendDataStore: dataStore, stateService: stateService)
         let tokenService = DefaultTokenService(stateService: stateService)
         let apiService = APIService(environmentService: environmentService, tokenService: tokenService)
         let syncService = DefaultSyncService(
+            cipherService: cipherService,
             clientCrypto: clientService.clientCrypto(),
             collectionService: collectionService,
             errorReporter: errorReporter,

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -352,6 +352,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         )
         try await dataStore.persistentContainer.viewContext.performAndSave {
             let context = self.dataStore.persistentContainer.viewContext
+            _ = try CipherData(context: context, userId: "1", cipher: .fixture(id: UUID().uuidString))
             _ = CollectionData(context: context, userId: "1", collection: .fixture())
             _ = FolderData(
                 context: context,
@@ -368,6 +369,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.passwordGenerationOptions, [:])
 
         let context = dataStore.persistentContainer.viewContext
+        try XCTAssertEqual(context.count(for: CipherData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: CollectionData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: FolderData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")), 0)

--- a/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
+++ b/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22225" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="CipherData" representedClassName=".CipherData" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="modelData" attributeType="Binary"/>
+        <attribute name="userId" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userId"/>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="CollectionData" representedClassName=".CollectionData" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="modelData" attributeType="Binary"/>

--- a/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
@@ -75,6 +75,7 @@ class DataStore {
     /// - Parameter userId: The ID of the user associated with the data to delete.
     ///
     func deleteDataForUser(userId: String) async throws {
+        try await deleteAllCiphers(userId: userId)
         try await deleteAllCollections(userId: userId)
         try await deleteAllFolders(userId: userId)
         try await deleteAllPasswordHistory(userId: userId)

--- a/BitwardenShared/Core/Tools/Services/Stores/SendDataStore.swift
+++ b/BitwardenShared/Core/Tools/Services/Stores/SendDataStore.swift
@@ -73,7 +73,7 @@ extension DataStore: SendDataStore {
 
     func replaceSends(_ sends: [Send], userId: String) async throws {
         let deleteRequest = SendData.deleteByUserIdRequest(userId: userId)
-        let insertRequest = SendData.batchInsertRequest(objects: sends, userId: userId)
+        let insertRequest = try SendData.batchInsertRequest(objects: sends, userId: userId)
         try await executeBatchReplace(
             deleteRequest: deleteRequest,
             insertRequest: insertRequest

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -24,6 +24,19 @@ extension AttachmentRequestModel {
     }
 }
 
+extension AttachmentResponseModel {
+    init(attachment: BitwardenSdk.Attachment) {
+        self.init(
+            fileName: attachment.fileName,
+            id: attachment.id,
+            key: attachment.key,
+            size: attachment.size,
+            sizeName: attachment.sizeName,
+            url: attachment.url
+        )
+    }
+}
+
 extension CipherCardModel {
     init(card: BitwardenSdk.Card) {
         self.init(
@@ -33,6 +46,37 @@ extension CipherCardModel {
             expMonth: card.expMonth,
             expYear: card.expYear,
             number: card.number
+        )
+    }
+}
+
+extension CipherDetailsResponseModel {
+    init(cipher: BitwardenSdk.Cipher) throws {
+        guard let id = cipher.id else { throw DataMappingError.invalidData }
+        self.init(
+            attachments: cipher.attachments?.map(AttachmentResponseModel.init),
+            card: cipher.card.map(CipherCardModel.init),
+            collectionIds: cipher.collectionIds,
+            creationDate: cipher.creationDate,
+            deletedDate: cipher.deletedDate,
+            edit: cipher.edit,
+            favorite: cipher.favorite,
+            fields: cipher.fields?.map(CipherFieldModel.init),
+            folderId: cipher.folderId,
+            id: id,
+            identity: cipher.identity.map(CipherIdentityModel.init),
+            key: cipher.key,
+            login: cipher.login.map(CipherLoginModel.init),
+            name: cipher.name,
+            notes: cipher.notes,
+            organizationId: cipher.organizationId,
+            organizationUseTotp: cipher.organizationUseTotp,
+            passwordHistory: cipher.passwordHistory?.map(CipherPasswordHistoryModel.init),
+            reprompt: BitwardenShared.CipherRepromptType(type: cipher.reprompt),
+            revisionDate: cipher.revisionDate,
+            secureNote: cipher.secureNote.map(CipherSecureNoteModel.init),
+            type: BitwardenShared.CipherType(type: cipher.type),
+            viewPassword: cipher.viewPassword
         )
     }
 }
@@ -215,6 +259,13 @@ extension BitwardenSdk.Card {
 }
 
 extension BitwardenSdk.Cipher {
+    init(cipherData: CipherData) throws {
+        guard let model = cipherData.model else {
+            throw DataMappingError.invalidData
+        }
+        self.init(responseModel: model)
+    }
+
     init(responseModel model: CipherDetailsResponseModel) {
         self.init(
             id: model.id,

--- a/BitwardenShared/Core/Vault/Models/Data/CipherData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/CipherData.swift
@@ -1,0 +1,70 @@
+import BitwardenSdk
+import CoreData
+import Foundation
+
+/// A data model for persisting ciphers.
+///
+class CipherData: NSManagedObject, ManagedUserObject, CodableModelData {
+    typealias Model = CipherDetailsResponseModel
+
+    // MARK: Properties
+
+    /// The cipher's identifier.
+    @NSManaged var id: String?
+
+    /// The data model encoded as JSON data.
+    @NSManaged var modelData: Data?
+
+    /// The ID of the user who owns the cipher.
+    @NSManaged var userId: String?
+
+    // MARK: Initialization
+
+    /// Initialize a `CipherData` object for insertion into the managed object context.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context to insert the initialized object.
+    ///   - userId: The user ID associated with the cipher.
+    ///   - cipher: The `Cipher` object used to create the object.
+    ///
+    convenience init(
+        context: NSManagedObjectContext,
+        userId: String,
+        cipher: Cipher
+    ) throws {
+        self.init(context: context)
+        id = cipher.id
+        model = try CipherDetailsResponseModel(cipher: cipher)
+        self.userId = userId
+    }
+
+    // MARK: Methods
+
+    /// Updates the `CipherData` object from a `Cipher` and user ID.
+    ///
+    /// - Parameters:
+    ///   - cipher: The `Cipher` object used to update the `CipherData` instance.
+    ///   - userId: The user ID associated with the cipher.
+    ///
+    func update(with cipher: Cipher, userId: String) throws {
+        id = cipher.id
+        model = try CipherDetailsResponseModel(cipher: cipher)
+        self.userId = userId
+    }
+}
+
+extension CipherData {
+    static func userIdPredicate(userId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(CipherData.userId), userId)
+    }
+
+    static func userIdAndIdPredicate(userId: String, id: String) -> NSPredicate {
+        NSPredicate(
+            format: "%K == %@ AND %K == %@",
+            #keyPath(CipherData.userId),
+            userId,
+            #keyPath(CipherData.id),
+            id
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Data/FolderData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/FolderData.swift
@@ -105,8 +105,8 @@ extension FolderData {
     ///   - userId: The user associated with the `FolderData` objects to insert.
     /// - Returns: A `NSBatchInsertRequest` that inserts `FolderData` objects for the user.
     ///
-    static func batchInsertRequest(folders: [Folder], userId: String) -> NSBatchInsertRequest {
-        batchInsertRequest(objects: folders) { folderData, folder in
+    static func batchInsertRequest(folders: [Folder], userId: String) throws -> NSBatchInsertRequest {
+        try batchInsertRequest(objects: folders) { folderData, folder in
             folderData.update(with: folder, userId: userId)
         }
     }

--- a/BitwardenShared/Core/Vault/Models/Response/Fixtures/CipherDetailsResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/Fixtures/CipherDetailsResponseModel+Fixtures.swift
@@ -7,7 +7,7 @@ extension CipherDetailsResponseModel {
         attachments: [AttachmentResponseModel]? = nil,
         card: CipherCardModel? = nil,
         collectionIds: [String] = [],
-        creationDate: Date,
+        creationDate: Date = Date(),
         deletedDate: Date? = nil,
         edit: Bool = false,
         favorite: Bool = false,
@@ -23,7 +23,7 @@ extension CipherDetailsResponseModel {
         organizationUseTotp: Bool = false,
         passwordHistory: [CipherPasswordHistoryModel]? = nil,
         reprompt: CipherRepromptType = .none,
-        revisionDate: Date,
+        revisionDate: Date = Date(),
         secureNote: CipherSecureNoteModel? = nil,
         type: CipherType = .login,
         viewPassword: Bool = false

--- a/BitwardenShared/Core/Vault/Services/CipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherService.swift
@@ -1,0 +1,46 @@
+import BitwardenSdk
+
+// MARK: - CipherService
+
+/// A protocol for a `CipherService` which manages syncing and updates to the user's ciphers.
+///
+protocol CipherService {
+    /// Replaces the persisted list of ciphers for the user.
+    ///
+    /// - Parameters:
+    ///   - ciphers: The updated list of ciphers for the user.
+    ///   - userId: The user ID associated with the ciphers.
+    ///
+    func replaceCiphers(_ ciphers: [CipherDetailsResponseModel], userId: String) async throws
+}
+
+// MARK: - DefaultCipherService
+
+class DefaultCipherService: CipherService {
+    // MARK: Properties
+
+    /// The data store for managing the persisted ciphers for the user.
+    let cipherDataStore: CipherDataStore
+
+    /// The service used by the application to manage account state.
+    let stateService: StateService
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultCipherService`.
+    ///
+    /// - Parameters:
+    ///   - cipherDataStore: The data store for managing the persisted ciphers for the user.
+    ///   - stateService: The service used by the application to manage account state.
+    ///
+    init(cipherDataStore: CipherDataStore, stateService: StateService) {
+        self.cipherDataStore = cipherDataStore
+        self.stateService = stateService
+    }
+}
+
+extension DefaultCipherService {
+    func replaceCiphers(_ ciphers: [CipherDetailsResponseModel], userId: String) async throws {
+        try await cipherDataStore.replaceCiphers(ciphers.map(Cipher.init), userId: userId)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
@@ -1,0 +1,46 @@
+import BitwardenSdk
+import XCTest
+
+@testable import BitwardenShared
+
+class CipherServiceTests: XCTestCase {
+    // MARK: Properties
+
+    var cipherDataStore: MockCipherDataStore!
+    var subject: CipherService!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        cipherDataStore = MockCipherDataStore()
+
+        subject = DefaultCipherService(
+            cipherDataStore: cipherDataStore,
+            stateService: MockStateService()
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        cipherDataStore = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `replaceCiphers(_:userId:)` replaces the persisted ciphers in the data store.
+    func test_replaceCiphers() async throws {
+        let ciphers: [CipherDetailsResponseModel] = [
+            CipherDetailsResponseModel.fixture(id: "1", name: "Cipher 1"),
+            CipherDetailsResponseModel.fixture(id: "2", name: "Cipher 2"),
+        ]
+
+        try await subject.replaceCiphers(ciphers, userId: "1")
+
+        XCTAssertEqual(cipherDataStore.replaceCiphersValue, ciphers.map(Cipher.init))
+        XCTAssertEqual(cipherDataStore.replaceCiphersUserId, "1")
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/CipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CipherDataStore.swift
@@ -1,0 +1,88 @@
+import BitwardenSdk
+import Combine
+import CoreData
+
+// MARK: - CipherDataStore
+
+/// A protocol for a data store that handles performing data requests for ciphers.
+///
+protocol CipherDataStore: AnyObject {
+    /// Deletes all `Cipher` objects for a specific user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the objects to delete.
+    ///
+    func deleteAllCiphers(userId: String) async throws
+
+    /// Deletes a `Cipher` by ID for a user.
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the `Cipher` to delete.
+    ///   - userId: The user ID of the user associated with the object to delete.
+    ///
+    func deleteCipher(id: String, userId: String) async throws
+
+    /// A publisher for a user's cipher objects.
+    ///
+    /// - Parameter userId: The user ID of the user to associated with the objects to fetch.
+    /// - Returns: A publisher for the user's ciphers.
+    ///
+    func cipherPublisher(userId: String) -> AnyPublisher<[Cipher], Error>
+
+    /// Replaces a list of `Cipher` objects for a user.
+    ///
+    /// - Parameters:
+    ///   - ciphers: The list of ciphers to replace any existing ciphers.
+    ///   - userId: The user ID of the user associated with the ciphers.
+    ///
+    func replaceCiphers(_ ciphers: [Cipher], userId: String) async throws
+
+    /// Inserts or updates a cipher for a user.
+    ///
+    /// - Parameters:
+    ///   - cipher: The cipher to insert or update.
+    ///   - userId: The user ID of the user associated with the cipher.
+    ///
+    func upsertCipher(_ cipher: Cipher, userId: String) async throws
+}
+
+extension DataStore: CipherDataStore {
+    func deleteAllCiphers(userId: String) async throws {
+        try await executeBatchDelete(CipherData.deleteByUserIdRequest(userId: userId))
+    }
+
+    func deleteCipher(id: String, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            let results = try self.backgroundContext.fetch(CipherData.fetchByIdRequest(id: id, userId: userId))
+            for result in results {
+                self.backgroundContext.delete(result)
+            }
+        }
+    }
+
+    func cipherPublisher(userId: String) -> AnyPublisher<[Cipher], Error> {
+        let fetchRequest = CipherData.fetchByUserIdRequest(userId: userId)
+        // A sort descriptor is needed by `NSFetchedResultsController`.
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \CipherData.id, ascending: true)]
+        return FetchedResultsPublisher(
+            context: persistentContainer.viewContext,
+            request: fetchRequest
+        )
+        .tryMap { try $0.map(Cipher.init) }
+        .eraseToAnyPublisher()
+    }
+
+    func replaceCiphers(_ ciphers: [Cipher], userId: String) async throws {
+        let deleteRequest = CipherData.deleteByUserIdRequest(userId: userId)
+        let insertRequest = try CipherData.batchInsertRequest(objects: ciphers, userId: userId)
+        try await executeBatchReplace(
+            deleteRequest: deleteRequest,
+            insertRequest: insertRequest
+        )
+    }
+
+    func upsertCipher(_ cipher: Cipher, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            _ = try CipherData(context: self.backgroundContext, userId: userId, cipher: cipher)
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/CipherDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CipherDataStoreTests.swift
@@ -1,0 +1,133 @@
+import BitwardenSdk
+import CoreData
+import XCTest
+
+@testable import BitwardenShared
+
+class CipherDataStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DataStore!
+
+    let ciphers = [
+        Cipher.fixture(id: "1", name: "CIPHER1"),
+        Cipher.fixture(id: "2", name: "CIPHER2"),
+        Cipher.fixture(id: "3", name: "CIPHER3"),
+    ]
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `deleteAllCiphers(user:)` removes all objects for the user.
+    func test_deleteAllCiphers() async throws {
+        try await insertCiphers(ciphers, userId: "1")
+        try await insertCiphers(ciphers, userId: "2")
+
+        try await subject.deleteAllCiphers(userId: "1")
+
+        try XCTAssertTrue(fetchCiphers(userId: "1").isEmpty)
+        try XCTAssertEqual(fetchCiphers(userId: "2").count, 3)
+    }
+
+    /// `deleteCipher(id:userId:)` removes the cipher with the given ID for the user.
+    func test_deleteCipher() async throws {
+        try await insertCiphers(ciphers, userId: "1")
+
+        try await subject.deleteCipher(id: "2", userId: "1")
+
+        try XCTAssertEqual(
+            fetchCiphers(userId: "1"),
+            ciphers.filter { $0.id != "2" }
+        )
+    }
+
+    /// `cipherPublisher(userId:)` returns a publisher for a user's cipher objects.
+    func test_cipherPublisher() async throws {
+        var publishedValues = [[Cipher]]()
+        let publisher = subject.cipherPublisher(userId: "1")
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { values in
+                    publishedValues.append(values)
+                }
+            )
+        defer { publisher.cancel() }
+
+        try await subject.replaceCiphers(ciphers, userId: "1")
+
+        waitFor { publishedValues.count == 2 }
+        XCTAssertTrue(publishedValues[0].isEmpty)
+        XCTAssertEqual(publishedValues[1], ciphers)
+    }
+
+    /// `replaceCiphers(_:userId)` replaces the list of ciphers for the user.
+    func test_replaceCiphers() async throws {
+        try await insertCiphers(ciphers, userId: "1")
+
+        let newCiphers = [
+            Cipher.fixture(id: "3", name: "CIPHER3"),
+            Cipher.fixture(id: "4", name: "CIPHER4"),
+            Cipher.fixture(id: "5", name: "CIPHER5"),
+        ]
+        try await subject.replaceCiphers(newCiphers, userId: "1")
+
+        XCTAssertEqual(try fetchCiphers(userId: "1"), newCiphers)
+    }
+
+    /// `upsertCipher(_:userId:)` inserts a cipher for a user.
+    func test_upsertCipher_insert() async throws {
+        let cipher = Cipher.fixture(id: "1")
+        try await subject.upsertCipher(cipher, userId: "1")
+
+        try XCTAssertEqual(fetchCiphers(userId: "1"), [cipher])
+
+        let cipher2 = Cipher.fixture(id: "2")
+        try await subject.upsertCipher(cipher2, userId: "1")
+
+        try XCTAssertEqual(fetchCiphers(userId: "1"), [cipher, cipher2])
+    }
+
+    /// `upsertCipher(_:userId:)` updates an existing cipher for a user.
+    func test_upsertCipher_update() async throws {
+        try await insertCiphers(ciphers, userId: "1")
+
+        let updatedCipher = Cipher.fixture(id: "2", name: "UPDATED CIPHER2")
+        try await subject.upsertCipher(updatedCipher, userId: "1")
+
+        var expectedCiphers = ciphers
+        expectedCiphers[1] = updatedCipher
+
+        try XCTAssertEqual(fetchCiphers(userId: "1"), expectedCiphers)
+    }
+
+    // MARK: Test Helpers
+
+    /// A test helper to fetch all cipher's for a user.
+    private func fetchCiphers(userId: String) throws -> [Cipher] {
+        let fetchRequest = CipherData.fetchByUserIdRequest(userId: userId)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \CipherData.id, ascending: true)]
+        return try subject.backgroundContext.fetch(fetchRequest).map(Cipher.init)
+    }
+
+    /// A test helper for inserting a list of ciphers for a user.
+    private func insertCiphers(_ ciphers: [Cipher], userId: String) async throws {
+        try await subject.backgroundContext.performAndSave {
+            for cipher in ciphers {
+                _ = try CipherData(context: self.subject.backgroundContext, userId: userId, cipher: cipher)
+            }
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStore.swift
@@ -73,7 +73,7 @@ extension DataStore: CollectionDataStore {
 
     func replaceCollections(_ collections: [Collection], userId: String) async throws {
         let deleteRequest = CollectionData.deleteByUserIdRequest(userId: userId)
-        let insertRequest = CollectionData.batchInsertRequest(objects: collections, userId: userId)
+        let insertRequest = try CollectionData.batchInsertRequest(objects: collections, userId: userId)
         try await executeBatchReplace(
             deleteRequest: deleteRequest,
             insertRequest: insertRequest

--- a/BitwardenShared/Core/Vault/Services/Stores/FolderDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/FolderDataStore.swift
@@ -73,7 +73,7 @@ extension DataStore: FolderDataStore {
 
     func replaceFolders(_ folders: [Folder], userId: String) async throws {
         let deleteRequest = FolderData.deleteByUserIdRequest(userId: userId)
-        let insertRequest = FolderData.batchInsertRequest(folders: folders, userId: userId)
+        let insertRequest = try FolderData.batchInsertRequest(folders: folders, userId: userId)
         try await executeBatchReplace(
             deleteRequest: deleteRequest,
             insertRequest: insertRequest

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
@@ -1,0 +1,42 @@
+import BitwardenSdk
+import Combine
+
+@testable import BitwardenShared
+
+class MockCipherDataStore: CipherDataStore {
+    var deleteAllCiphersUserId: String?
+
+    var deleteCipherId: String?
+    var deleteCipherUserId: String?
+
+    var cipherSubject = CurrentValueSubject<[Cipher], Error>([])
+
+    var replaceCiphersValue: [Cipher]?
+    var replaceCiphersUserId: String?
+
+    var upsertCipherValue: Cipher?
+    var upsertCipherUserId: String?
+
+    func deleteAllCiphers(userId: String) async throws {
+        deleteAllCiphersUserId = userId
+    }
+
+    func deleteCipher(id: String, userId: String) async throws {
+        deleteCipherId = id
+        deleteCipherUserId = userId
+    }
+
+    func cipherPublisher(userId: String) -> AnyPublisher<[Cipher], Error> {
+        cipherSubject.eraseToAnyPublisher()
+    }
+
+    func replaceCiphers(_ ciphers: [Cipher], userId: String) async throws {
+        replaceCiphersValue = ciphers
+        replaceCiphersUserId = userId
+    }
+
+    func upsertCipher(_ cipher: Cipher, userId: String) async throws {
+        upsertCipherValue = cipher
+        upsertCipherUserId = userId
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -31,6 +31,9 @@ protocol SyncService: AnyObject {
 class DefaultSyncService: SyncService {
     // MARK: Properties
 
+    /// The service for managing the ciphers for the user.
+    let cipherService: CipherService
+
     /// The client used by the application to handle encryption and decryption setup tasks.
     let clientCrypto: ClientCryptoProtocol
 
@@ -60,6 +63,7 @@ class DefaultSyncService: SyncService {
     /// Initializes a `DefaultSyncService`.
     ///
     /// - Parameters:
+    ///   - cipherService: The service for managing the ciphers for the user.
     ///   - clientCrypto: The client used by the application to handle encryption and decryption setup tasks.
     ///   - collectionService: The service for managing the collections for the user.
     ///   - errorReporter: The service used by the application to report non-fatal errors.
@@ -69,6 +73,7 @@ class DefaultSyncService: SyncService {
     ///   - syncAPIService: The API service used to perform sync API requests.
     ///
     init(
+        cipherService: CipherService,
         clientCrypto: ClientCryptoProtocol,
         collectionService: CollectionService,
         errorReporter: ErrorReporter,
@@ -77,6 +82,7 @@ class DefaultSyncService: SyncService {
         stateService: StateService,
         syncAPIService: SyncAPIService
     ) {
+        self.cipherService = cipherService
         self.clientCrypto = clientCrypto
         self.collectionService = collectionService
         self.errorReporter = errorReporter
@@ -119,6 +125,7 @@ extension DefaultSyncService {
         let response = try await syncAPIService.getSync()
         await initializeOrganizationCrypto(syncResponse: response)
 
+        try await cipherService.replaceCiphers(response.ciphers, userId: userId)
         try await collectionService.replaceCollections(response.collections, userId: userId)
         try await folderService.replaceFolders(response.folders, userId: userId)
         try await sendService.replaceSends(response.sends, userId: userId)

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
@@ -1,0 +1,11 @@
+@testable import BitwardenShared
+
+class MockCipherService: CipherService {
+    var replaceCiphersCiphers: [CipherDetailsResponseModel]?
+    var replaceCiphersUserId: String?
+
+    func replaceCiphers(_ ciphers: [CipherDetailsResponseModel], userId: String) async throws {
+        replaceCiphersCiphers = ciphers
+        replaceCiphersUserId = userId
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-453](https://livefront.atlassian.net/browse/BIT-453)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the CipherDataStore used to persist ciphers to the database along with the main operations for delete, delete all, replace and insert/update.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

- **DataStore.swift:** Clears send data for the user on logout.
- **CipherData.swift:** The data model for persisting ciphers.
- **CipherService.swift:** The service for managing syncing and updating the user's ciphers.
- **CipherDataService.swift:** The data store for persisting ciphers.
- **SyncService.swift:** Updates ciphers after receiving a sync response.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
