### PR TITLE
BIT-260: Add toast for folder operations

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderProcessorTests.swift
@@ -6,6 +6,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<SettingsRoute>!
+    var delegate: MockAddEditFolderDelegate!
     var errorReporter: MockErrorReporter!
     var settingsRepository: MockSettingsRepository!
     var subject: AddEditFolderProcessor!
@@ -16,6 +17,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
         super.setUp()
 
         coordinator = MockCoordinator<SettingsRoute>()
+        delegate = MockAddEditFolderDelegate()
         errorReporter = MockErrorReporter()
         settingsRepository = MockSettingsRepository()
         let settings = ServiceContainer.withMocks(
@@ -24,6 +26,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
         )
         subject = AddEditFolderProcessor(
             coordinator: coordinator.asAnyCoordinator(),
+            delegate: delegate,
             services: settings,
             state: AddEditFolderState(mode: .add)
         )
@@ -33,6 +36,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
         super.tearDown()
 
         coordinator = nil
+        delegate = nil
         errorReporter = nil
         settingsRepository = nil
         subject = nil
@@ -112,6 +116,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
         // Ensure the folder is deleted and the view is dismissed.
         XCTAssertEqual(settingsRepository.deletedFolderId, "testID")
         XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertTrue(delegate.folderDeletedCalled)
     }
 
     /// `perform(_:)` with `.savePressed` displays an alert if name field is invalid.
@@ -186,6 +191,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(settingsRepository.addedFolderName, folderName)
         XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertTrue(delegate.folderAddedCalled)
     }
 
     /// `perform(_:)` with `.savePressed` edits the existing folder.
@@ -197,6 +203,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(settingsRepository.editedFolderName, folderName)
         XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertTrue(delegate.folderEditedCalled)
     }
 
     /// `receive(_:)` with `.dismiss` dismisses the view.
@@ -213,5 +220,23 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
 
         subject.receive(.folderNameTextChanged("updated name"))
         XCTAssertTrue(subject.state.folderName == "updated name")
