### PR TITLE
BIT-1287 BIT 1307: Error and loading states, and remember

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -8,6 +8,9 @@ import Foundation
 /// A protocol for a `StateService` which manages the state of the accounts in the app.
 ///
 protocol StateService: AnyObject {
+    /// The organization identifier being remembered on the single-sign on screen.
+    var rememberedOrgIdentifier: String? { get set }
+
     /// Adds a new account to the app's state after a successful login.
     ///
     /// - Parameter account: The `Account` to add.
@@ -345,6 +348,12 @@ enum StateServiceError: Error {
 ///
 actor DefaultStateService: StateService {
     // MARK: Properties
+
+    /// The organization identifier being remembered on the single-sign on screen.
+    nonisolated var rememberedOrgIdentifier: String? {
+        get { appSettingsStore.rememberedOrgIdentifier }
+        set { appSettingsStore.rememberedOrgIdentifier = newValue }
+    }
 
     /// The service that persists app settings.
     let appSettingsStore: AppSettingsStore

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -505,6 +505,17 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, ["2": "2:USER_KEY"])
     }
 
+    /// `rememberedOrgIdentifier` gets and sets the value as expected.
+    func test_rememberedOrgIdentifier() {
+        // Getting the value should get the value from the app settings store.
+        appSettingsStore.rememberedOrgIdentifier = "ImALumberjack"
+        XCTAssertEqual(subject.rememberedOrgIdentifier, "ImALumberjack")
+
+        // Setting the value should update the value in the app settings store.
+        subject.rememberedOrgIdentifier = "AndImOk"
+        XCTAssertEqual(appSettingsStore.rememberedOrgIdentifier, "AndImOk")
+    }
+
     /// `setAccountEncryptionKeys(_:userId:)` sets the encryption keys for the user account.
     func test_setAccountEncryptionKeys() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -18,6 +18,9 @@ protocol AppSettingsStore: AnyObject {
     /// The email being remembered on the landing screen.
     var rememberedEmail: String? { get set }
 
+    /// The organization identifier being remembered on the single-sign on screen.
+    var rememberedOrgIdentifier: String? { get set }
+
     /// The app's account state.
     var state: State? { get set }
 
@@ -271,6 +274,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case passwordGenerationOptions(userId: String)
         case preAuthEnvironmentUrls
         case rememberedEmail
+        case rememberedOrgIdentifier
         case state
         case usernameGenerationOptions(userId: String)
 
@@ -298,6 +302,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "preAuthEnvironmentUrls"
             case .rememberedEmail:
                 key = "rememberedEmail"
+            case .rememberedOrgIdentifier:
+                key = "rememberedOrgIdentifier"
             case .state:
                 key = "state"
             case let .usernameGenerationOptions(userId):
@@ -320,6 +326,11 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     var rememberedEmail: String? {
         get { fetch(for: .rememberedEmail) }
         set { store(newValue, for: .rememberedEmail) }
+    }
+
+    var rememberedOrgIdentifier: String? {
+        get { fetch(for: .rememberedOrgIdentifier) }
+        set { store(newValue, for: .rememberedOrgIdentifier) }
     }
 
     var state: State? {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -346,6 +346,22 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNil(userDefaults.string(forKey: "bwPreferencesStorage:rememberedEmail"))
     }
 
+    /// `rememberedOrgIdentifier` returns `nil` if there isn't a previously stored value.
+    func test_rememberedOrgIdentifier_isInitiallyNil() {
+        XCTAssertNil(subject.rememberedOrgIdentifier)
+    }
+
+    /// `rememberedOrgIdentifier` can be used to get and set the persisted value in user defaults.
+    func test_rememberedOrgIdentifier_withValue() {
+        subject.rememberedOrgIdentifier = "OrgIdentifier9000"
+        XCTAssertEqual(subject.rememberedOrgIdentifier, "OrgIdentifier9000")
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:rememberedOrgIdentifier"), "OrgIdentifier9000")
+
+        subject.rememberedOrgIdentifier = nil
+        XCTAssertNil(subject.rememberedOrgIdentifier)
+        XCTAssertNil(userDefaults.string(forKey: "bwPreferencesStorage:rememberedOrgIdentifier"))
+    }
+
     /// `state` returns `nil` if there isn't a previously stored value.
     func test_state_isInitiallyNil() {
         XCTAssertNil(subject.state)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -14,6 +14,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
     var rememberedEmail: String?
+    var rememberedOrgIdentifier: String?
     var state: State? {
         didSet {
             activeIdSubject.send(state?.activeUserId)

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -19,6 +19,7 @@ class MockStateService: StateService {
     var masterPasswordHashes = [String: String]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
+    var rememberedOrgIdentifier: String?
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
     lazy var activeIdSubject = CurrentValueSubject<String?, Never>(self.activeAccount?.profile.userId)

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
@@ -36,6 +36,34 @@ class SingleSignOnProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `perform(_:)` with `.loginPressed` displays an alert if organization identifier field is invalid.
+    func test_perform_loginPressed_invalidIdentifier() async throws {
+        subject.state.identifierText = "    "
+
+        await subject.perform(.loginTapped)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.first)
+        XCTAssertEqual(
+            alert,
+            Alert.defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.validationFieldRequired(Localizations.orgIdentifier),
+                alertActions: [AlertAction(title: Localizations.ok, style: .default)]
+            )
+        )
+    }
+
+    /// `perform(_:)` with `.loginPressed` attempts to login.
+    func test_perform_loginPressed_success() async throws {
+        subject.state.identifierText = "TestIdentifier"
+
+        await subject.perform(.loginTapped)
+
+        // TODO: BIT-1308
+
+        XCTAssertEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
+    }
+
     /// `receive(_:)` with `.dismiss` dismisses the view.
     func test_receive_dismiss() {
         subject.receive(.dismiss)


### PR DESCRIPTION


## 🎟️ Tracking

[BIT-1287](https://livefront.atlassian.net/browse/BIT-1287)
[BIT-1307](https://livefront.atlassian.net/browse/BIT-1307)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

Show the error and loading states and persist + remember the org identifier

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AppSettingsStore.swift:** Remember the org identifier
-   **StateService.swift:** Remember the org identifier
-   **SingleSignOnProcessor.swift:** Remember the org identifier, check that the text is not empty, show error states, and show the loading overlay

## 📸 Screenshots

<video width="400px" src="https://github.com/bitwarden/ios/assets/125921730/704778ca-9431-477a-980e-5b670e7dc6ef" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
