### PR TITLE
BIT-1269: Adds pull to refresh to Sends List

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -254,6 +254,7 @@ public class ServiceContainer: Services {
 
         let sendRepository = DefaultSendRepository(
             clientVault: clientService.clientVault(),
+            stateService: stateService,
             syncService: syncService
         )
 

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -8,12 +8,14 @@ class MockSendRepository: SendRepository {
     // MARK: Properties
 
     var fetchSyncCalled = false
+    var fetchSyncIsManualRefresh: Bool?
     var sendListSubject = CurrentValueSubject<[SendListSection], Never>([])
 
     // MARK: Methods
 
-    func fetchSync() async throws {
+    func fetchSync(isManualRefresh: Bool) async throws {
         fetchSyncCalled = true
+        fetchSyncIsManualRefresh = isManualRefresh
     }
 
     func sendListPublisher() -> AsyncPublisher<AnyPublisher<[SendListSection], Never>> {

--- a/BitwardenShared/UI/Tools/Send/SendList/SendListEffect.swift
+++ b/BitwardenShared/UI/Tools/Send/SendList/SendListEffect.swift
@@ -4,4 +4,7 @@
 enum SendListEffect {
     /// The send list appeared on screen.
     case appeared
+
+    /// The send list is being refreshed.
+    case refresh
 }

--- a/BitwardenShared/UI/Tools/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendList/SendListProcessor.swift
@@ -42,6 +42,13 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
             for await sections in services.sendRepository.sendListPublisher() {
                 state.sections = sections
             }
+        case .refresh:
+            do {
+                try await services.sendRepository.fetchSync(isManualRefresh: true)
+            } catch {
+                // TODO: BIT-1034 Add an error alert
+                print("error: \(error)")
+            }
         }
     }
 

--- a/BitwardenShared/UI/Tools/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendList/SendListProcessorTests.swift
@@ -50,6 +50,12 @@ class SendListProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.sections[0].items, [sendListItem])
     }
 
+    func test_perform_refresh() async {
+        await subject.perform(.refresh)
+
+        XCTAssertTrue(sendRepository.fetchSyncCalled)
+    }
+
     /// `receive(_:)` with `.addItemPressed` navigates to the `.addItem` route.
     func test_receive_addItemPressed() {
         subject.receive(.addItemPressed)

--- a/BitwardenShared/UI/Tools/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendList/SendListView.swift
@@ -132,6 +132,7 @@ struct SendListView: View {
                 placement: .navigationBarDrawer(displayMode: .always),
                 prompt: Localizations.search
             )
+            .refreshable { await store.perform(.refresh) }
             .navigationBar(title: Localizations.send, titleDisplayMode: .large)
             .toolbar {
                 ToolbarItem(placement: .navigationBarLeading) {


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1269](https://livefront.atlassian.net/browse/BIT-1269)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

This PR adds the pull to refresh feature to the Sends List screen.

## 📋 Code changes

- **SendRepository.swift:** Added functionality for only refreshing if manual refreshing is allowed.
- **SendListView.swift:** Added the `refreshable` view modifier to the view.
- **SendListEffect.swift:** Added an effect for refreshing the sends list.

## 📸 Screenshots

https://github.com/bitwarden/ios/assets/125909022/02b70a23-2020-4160-a449-a9b7671cc8c6

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