+    }
+}
+
+class MockAddEditFolderDelegate: AddEditFolderDelegate {
+    var folderAddedCalled = false
+    var folderDeletedCalled = false
+    var folderEditedCalled = false
+
+    func folderAdded() {
+        folderAddedCalled = true
+    }
+
+    func folderDeleted() {
+        folderDeletedCalled = true
+    }
+
+    func folderEdited() {
+        folderEditedCalled = true
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersAction.swift
@@ -8,4 +8,7 @@ enum FoldersAction: Equatable {
 
     /// A folder was tapped.
     case folderTapped(id: String)
+
+    /// The toast was shown or hidden.
+    case toastShown(Toast?)
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersProcessor.swift
@@ -47,10 +47,12 @@ final class FoldersProcessor: StateProcessor<FoldersState, FoldersAction, Folder
     override func receive(_ action: FoldersAction) {
         switch action {
         case .add:
-            coordinator.navigate(to: .addEditFolder(folder: nil))
+            coordinator.navigate(to: .addEditFolder(folder: nil), context: self)
         case let .folderTapped(folderID):
             guard let folder = state.folders.first(where: { $0.id == folderID }) else { return }
-            coordinator.navigate(to: .addEditFolder(folder: folder))
+            coordinator.navigate(to: .addEditFolder(folder: folder), context: self)
+        case let .toastShown(newValue):
+            state.toast = newValue
         }
     }
 
@@ -66,5 +68,24 @@ final class FoldersProcessor: StateProcessor<FoldersState, FoldersAction, Folder
         } catch {
             services.errorReporter.log(error: error)
         }
+    }
+}
+
+// MARK: - CaptchaFlowDelegate
+
+extension FoldersProcessor: AddEditFolderDelegate {
+    /// Show the toast that the folder was successfully added.
+    func folderAdded() {
+        state.toast = Toast(text: Localizations.folderCreated)
+    }
+
+    /// Show the toast that the folder was successfully deleted.
+    func folderDeleted() {
+        state.toast = Toast(text: Localizations.folderDeleted)
+    }
+
+    /// Show the toast that the folder was successfully edited.
+    func folderEdited() {
+        state.toast = Toast(text: Localizations.folderUpdated)
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersProcessorTests.swift
@@ -41,6 +41,30 @@ class FoldersProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `folderAdded()` delegate method shows the expected toast.
+    func test_delegate_folderAdded() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.folderAdded()
+        XCTAssertEqual(subject.state.toast?.text, Localizations.folderCreated)
+    }
+
+    /// `folderDeleted()` delegate method shows the expected toast.
+    func test_delegate_folderDeleted() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.folderDeleted()
+        XCTAssertEqual(subject.state.toast?.text, Localizations.folderDeleted)
+    }
+
+    /// `folderEdited()` delegate method shows the expected toast.
+    func test_delegate_folderEdited() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.folderEdited()
+        XCTAssertEqual(subject.state.toast?.text, Localizations.folderUpdated)
+    }
+
     /// `perform(_:)` with `.streamFolders` updates the state's list of folders whenever it changes.
     func test_perform_streamFolders() {
         let task = Task {
@@ -80,5 +104,15 @@ class FoldersProcessorTests: BitwardenTestCase {
         subject.receive(.folderTapped(id: folder.id))
 
         XCTAssertEqual(coordinator.routes.last, .addEditFolder(folder: folder))
+    }
+
+    /// `receive(_:)` with `.toastShown` updates the state's toast value.
+    func test_receive_toastShown() {
+        let toast = Toast(text: "toast!")
+        subject.receive(.toastShown(toast))
+        XCTAssertEqual(subject.state.toast, toast)
+
+        subject.receive(.toastShown(nil))
+        XCTAssertNil(subject.state.toast)
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersState.swift
@@ -7,4 +7,7 @@ import BitwardenSdk
 struct FoldersState: Equatable {
     /// The user's folders.
     var folders: [FolderView] = []
+
+    /// A toast message to show in the view.
+    var toast: Toast?
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersView.swift
@@ -31,6 +31,10 @@ struct FoldersView: View {
         .task {
             await store.perform(.streamFolders)
         }
+        .toast(store.binding(
+            get: \.toast,
+            send: FoldersAction.toastShown
+        ))
     }
 
     // MARK: Private views

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -76,14 +76,14 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
 
     // MARK: Methods
 
-    func navigate(to route: SettingsRoute, context _: AnyObject?) {
+    func navigate(to route: SettingsRoute, context: AnyObject?) {
         switch route {
         case .about:
             showAbout()
         case .accountSecurity:
             showAccountSecurity()
         case let .addEditFolder(folder):
-            showAddEditFolder(folder)
+            showAddEditFolder(folder, delegate: context as? AddEditFolderDelegate)
         case .appearance:
             showAppearance()
         case let .alert(alert):
@@ -155,10 +155,11 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
     ///
     /// - Parameter folder: The existing folder to edit, if applicable.
     ///
-    private func showAddEditFolder(_ folder: FolderView?) {
+    private func showAddEditFolder(_ folder: FolderView?, delegate: AddEditFolderDelegate?) {
         let mode: AddEditFolderState.Mode = if let folder { .edit(folder) } else { .add }
         let processor = AddEditFolderProcessor(
             coordinator: asAnyCoordinator(),
+            delegate: delegate,
             services: services,
             state: AddEditFolderState(folderName: folder?.name ?? "", mode: mode)
         )


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-260](https://livefront.atlassian.net/browse/BIT-260)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

Added toast to the folders view for successful folder operations.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AddEditFolderProcessor.swift:** Added a delegate to tell the parent view when an operation completes successfully
-   **FoldersProcessor.swift:** Show toast

## 📸 Screenshots

<video width="400px" src="https://github.com/bitwarden/ios/assets/125921730/743255bc-5dbd-4c2e-8fd5-7e226c538aa2" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
