### PR TITLE
BIT-694: Implement password strength with the SDK

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -36,6 +36,15 @@ protocol AuthRepository: AnyObject {
     ///
     func logout() async throws
 
+    /// Calculates the password strength of a password.
+    ///
+    /// - Parameters:
+    ///   - email: The user's email.
+    ///   - password: The user's password.
+    /// - Returns: The password strength of the password.
+    ///
+    func passwordStrength(email: String, password: String) async -> UInt8
+
     /// Sets the active account by User Id.
     ///
     /// - Parameter userId: The user Id to be set as active.
@@ -155,6 +164,10 @@ extension DefaultAuthRepository: AuthRepository {
     func logout() async throws {
         await vaultTimeoutService.remove(userId: nil)
         try await stateService.logoutAccount()
+    }
+
+    func passwordStrength(email: String, password: String) async -> UInt8 {
+        await clientAuth.passwordStrength(password: password, email: email, additionalInputs: [])
     }
 
     func setActiveAccount(userId: String) async throws -> Account {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -290,6 +290,27 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         }
     }
 
+    /// `passwordStrength(email:password)` returns the calculated password strength.
+    func test_passwordStrength() async {
+        clientAuth.passwordStrengthResult = 0
+        let weakPasswordStrength = await subject.passwordStrength(email: "user@bitwarden.com", password: "password")
+        XCTAssertEqual(weakPasswordStrength, 0)
+        XCTAssertEqual(clientAuth.passwordStrengthEmail, "user@bitwarden.com")
+        XCTAssertEqual(clientAuth.passwordStrengthPassword, "password")
+
+        clientAuth.passwordStrengthResult = 4
+        let strongPasswordStrength = await subject.passwordStrength(
+            email: "user@bitwarden.com",
+            password: "ghu65zQ0*TjP@ij74g*&FykWss#Kgv8L8j8XmC03"
+        )
+        XCTAssertEqual(strongPasswordStrength, 4)
+        XCTAssertEqual(clientAuth.passwordStrengthEmail, "user@bitwarden.com")
+        XCTAssertEqual(
+            clientAuth.passwordStrengthPassword,
+            "ghu65zQ0*TjP@ij74g*&FykWss#Kgv8L8j8XmC03"
+        )
+    }
+
     /// `setActiveAccount(userId: )` loads the environment URLs for the active account.
     func test_setActiveAccount_loadsEnvironmentUrls() async throws {
         let urls = EnvironmentUrlData(base: .example)

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -6,6 +6,9 @@ class MockAuthRepository: AuthRepository {
     var accountForItemResult: Result<Account, Error> = .failure(StateServiceError.noAccounts)
     var deleteAccountCalled = false
     var logoutCalled = false
+    var passwordStrengthEmail: String?
+    var passwordStrengthPassword: String?
+    var passwordStrengthResult: UInt8 = 0
     var setActiveAccountResult: Result<Account, Error> = .failure(StateServiceError.noAccounts)
     var unlockVaultPassword: String?
     var unlockVaultResult: Result<Void, Error> = .success(())
@@ -24,6 +27,12 @@ class MockAuthRepository: AuthRepository {
 
     func getAccount(for userId: String) async throws -> BitwardenShared.Account {
         try accountForItemResult.get()
+    }
+
+    func passwordStrength(email: String, password: String) async -> UInt8 {
+        passwordStrengthEmail = email
+        passwordStrengthPassword = password
+        return passwordStrengthResult
     }
 
     func logout() async throws {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-694](https://livefront.atlassian.net/browse/BIT-694)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implements the password strength indicator with the SDK.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AuthRepository.swift:** Adds a method to calculate the password strength for a password.
- **CreateAccountProcessor.swift:** Replaces the mock strength score with the SDK's password strength calculation.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/27aebced-6451-44d4-b217-c2671be82e67


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
