### PR TITLE
BIT-1363 BIT-1367: More options for login items

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -11,6 +11,8 @@ class MockVaultRepository: VaultRepository {
     var deletedCipher = [String]()
     var deleteCipherResult: Result<Void, Error> = .success(())
     var doesActiveAccountHavePremiumCalled = false
+    var fetchCipherId: String?
+    var fetchCipherResult: Result<CipherView?, Error> = .success(nil)
     var fetchCipherOwnershipOptionsIncludePersonal: Bool? // swiftlint:disable:this identifier_name
     var fetchCipherOwnershipOptions = [CipherOwner]()
     var fetchCollectionsIncludeReadOnly: Bool?
@@ -32,10 +34,6 @@ class MockVaultRepository: VaultRepository {
     var vaultListSubject = CurrentValueSubject<[VaultListSection], Never>([])
     var vaultListGroupSubject = CurrentValueSubject<[VaultListItem], Never>([])
     var vaultListFilter: VaultFilterType?
-
-    func fetchSync(isManualRefresh _: Bool) async throws {
-        fetchSyncCalled = true
-    }
 
     func addCipher(_ cipher: BitwardenSdk.CipherView) async throws {
         addCipherCiphers.append(cipher)
@@ -60,6 +58,11 @@ class MockVaultRepository: VaultRepository {
         return try hasPremiumResult.get()
     }
 
+    func fetchCipher(withId id: String) async throws -> CipherView? {
+        fetchCipherId = id
+        return try fetchCipherResult.get()
+    }
+
     func fetchCipherOwnershipOptions(includePersonal: Bool) async throws -> [CipherOwner] {
         fetchCipherOwnershipOptionsIncludePersonal = includePersonal
         return fetchCipherOwnershipOptions
@@ -72,6 +75,10 @@ class MockVaultRepository: VaultRepository {
 
     func fetchFolders() async throws -> [FolderView] {
         try fetchFoldersResult.get()
+    }
+
+    func fetchSync(isManualRefresh _: Bool) async throws {
+        fetchSyncCalled = true
     }
 
     func remove(userId: String?) async {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -34,6 +34,13 @@ protocol VaultRepository: AnyObject {
     ///
     func doesActiveAccountHavePremium() async throws -> Bool
 
+    /// Attempt to fetch a cipher with the given id.
+    ///
+    /// - Parameter id: The id of the cipher to find.
+    /// - Returns: The cipher if it was found and `nil` if not.
+    ///
+    func fetchCipher(withId id: String) async throws -> CipherView?
+
     /// Fetches the ownership options that the user can select from for a cipher.
     ///
     /// - Parameter includePersonal: Whether to include the user's personal vault in the list.
@@ -423,6 +430,11 @@ extension DefaultVaultRepository: VaultRepository {
         }
         // TODO: BIT-92 Insert response into database instead of fetching sync.
         try await fetchSync(isManualRefresh: false)
+    }
+
+    func fetchCipher(withId id: String) async throws -> CipherView? {
+        guard let cipher = try await cipherService.fetchCipher(withId: id) else { return nil }
+        return try? await clientVault.ciphers().decrypt(cipher: cipher)
     }
 
     func fetchCipherOwnershipOptions(includePersonal: Bool) async throws -> [CipherOwner] {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -187,6 +187,22 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertTrue(hasPremium)
     }
 
+    /// `fetchCipher(withId:)` returns the cipher if it exists and `nil` otherwise.
+    func test_fetchCipher() async throws {
+        var cipher = try await subject.fetchCipher(withId: "1")
+
+        XCTAssertEqual(cipherService.fetchCipherId, "1")
+        XCTAssertNil(cipher)
+
+        let testCipher = Cipher.fixture(id: "2")
+        cipherService.fetchCipherResult = .success(testCipher)
+
+        cipher = try await subject.fetchCipher(withId: "2")
+
+        XCTAssertEqual(cipherService.fetchCipherId, "2")
+        XCTAssertEqual(cipher, CipherView(cipher: testCipher))
+    }
+
     /// `fetchCipherOwnershipOptions()` returns the ownership options containing organizations.
     func test_fetchCipherOwnershipOptions_organizations() async throws {
         stateService.activeAccount = .fixture()

--- a/BitwardenShared/Core/Vault/Services/CipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherService.swift
@@ -12,6 +12,13 @@ protocol CipherService {
     ///
     func deleteCipherWithServer(id: String) async throws
 
+    /// Attempt to fetch a cipher with the given id.
+    ///
+    /// - Parameter id: The id of the cipher to find.
+    /// - Returns: The cipher if it was found and `nil` if not.
+    ///
+    func fetchCipher(withId id: String) async throws -> Cipher?
+
     /// Replaces the persisted list of ciphers for the user.
     ///
     /// - Parameters:
@@ -84,6 +91,11 @@ extension DefaultCipherService {
 
         // Delete cipher from local storage
         try await cipherDataStore.deleteCipher(id: id, userId: userID)
+    }
+
+    func fetchCipher(withId id: String) async throws -> Cipher? {
+        let userId = try await stateService.getActiveAccountId()
+        return try await cipherDataStore.fetchCipher(withId: id, userId: userId)
     }
 
     func replaceCiphers(_ ciphers: [CipherDetailsResponseModel], userId: String) async throws {

--- a/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
@@ -62,6 +62,22 @@ class CipherServiceTests: XCTestCase {
         XCTAssertEqual(cipherDataStore.deleteCipherUserId, "13512467-9cfe-43b0-969f-07534084764b")
     }
 
+    /// `fetchCipher(withId:)` returns the cipher if it exists and nil otherwise.
+    func test_fetchCipher() async throws {
+        stateService.activeAccount = .fixture()
+
+        var cipher = try await subject.fetchCipher(withId: "1")
+        XCTAssertNil(cipher)
+        XCTAssertEqual(cipherDataStore.fetchCipherId, "1")
+
+        let testCipher = Cipher.fixture(id: "2")
+        cipherDataStore.fetchCipherResult = testCipher
+
+        cipher = try await subject.fetchCipher(withId: "2")
+        XCTAssertEqual(cipher, testCipher)
+        XCTAssertEqual(cipherDataStore.fetchCipherId, "2")
+    }
+
     /// `replaceCiphers(_:userId:)` replaces the persisted ciphers in the data store.
     func test_replaceCiphers() async throws {
         let ciphers: [CipherDetailsResponseModel] = [

--- a/BitwardenShared/Core/Vault/Services/Stores/CipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CipherDataStore.swift
@@ -21,6 +21,15 @@ protocol CipherDataStore: AnyObject {
     ///
     func deleteCipher(id: String, userId: String) async throws
 
+    /// Attempt to fetch a cipher with the given id.
+    ///
+    /// - Parameters:
+    ///   - id: The id of the cipher to find.
+    ///   - userId: The user ID of the user associated with the ciphers.
+    /// - Returns: The cipher if it was found and `nil` if not.
+    ///
+    func fetchCipher(withId id: String, userId: String) async throws -> Cipher?
+
     /// A publisher for a user's cipher objects.
     ///
     /// - Parameter userId: The user ID of the user to associated with the objects to fetch.
@@ -56,6 +65,14 @@ extension DataStore: CipherDataStore {
             for result in results {
                 self.backgroundContext.delete(result)
             }
+        }
+    }
+
+    func fetchCipher(withId id: String, userId: String) async throws -> Cipher? {
+        try await backgroundContext.perform {
+            try self.backgroundContext.fetch(CipherData.fetchByIdRequest(id: id, userId: userId))
+                .compactMap(Cipher.init)
+                .first
         }
     }
 

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
@@ -9,6 +9,9 @@ class MockCipherDataStore: CipherDataStore {
     var deleteCipherId: String?
     var deleteCipherUserId: String?
 
+    var fetchCipherId: String?
+    var fetchCipherResult: Cipher?
+
     var cipherSubject = CurrentValueSubject<[Cipher], Error>([])
 
     var replaceCiphersValue: [Cipher]?
@@ -26,7 +29,12 @@ class MockCipherDataStore: CipherDataStore {
         deleteCipherUserId = userId
     }
 
-    func cipherPublisher(userId: String) -> AnyPublisher<[Cipher], Error> {
+    func fetchCipher(withId id: String, userId _: String) async -> Cipher? {
+        fetchCipherId = id
+        return fetchCipherResult
+    }
+
+    func cipherPublisher(userId _: String) -> AnyPublisher<[Cipher], Error> {
         cipherSubject.eraseToAnyPublisher()
     }
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
@@ -5,6 +5,10 @@ import Combine
 
 class MockCipherService: CipherService {
     var ciphersSubject = CurrentValueSubject<[Cipher], Error>([])
+
+    var fetchCipherId: String?
+    var fetchCipherResult: Result<Cipher?, Error> = .success(nil)
+
     var replaceCiphersCiphers: [CipherDetailsResponseModel]?
     var replaceCiphersUserId: String?
 
@@ -21,6 +25,11 @@ class MockCipherService: CipherService {
     func deleteCipherWithServer(id: String) async throws {
         deleteCipherId = id
         try deleteWithServerResult.get()
+    }
+
+    func fetchCipher(withId id: String) async throws -> Cipher? {
+        fetchCipherId = id
+        return try fetchCipherResult.get()
     }
 
     func replaceCiphers(_ ciphers: [CipherDetailsResponseModel], userId: String) async throws {

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -1,0 +1,83 @@
+import BitwardenSdk
+import UIKit
+
+// MARK: - Alert+Vault
+
+extension Alert {
+    /// An alert presenting the user with more options for a vault list item.
+    ///
+    /// - Parameters:
+    ///   - cipherView: The cipher view to show.
+    ///   - id: The id of the item.
+    ///   - showEdit: Whether to show the edit option (should be `false` for items in the trash).
+    ///   - action: The action to perform after selecting an option.
+    ///
+    /// - Returns: An alert presenting the user with options to select an attachment type.
+    @MainActor
+    static func moreOptions( // swiftlint:disable:this function_body_length
+        cipherView: CipherView,
+        id: String,
+        showEdit: Bool,
+        action: @escaping (_ action: MoreOptionsAction) -> Void
+    ) -> Alert {
+        // All the cipher types have the option to view the cipher.
+        var alertActions = [
+            AlertAction(title: Localizations.view, style: .default) { _, _ in action(.view(id: id)) },
+        ]
+
+        // Add the option to edit the cipher if desired.
+        if showEdit {
+            alertActions.append(AlertAction(title: Localizations.edit, style: .default) { _, _ in
+                action(.edit(cipherView: cipherView))
+            })
+        }
+
+        // Add any additional actions for the type of cipher selected.
+        switch cipherView.type {
+        case .card:
+            // TODO: BIT-1365
+            // TODO: BIT-1374
+            break
+        case .login:
+            if let username = cipherView.login?.username {
+                alertActions.append(AlertAction(title: Localizations.copyUsername, style: .default) { _, _ in
+                    action(.copy(
+                        toast: Localizations.username,
+                        value: username
+                    ))
+                })
+            }
+            if let password = cipherView.login?.password {
+                alertActions.append(AlertAction(title: Localizations.copyPassword, style: .default) { _, _ in
+                    action(.copy(
+                        toast: Localizations.password,
+                        value: password
+                    ))
+                })
+            }
+            if let uri = cipherView.login?.uris?.first?.uri,
+               let url = URL(string: uri) {
+                alertActions
+                    .append(AlertAction(title: Localizations.launch, style: .default) { _, _ in
+                        action(.launch(url: url))
+                    })
+            }
+        case .identity:
+            // TODO: BIT-1364
+            // TODO: BIT-1368
+            break
+        case .secureNote:
+            // TODO: BIT-1366
+            // TODO: BIT-1375
+            break
+        }
+
+        // Return the alert.
+        return Alert(
+            title: cipherView.name,
+            message: nil,
+            preferredStyle: .actionSheet,
+            alertActions: alertActions + [AlertAction(title: Localizations.cancel, style: .cancel)]
+        )
+    }
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import SwiftUI
 
 // MARK: - VaultCoordinatorDelegate
@@ -91,6 +92,8 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
             stackNavigator.present(alert)
         case .autofillList:
             showAutofillList()
+        case let .editItem(cipher: cipher):
+            showVaultItem(route: .editItem(cipher: cipher))
         case .dismiss:
             stackNavigator.dismiss()
         case let .group(group):

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -86,6 +86,16 @@ class VaultCoordinatorTests: BitwardenTestCase {
         XCTAssertEqual(stackNavigator.alerts.last, alert)
     }
 
+    /// `.navigate(to:)` with `.editItem` presents the edit item screen.
+    func test_navigateTo_editItem() throws {
+        subject.navigate(to: .editItem(cipher: .fixture()))
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(module.vaultItemCoordinator.isStarted)
+        XCTAssertEqual(module.vaultItemCoordinator.routes.last, .editItem(cipher: .fixture()))
+    }
+
     /// `navigate(to:)` with `.dismiss` dismisses the top most view presented by the stack
     /// navigator.
     func test_navigate_dismiss() throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
@@ -5,15 +5,13 @@ enum VaultGroupAction: Equatable {
     /// The add item button was pressed.
     case addItemPressed
 
+    /// The url has been opened so clear the value in the state.
+    case clearURL
+
     /// An item in the vault group was tapped.
     ///
     /// - Parameter item: The item that was tapped.
     case itemPressed(_ item: VaultListItem)
-
-    /// The more button on an item in the vault group was tapped.
-    ///
-    /// - Parameter item: The item associated with the more button that was tapped.
-    case morePressed(_ item: VaultListItem)
 
     /// The search bar's text was changed.
     case searchTextChanged(String)

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
@@ -5,6 +5,11 @@ enum VaultGroupEffect: Equatable {
     /// The vault group view appeared on screen.
     case appeared
 
+    /// The more button on an item in the vault group was tapped.
+    ///
+    /// - Parameter item: The item associated with the more button that was tapped.
+    case morePressed(_ item: VaultListItem)
+
     /// The refresh control was triggered.
     case refresh
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import Foundation
 
 // MARK: - VaultGroupProcessor
@@ -6,7 +7,9 @@ import Foundation
 final class VaultGroupProcessor: StateProcessor<VaultGroupState, VaultGroupAction, VaultGroupEffect> {
     // MARK: Types
 
-    typealias Services = HasVaultRepository
+    typealias Services = HasErrorReporter
+        & HasPasteboardService
+        & HasVaultRepository
 
     // MARK: Private Properties
 
@@ -43,6 +46,8 @@ final class VaultGroupProcessor: StateProcessor<VaultGroupState, VaultGroupActio
             for await value in services.vaultRepository.vaultListPublisher(group: state.group) {
                 state.loadingState = .data(value)
             }
+        case let .morePressed(item):
+            await showMoreOptionsAlert(for: item)
         case .refresh:
             await refreshVaultGroup()
         }
@@ -52,6 +57,8 @@ final class VaultGroupProcessor: StateProcessor<VaultGroupState, VaultGroupActio
         switch action {
         case .addItemPressed:
             coordinator.navigate(to: .addItem(group: state.group))
+        case .clearURL:
+            state.url = nil
         case let .itemPressed(item):
             switch item.itemType {
             case .cipher:
@@ -61,9 +68,6 @@ final class VaultGroupProcessor: StateProcessor<VaultGroupState, VaultGroupActio
             case let .totp(id: id, _, _):
                 coordinator.navigate(to: .viewItem(id: id))
             }
-        case let .morePressed(item):
-            // TODO: BIT-375 Show the more menu
-            print("more: \(item.id)")
         case let .searchTextChanged(newValue):
             state.searchText = newValue
         case let .toastShown(newValue):
@@ -81,6 +85,46 @@ final class VaultGroupProcessor: StateProcessor<VaultGroupState, VaultGroupActio
         } catch {
             // TODO: BIT-1034 Add an error alert
             print(error)
+        }
+    }
+
+    /// Show the more options alert for the selected item.
+    ///
+    /// - Parameter item: The selected item to show the options for.
+    ///
+    private func showMoreOptionsAlert(for item: VaultListItem) async {
+        // Load the content of the cipher item to determine which values to show in the menu.
+        do {
+            guard let cipherView = try await services.vaultRepository.fetchCipher(withId: item.id)
+            else { return }
+
+            coordinator.showAlert(.moreOptions(
+                cipherView: cipherView,
+                id: item.id,
+                showEdit: state.group != .trash,
+                action: handleMoreOptionsAction
+            ))
+        } catch {
+            coordinator.showAlert(.networkResponseError(error))
+            services.errorReporter.log(error: error)
+        }
+    }
+
+    /// Handle the result of the selected option on the More Options alert..
+    ///
+    /// - Parameter action: The selected action.
+    ///
+    private func handleMoreOptionsAction(_ action: MoreOptionsAction) {
+        switch action {
+        case let .copy(toast: toast, value: value):
+            services.pasteboardService.copy(value)
+            state.toast = Toast(text: Localizations.valueHasBeenCopied(toast))
+        case let .edit(cipherView: cipherView):
+            coordinator.navigate(to: .editItem(cipher: cipherView))
+        case let .launch(url: url):
+            state.url = url.sanitized
+        case let .view(id: id):
+            coordinator.navigate(to: .viewItem(id: id))
         }
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import XCTest
 
 @testable import BitwardenShared
@@ -8,6 +9,8 @@ class VaultGroupProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<VaultRoute>!
+    var errorReporter: MockErrorReporter!
+    var pasteboardService: MockPasteboardService!
     var subject: VaultGroupProcessor!
     var vaultRepository: MockVaultRepository!
 
@@ -15,23 +18,42 @@ class VaultGroupProcessorTests: BitwardenTestCase {
 
     override func setUp() {
         super.setUp()
+
         coordinator = MockCoordinator()
+        errorReporter = MockErrorReporter()
+        pasteboardService = MockPasteboardService()
         vaultRepository = MockVaultRepository()
+
         subject = VaultGroupProcessor(
             coordinator: coordinator.asAnyCoordinator(),
-            services: ServiceContainer.withMocks(vaultRepository: vaultRepository),
+            services: ServiceContainer.withMocks(
+                errorReporter: errorReporter,
+                pasteboardService: pasteboardService,
+                vaultRepository: vaultRepository
+            ),
             state: VaultGroupState()
         )
     }
 
     override func tearDown() {
         super.tearDown()
+
         coordinator = nil
+        errorReporter = nil
+        pasteboardService = nil
         subject = nil
         vaultRepository = nil
     }
 
     // MARK: Tests
+
+    /// `itemDeleted()` delegate method shows the expected toast.
+    func test_delegate_itemDeleted() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.itemDeleted()
+        XCTAssertEqual(subject.state.toast?.text, Localizations.itemSoftDeleted)
+    }
 
     /// `perform(_:)` with `.appeared` starts streaming vault items.
     func test_perform_appeared() {
@@ -51,6 +73,104 @@ class VaultGroupProcessorTests: BitwardenTestCase {
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
 
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
+    func test_perform_morePressed_card() async throws {
+        // TODO: BIT-1365
+        // TODO: BIT-1374
+    }
+
+    /// `perform(_:)` with `.morePressed` handles errors correctly.
+    func test_perform_morePressed_error() async throws {
+        vaultRepository.fetchCipherResult = .failure(BitwardenTestError.example)
+
+        await subject.perform(.morePressed(.fixture()))
+
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
+    func test_perform_morePressed_login() async throws {
+        let item = try XCTUnwrap(VaultListItem(cipherListView: CipherListView.fixture(type: .login)))
+
+        // If the login item has no username, password, or url, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.loginFixture())
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // If the item is in the trash, the edit option should not display.
+        subject.state.group = .trash
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+
+        // A login with data should show the copy and launch actions.
+        let loginWithData = CipherView.loginFixture(login: .fixture(
+            password: "password",
+            uris: [.init(uri: URL.example.relativeString, match: nil)],
+            username: "username"
+        ))
+        vaultRepository.fetchCipherResult = .success(loginWithData)
+        subject.state.group = .login
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 6)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyUsername)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.launch)
+        XCTAssertEqual(alert.alertActions[5].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(cipher: loginWithData))
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's username.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "password")
+
+        // Launch action set's the url to open.
+        let launchAction = try XCTUnwrap(alert.alertActions[4])
+        await launchAction.handler?(launchAction, [])
+        XCTAssertEqual(subject.state.url, .example)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for an identity cipher.
+    func test_perform_morePressed_identity() async throws {
+        // TODO: BIT-1364
+        // TODO: BIT-1368
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a secure note cipher.
+    func test_perform_morePressed_secureNote() async throws {
+        // TODO: BIT-1366
+        // TODO: BIT-1375
+    }
+
     /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository.
     func test_perform_refreshed() async {
         await subject.perform(.refresh)
@@ -64,24 +184,23 @@ class VaultGroupProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .addItem(group: .card))
     }
 
-    /// `itemDeleted()` delegate method shows the expected toast.
-    func test_delegate_itemDeleted() {
-        XCTAssertNil(subject.state.toast)
-
-        subject.itemDeleted()
-        XCTAssertEqual(subject.state.toast?.text, Localizations.itemSoftDeleted)
+    /// `receive(_:)` with `.clearURL` clears the url in the state.
+    func test_receive_clearURL() {
+        subject.state.url = .example
+        subject.receive(.clearURL)
+        XCTAssertNil(subject.state.url)
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to the `.viewItem` route.
-    func test_receive_itemPressed() {
+    /// `receive(_:)` with `.itemPressed` on a cipher navigates to the `.viewItem` route.
+    func test_receive_itemPressed_cipher() {
         subject.receive(.itemPressed(.fixture(cipherListView: .fixture(id: "id"))))
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: "id"))
     }
 
-    /// `receive(_:)` with `.morePressed` navigates to the more menu.
-    func test_receive_morePressed() {
-        subject.receive(.morePressed(.fixture()))
-        // TODO: BIT-375 Assert navigation to the more menu
+    /// `receive(_:)` with `.itemPressed` on a group navigates to the `.group` route.
+    func test_receive_itemPressed_group() {
+        subject.receive(.itemPressed(VaultListItem(id: "1", itemType: .group(.card, 2))))
+        XCTAssertEqual(coordinator.routes.last, .group(.card))
     }
 
     /// `receive(_:)` with `.searchTextChanged` and no value sets the state correctly.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -17,4 +17,7 @@ struct VaultGroupState: Equatable {
 
     /// A toast message to show in the view.
     var toast: Toast?
+
+    /// The url to open in the device's web browser.
+    var url: URL?
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -6,8 +6,13 @@ import SwiftUI
 struct VaultGroupView: View {
     // MARK: Properties
 
+    /// An object used to open urls from this view.
+    @Environment(\.openURL) private var openURL
+
     /// The `Store` for this view.
     @ObservedObject var store: Store<VaultGroupState, VaultGroupAction, VaultGroupEffect>
+
+    // MARK: View
 
     var body: some View {
         LoadingView(
@@ -43,9 +48,14 @@ struct VaultGroupView: View {
             get: \.toast,
             send: VaultGroupAction.toastShown
         ))
+        .onChange(of: store.state.url) { newValue in
+            guard let url = newValue else { return }
+            openURL(url)
+            store.send(.clearURL)
+        }
     }
 
-    // MARK: Private Properties
+    // MARK: Private Views
 
     /// A view that displays an empty state for this vault group.
     @ViewBuilder private var emptyView: some View {
@@ -99,13 +109,9 @@ struct VaultGroupView: View {
                                         hasDivider: items.last != item
                                     )
                                 },
-                                mapAction: { action in
-                                    switch action {
-                                    case .morePressed:
-                                        return .morePressed(item)
-                                    }
-                                },
-                                mapEffect: nil
+                                mapAction: nil,
+                                mapEffect: { _ in .morePressed(item)
+                                }
                             ))
                         }
                     }
@@ -120,83 +126,80 @@ struct VaultGroupView: View {
 
 // MARK: Previews
 
-#if DEBUG
-struct VaultItemListView_Previews: PreviewProvider {
-    static var previews: some View {
-        NavigationView {
-            VaultGroupView(
-                store: Store(
-                    processor: StateProcessor(
-                        state: VaultGroupState(
-                            loadingState: .loading
-                        )
+#Preview("Loading") {
+    NavigationView {
+        VaultGroupView(
+            store: Store(
+                processor: StateProcessor(
+                    state: VaultGroupState(
+                        loadingState: .loading
                     )
                 )
             )
-        }
-        .previewDisplayName("Loading")
-
-        NavigationView {
-            VaultGroupView(
-                store: Store(
-                    processor: StateProcessor(
-                        state: VaultGroupState(
-                            loadingState: .data([])
-                        )
-                    )
-                )
-            )
-        }
-        .previewDisplayName("Empty")
-
-        NavigationView {
-            VaultGroupView(
-                store: Store(
-                    processor: StateProcessor(
-                        state: VaultGroupState(
-                            group: .login,
-                            loadingState: .data([
-                                .init(cipherListView: .init(
-                                    id: UUID().uuidString,
-                                    organizationId: nil,
-                                    folderId: nil,
-                                    collectionIds: [],
-                                    name: "Example",
-                                    subTitle: "email@example.com",
-                                    type: .login,
-                                    favorite: true,
-                                    reprompt: .none,
-                                    edit: false,
-                                    viewPassword: true,
-                                    attachments: 0,
-                                    creationDate: Date(),
-                                    deletedDate: nil,
-                                    revisionDate: Date()
-                                ))!,
-                                .init(cipherListView: .init(
-                                    id: UUID().uuidString,
-                                    organizationId: nil,
-                                    folderId: nil,
-                                    collectionIds: [],
-                                    name: "Example 2",
-                                    subTitle: "email2@example.com",
-                                    type: .login,
-                                    favorite: true,
-                                    reprompt: .none,
-                                    edit: false,
-                                    viewPassword: true,
-                                    attachments: 0,
-                                    creationDate: Date(),
-                                    deletedDate: nil,
-                                    revisionDate: Date()
-                                ))!,
-                            ])
-                        )
-                    )
-                )
-            )
-        }
-        .previewDisplayName("Logins")
+        )
     }
 }
-#endif
+
+#Preview("Empty") {
+    NavigationView {
+        VaultGroupView(
+            store: Store(
+                processor: StateProcessor(
+                    state: VaultGroupState(
+                        loadingState: .data([])
+                    )
+                )
+            )
+        )
+    }
+}
+
+#Preview("Logins") {
+    NavigationView {
+        VaultGroupView(
+            store: Store(
+                processor: StateProcessor(
+                    state: VaultGroupState(
+                        group: .login,
+                        loadingState: .data([
+                            .init(cipherListView: .init(
+                                id: UUID().uuidString,
+                                organizationId: nil,
+                                folderId: nil,
+                                collectionIds: [],
+                                name: "Example",
+                                subTitle: "email@example.com",
+                                type: .login,
+                                favorite: true,
+                                reprompt: .none,
+                                edit: false,
+                                viewPassword: true,
+                                attachments: 0,
+                                creationDate: Date(),
+                                deletedDate: nil,
+                                revisionDate: Date()
+                            ))!,
+                            .init(cipherListView: .init(
+                                id: UUID().uuidString,
+                                organizationId: nil,
+                                folderId: nil,
+                                collectionIds: [],
+                                name: "Example 2",
+                                subTitle: "email2@example.com",
+                                type: .login,
+                                favorite: true,
+                                reprompt: .none,
+                                edit: false,
+                                viewPassword: true,
+                                attachments: 0,
+                                creationDate: Date(),
+                                deletedDate: nil,
+                                revisionDate: Date()
+                            ))!,
+                        ])
+                    )
+                )
+            )
+        )
+    }
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupViewTests.swift
@@ -31,6 +31,14 @@ class VaultGroupViewTests: BitwardenTestCase {
     /// Tapping the add an item button dispatches the `.addItemPressed` action.
     func test_addAnItemButton_tap() throws {
         processor.state.loadingState = .data([])
+        let button = try subject.inspect().find(button: Localizations.addAnItem)
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed)
+    }
+
+    /// Tapping the add an item toolbar button dispatches the `.addItemPressed` action.
+    func test_addAnItemToolbarButton_tap() throws {
+        processor.state.loadingState = .data([])
         let button = try subject.inspect().find(button: Localizations.add)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed)
@@ -46,12 +54,12 @@ class VaultGroupViewTests: BitwardenTestCase {
     }
 
     /// Tapping the more button on a vault item dispatches the `.morePressed` action.
-    func test_vaultItemMoreButton_tap() throws {
+    func test_vaultItemMoreButton_tap() async throws {
         let item = VaultListItem.fixture()
         processor.state.loadingState = .data([item])
-        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.more)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed(item))
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .morePressed(item))
     }
 
     // MARK: Snapshots

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
@@ -7,11 +7,11 @@ enum VaultListAction: Equatable {
     /// The add item button was pressed.
     case addItemPressed
 
+    /// The url has been opened so clear the value in the state.
+    case clearURL
+
     /// An item in the vault was pressed.
     case itemPressed(item: VaultListItem)
-
-    /// The more button was pressed on an item in the vault.
-    case morePressed(item: VaultListItem)
 
     /// A forwarded profile switcher action
     case profileSwitcherAction(ProfileSwitcherAction)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
@@ -1,9 +1,12 @@
 // MARK: - VaultListEffect
 
 /// Effects that can be processed by a `VaultListProcessor`.
-enum VaultListEffect {
+enum VaultListEffect: Equatable {
     /// The vault list appeared on screen.
     case appeared
+
+    /// The more button was pressed on an item in the vault.
+    case morePressed(item: VaultListItem)
 
     /// A Profile Switcher Effect.
     case profileSwitcher(ProfileSwitcherEffect)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import SwiftUI
 
 // MARK: - VaultListProcessor
@@ -9,6 +10,7 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
 
     typealias Services = HasAuthRepository
         & HasErrorReporter
+        & HasPasteboardService
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -44,6 +46,8 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
         switch effect {
         case .appeared:
             await refreshVault(isManualRefresh: false)
+        case let .morePressed(item):
+            await showMoreOptionsAlert(for: item)
         case let .profileSwitcher(profileEffect):
             switch profileEffect {
             case let .rowAppeared(rowType):
@@ -70,6 +74,8 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
         case .addItemPressed:
             setProfileSwitcher(visible: false)
             coordinator.navigate(to: .addItem())
+        case .clearURL:
+            state.url = nil
         case let .itemPressed(item):
             switch item.itemType {
             case .cipher:
@@ -79,9 +85,6 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
             case let .totp(id: id, _, _):
                 coordinator.navigate(to: .viewItem(id: id))
             }
-        case .morePressed:
-            // TODO: BIT-375 Show item actions
-            break
         case let .profileSwitcherAction(profileAction):
             switch profileAction {
             case let .accountPressed(account):
@@ -194,7 +197,7 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
         }
     }
 
-    /// Sets the visibility of the profiles view and updates accessbility focus
+    /// Sets the visibility of the profiles view and updates accessibility focus
     /// - Parameter visible: the intended visibility of the view
     private func setProfileSwitcher(visible: Bool) {
         if !visible {
@@ -214,6 +217,46 @@ final class VaultListProcessor: StateProcessor<VaultListState, VaultListAction, 
             services.errorReporter.log(error: error)
         }
     }
+
+    /// Show the more options alert for the selected item.
+    ///
+    /// - Parameter item: The selected item to show the options for.
+    ///
+    private func showMoreOptionsAlert(for item: VaultListItem) async {
+        // Load the content of the cipher item to determine which values to show in the menu.
+        do {
+            guard let cipherView = try await services.vaultRepository.fetchCipher(withId: item.id)
+            else { return }
+
+            coordinator.showAlert(.moreOptions(
+                cipherView: cipherView,
+                id: item.id,
+                showEdit: true,
+                action: handleMoreOptionsAction
+            ))
+        } catch {
+            coordinator.showAlert(.networkResponseError(error))
+            services.errorReporter.log(error: error)
+        }
+    }
+
+    /// Handle the result of the selected option on the More Options alert..
+    ///
+    /// - Parameter action: The selected action.
+    ///
+    private func handleMoreOptionsAction(_ action: MoreOptionsAction) {
+        switch action {
+        case let .copy(toast: toast, value: value):
+            services.pasteboardService.copy(value)
+            state.toast = Toast(text: Localizations.valueHasBeenCopied(toast))
+        case let .edit(cipherView: cipherView):
+            coordinator.navigate(to: .editItem(cipher: cipherView))
+        case let .launch(url: url):
+            state.url = url.sanitized
+        case let .view(id: id):
+            coordinator.navigate(to: .viewItem(id: id))
+        }
+    }
 }
 
 // MARK: - CipherItemOperationDelegate
@@ -222,4 +265,21 @@ extension VaultListProcessor: CipherItemOperationDelegate {
     func itemDeleted() {
         state.toast = Toast(text: Localizations.itemSoftDeleted)
     }
+}
+
+// MARK: - MoreOptionsAction
+
+/// The actions available from the More Options alert.
+enum MoreOptionsAction {
+    /// Copy the `value` and show a toast with the `toast` string.
+    case copy(toast: String, value: String)
+
+    /// Navigate to the view to edit the `cipherView`.
+    case edit(cipherView: CipherView)
+
+    /// Launch the `url` in the device's browser.
+    case launch(url: URL)
+
+    /// Navigate to view the item with the given `id`.
+    case view(id: String)
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -1,14 +1,19 @@
+import BitwardenSdk
 import XCTest
 
 @testable import BitwardenShared
 
 // MARK: - VaultListProcessorTests
 
-class VaultListProcessorTests: BitwardenTestCase {
+// swiftlint:disable file_length
+
+class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var authRepository: MockAuthRepository!
     var coordinator: MockCoordinator<VaultRoute>!
+    var errorReporter: MockErrorReporter!
+    var pasteboardService: MockPasteboardService!
     var subject: VaultListProcessor!
     var vaultRepository: MockVaultRepository!
 
@@ -19,13 +24,19 @@ class VaultListProcessorTests: BitwardenTestCase {
 
     override func setUp() {
         super.setUp()
+
         authRepository = MockAuthRepository()
+        errorReporter = MockErrorReporter()
         coordinator = MockCoordinator()
+        pasteboardService = MockPasteboardService()
         vaultRepository = MockVaultRepository()
         let services = ServiceContainer.withMocks(
             authRepository: authRepository,
+            errorReporter: errorReporter,
+            pasteboardService: pasteboardService,
             vaultRepository: vaultRepository
         )
+
         subject = VaultListProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: services,
@@ -35,19 +46,118 @@ class VaultListProcessorTests: BitwardenTestCase {
 
     override func tearDown() {
         super.tearDown()
+
         authRepository = nil
         coordinator = nil
+        errorReporter = nil
+        pasteboardService = nil
         subject = nil
         vaultRepository = nil
     }
 
     // MARK: Tests
 
+    /// `itemDeleted()` delegate method shows the expected toast.
+    func test_delegate_itemDeleted() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.itemDeleted()
+        XCTAssertEqual(subject.state.toast?.text, Localizations.itemSoftDeleted)
+    }
+
     /// `perform(_:)` with `.appeared` starts listening for updates with the vault repository.
     func test_perform_appeared() async {
         await subject.perform(.appeared)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
+    func test_perform_morePressed_card() async throws {
+        // TODO: BIT-1365
+        // TODO: BIT-1374
+    }
+
+    /// `perform(_:)` with `.morePressed` handles errors correctly.
+    func test_perform_morePressed_error() async throws {
+        vaultRepository.fetchCipherResult = .failure(BitwardenTestError.example)
+
+        await subject.perform(.morePressed(item: .fixture()))
+
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
+    func test_perform_morePressed_login() async throws {
+        let item = try XCTUnwrap(VaultListItem(cipherListView: CipherListView.fixture(type: .login)))
+
+        // If the login item has no username, password, or url, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.loginFixture())
+        await subject.perform(.morePressed(item: item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // A login with data should show the copy and launch actions.
+        let loginWithData = CipherView.loginFixture(login: .fixture(
+            password: "password",
+            uris: [.init(uri: URL.example.relativeString, match: nil)],
+            username: "username"
+        ))
+        vaultRepository.fetchCipherResult = .success(loginWithData)
+        await subject.perform(.morePressed(item: item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 6)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyUsername)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.launch)
+        XCTAssertEqual(alert.alertActions[5].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(cipher: loginWithData))
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's username.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "password")
+
+        // Launch action set's the url to open.
+        let launchAction = try XCTUnwrap(alert.alertActions[4])
+        await launchAction.handler?(launchAction, [])
+        XCTAssertEqual(subject.state.url, .example)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for an identity cipher.
+    func test_perform_morePressed_identity() async throws {
+        // TODO: BIT-1364
+        // TODO: BIT-1368
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a secure note cipher.
+    func test_perform_morePressed_secureNote() async throws {
+        // TODO: BIT-1366
+        // TODO: BIT-1375
     }
 
     /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository.
@@ -65,8 +175,8 @@ class VaultListProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.profileSwitcherState.alternateAccounts, [])
     }
 
-    // swiftlint:disable:next line_length
-    /// `perform(.refreshAccountProfiles)` with mismatched active account and accounts should yield an empty profile switcher state.
+    /// `perform(.refreshAccountProfiles)` with mismatched active account and accounts should yield an empty
+    /// profile switcher state.
     func test_perform_refresh_profiles_mismatch() async {
         let profile = ProfileSwitcherItem()
         authRepository.accountsResult = .success([])
@@ -86,8 +196,8 @@ class VaultListProcessorTests: BitwardenTestCase {
         XCTAssertEqual(profile1, subject.state.profileSwitcherState.activeAccountProfile)
     }
 
-    // swiftlint:disable:next line_length
-    /// `perform(.refreshAccountProfiles)` with no active account and accounts should yield an empty profile switcher state.
+    /// `perform(.refreshAccountProfiles)` with no active account and accounts should yield an empty
+    /// profile switcher state.
     func test_perform_refresh_profiles_single_notActive() async {
         authRepository.accountsResult = .success([profile1])
         await subject.perform(.refreshAccountProfiles)
@@ -97,8 +207,8 @@ class VaultListProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.profileSwitcherState.accounts, [profile1])
     }
 
-    // swiftlint:disable:next line_length
-    /// `perform(.refreshAccountProfiles)` with an active account and multiple accounts should yield a profile switcher state.
+    /// `perform(.refreshAccountProfiles)` with an active account and multiple accounts should yield a
+    /// profile switcher state.
     func test_perform_refresh_profiles_single_multiAccount() async {
         authRepository.accountsResult = .success([profile1, profile2])
         authRepository.activeAccountResult = .success(profile1)
@@ -230,28 +340,41 @@ class VaultListProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
     }
 
-    /// `itemDeleted()` delegate method shows the expected toast.
-    func test_delegate_itemDeleted() {
-        XCTAssertNil(subject.state.toast)
-
-        subject.itemDeleted()
-        XCTAssertEqual(subject.state.toast?.text, Localizations.itemSoftDeleted)
+    /// `receive(_:)` with `.clearURL` clears the url in the state.
+    func test_receive_clearURL() {
+        subject.state.url = .example
+        subject.receive(.clearURL)
+        XCTAssertNil(subject.state.url)
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to the `.viewItem` route.
-    func test_receive_itemPressed() {
+    /// `receive(_:)` with `.itemPressed` navigates to the `.viewItem` route for a cipher.
+    func test_receive_itemPressed_cipher() {
         let item = VaultListItem.fixture()
         subject.receive(.itemPressed(item: item))
 
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
     }
 
+    /// `receive(_:)` with `.itemPressed` navigates to the `.group` route for a group.
+    func test_receive_itemPressed_group() {
+        subject.receive(.itemPressed(item: VaultListItem(id: "1", itemType: .group(.card, 1))))
+
+        XCTAssertEqual(coordinator.routes.last, .group(.card))
+    }
+
     /// `receive(_:)` with `ProfileSwitcherAction.backgroundPressed` turns off the Profile Switcher Visibility.
-    func test_receive_profileSwitcherBacgroundPressed() {
+    func test_receive_profileSwitcherBackgroundPressed() {
         subject.state.profileSwitcherState.isVisible = true
         subject.receive(.profileSwitcherAction(.backgroundPressed))
 
         XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
+    }
+
+    /// `receive(_:)` with `ProfileSwitcherAction.scrollOffsetChanged` updates the scroll offset.
+    func test_receive_profileSwitcherScrollOffset() {
+        subject.state.profileSwitcherState.scrollOffset = .zero
+        subject.receive(.profileSwitcherAction(.scrollOffsetChanged(CGPoint(x: 10, y: 10))))
+        XCTAssertEqual(subject.state.profileSwitcherState.scrollOffset, CGPoint(x: 10, y: 10))
     }
 
     /// `receive(_:)` with `.searchStateChanged(isSearching: false)` hides the profile switcher

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // MARK: - VaultListState
 
 /// An object that defines the current state of a `VaultListView`.
@@ -22,6 +24,9 @@ struct VaultListState: Equatable {
 
     /// A toast message to show in the view.
     var toast: Toast?
+
+    /// The url to open in the device's web browser.
+    var url: URL?
 
     /// The vault filter used to display a single or all vaults for the user.
     var vaultFilterType: VaultFilterType = .allVaults

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -12,6 +12,9 @@ private struct VaultMainView: View {
     /// A flag indicating if the search bar is focused.
     @Environment(\.isSearching) private var isSearching
 
+    /// An object used to open urls from this view.
+    @Environment(\.openURL) private var openURL
+
     /// The `Store` for this view.
     @ObservedObject var store: Store<VaultListState, VaultListAction, VaultListEffect>
 
@@ -36,6 +39,15 @@ private struct VaultMainView: View {
                 .hidden(!isSearching)
         }
         .background(Asset.Colors.backgroundSecondary.swiftUIColor.ignoresSafeArea())
+        .toast(store.binding(
+            get: \.toast,
+            send: VaultListAction.toastShown
+        ))
+        .onChange(of: store.state.url) { newValue in
+            guard let url = newValue else { return }
+            openURL(url)
+            store.send(.clearURL)
+        }
         .onChange(of: isSearching) { newValue in
             store.send(.searchStateChanged(isSearching: newValue))
         }
@@ -198,13 +210,8 @@ private struct VaultMainView: View {
                     hasDivider: !isLastInSection
                 )
             },
-            mapAction: { action in
-                switch action {
-                case .morePressed:
-                    return .morePressed(item: item)
-                }
-            },
-            mapEffect: nil
+            mapAction: nil,
+            mapEffect: { _ in .morePressed(item: item) }
         ))
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
@@ -109,12 +109,12 @@ class VaultListViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .itemPressed(item: item))
     }
 
-    func test_vaultItemMoreButton_tap() throws {
+    func test_vaultItemMoreButton_tap() async throws {
         let item = VaultListItem.fixture()
         processor.state.loadingState = .data([VaultListSection(id: "1", items: [item], name: "Group")])
-        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.more)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed(item: item))
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .morePressed(item: item))
     }
 
     // MARK: Snapshots

--- a/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import Foundation
 
 // MARK: - VaultRoute
@@ -19,6 +20,10 @@ public enum VaultRoute: Equatable, Hashable {
 
     /// A route to the autofill list screen.
     case autofillList
+
+    /// A route to edit an item
+    ///
+    case editItem(cipher: CipherView)
 
     /// A route to dismiss the screen currently presented modally.
     case dismiss

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -21,7 +21,7 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
         /// An error for card action handling
         case nonCardTypeToggle(String)
 
-        /// A password visibility toggle occured when not possible.
+        /// A password visibility toggle occurred when not possible.
         case nonLoginPasswordToggle(String)
     }
 
@@ -39,7 +39,7 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
     /// The services used by this processor.
     private let services: Services
 
-    // MARK: Intialization
+    // MARK: Initialization
 
     /// Creates a new `ViewItemProcessor`.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -11,7 +11,7 @@ struct ViewItemState: Equatable {
     /// appropriate internal state.
     var loadingState: LoadingState<CipherItemState> = .loading
 
-    /// A flag indicating if the user has premium fatures.
+    /// A flag indicating if the user has premium features.
     var hasPremiumFeatures = false
 
     /// A flag indicating if the master password has been verified yet.

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRowView.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRowView.swift
@@ -17,7 +17,7 @@ struct VaultListItemRowState {
 // MARK: - VaultListItemRowAction
 
 /// Actions that can be sent from a `VaultListItemRowView`.
-enum VaultListItemRowAction {
+enum VaultListItemRowEffect {
     /// The more button was pressed.
     case morePressed
 }
@@ -29,7 +29,7 @@ struct VaultListItemRowView: View {
     // MARK: Properties
 
     /// The `Store` for this view.
-    var store: Store<VaultListItemRowState, VaultListItemRowAction, Void>
+    var store: Store<VaultListItemRowState, Void, VaultListItemRowEffect>
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -69,8 +69,8 @@ struct VaultListItemRowView: View {
 
                         Spacer()
 
-                        Button {
-                            store.send(.morePressed)
+                        AsyncButton {
+                            await store.perform(.morePressed)
                         } label: {
                             Asset.Images.horizontalKabob.swiftUIImage
                         }

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRowViewTests.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRowViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class VaultListItemRowViewTests: BitwardenTestCase {
     // MARK: Properties
 
-    var processor: MockProcessor<VaultListItemRowState, VaultListItemRowAction, Void>!
+    var processor: MockProcessor<VaultListItemRowState, Void, VaultListItemRowEffect>!
     var subject: VaultListItemRowView!
 
     // MARK: Setup & Teardown
@@ -28,9 +28,9 @@ class VaultListItemRowViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    func test_moreButton_tap() throws {
-        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.more)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed)
+    func test_moreButton_tap() async throws {
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .morePressed)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1363](https://livefront.atlassian.net/browse/BIT-1363)
[BIT-1367](https://livefront.atlassian.net/browse/BIT-1367)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

Added menu alert and functionality for login items on the vault views.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **CipherData.swift:** Added ability to fetch single cipher by id
-   **VaultRepository.swift:** Added ability to fetch single cipher by id
-   **CipherDataStore.swift:** Added ability to fetch single cipher by id
-   **CipherService.swift:** Added ability to fetch single cipher by id
-   **Store.swift:** Made the action of a child store optional in case the child view has effects only 💥 
-   **Alert+Vault.swift:** The alert of more options for a vault list item
-   **VaultGroupAction.swift:** Changed `morePressed` to an effect and added an action to clear the state url
-   **VaultGroupEffect.swift:** Changed `morePressed` to an effect
-   **VaultGroupProcessor.swift:** Added the functional alert for the login items and the ability to clear a url
-   **VaultGroupState.swift:** Added a url to launch from the view
-   **VaultGroupView.swift:** Added the ability to open a url and changed the `moveItem` to an effect
-   **VaultListAction.swift:** Changed `morePressed` to an effect and added an action to clear the state url
-   **VaultListEffect.swift:** Changed `morePressed` to an effect
-   **VaultListProcessor.swift:** Added the functional alert for the login items and the ability to clear a url
-   **VaultListState.swift:** Added a url to launch from the view
-   **VaultListView.swift:** Added the ability to open a url and changed the `moveItem` to an effect
-   **VaultCoordinator.swift:** Added navigation to edit an item
-   **VaultListItemRowView.swift:** Changed `morePressed` to an effect

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="400px" src="https://github.com/bitwarden/ios/assets/125921730/8ce57421-2221-42f4-b187-a093df1f4a39" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
