### PR TITLE
BIT-1365 BIT-1374: More options card items

### DIFF
--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -35,9 +35,22 @@ extension Alert {
         // Add any additional actions for the type of cipher selected.
         switch cipherView.type {
         case .card:
-            // TODO: BIT-1365
-            // TODO: BIT-1374
-            break
+            if let number = cipherView.card?.number {
+                alertActions.append(AlertAction(title: Localizations.copyNumber, style: .default) { _, _ in
+                    action(.copy(
+                        toast: Localizations.number,
+                        value: number
+                    ))
+                })
+            }
+            if let code = cipherView.card?.code {
+                alertActions.append(AlertAction(title: Localizations.copySecurityCode, style: .default) { _, _ in
+                    action(.copy(
+                        toast: Localizations.securityCode,
+                        value: code
+                    ))
+                })
+            }
         case .login:
             if let username = cipherView.login?.username {
                 alertActions.append(AlertAction(title: Localizations.copyUsername, style: .default) { _, _ in

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -75,8 +75,65 @@ class VaultGroupProcessorTests: BitwardenTestCase {
 
     /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
     func test_perform_morePressed_card() async throws {
-        // TODO: BIT-1365
-        // TODO: BIT-1374
+        let item = try XCTUnwrap(VaultListItem(cipherListView: CipherListView.fixture(type: .card)))
+
+        // If the card item has no number or code, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.cardFixture())
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // If the item is in the trash, the edit option should not display.
+        subject.state.group = .trash
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+
+        // A card with data should show the copy actions.
+        let cardWithData = CipherView.cardFixture(card: .fixture(
+            code: "123",
+            number: "123456789"
+        ))
+        vaultRepository.fetchCipherResult = .success(cardWithData)
+        subject.state.group = .card
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 5)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNumber)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copySecurityCode)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(cipher: cardWithData))
+
+        // Copy number copies the card's number.
+        let copyNumberAction = try XCTUnwrap(alert.alertActions[2])
+        await copyNumberAction.handler?(copyNumberAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123456789")
+
+        // Copy security code copies the card's security code.
+        let copyCodeAction = try XCTUnwrap(alert.alertActions[3])
+        await copyCodeAction.handler?(copyCodeAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123")
     }
 
     /// `perform(_:)` with `.morePressed` handles errors correctly.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1365](https://livefront.atlassian.net/browse/BIT-1365)
[BIT-1374](https://livefront.atlassian.net/browse/BIT-1374)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Implemented more options for card items.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **VaultGroupProcessor.swift:** Added relevant more options for card items.
-   **VaultListProcessor.swift:** Added relevant more options for card items.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<img width="400px" src="https://github.com/bitwarden/ios/assets/125921730/97c98e1a-52fd-4cbf-927c-570237ebc697" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
