### PR TITLE
BIT-424: Alert to export unencrypted vault

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -3,9 +3,31 @@
 extension Alert {
     // MARK: Methods
 
+    /// Confirm that the user wants to export their vault.
+    ///
+    /// - Parameters:
+    ///   - encrypted: Whether the user is attempting to export their vault encrypted or not.
+    ///   - action: The action performed when they select export vault.
+    ///
+    /// - Returns: An alert confirming that the user wants to export their vault unencrypted.
+    ///
+    static func confirmExportVault(encrypted: Bool, action: @escaping () async -> Void) -> Alert {
+        Alert(
+            title: Localizations.exportVaultConfirmationTitle,
+            message: encrypted ?
+                (Localizations.encExportKeyWarning + "\n\n" + Localizations.encExportAccountWarning) :
+                Localizations.exportVaultWarning,
+            alertActions: [
+                AlertAction(title: Localizations.exportVault, style: .default) { _ in await action() },
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ]
+        )
+    }
+
     /// Confirms that the user wants to logout if their session times out.
     ///
     /// - Parameter action: The action performed when they select `Yes`.
+    ///
     /// - Returns: An alert confirming that the user wants to logout if their session times out.
     ///
     static func logoutOnTimeoutAlert(action: @escaping () async -> Void) -> Alert {
@@ -21,8 +43,7 @@ extension Alert {
 
     /// An alert notifying the user that they will be navigated to the web app to set up two step login.
     ///
-    /// - Parameters:
-    ///   - action: The action to perform when the user confirms that they want to be navigated to the
+    /// - Parameter action: The action to perform when the user confirms that they want to be navigated to the
     ///   web app.
     ///
     /// - Returns: An alert notifying the user that they will be navigated to the web app to set up two step login.

--- a/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -3,6 +3,27 @@ import XCTest
 @testable import BitwardenShared
 
 class AlertSettingsTests: BitwardenTestCase {
+    /// `confirmExportVault(encrypted:action:)` constructs an `Alert` with the title, message, and Yes and Export vault
+    /// buttons.
+    func test_confirmExportVault() {
+        var subject = Alert.confirmExportVault(encrypted: true) {}
+
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.title, Localizations.exportVaultConfirmationTitle)
+        XCTAssertEqual(
+            subject.message,
+            Localizations.encExportKeyWarning + "\n\n" + Localizations.encExportAccountWarning
+        )
+
+        subject = Alert.confirmExportVault(encrypted: false) {}
+
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.title, Localizations.exportVaultConfirmationTitle)
+        XCTAssertEqual(subject.message, Localizations.exportVaultWarning)
+    }
+
     /// `logoutOnTimeoutAlert(action:)` constructs an `Alert` with the title, message, and Yes and Cancel buttons.
     func test_logoutOnTimeoutAlert() {
         let subject = Alert.logoutOnTimeoutAlert {}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultAction.swift
@@ -5,6 +5,9 @@ enum ExportVaultAction: Equatable {
     /// Dismiss the sheet.
     case dismiss
 
+    /// The export vault button was tapped.
+    case exportVaultTapped
+
     /// The file format type was changed.
     case fileFormatTypeChanged(ExportFormatType)
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultEffect.swift
@@ -1,4 +1,0 @@
-// MARK: - ExportVaultEffect
-
-/// Effects that can be processed by an `ExportVaultProcessor`.
-enum ExportVaultEffect: Equatable {}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
@@ -1,7 +1,7 @@
 // MARK: - ExportVaultProcessor
 
 /// The processor used to manage state and handle actions for the `ExportVaultView`.
-final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAction, ExportVaultEffect> {
+final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAction, Void> {
     // MARK: Types
 
     typealias Services = HasErrorReporter
@@ -34,12 +34,12 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
 
     // MARK: Methods
 
-    override func perform(_: ExportVaultEffect) async {}
-
     override func receive(_ action: ExportVaultAction) {
         switch action {
         case .dismiss:
             coordinator.navigate(to: .dismiss)
+        case .exportVaultTapped:
+            confirmExportVault()
         case let .fileFormatTypeChanged(fileFormat):
             state.fileFormat = fileFormat
         case let .passwordTextChanged(newValue):
@@ -47,5 +47,19 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
         case let .togglePasswordVisibility(isOn):
             state.isPasswordVisible = isOn
         }
+    }
+
+    // MARK: Private Methods
+
+    /// Show an alert to confirm exporting the vault.
+    private func confirmExportVault() {
+        let encrypted = (state.fileFormat == .jsonEncrypted)
+
+        // She the alert to confirm exporting the vault.
+        coordinator.showAlert(.confirmExportVault(encrypted: encrypted) {
+            // TODO: BIT-429
+            // TODO: BIT-447
+            // TODO: BIT-449
+        })
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessorTests.swift
@@ -29,28 +29,46 @@ class ExportVaultProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// Receiving `.dismiss` dismisses the view.
+    /// `.receive()` with `.dismiss` dismisses the view.
     func test_receive_dismiss() {
         subject.receive(.dismiss)
 
         XCTAssertEqual(coordinator.routes.last, .dismiss)
     }
 
-    /// Receiving `.fileFormatTypeChanged()` updates the file format.
+    /// `.receive()` with  `.exportVaultTapped` shows the confirm alert for encrypted formats.
+    func test_receive_exportVaultTapped_encrypted() {
+        subject.state.fileFormat = .jsonEncrypted
+        subject.receive(.exportVaultTapped)
+
+        // Confirm that the correct alert is displayed.
+        XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: true, action: {}))
+    }
+
+    /// `.receive()` with `.exportVaultTapped` shows the confirm alert for unencrypted formats.
+    func test_receive_exportVaultTapped_unencrypted() {
+        subject.state.fileFormat = .json
+        subject.receive(.exportVaultTapped)
+
+        // Confirm that the correct alert is displayed.
+        XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: false, action: {}))
+    }
+
+    /// `.receive()` with `.fileFormatTypeChanged()` updates the file format.
     func test_receive_fileFormatTypeChanged() {
         subject.receive(.fileFormatTypeChanged(.csv))
 
         XCTAssertEqual(subject.state.fileFormat, .csv)
     }
 
-    /// Receiving `.passwordTextChanged()` updates the password text.
+    /// `.receive()` with `.passwordTextChanged()` updates the password text.
     func test_receive_passwordTextChanged() {
         subject.receive(.passwordTextChanged("password"))
 
         XCTAssertEqual(subject.state.passwordText, "password")
     }
 
-    /// Receiving `.togglePasswordVisibility()` toggles the password visibility.
+    /// `.receive()` with `.togglePasswordVisibility()` toggles the password visibility.
     func test_receive_togglePasswordVisibility() {
         subject.receive(.togglePasswordVisibility(true))
         XCTAssertTrue(subject.state.isPasswordVisible)

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultView.swift
@@ -8,7 +8,7 @@ struct ExportVaultView: View {
     // MARK: Properties
 
     /// The `Store` for this view.
-    @ObservedObject var store: Store<ExportVaultState, ExportVaultAction, ExportVaultEffect>
+    @ObservedObject var store: Store<ExportVaultState, ExportVaultAction, Void>
 
     // MARK: View
 
@@ -34,7 +34,7 @@ struct ExportVaultView: View {
     /// The button to export the vault.
     private var exportVaultButton: some View {
         Button(Localizations.exportVault) {
-            // TODO: BIT-449
+            store.send(.exportVaultTapped)
         }
         .buttonStyle(.tertiary())
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultViewTests.swift
@@ -6,7 +6,7 @@ import XCTest
 class ExportVaultViewTests: BitwardenTestCase {
     // MARK: Properties
 
-    var processor: MockProcessor<ExportVaultState, ExportVaultAction, ExportVaultEffect>!
+    var processor: MockProcessor<ExportVaultState, ExportVaultAction, Void>!
     var subject: ExportVaultView!
 
     // MARK: Setup & Teardown
@@ -34,6 +34,14 @@ class ExportVaultViewTests: BitwardenTestCase {
         let button = try subject.inspect().find(button: Localizations.cancel)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .dismiss)
+    }
+
+    /// Tapping the export vault button sends the `.exportVault` action.
+    func test_exportVaultButton_tap() throws {
+        let button = try subject.inspect().find(button: Localizations.exportVault)
+        try button.tap()
+
+        XCTAssertEqual(processor.dispatchedActions.last, .exportVaultTapped)
     }
 
     /// Updating the value of the file format sends the  `.fileFormatTypeChanged()` action.


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-424](https://livefront.atlassian.net/browse/BIT-424)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

Adds alerts for confirming the user wants to export the vault (both encrypted and unencrypted formats, as in the production app).

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Alert+Settings.swift:** Added the alert to confirm exporting the vault
-   **ExportVaultEffect.swift:** Effect for showing the alert when the Export vault button is tapped
-   **ExportVaultProcessor.swift:** Logic to show the alert when the effect is received
-   **ExportVaultView.swift:** Button functionality for showing the alert when the Export vault button is tapped

## 📸 Screenshots

<img width="400px" src="https://github.com/bitwarden/ios/assets/125921730/f2cdeb52-50d8-440e-8e09-7b806406ad8b" />

<img width="400px" src="https://github.com/bitwarden/ios/assets/125921730/63a3ab36-fca4-47e9-8356-5aa274110633" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
