### PR TITLE
BIT-1288: Change toast text

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -873,3 +873,4 @@ Do you want to switch to this account?";
 "Search" = "Search";
 "NoItemsFound" = "No items found";
 "SetUpAppleWatchPasscodeInOrderToUseBitwarden" = "Set up Apple Watch passcode in order to use Bitwarden";
+"AppInfo" = "App info";

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
@@ -58,6 +58,6 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, Void> {
         // Copy the copyright text followed by the version info.
         let text = state.copyrightText + "\n\n" + state.version
         services.pasteboardService.copy(text)
-        state.toast = Toast(text: Localizations.valueHasBeenCopied(Localizations.version))
+        state.toast = Toast(text: Localizations.valueHasBeenCopied(Localizations.appInfo))
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
@@ -57,6 +57,6 @@ class AboutProcessorTests: BitwardenTestCase {
         subject.receive(.versionTapped)
         let text = subject.state.copyrightText + "\n\n" + subject.state.version
         XCTAssertEqual(pasteboardService.copiedString, text)
-        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.version))
+        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.appInfo))
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1288](https://livefront.atlassian.net/browse/BIT-1288)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

Change the text of the toast when the user copies the version info.

NOTE: Talked to the team about it and they understand this will need to be added for other languages later but didn't want it to block the work.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Localizable.strings:** Added the desired string to the English localizable files.
-   **AboutProcessor.swift:** Changed the text of the toast

## 📸 Screenshots

| Before | After |
| --- | --- |
| <img src="https://github.com/bitwarden/ios/assets/125921730/0ede4d65-28c4-4c04-bc15-aded6de6ce5f" /> | <img src="https://github.com/bitwarden/ios/assets/125921730/b02e5d18-c92b-4393-96c4-ead819c2e205" /> |

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
