### PR TITLE
BIT-1369: Add support for persisting organizations

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -69,6 +69,9 @@ class DefaultAuthRepository {
     /// The service used by the application to manage the environment settings.
     let environmentService: EnvironmentService
 
+    /// The service used to manage syncing and updates to the user's organizations.
+    let organizationService: OrganizationService
+
     /// The service used by the application to manage account state.
     let stateService: StateService
 
@@ -84,6 +87,7 @@ class DefaultAuthRepository {
     ///   - clientAuth: The client used by the application to handle auth related encryption and decryption tasks.
     ///   - clientCrypto: The client used by the application to handle encryption and decryption setup tasks.
     ///   - environmentService: The service used by the application to manage the environment settings.
+    ///   - organizationService: The service used to manage syncing and updates to the user's organizations.
     ///   - stateService: The service used by the application to manage account state.
     ///   - vaultTimeoutService: The service used by the application to manage vault access.
     ///
@@ -92,6 +96,7 @@ class DefaultAuthRepository {
         clientAuth: ClientAuthProtocol,
         clientCrypto: ClientCryptoProtocol,
         environmentService: EnvironmentService,
+        organizationService: OrganizationService,
         stateService: StateService,
         vaultTimeoutService: VaultTimeoutService
     ) {
@@ -99,6 +104,7 @@ class DefaultAuthRepository {
         self.clientAuth = clientAuth
         self.clientCrypto = clientCrypto
         self.environmentService = environmentService
+        self.organizationService = organizationService
         self.stateService = stateService
         self.vaultTimeoutService = vaultTimeoutService
     }
@@ -185,6 +191,7 @@ extension DefaultAuthRepository: AuthRepository {
             )
         )
         await vaultTimeoutService.unlockVault(userId: account.profile.userId)
+        try await organizationService.initializeOrganizationCrypto()
     }
 
     /// A function to convert an `Account` to a `ProfileSwitcherItem`

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -11,6 +11,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     var clientAuth: MockClientAuth!
     var clientCrypto: MockClientCrypto!
     var environmentService: MockEnvironmentService!
+    var organizationService: MockOrganizationService!
     var subject: DefaultAuthRepository!
     var stateService: MockStateService!
     var vaultTimeoutService: MockVaultTimeoutService!
@@ -75,6 +76,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         accountAPIService = APIService(client: client)
         clientCrypto = MockClientCrypto()
         environmentService = MockEnvironmentService()
+        organizationService = MockOrganizationService()
         stateService = MockStateService()
         vaultTimeoutService = MockVaultTimeoutService()
 
@@ -83,6 +85,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             clientAuth: clientAuth,
             clientCrypto: clientCrypto,
             environmentService: environmentService,
+            organizationService: organizationService,
             stateService: stateService,
             vaultTimeoutService: vaultTimeoutService
         )
@@ -96,6 +99,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         clientAuth = nil
         clientCrypto = nil
         environmentService = nil
+        organizationService = nil
         subject = nil
         stateService = nil
         vaultTimeoutService = nil
@@ -353,6 +357,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             )
         )
         XCTAssertEqual(vaultTimeoutService.timeoutStore, ["1": false])
+        XCTAssertTrue(organizationService.initializeOrganizationCryptoCalled)
     }
 
     /// `unlockVault(password:)` throws an error if the vault is unable to be unlocked.
@@ -395,4 +400,4 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertEqual([account.profile.userId], stateService.accountsLoggedOut)
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -179,13 +179,18 @@ public class ServiceContainer: Services {
             folderDataStore: dataStore,
             stateService: stateService
         )
+        let organizationService = DefaultOrganizationService(
+            clientCrypto: clientService.clientCrypto(),
+            errorReporter: errorReporter,
+            organizationDataStore: dataStore,
+            stateService: stateService
+        )
 
         let syncService = DefaultSyncService(
             cipherService: cipherService,
-            clientCrypto: clientService.clientCrypto(),
             collectionService: collectionService,
-            errorReporter: errorReporter,
             folderService: folderService,
+            organizationService: organizationService,
             sendService: sendService,
             stateService: stateService,
             syncAPIService: apiService
@@ -207,6 +212,7 @@ public class ServiceContainer: Services {
             clientAuth: clientService.clientAuth(),
             clientCrypto: clientService.clientCrypto(),
             environmentService: environmentService,
+            organizationService: organizationService,
             stateService: stateService,
             vaultTimeoutService: vaultTimeoutService
         )
@@ -236,6 +242,7 @@ public class ServiceContainer: Services {
             collectionService: collectionService,
             errorReporter: errorReporter,
             folderService: folderService,
+            organizationService: organizationService,
             stateService: stateService,
             syncService: syncService,
             vaultTimeoutService: vaultTimeoutService

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -408,6 +408,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
                 userId: "1",
                 folder: Folder(id: "1", name: "FOLDER1", revisionDate: Date())
             )
+            _ = OrganizationData(context: context, userId: "1", organization: .fixture())
             _ = SendData(context: context, userId: "1", send: .fixture())
         }
 
