### PR TITLE
BIT-1208: Add master password validation

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -214,6 +214,7 @@ public class ServiceContainer: Services {
 
         let vaultRepository = DefaultVaultRepository(
             cipherAPIService: apiService,
+            clientAuth: clientService.clientAuth(),
             clientCrypto: clientService.clientCrypto(),
             clientVault: clientService.clientVault(),
             errorReporter: errorReporter,

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -38,6 +38,12 @@ protocol AppSettingsStore: AnyObject {
     ///
     func lastSyncTime(userId: String) -> Date?
 
+    /// Gets the master password hash for the user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the master password hash.
+    ///
+    func masterPasswordHash(userId: String) -> String?
+
     /// Gets the password generation options for a user ID.
     ///
     /// - Parameter userId: The user ID associated with the password generation options.
@@ -75,6 +81,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the last sync time.
     ///
     func setLastSyncTime(_ date: Date?, userId: String)
+
+    /// Sets the master password hash for a user ID.
+    ///
+    /// - Parameters:
+    ///   - hash: The user's master password hash.
+    ///   - userId: The user ID associated with the master password hash.
+    ///
+    func setMasterPasswordHash(_ hash: String?, userId: String)
 
     /// Sets the password generation options for a user ID.
     ///
@@ -197,6 +211,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case encryptedPrivateKey(userId: String)
         case encryptedUserKey(userId: String)
         case lastSync(userId: String)
+        case masterPasswordHash(userId: String)
         case passwordGenerationOptions(userId: String)
         case preAuthEnvironmentUrls
         case rememberedEmail
@@ -215,6 +230,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "encPrivateKey_\(userId)"
             case let .lastSync(userId):
                 key = "lastSync_\(userId)"
+            case let .masterPasswordHash(userId):
+                key = "keyHash_\(userId)"
             case let .passwordGenerationOptions(userId):
                 key = "passwordGenerationOptions_\(userId)"
             case .preAuthEnvironmentUrls:
@@ -265,6 +282,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .lastSync(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
 
+    func masterPasswordHash(userId: String) -> String? {
+        fetch(for: .masterPasswordHash(userId: userId))
+    }
+
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions? {
         fetch(for: .passwordGenerationOptions(userId: userId))
     }
@@ -283,6 +304,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setLastSyncTime(_ date: Date?, userId: String) {
         store(date?.timeIntervalSince1970, for: .lastSync(userId: userId))
+    }
+
+    func setMasterPasswordHash(_ hash: String?, userId: String) {
+        store(hash, for: .masterPasswordHash(userId: userId))
     }
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - AppSettingsStoreTests
 
-class AppSettingsStoreTests: BitwardenTestCase {
+class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var subject: AppSettingsStore!
@@ -156,6 +156,30 @@ class AppSettingsStoreTests: BitwardenTestCase {
         XCTAssertEqual(subject.lastSyncTime(userId: "2"), date4)
         XCTAssertEqual(userDefaults.double(forKey: "bwPreferencesStorage:lastSync_1"), 1_690_848_000.0)
         XCTAssertEqual(userDefaults.double(forKey: "bwPreferencesStorage:lastSync_2"), 1_685_664_000.0)
+    }
+
+    /// `masterPasswordHash(userId:)` returns `nil` if there isn't a previously stored value.
+    func test_masterPasswordHash_isInitiallyNil() {
+        XCTAssertNil(subject.masterPasswordHash(userId: "-1"))
+    }
+
+    /// `masterPasswordHash(userId:)` can be used to get the master password hash for a user.
+    func test_masterPasswordHash_withValue() {
+        subject.setMasterPasswordHash("1234", userId: "1")
+        subject.setMasterPasswordHash("9876", userId: "2")
+
+        XCTAssertEqual(subject.masterPasswordHash(userId: "1"), "1234")
+        XCTAssertEqual(subject.masterPasswordHash(userId: "2"), "9876")
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:keyHash_1"), "1234")
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:keyHash_2"), "9876")
+
+        subject.setMasterPasswordHash("abcd", userId: "1")
+        subject.setMasterPasswordHash("zyxw", userId: "2")
+
+        XCTAssertEqual(subject.masterPasswordHash(userId: "1"), "abcd")
+        XCTAssertEqual(subject.masterPasswordHash(userId: "2"), "zyxw")
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:keyHash_1"), "abcd")
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:keyHash_2"), "zyxw")
     }
 
     /// `passwordGenerationOptions(userId:)` returns `nil` if there isn't a previously stored value.

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -8,6 +8,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var encryptedPrivateKeys = [String: String]()
     var encryptedUserKeys = [String: String]()
     var lastSyncTimeByUserId = [String: Date]()
+    var masterPasswordHashes = [String: String]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
     var rememberedEmail: String?
@@ -31,6 +32,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func lastSyncTime(userId: String) -> Date? {
         lastSyncTimeByUserId[userId]
+    }
+
+    func masterPasswordHash(userId: String) -> String? {
+        masterPasswordHashes[userId]
     }
 
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions? {
@@ -59,6 +64,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func setLastSyncTime(_ date: Date?, userId: String) {
         lastSyncTimeByUserId[userId] = date
+    }
+
+    func setMasterPasswordHash(_ hash: String?, userId: String) {
+        masterPasswordHashes[userId] = hash
     }
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -13,6 +13,7 @@ class MockStateService: StateService {
     var environmentUrls = [String: EnvironmentUrlData]()
     var lastSyncTimeByUserId = [String: Date]()
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
+    var masterPasswordHashes = [String: String]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
@@ -72,6 +73,11 @@ class MockStateService: StateService {
         return environmentUrls[userId]
     }
 
+    func getMasterPasswordHash(userId: String?) async throws -> String? {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        return masterPasswordHashes[userId]
+    }
+
     func getPasswordGenerationOptions(userId: String?) async throws -> PasswordGenerationOptions? {
         let userId = try userId ?? getActiveAccount().profile.userId
         return passwordGenerationOptions[userId]
@@ -112,6 +118,11 @@ class MockStateService: StateService {
     func setLastSyncTime(_ date: Date?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccount().profile.userId
         lastSyncTimeByUserId[userId] = date
+    }
+
+    func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        masterPasswordHashes[userId] = hash
     }
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String?) async throws {

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -12,6 +12,8 @@ class MockVaultRepository: VaultRepository {
     var removeAccountIds = [String?]()
     var updateCipherCiphers = [BitwardenSdk.CipherView]()
     var updateCipherResult: Result<Void, Error> = .success(())
+    var validatePasswordPasswords = [String]()
+    var validatePasswordResult: Result<Bool, Error> = .success(true)
     var vaultListSubject = CurrentValueSubject<[VaultListSection], Never>([])
     var vaultListGroupSubject = CurrentValueSubject<[VaultListItem], Never>([])
 
@@ -35,6 +37,11 @@ class MockVaultRepository: VaultRepository {
     func updateCipher(_ cipher: BitwardenSdk.CipherView) async throws {
         updateCipherCiphers.append(cipher)
         try updateCipherResult.get()
+    }
+
+    func validatePassword(_ password: String) async throws -> Bool {
+        validatePasswordPasswords.append(password)
+        return try validatePasswordResult.get()
     }
 
     func vaultListPublisher() -> AsyncPublisher<AnyPublisher<[BitwardenShared.VaultListSection], Never>> {

--- a/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - LoginProcessorTests
 
-class LoginProcessorTests: BitwardenTestCase {
+class LoginProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var appSettingsStore: MockAppSettingsStore!
@@ -219,6 +219,10 @@ class LoginProcessorTests: BitwardenTestCase {
                     encryptedUserKey: "KEY"
                 ),
             ]
+        )
+        XCTAssertEqual(
+            stateService.masterPasswordHashes,
+            ["13512467-9cfe-43b0-969f-07534084764b": "hashed password"]
         )
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - ViewItemProcessorTests
 
-class ViewItemProcessorTests: BitwardenTestCase {
+class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Propteries
 
     var coordinator: MockCoordinator<VaultItemRoute>!
@@ -291,12 +291,55 @@ class ViewItemProcessorTests: BitwardenTestCase {
         subject.receive(.passwordVisibilityPressed)
 
         let alert = try coordinator.unwrapLastRouteAsAlert()
-        let textField = try XCTUnwrap(alert.alertTextFields.first)
+        XCTAssertNotNil(alert.alertTextFields.first)
         let action = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
-        await action.handler?(action, [textField])
+        await action.handler?(action, [AlertTextField(id: "password", text: "password1234")])
+
+        XCTAssertEqual(vaultRepository.validatePasswordPasswords, ["password1234"])
 
         cipherState.loginState.isPasswordVisible = true
         XCTAssertEqual(subject.state.loadingState, .data(cipherState))
         XCTAssertTrue(subject.state.hasVerifiedMasterPassword)
+    }
+
+    /// If validation the user's password fails, an error is logged.
+    func test_masterPasswordReprompt_submitButtonPressed_error() async throws {
+        struct ValidatePasswordError: Error {}
+        vaultRepository.validatePasswordResult = .failure(ValidatePasswordError())
+
+        let cipherView = CipherView.fixture(id: "1", reprompt: .password)
+        let cipherState = CipherItemState(existing: cipherView)!
+        subject.state.loadingState = .data(cipherState)
+        subject.receive(.passwordVisibilityPressed)
+
+        let alert = try coordinator.unwrapLastRouteAsAlert()
+        XCTAssertNotNil(alert.alertTextFields.first)
+        let action = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
+        await action.handler?(action, [AlertTextField(id: "password", text: "password1234")])
+
+        XCTAssertEqual(vaultRepository.validatePasswordPasswords, ["password1234"])
+        XCTAssertFalse(subject.state.hasVerifiedMasterPassword)
+        XCTAssertTrue(errorReporter.errors.last is ValidatePasswordError)
+    }
+
+    /// If the user's password validation fails, an invalid password alert is presented.
+    func test_masterPasswordReprompt_submitButtonPressed_invalidPassword() async throws {
+        vaultRepository.validatePasswordResult = .success(false)
+
+        let cipherView = CipherView.fixture(id: "1", reprompt: .password)
+        let cipherState = CipherItemState(existing: cipherView)!
+        subject.state.loadingState = .data(cipherState)
+        subject.receive(.passwordVisibilityPressed)
+
+        let alert = try coordinator.unwrapLastRouteAsAlert()
+        XCTAssertNotNil(alert.alertTextFields.first)
+        let action = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
+        await action.handler?(action, [AlertTextField(id: "password", text: "password1234")])
+
+        XCTAssertEqual(vaultRepository.validatePasswordPasswords, ["password1234"])
+        XCTAssertFalse(subject.state.hasVerifiedMasterPassword)
+
+        let invalidPasswordAlert = try coordinator.unwrapLastRouteAsAlert()
+        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1208](https://livefront.atlassian.net/browse/BIT-1208)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for verifying the user's master password when master password reprompt is enabled for a cipher. Validation confirms that a hash of the user's master password matches the hash of their password at the time of login.

Note: This relies on a stored hash of the user's master password that is created at the time of login. This means for any current users of this app, validation will always fail until they log out and back into their account. The stored hash matches the same hash used by the Xamarin app, so this shouldn't affect users upgrading from the Xamarin app.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **StateService.swift:** Adds support for getting and setting the user's master password hash.
- **AppSettingsStore.swift:** Adds support for persisting the master password hash.
- **VaultRepository.swift:** Adds a method to validate the user's password.
- **LoginProcessor.swift:** Persists the user's master password hash at the time of login.
- **ViewItemProcessor.swift:** Performs validation of the user's master password.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/b1d5dcdf-94ad-4a18-beda-512e1f075692



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
