### PR TITLE
BIT-249: Fixes an accessibility issue with the expiration date field

### DIFF
--- a/BitwardenShared/UI/Tools/Send/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/AddEditSendItem/AddEditSendItemView.swift
@@ -98,7 +98,7 @@ struct AddEditSendItemView: View {
             )
 
             if store.state.expirationDate == .custom {
-                HStack(spacing: 8) {
+                AccessibleHStack(alignment: .leading, spacing: 8) {
                     BitwardenDatePicker(
                         selection: store.binding(
                             get: \.customExpirationDate,


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-249](https://livefront.atlassian.net/browse/BIT-249)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

This PR fixes an issue with the expiration date's custom date field. This same issue was fixed for the deletion date field, but I missed the expiration date issue in #232.

## 📋 Code changes

- **AddEditSendItemView.swift:** Changed the `HStack` used to display the custom expiration date into an `AccessibleHStack`.

## 📸 Screenshots

https://github.com/bitwarden/ios/assets/125909022/f918cef7-f6c2-4ff4-94f2-f661d1f4e67a

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