@@ -421,6 +422,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try XCTAssertEqual(context.count(for: CipherData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: CollectionData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: FolderData.fetchByUserIdRequest(userId: "1")), 0)
+        try XCTAssertEqual(context.count(for: OrganizationData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: SendData.fetchByUserIdRequest(userId: "1")), 0)
     }

--- a/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
+++ b/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
@@ -33,6 +33,11 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="OrganizationData" representedClassName=".OrganizationData" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="modelData" attributeType="Binary"/>
+        <attribute name="userId" attributeType="String"/>
+    </entity>
     <entity name="PasswordHistoryData" representedClassName=".PasswordHistoryData" syncable="YES">
         <attribute name="lastUsedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="password" attributeType="String"/>

--- a/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
@@ -78,6 +78,7 @@ class DataStore {
         try await deleteAllCiphers(userId: userId)
         try await deleteAllCollections(userId: userId)
         try await deleteAllFolders(userId: userId)
+        try await deleteAllOrganizations(userId: userId)
         try await deleteAllPasswordHistory(userId: userId)
         try await deleteAllSends(userId: userId)
     }

--- a/BitwardenShared/Core/Vault/Models/Data/OrganizationData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/OrganizationData.swift
@@ -1,0 +1,71 @@
+import BitwardenSdk
+import CoreData
+import Foundation
+
+/// A data model for persisting organizations.
+///
+class OrganizationData: NSManagedObject, ManagedUserObject, CodableModelData {
+    typealias Model = ProfileOrganizationResponseModel
+
+    // MARK: Properties
+
+    /// The organization's identifier.
+    @NSManaged var id: String?
+
+    /// The data model encoded as JSON data.
+    @NSManaged var modelData: Data?
+
+    /// The ID of the user who owns the organization.
+    @NSManaged var userId: String?
+
+    // MARK: Initialization
+
+    /// Initialize a `OrganizationData` object for insertion into the managed object context.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context to insert the initialized object.
+    ///   - userId: The user ID associated with the organization.
+    ///   - organization: The `ProfileOrganizationResponseModel` object used to create the object.
+    ///
+    convenience init(
+        context: NSManagedObjectContext,
+        userId: String,
+        organization: ProfileOrganizationResponseModel
+    ) {
+        self.init(context: context)
+        id = organization.id
+        model = organization
+        self.userId = userId
+    }
+
+    // MARK: Methods
+
+    /// Updates the `OrganizationData` object from a `Organization` and user ID.
+    ///
+    /// - Parameters:
+    ///   - organization: The `ProfileOrganizationResponseModel` object used to update the
+    ///     `OrganizationData` instance.
+    ///   - userId: The user ID associated with the organization.
+    ///
+    func update(with organization: ProfileOrganizationResponseModel, userId: String) {
+        id = organization.id
+        model = organization
+        self.userId = userId
+    }
+}
+
+extension OrganizationData {
+    static func userIdPredicate(userId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(OrganizationData.userId), userId)
+    }
+
+    static func userIdAndIdPredicate(userId: String, id: String) -> NSPredicate {
+        NSPredicate(
+            format: "%K == %@ AND %K == %@",
+            #keyPath(OrganizationData.userId),
+            userId,
+            #keyPath(OrganizationData.id),
+            id
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Domain/Fixtures/Organization+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Fixtures/Organization+Fixtures.swift
@@ -4,12 +4,18 @@ import Foundation
 
 extension Organization {
     static func fixture(
+        enabled: Bool = true,
         id: String = "organization-1",
-        name: String = ""
+        key: String? = nil,
+        name: String = "",
+        status: OrganizationUserStatusType = .confirmed
     ) -> Organization {
         Organization(
+            enabled: enabled,
             id: id,
-            name: name
+            key: key,
+            name: name,
+            status: status
         )
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Domain/Organization.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Organization.swift
@@ -3,16 +3,38 @@
 struct Organization: Equatable, Hashable {
     // MARK: Properties
 
+    /// Whether the profile organization is enabled.
+    let enabled: Bool
+
     /// The organization's identifier.
     let id: String
 
+    /// The profile organization's key.
+    let key: String?
+
     /// The organization's name.
     let name: String
+
+    /// The profile's organization's status.
+    let status: OrganizationUserStatusType
 }
 
 extension Organization {
     init?(responseModel: ProfileOrganizationResponseModel) {
         guard let name = responseModel.name else { return nil }
-        self.init(id: responseModel.id, name: name)
+        self.init(
+            enabled: responseModel.enabled,
+            id: responseModel.id,
+            key: responseModel.key,
+            name: name,
+            status: responseModel.status
+        )
+    }
+
+    init?(organizationData: OrganizationData) throws {
+        guard let model = organizationData.model else {
+            throw DataMappingError.invalidData
+        }
+        self.init(responseModel: model)
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/VaultFilterTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/VaultFilterTypeTests.swift
@@ -62,7 +62,7 @@ class VaultFilterTypeTests: BitwardenTestCase {
         XCTAssertEqual(VaultFilterType.allVaults.filterTitle, "Vaults: All")
         XCTAssertEqual(VaultFilterType.myVault.filterTitle, "Vault: My vault")
         XCTAssertEqual(
-            VaultFilterType.organization(Organization(id: "", name: "Test Organization")).filterTitle,
+            VaultFilterType.organization(.fixture(id: "", name: "Test Organization")).filterTitle,
             "Vault: Test Organization"
         )
     }
@@ -87,7 +87,7 @@ class VaultFilterTypeTests: BitwardenTestCase {
         XCTAssertEqual(VaultFilterType.allVaults.title, "All vaults")
         XCTAssertEqual(VaultFilterType.myVault.title, "My vault")
         XCTAssertEqual(
-            VaultFilterType.organization(Organization(id: "", name: "Test Organization")).title,
+            VaultFilterType.organization(.fixture(id: "", name: "Test Organization")).title,
             "Test Organization"
         )
     }

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -21,7 +21,7 @@ class MockVaultRepository: VaultRepository {
     var sharedCiphers = [CipherView]()
     var updateCipherCiphers = [BitwardenSdk.CipherView]()
     var updateCipherResult: Result<Void, Error> = .success(())
-    var organizationsSubject = CurrentValueSubject<[Organization], Never>([])
+    var organizationsSubject = CurrentValueSubject<[Organization], Error>([])
     var validatePasswordPasswords = [String]()
     var validatePasswordResult: Result<Bool, Error> = .success(true)
     var vaultListSubject = CurrentValueSubject<[VaultListSection], Never>([])
@@ -74,7 +74,7 @@ class MockVaultRepository: VaultRepository {
         try updateCipherResult.get()
     }
 
-    func organizationsPublisher() -> AsyncPublisher<AnyPublisher<[Organization], Never>> {
+    func organizationsPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[Organization], Error>> {
         organizationsSubject.eraseToAnyPublisher().values
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -87,7 +87,7 @@ protocol VaultRepository: AnyObject {
     ///
     /// - Returns: A publisher for the list of organizations the user is a member of.
     ///
-    func organizationsPublisher() -> AsyncPublisher<AnyPublisher<[Organization], Never>>
+    func organizationsPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[Organization], Error>>
 
     /// A publisher for the vault list which returns a list of sections and items that are
     /// displayed in the vault.
@@ -135,6 +135,9 @@ class DefaultVaultRepository {
     /// The service used to manage syncing and updates to the user's folders.
     let folderService: FolderService
 
+    /// The service used to manage syncing and updates to the user's organizations.
+    let organizationService: OrganizationService
+
     /// The service used by the application to manage account state.
     let stateService: StateService
 
@@ -157,6 +160,7 @@ class DefaultVaultRepository {
     ///   - collectionService: The service for managing the collections for the user.
     ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - folderService: The service used to manage syncing and updates to the user's folders.
+    ///   - organizationService: The service used to manage syncing and updates to the user's organizations.
     ///   - stateService: The service used by the application to manage account state.
     ///   - syncService: The service used to handle syncing vault data with the API.
     ///   - vaultTimeoutService: The service used by the application to manage vault access.
@@ -170,6 +174,7 @@ class DefaultVaultRepository {
         collectionService: CollectionService,
         errorReporter: ErrorReporter,
         folderService: FolderService,
+        organizationService: OrganizationService,
         stateService: StateService,
         syncService: SyncService,
         vaultTimeoutService: VaultTimeoutService
@@ -182,6 +187,7 @@ class DefaultVaultRepository {
         self.collectionService = collectionService
         self.errorReporter = errorReporter
         self.folderService = folderService
+        self.organizationService = organizationService
         self.stateService = stateService
         self.syncService = syncService
         self.vaultTimeoutService = vaultTimeoutService
@@ -323,13 +329,12 @@ extension DefaultVaultRepository: VaultRepository {
     }
 
     func fetchCipherOwnershipOptions(includePersonal: Bool) async throws -> [CipherOwner] {
-        let organizations = syncService.organizations()
-        let organizationOwners: [CipherOwner] = organizations?
+        let organizations = try await organizationService.fetchAllOrganizations()
+        let organizationOwners: [CipherOwner] = organizations
             .filter { $0.enabled && $0.status == .confirmed }
-            .compactMap { organization in
-                guard let name = organization.name else { return nil }
-                return CipherOwner.organization(id: organization.id, name: name)
-            } ?? []
+            .map { organization in
+                CipherOwner.organization(id: organization.id, name: organization.name)
+            }
 
         if includePersonal {
             let email = try await stateService.getActiveAccount().profile.email
@@ -396,13 +401,8 @@ extension DefaultVaultRepository: VaultRepository {
             .values
     }
 
-    func organizationsPublisher() -> AsyncPublisher<AnyPublisher<[Organization], Never>> {
-        syncService.syncResponsePublisher()
-            .compactMap { response in
-                response?.profile?.organizations?.compactMap(Organization.init)
-            }
-            .eraseToAnyPublisher()
-            .values
+    func organizationsPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[Organization], Error>> {
+        try await organizationService.organizationsPublisher().eraseToAnyPublisher().values
     }
 
     func vaultListPublisher(filter: VaultFilterType) -> AsyncPublisher<AnyPublisher<[VaultListSection], Never>> {

--- a/BitwardenShared/Core/Vault/Services/OrganizationService.swift
+++ b/BitwardenShared/Core/Vault/Services/OrganizationService.swift
@@ -1,0 +1,118 @@
+import BitwardenSdk
+import Combine
+
+// MARK: - OrganizationService
+
+/// A protocol for a `OrganizationService` which manages syncing and updates to the user's organizations.
+///
+protocol OrganizationService {
+    /// Fetches the organizations for a user.
+    ///
+    /// - Returns: The organizations for a user.
+    ///
+    func fetchAllOrganizations() async throws -> [Organization]
+
+    /// Initializes the SDK's crypto for any organizations the users is a member of, using the
+    /// organizations already loaded into the data store.
+    ///
+    func initializeOrganizationCrypto() async throws
+
+    /// Initializes the SDK's crypto for any organizations the users is a member of.
+    ///
+    /// - Parameter organizations: The user's organizations.
+    ///
+    func initializeOrganizationCrypto(organizations: [Organization]) async
+
+    /// Replaces the persisted list of organizations for the user.
+    ///
+    /// - Parameters:
+    ///   - organizations: The updated list of organizations for the user.
+    ///   - userId: The user ID associated with the organizations.
+    ///
+    func replaceOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws
+
+    // MARK: Publishers
+
+    /// A publisher for a user's organizations.
+    ///
+    /// - Returns: The list of the user's organizations.
+    ///
+    func organizationsPublisher() async throws -> AnyPublisher<[Organization], Error>
+}
+
+// MARK: - DefaultOrganizationService
+
+class DefaultOrganizationService: OrganizationService {
+    // MARK: Properties
+
+    /// The client used by the application to handle encryption and decryption setup tasks.
+    let clientCrypto: ClientCryptoProtocol
+
+    /// The service used by the application to report non-fatal errors.
+    let errorReporter: ErrorReporter
+
+    /// The data store for managing the persisted organizations for the user.
+    let organizationDataStore: OrganizationDataStore
+
+    /// The service used by the application to manage account state.
+    let stateService: StateService
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultOrganizationService`.
+    ///
+    /// - Parameters:
+    ///   - clientCrypto: The client used by the application to handle encryption and decryption setup tasks.
+    ///   - errorReporter: The service used by the application to report non-fatal errors.
+    ///   - organizationDataStore: The data store for managing the persisted organizations for the user.
+    ///   - stateService: The service used by the application to manage account state.
+    ///
+    init(
+        clientCrypto: ClientCryptoProtocol,
+        errorReporter: ErrorReporter,
+        organizationDataStore: OrganizationDataStore,
+        stateService: StateService
+    ) {
+        self.clientCrypto = clientCrypto
+        self.errorReporter = errorReporter
+        self.organizationDataStore = organizationDataStore
+        self.stateService = stateService
+    }
+}
+
+extension DefaultOrganizationService {
+    func fetchAllOrganizations() async throws -> [Organization] {
+        let userId = try await stateService.getActiveAccountId()
+        return try await organizationDataStore.fetchAllOrganizations(userId: userId)
+    }
+
+    func initializeOrganizationCrypto() async throws {
+        try await initializeOrganizationCrypto(organizations: fetchAllOrganizations())
+    }
+
+    func initializeOrganizationCrypto(organizations: [Organization]) async {
+        let organizationKeysById = organizations
+            .reduce(into: [String: String]()) { result, organization in
+                guard let key = organization.key else { return }
+                result[organization.id] = key
+            }
+        do {
+            try await clientCrypto.initializeOrgCrypto(
+                req: InitOrgCryptoRequest(organizationKeys: organizationKeysById)
+            )
+        } catch {
+            errorReporter.log(error: error)
+        }
+    }
+
+    func replaceOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws {
+        try await organizationDataStore.replaceOrganizations(organizations, userId: userId)
+    }
+
+    // MARK: Publishers
+
+    func organizationsPublisher() async throws -> AnyPublisher<[Organization], Error> {
+        let userID = try await stateService.getActiveAccountId()
+        return organizationDataStore.organizationPublisher(userId: userID)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/OrganizationServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/OrganizationServiceTests.swift
@@ -1,0 +1,150 @@
+import BitwardenSdk
+import XCTest
+
+@testable import BitwardenShared
+
+class OrganizationServiceTests: XCTestCase {
+    // MARK: Properties
+
+    var clientCrypto: MockClientCrypto!
+    var errorReporter: MockErrorReporter!
+    var organizationDataStore: MockOrganizationDataStore!
+    var subject: OrganizationService!
+    var stateService: MockStateService!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        clientCrypto = MockClientCrypto()
+        errorReporter = MockErrorReporter()
+        organizationDataStore = MockOrganizationDataStore()
+        stateService = MockStateService()
+
+        subject = DefaultOrganizationService(
+            clientCrypto: clientCrypto,
+            errorReporter: errorReporter,
+            organizationDataStore: organizationDataStore,
+            stateService: stateService
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        clientCrypto = nil
+        errorReporter = nil
+        organizationDataStore = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `fetchAllOrganizations` returns all organizations,
+    func test_fetchAllOrganizations() async throws {
+        let organizations: [Organization] = [
+            .fixture(id: "1", name: "Organization 1"),
+            .fixture(id: "2", name: "Organization 2"),
+            .fixture(id: "3", name: "Organization 3"),
+        ]
+
+        organizationDataStore.fetchAllOrganizationsResult = .success(organizations)
+        stateService.activeAccount = .fixture()
+
+        let fetchedOrganizations = try await subject.fetchAllOrganizations()
+
+        XCTAssertEqual(fetchedOrganizations, organizations)
+    }
+
+    /// `initializeOrganizationCrypto()` initializes the SDK for decrypting organization ciphers.
+    func test_initializeOrganizationCrypto() async throws {
+        organizationDataStore.fetchAllOrganizationsResult = .success([
+            .fixture(id: "ORG_1", key: "ORG_1_KEY"),
+            .fixture(id: "ORG_2", key: "ORG_2_KEY"),
+        ])
+        stateService.activeAccount = .fixture()
+
+        try await subject.initializeOrganizationCrypto()
+
+        XCTAssertEqual(
+            clientCrypto.initializeOrgCryptoRequest,
+            InitOrgCryptoRequest(organizationKeys: [
+                "ORG_2": "ORG_2_KEY",
+                "ORG_1": "ORG_1_KEY",
+            ])
+        )
+    }
+
+    /// `initializeOrganizationCrypto()` logs an error to the error reporter if initializing
+    /// organization crypto fails.
+    func test_initializeOrganizationCrypto_error() async throws {
+        struct InitializeOrgCryptoError: Error {}
+
+        clientCrypto.initializeOrgCryptoResult = .failure(InitializeOrgCryptoError())
+        stateService.activeAccount = .fixture()
+
+        try await subject.initializeOrganizationCrypto()
+
+        XCTAssertTrue(errorReporter.errors.last is InitializeOrgCryptoError)
+    }
+
+    /// `initializeOrganizationCrypto()` initializes the SDK for decrypting organization ciphers
+    /// with an empty dictionary if the user isn't a part of any organizations.
+    func test_initializeOrganizationCrypto_noOrganizations() async throws {
+        organizationDataStore.fetchAllOrganizationsResult = .success([])
+        stateService.activeAccount = .fixture()
+
+        try await subject.initializeOrganizationCrypto()
+
+        XCTAssertEqual(
+            clientCrypto.initializeOrgCryptoRequest,
+            InitOrgCryptoRequest(organizationKeys: [:])
+        )
+    }
+
+    /// `initializeOrganizationCrypto()` initializes the SDK for decrypting organization ciphers for
+    /// a given set of organizations.
+    func test_initializeOrganizationCrypto_withOrganizations() async {
+        let organizations: [Organization] = [
+            .fixture(id: "ORG_1", key: "ORG_1_KEY"),
+            .fixture(id: "ORG_2", key: "ORG_2_KEY"),
+        ]
+
+        await subject.initializeOrganizationCrypto(organizations: organizations)
+
+        XCTAssertEqual(
+            clientCrypto.initializeOrgCryptoRequest,
+            InitOrgCryptoRequest(organizationKeys: [
+                "ORG_2": "ORG_2_KEY",
+                "ORG_1": "ORG_1_KEY",
+            ])
+        )
+    }
+
+    /// `organizationsPublisher()` returns a publisher that emits data as the data store changes.
+    func test_organizationsPublisher() async throws {
+        stateService.activeAccount = .fixtureAccountLogin()
+
+        var iterator = try await subject.organizationsPublisher().values.makeAsyncIterator()
+        _ = try await iterator.next()
+
+        let organization = Organization.fixture()
+        organizationDataStore.organizationSubject.value = [organization]
+        let publisherValue = try await iterator.next()
+        try XCTAssertEqual(XCTUnwrap(publisherValue), [organization])
+    }
+
+    /// `replaceOrganizations(_:userId:)` replaces the persisted organizations in the data store.
+    func test_replaceOrganizations() async throws {
+        let organizations: [ProfileOrganizationResponseModel] = [
+            .fixture(id: "1", name: "Organization 1"),
+            .fixture(id: "2", name: "Organization 2"),
+        ]
+
+        try await subject.replaceOrganizations(organizations, userId: "1")
+
+        XCTAssertEqual(organizationDataStore.replaceOrganizationsValue, organizations)
+        XCTAssertEqual(organizationDataStore.replaceOrganizationsUserId, "1")
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/OrganizationDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/OrganizationDataStore.swift
@@ -1,0 +1,71 @@
+import BitwardenSdk
+import Combine
+import CoreData
+
+// MARK: - OrganizationDataStore
+
+/// A protocol for a data store that handles performing data requests for organizations.
+///
+protocol OrganizationDataStore: AnyObject {
+    /// Deletes all `Organization` objects for a specific user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the objects to delete.
+    ///
+    func deleteAllOrganizations(userId: String) async throws
+
+    /// A publisher for a user's organization objects.
+    ///
+    /// - Parameter userId: The user ID of the user to associated with the objects to fetch.
+    /// - Returns: A publisher for the user's organizations.
+    ///
+    func organizationPublisher(userId: String) -> AnyPublisher<[Organization], Error>
+
+    /// Fetches the organizations that are available to the user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the organizations to fetch.
+    /// - Returns: The organizations that are available to the user.
+    ///
+    func fetchAllOrganizations(userId: String) async throws -> [Organization]
+
+    /// Replaces a list of `Organization` objects for a user.
+    ///
+    /// - Parameters:
+    ///   - organizations: The list of organizations to replace any existing organizations.
+    ///   - userId: The user ID of the user associated with the organizations.
+    ///
+    func replaceOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws
+}
+
+extension DataStore: OrganizationDataStore {
+    func deleteAllOrganizations(userId: String) async throws {
+        try await executeBatchDelete(OrganizationData.deleteByUserIdRequest(userId: userId))
+    }
+
+    func organizationPublisher(userId: String) -> AnyPublisher<[Organization], Error> {
+        let fetchRequest = OrganizationData.fetchByUserIdRequest(userId: userId)
+        // A sort descriptor is needed by `NSFetchedResultsController`.
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \OrganizationData.id, ascending: true)]
+        return FetchedResultsPublisher(
+            context: persistentContainer.viewContext,
+            request: fetchRequest
+        )
+        .tryMap { try $0.compactMap(Organization.init) }
+        .eraseToAnyPublisher()
+    }
+
+    func fetchAllOrganizations(userId: String) async throws -> [Organization] {
+        try await backgroundContext.perform {
+            let fetchRequest = OrganizationData.fetchByUserIdRequest(userId: userId)
+            return try self.backgroundContext.fetch(fetchRequest).compactMap(Organization.init)
+        }
+    }
+
+    func replaceOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws {
+        let deleteRequest = OrganizationData.deleteByUserIdRequest(userId: userId)
+        let insertRequest = try OrganizationData.batchInsertRequest(objects: organizations, userId: userId)
+        try await executeBatchReplace(
+            deleteRequest: deleteRequest,
+            insertRequest: insertRequest
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/OrganizationDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/OrganizationDataStoreTests.swift
@@ -1,0 +1,113 @@
+import BitwardenSdk
+import CoreData
+import XCTest
+
+@testable import BitwardenShared
+
+class OrganizationDataStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DataStore!
+
+    let organizations = [
+        ProfileOrganizationResponseModel.fixture(id: "1", name: "ORGANIZATION1"),
+        ProfileOrganizationResponseModel.fixture(id: "2", name: "ORGANIZATION2"),
+        ProfileOrganizationResponseModel.fixture(id: "3", name: "ORGANIZATION3"),
+    ]
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `deleteAllOrganizations(user:)` removes all objects for the user.
+    func test_deleteAllOrganizations() async throws {
+        try await insertOrganizations(organizations, userId: "1")
+        try await insertOrganizations(organizations, userId: "2")
+
+        try await subject.deleteAllOrganizations(userId: "1")
+
+        try XCTAssertTrue(fetchOrganizations(userId: "1").isEmpty)
+        try XCTAssertEqual(fetchOrganizations(userId: "2").count, 3)
+    }
+
+    /// `organizationPublisher(userId:)` returns a publisher for a user's organization objects.
+    func test_organizationPublisher() async throws {
+        var publishedValues = [[Organization]]()
+        let publisher = subject.organizationPublisher(userId: "1")
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { values in
+                    publishedValues.append(values)
+                }
+            )
+        defer { publisher.cancel() }
+
+        try await subject.replaceOrganizations(organizations, userId: "1")
+
+        waitFor { publishedValues.count == 2 }
+        XCTAssertTrue(publishedValues[0].isEmpty)
+        XCTAssertEqual(publishedValues[1], organizations.compactMap(Organization.init))
+    }
+
+    /// `fetchAllOrganizations(userId:)` fetches all organizations for a user.
+    func test_fetchAllOrganizations() async throws {
+        try await insertOrganizations(organizations, userId: "1")
+
+        let fetchedOrganizations = try await subject.fetchAllOrganizations(userId: "1")
+        XCTAssertEqual(
+            fetchedOrganizations.sorted(using: KeyPathComparator(\.id)),
+            organizations.compactMap(Organization.init)
+        )
+
+        let emptyOrganizations = try await subject.fetchAllOrganizations(userId: "-1")
+        XCTAssertEqual(emptyOrganizations, [])
+    }
+
+    /// `replaceOrganizations(_:userId)` replaces the list of organizations for the user.
+    func test_replaceOrganizations() async throws {
+        try await insertOrganizations(organizations, userId: "1")
+
+        let newOrganizations = [
+            ProfileOrganizationResponseModel.fixture(id: "3", name: "ORGANIZATION3"),
+            ProfileOrganizationResponseModel.fixture(id: "4", name: "ORGANIZATION4"),
+            ProfileOrganizationResponseModel.fixture(id: "5", name: "ORGANIZATION5"),
+        ]
+        try await subject.replaceOrganizations(newOrganizations, userId: "1")
+
+        XCTAssertEqual(try fetchOrganizations(userId: "1"), newOrganizations.compactMap(Organization.init))
+    }
+
+    // MARK: Test Helpers
+
+    /// A test helper to fetch all organization's for a user.
+    private func fetchOrganizations(userId: String) throws -> [Organization] {
+        let fetchRequest = OrganizationData.fetchByUserIdRequest(userId: userId)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \OrganizationData.id, ascending: true)]
+        return try subject.backgroundContext.fetch(fetchRequest).compactMap(Organization.init)
+    }
+
+    /// A test helper for inserting a list of organizations for a user.
+    private func insertOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws {
+        try await subject.backgroundContext.performAndSave {
+            for organization in organizations {
+                _ = OrganizationData(
+                    context: self.subject.backgroundContext,
+                    userId: userId,
+                    organization: organization
+                )
+            }
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockOrganizationDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockOrganizationDataStore.swift
@@ -1,0 +1,32 @@
+import BitwardenSdk
+import Combine
+
+@testable import BitwardenShared
+
+class MockOrganizationDataStore: OrganizationDataStore {
+    var deleteAllOrganizationsUserId: String?
+
+    var fetchAllOrganizationsResult: Result<[Organization], Error> = .success([])
+
+    var organizationSubject = CurrentValueSubject<[Organization], Error>([])
+
+    var replaceOrganizationsValue: [ProfileOrganizationResponseModel]?
+    var replaceOrganizationsUserId: String?
+
+    func deleteAllOrganizations(userId: String) async throws {
+        deleteAllOrganizationsUserId = userId
+    }
+
+    func fetchAllOrganizations(userId: String) async throws -> [Organization] {
+        try fetchAllOrganizationsResult.get()
+    }
+
+    func organizationPublisher(userId: String) -> AnyPublisher<[Organization], Error> {
+        organizationSubject.eraseToAnyPublisher()
+    }
+
+    func replaceOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws {
+        replaceOrganizationsValue = organizations
+        replaceOrganizationsUserId = userId
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -9,10 +9,9 @@ class SyncServiceTests: BitwardenTestCase {
 
     var cipherService: MockCipherService!
     var client: MockHTTPClient!
-    var clientCrypto: MockClientCrypto!
     var collectionService: MockCollectionService!
-    var errorReporter: MockErrorReporter!
     var folderService: MockFolderService!
+    var organizationService: MockOrganizationService!
     var sendService: MockSendService!
     var stateService: MockStateService!
     var subject: SyncService!
@@ -24,19 +23,17 @@ class SyncServiceTests: BitwardenTestCase {
 
         cipherService = MockCipherService()
         client = MockHTTPClient()
-        clientCrypto = MockClientCrypto()
         collectionService = MockCollectionService()
-        errorReporter = MockErrorReporter()
         folderService = MockFolderService()
+        organizationService = MockOrganizationService()
         sendService = MockSendService()
         stateService = MockStateService()
 
         subject = DefaultSyncService(
             cipherService: cipherService,
-            clientCrypto: clientCrypto,
             collectionService: collectionService,
-            errorReporter: errorReporter,
             folderService: folderService,
+            organizationService: organizationService,
             sendService: sendService,
             stateService: stateService,
             syncAPIService: APIService(client: client)
@@ -48,10 +45,9 @@ class SyncServiceTests: BitwardenTestCase {
 
         cipherService = nil
         client = nil
-        clientCrypto = nil
         collectionService = nil
-        errorReporter = nil
         folderService = nil
+        organizationService = nil
         sendService = nil
         stateService = nil
         subject = nil
@@ -216,6 +212,20 @@ class SyncServiceTests: BitwardenTestCase {
         XCTAssertEqual(folderService.replaceFoldersUserId, "1")
     }
 
+    /// `fetchSync()` replaces the list of the user's organizations.
+    func test_fetchSync_organizations() async throws {
+        client.result = .httpSuccess(testData: .syncWithProfileOrganizations)
+        stateService.activeAccount = .fixture()
+
+        try await subject.fetchSync()
+
+        XCTAssertTrue(organizationService.initializeOrganizationCryptoWithOrgsCalled)
+        XCTAssertEqual(organizationService.replaceOrganizationsOrganizations?.count, 2)
+        XCTAssertEqual(organizationService.replaceOrganizationsOrganizations?[0].id, "ORG_1")
+        XCTAssertEqual(organizationService.replaceOrganizationsOrganizations?[1].id, "ORG_2")
+        XCTAssertEqual(organizationService.replaceOrganizationsUserId, "1")
+    }
+
     /// `fetchSync()` throws an error if the request fails.
     func test_fetchSync_error() async throws {
         client.result = .httpFailure()
@@ -224,48 +234,5 @@ class SyncServiceTests: BitwardenTestCase {
         await assertAsyncThrows {
             try await subject.fetchSync()
         }
-    }
-
-    /// `fetchSync()` initializes the SDK for decrypting organization ciphers.
-    func test_fetchSync_initializeOrgCrypto() async throws {
-        client.result = .httpSuccess(testData: .syncWithProfileOrganizations)
-        stateService.activeAccount = .fixture()
-
-        try await subject.fetchSync()
-
-        XCTAssertEqual(
-            clientCrypto.initializeOrgCryptoRequest,
-            InitOrgCryptoRequest(organizationKeys: [
-                "ORG_2": "ORG_2_KEY",
-                "ORG_1": "ORG_1_KEY",
-            ])
-        )
-    }
-
-    /// `fetchSync()` logs an error to the error reporter if initializing organization crypto fails.
-    func test_fetchSync_initializeOrgCrypto_error() async throws {
-        struct InitializeOrgCryptoError: Error {}
-
-        client.result = .httpSuccess(testData: .syncWithProfileOrganizations)
-        clientCrypto.initializeOrgCryptoResult = .failure(InitializeOrgCryptoError())
-        stateService.activeAccount = .fixture()
-
-        try await subject.fetchSync()
-
-        XCTAssertTrue(errorReporter.errors.last is InitializeOrgCryptoError)
-    }
-
-    /// `fetchSync()` initializes the SDK for decrypting organization ciphers with an empty
-    /// dictionary if the user isn't a part of any organizations.
-    func test_fetchSync_initializesOrgCrypto_noOrganizations() async throws {
-        client.result = .httpSuccess(testData: .syncWithProfile)
-        stateService.activeAccount = .fixture()
-
-        try await subject.fetchSync()
-
-        XCTAssertEqual(
-            clientCrypto.initializeOrgCryptoRequest,
-            InitOrgCryptoRequest(organizationKeys: [:])
-        )
     }
 }

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockOrganizationService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockOrganizationService.swift
@@ -1,0 +1,37 @@
+import BitwardenSdk
+import Combine
+
+@testable import BitwardenShared
+
+class MockOrganizationService: OrganizationService {
+    var fetchAllOrganizationsResult: Result<[Organization], Error> = .success([])
+
+    var initializeOrganizationCryptoCalled = false
+    var initializeOrganizationCryptoWithOrgsCalled = false // swiftlint:disable:this identifier_name
+
+    var organizationsSubject = CurrentValueSubject<[Organization], Error>([])
+
+    var replaceOrganizationsOrganizations: [ProfileOrganizationResponseModel]?
+    var replaceOrganizationsUserId: String?
+
+    func fetchAllOrganizations() async throws -> [Organization] {
+        try fetchAllOrganizationsResult.get()
+    }
+
+    func initializeOrganizationCrypto() async throws {
+        initializeOrganizationCryptoCalled = true
+    }
+
+    func initializeOrganizationCrypto(organizations: [Organization]) async {
+        initializeOrganizationCryptoWithOrgsCalled = true
+    }
+
+    func organizationsPublisher() async throws -> AnyPublisher<[Organization], Error> {
+        organizationsSubject.eraseToAnyPublisher()
+    }
+
+    func replaceOrganizations(_ organizations: [ProfileOrganizationResponseModel], userId: String) async throws {
+        replaceOrganizationsOrganizations = organizations
+        replaceOrganizationsUserId = userId
+    }
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -115,8 +115,8 @@ class VaultListProcessorTests: BitwardenTestCase {
         }
 
         let organizations = [
-            Organization(id: "1", name: "Organization1"),
-            Organization(id: "2", name: "Organization2"),
+            Organization.fixture(id: "1", name: "Organization1"),
+            Organization.fixture(id: "2", name: "Organization2"),
         ]
 
         vaultRepository.organizationsSubject.value = organizations

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -487,7 +487,15 @@ struct VaultListView_Previews: PreviewProvider {
                                     name: "Items"
                                 ),
                             ]),
-                            organizations: [Organization(id: "", name: "Org")]
+                            organizations: [
+                                Organization(
+                                    enabled: true,
+                                    id: "",
+                                    key: nil,
+                                    name: "Org",
+                                    status: .confirmed
+                                ),
+                            ]
                         )
                     )
                 )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1369](https://livefront.atlassian.net/browse/BIT-1369)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the OrganizationDataStore used to persist collections to the database along with the main operations for delete, delete all, and replace.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AuthRepository.swift:** Initializes the SDK for decrypting organization ciphers after the vault is unlocked.
- **DataStore.swift:** Clears organization data for the user on logout.
- **OrganizationData.swift:** The data model for persisting organizations.
- **OrganizationService.swift:** The service for managing syncing and updating the user's organizations.
- **OrganizationDataService.swift:** The data store for persisting organizations.
- **SyncService.swift:** Updates organizations after receiving a sync response.
- **VaultRepository.swift:** Updates to use the organization service for fetching organization data.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
