### PR TITLE
BIT-227: Pull to refresh vault

### DIFF
--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
@@ -26,6 +26,9 @@ protocol SettingsRepository: AnyObject {
     ///
     func fetchSync() async throws
 
+    /// Get the current value of the allow sync on refresh value.
+    func getAllowSyncOnRefresh() async throws -> Bool
+
     /// A publisher for the last sync time.
     ///
     /// - Returns: A publisher for the last sync time.
@@ -49,6 +52,12 @@ protocol SettingsRepository: AnyObject {
     ///     Defaults to active account if nil.
     ///
     func unlockVault(userId: String?) async
+
+    /// Update the cached value of the sync on refresh setting.
+    ///
+    /// - Parameter allowSyncOnRefresh: Whether the vault should sync on refreshing.
+    ///
+    func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws
 
     // MARK: Publishers
 
@@ -136,6 +145,10 @@ extension DefaultSettingsRepository: SettingsRepository {
         try await syncService.fetchSync()
     }
 
+    func getAllowSyncOnRefresh() async throws -> Bool {
+        try await stateService.getAllowSyncOnRefresh()
+    }
+
     func lastSyncTimePublisher() async throws -> AsyncPublisher<AnyPublisher<Date?, Never>> {
         try await stateService.lastSyncTimePublisher().values
     }
@@ -150,6 +163,10 @@ extension DefaultSettingsRepository: SettingsRepository {
 
     func unlockVault(userId: String?) async {
         await vaultTimeoutService.unlockVault(userId: userId)
+    }
+
+    func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
+        try await stateService.setAllowSyncOnRefresh(allowSyncOnRefresh)
     }
 
     // MARK: Publishers

--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
@@ -81,6 +81,19 @@ class SettingsRepositoryTests: BitwardenTestCase {
         XCTAssertTrue(syncService.didFetchSync)
     }
 
+    /// `getAllowSyncOnRefresh()` returns the expected value.
+    func test_getAllowSyncOnRefresh() async throws {
+        stateService.activeAccount = .fixture()
+
+        // Defaults to false if no value is set.
+        var value = try await subject.getAllowSyncOnRefresh()
+        XCTAssertFalse(value)
+
+        stateService.allowSyncOnRefresh["1"] = true
+        value = try await subject.getAllowSyncOnRefresh()
+        XCTAssertTrue(value)
+    }
+
     /// `fetchSync()` throws an error if syncing fails.
     func test_fetchSync_error() async throws {
         struct SyncError: Error, Equatable {}
@@ -176,5 +189,19 @@ class SettingsRepositoryTests: BitwardenTestCase {
         waitFor(!vaultTimeoutService.unlockedIds.isEmpty)
         task.cancel()
         XCTAssertEqual(vaultTimeoutService.unlockedIds, ["123"])
+    }
+
+    /// `updateAllowSyncOnRefresh(_:)` updates the value in the app settings store.
+    func test_updateAllowSyncOnRefresh() async throws {
+        stateService.activeAccount = .fixture()
+
+        // The value should start off with a default of false.
+        var value = try await stateService.getAllowSyncOnRefresh()
+        XCTAssertFalse(value)
+
+        // Set the value and ensure it updates.
+        try await subject.updateAllowSyncOnRefresh(true)
+        value = try await stateService.getAllowSyncOnRefresh()
+        XCTAssertTrue(value)
     }
 }

--- a/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
@@ -7,6 +7,8 @@ import Foundation
 class MockSettingsRepository: SettingsRepository {
     var addedFolderName: String?
     var addFolderResult: Result<Void, Error> = .success(())
+    var allowSyncOnRefresh = false
+    var allowSyncOnRefreshResult: Result<Void, Error> = .success(())
     var editedFolderName: String?
     var editFolderResult: Result<Void, Error> = .success(())
     var fetchSyncCalled = false
@@ -37,6 +39,11 @@ class MockSettingsRepository: SettingsRepository {
         try fetchSyncResult.get()
     }
 
+    func getAllowSyncOnRefresh() async throws -> Bool {
+        try allowSyncOnRefreshResult.get()
+        return allowSyncOnRefresh
+    }
+
     func isLocked(userId _: String) throws -> Bool {
         try isLockedResult.get()
     }
@@ -54,6 +61,11 @@ class MockSettingsRepository: SettingsRepository {
 
     func unlockVault(userId: String?) {
         lockVaultCalls.append(userId)
+    }
+
+    func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
+        self.allowSyncOnRefresh = allowSyncOnRefresh
+        try allowSyncOnRefreshResult.get()
     }
 
     func logout() async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -208,6 +208,21 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(accountId, account.profile.userId)
     }
 
+    /// `allowSyncOnRefreshes()` returns the allow sync on refresh value for the active account.
+    func test_getAllowSyncOnRefresh() async throws {
+        await subject.addAccount(.fixture())
+        appSettingsStore.allowSyncOnRefreshes["1"] = true
+        let value = try await subject.getAllowSyncOnRefresh()
+        XCTAssertTrue(value)
+    }
+
+    /// `allowSyncOnRefreshes()` defaults to `false` if the active account doesn't have a value set.
+    func test_getAllowSyncOnRefresh_notSet() async throws {
+        await subject.addAccount(.fixture())
+        let value = try await subject.getAllowSyncOnRefresh()
+        XCTAssertFalse(value)
+    }
+
     /// `getClearClipboardValue()` returns the clear clipboard value for the active account.
     func test_getClearClipboardValue() async throws {
         await subject.addAccount(.fixture())
@@ -585,6 +600,14 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try await subject.setActiveAccount(userId: "1")
         active = try await subject.getActiveAccount()
         XCTAssertEqual(active, account1)
+    }
+
+    /// `setAllowSyncOnRefresh(_:userId:)` sets the allow sync on refresh value for a user.
+    func test_setAllowSyncOnRefresh() async throws {
+        await subject.addAccount(.fixture())
+
+        try await subject.setAllowSyncOnRefresh(true)
+        XCTAssertEqual(appSettingsStore.allowSyncOnRefreshes["1"], true)
     }
 
     /// `setClearClipboardValue(_:userId:)` sets the clear clipboard value for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -56,6 +56,22 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNil(userDefaults.string(forKey: "bwPreferencesStorage:appId"))
     }
 
+    /// `allowSyncOnRefresh(userId:)` returns `false` if there isn't a previously stored value.
+    func test_allowSyncOnRefresh_isInitiallyFalse() {
+        XCTAssertFalse(subject.allowSyncOnRefresh(userId: "-1"))
+    }
+
+    /// `allowSyncOnRefresh(userId:)` can be used to get the allow sync on refresh value for a user.
+    func test_allowSyncOnRefresh_withValue() {
+        subject.setAllowSyncOnRefresh(true, userId: "1")
+        subject.setAllowSyncOnRefresh(false, userId: "2")
+
+        XCTAssertTrue(subject.allowSyncOnRefresh(userId: "1"))
+        XCTAssertFalse(subject.allowSyncOnRefresh(userId: "2"))
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:syncOnRefresh_1"))
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:syncOnRefresh_w"))
+    }
+
     /// `clearClipboardValue(userId:)` returns `.never` if there isn't a previously stored value.
     func test_clearClipboardValue_isInitiallyNil() {
         XCTAssertEqual(subject.clearClipboardValue(userId: "0"), .never)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -4,6 +4,7 @@ import Foundation
 @testable import BitwardenShared
 
 class MockAppSettingsStore: AppSettingsStore {
+    var allowSyncOnRefreshes = [String: Bool]()
     var appId: String?
     var clearClipboardValues = [String: ClearClipboardValue]()
     var encryptedPrivateKeys = [String: String]()
@@ -22,6 +23,10 @@ class MockAppSettingsStore: AppSettingsStore {
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
     lazy var activeIdSubject = CurrentValueSubject<String?, Never>(self.state?.activeUserId)
+
+    func allowSyncOnRefresh(userId: String) -> Bool {
+        allowSyncOnRefreshes[userId] ?? false
+    }
 
     func clearClipboardValue(userId: String) -> ClearClipboardValue {
         clearClipboardValues[userId] ?? .never
@@ -49,6 +54,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func usernameGenerationOptions(userId: String) -> UsernameGenerationOptions? {
         usernameGenerationOptions[userId]
+    }
+
+    func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool?, userId: String) {
+        allowSyncOnRefreshes[userId] = allowSyncOnRefresh
     }
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -10,6 +10,7 @@ class MockStateService: StateService {
     var accountsLoggedOut = [String]()
     var activeAccount: Account?
     var accounts: [Account]?
+    var allowSyncOnRefresh = [String: Bool]()
     var clearClipboardValues = [String: ClearClipboardValue]()
     var environmentUrls = [String: EnvironmentUrlData]()
     var lastSyncTimeByUserId = [String: Date]()
@@ -69,6 +70,11 @@ class MockStateService: StateService {
         try getActiveAccount().profile.userId
     }
 
+    func getAllowSyncOnRefresh(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        return allowSyncOnRefresh[userId] ?? false
+    }
+
     func getClearClipboardValue(userId: String?) async throws -> ClearClipboardValue {
         let userId = try userId ?? getActiveAccount().profile.userId
         return clearClipboardValues[userId] ?? .never
@@ -114,6 +120,11 @@ class MockStateService: StateService {
                   account.profile.userId == userId
               }) else { throw StateServiceError.noAccounts }
         activeAccount = match
+    }
+
+    func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        self.allowSyncOnRefresh[userId] = allowSyncOnRefresh
     }
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws {

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -17,7 +17,7 @@ class MockVaultRepository: VaultRepository {
     var vaultListSubject = CurrentValueSubject<[VaultListSection], Never>([])
     var vaultListGroupSubject = CurrentValueSubject<[VaultListItem], Never>([])
 
-    func fetchSync() async throws {
+    func fetchSync(isManualRefresh _: Bool) async throws {
         fetchSyncCalled = true
     }
 
@@ -26,7 +26,7 @@ class MockVaultRepository: VaultRepository {
         try addCipherResult.get()
     }
 
-    func cipherDetailsPublisher(id: String) -> AsyncPublisher<AnyPublisher<BitwardenSdk.CipherView, Never>> {
+    func cipherDetailsPublisher(id _: String) -> AsyncPublisher<AnyPublisher<BitwardenSdk.CipherView, Never>> {
         cipherDetailsSubject.eraseToAnyPublisher().values
     }
 
@@ -49,7 +49,7 @@ class MockVaultRepository: VaultRepository {
     }
 
     func vaultListPublisher(
-        group: BitwardenShared.VaultListGroup
+        group _: BitwardenShared.VaultListGroup
     ) -> AsyncPublisher<AnyPublisher<[VaultListItem], Never>> {
         vaultListGroupSubject.eraseToAnyPublisher().values
     }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -10,7 +10,9 @@ protocol VaultRepository: AnyObject {
     /// Performs an API request to sync the user's vault data. The publishers in the repository can
     /// be used to subscribe to the vault data, which are updated as a result of the request.
     ///
-    func fetchSync() async throws
+    /// - Parameter isRefresh: Whether the sync is being performed as a manual refresh.
+    ///
+    func fetchSync(isManualRefresh: Bool) async throws
 
     // MARK: Data Methods
 
@@ -238,8 +240,11 @@ class DefaultVaultRepository {
 extension DefaultVaultRepository: VaultRepository {
     // MARK: API Methods
 
-    func fetchSync() async throws {
-        try await syncService.fetchSync()
+    func fetchSync(isManualRefresh: Bool) async throws {
+        let allowSyncOnRefresh = try await stateService.getAllowSyncOnRefresh()
+        if !isManualRefresh || allowSyncOnRefresh {
+            try await syncService.fetchSync()
+        }
     }
 
     // MARK: Data Methods
@@ -248,7 +253,7 @@ extension DefaultVaultRepository: VaultRepository {
         let cipher = try await clientVault.ciphers().encrypt(cipherView: cipher)
         _ = try await cipherAPIService.addCipher(cipher)
         // TODO: BIT-92 Insert response into database instead of fetching sync.
-        try await fetchSync()
+        try await fetchSync(isManualRefresh: false)
     }
 
     func remove(userId: String?) async {
@@ -259,7 +264,7 @@ extension DefaultVaultRepository: VaultRepository {
         let updatedCipher = try await clientVault.ciphers().encrypt(cipherView: updatedCipherView)
         _ = try await cipherAPIService.updateCipher(updatedCipher)
         // TODO: BIT-92 Insert response into database instead of fetching sync.
-        try await fetchSync()
+        try await fetchSync(isManualRefresh: false)
     }
 
     func validatePassword(_ password: String) async throws -> Bool {

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsEffect.swift
@@ -3,6 +3,9 @@
 /// Effects handled by the `OtherSettingsProcessor`.
 ///
 enum OtherSettingsEffect {
+    /// Load the initial values for the view.
+    case loadInitialValues
+
     /// Streams the last sync time.
     case streamLastSyncTime
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsView.swift
@@ -27,7 +27,12 @@ struct OtherSettingsView: View {
             get: \.toast,
             send: OtherSettingsAction.toastShown
         ))
-        .task { await store.perform(.streamLastSyncTime) }
+        .task {
+            await store.perform(.streamLastSyncTime)
+        }
+        .task {
+            await store.perform(.loadInitialValues)
+        }
     }
 
     // MARK: Private views

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -73,7 +73,7 @@ final class VaultGroupProcessor: StateProcessor<VaultGroupState, VaultGroupActio
     ///
     private func refreshVaultGroup() async {
         do {
-            try await services.vaultRepository.fetchSync()
+            try await services.vaultRepository.fetchSync(isManualRefresh: true)
         } catch {
             // TODO: BIT-1034 Add an error alert
             print(error)


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-227](https://livefront.atlassian.net/browse/BIT-227)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

Record the user's selection of the "Allow sync on refresh" setting and apply it to the "pull to refresh" action on the vault view.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SettingsRepository.swift:** Implement getting and setting the `allowSyncOnRefresh` value
-   **AppSettingsStore.swift:** Allow the `allowSyncOnRefresh` value to be cached for each user
-   **VaultRepository.swift:** Add a parameter to the `fetchSync` function to distinguish between a manual refresh that might need to be disabled vs an expected/mandatory call to the sync endpoint. If it is a manual refresh, only sync if the setting is enabled
-   ** OtherSettingsProcessor.swift:** Load the allowSyncOnRefresh` value when the view appears and update it when the user toggles the switch, and record any errors
-   **VaultGroupProcessor.swift:** Specify if the sync is a manual refresh or not
-   **VaultListProcessor.swift:** Specify if the sync is a manual refresh or not

## 📸 Screenshots

N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
