### PR TITLE
BIT-1185: Add default URI match type menu to settings

### DIFF
--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
@@ -35,6 +35,10 @@ protocol SettingsRepository: AnyObject {
     /// Get the current value of the allow sync on refresh value.
     func getAllowSyncOnRefresh() async throws -> Bool
 
+    /// Gets the default URI match type setting for the current user.
+    ///
+    func getDefaultUriMatchType() async throws -> UriMatchType
+
     /// Get the value of the disable auto-copy TOTP setting for the current user.
     ///
     func getDisableAutoTotpCopy() async throws -> Bool
@@ -68,6 +72,12 @@ protocol SettingsRepository: AnyObject {
     /// - Parameter allowSyncOnRefresh: Whether the vault should sync on refreshing.
     ///
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws
+
+    /// Update the cached value of the default URI match type setting.
+    ///
+    /// - Parameter defaultUriMatchType: The default URI match type.
+    ///
+    func updateDefaultUriMatchType(_ defaultUriMatchType: UriMatchType) async throws
 
     /// Update the cached value of the disable auto-copy TOTP setting.
     ///
@@ -181,6 +191,10 @@ extension DefaultSettingsRepository: SettingsRepository {
         try await stateService.getAllowSyncOnRefresh()
     }
 
+    func getDefaultUriMatchType() async throws -> UriMatchType {
+        try await stateService.getDefaultUriMatchType()
+    }
+
     func getDisableAutoTotpCopy() async throws -> Bool {
         try await stateService.getDisableAutoTotpCopy()
     }
@@ -203,6 +217,10 @@ extension DefaultSettingsRepository: SettingsRepository {
 
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
         try await stateService.setAllowSyncOnRefresh(allowSyncOnRefresh)
+    }
+
+    func updateDefaultUriMatchType(_ defaultUriMatchType: UriMatchType) async throws {
+        try await stateService.setDefaultUriMatchType(defaultUriMatchType)
     }
 
     func updateDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool) async throws {

--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
@@ -104,6 +104,18 @@ class SettingsRepositoryTests: BitwardenTestCase {
         XCTAssertTrue(value)
     }
 
+    /// `getDefaultUriMatchType()` returns the default URI match type value.
+    func test_getDefaultUriMatchType() async throws {
+        stateService.activeAccount = .fixture()
+
+        let initialValue = try await subject.getDefaultUriMatchType()
+        XCTAssertEqual(initialValue, .domain)
+
+        stateService.defaultUriMatchTypeByUserId["1"] = .never
+        let value = try await subject.getDefaultUriMatchType()
+        XCTAssertEqual(value, .never)
+    }
+
     /// `getDisableAutoTotpCopy()` returns the disable auto-copy TOTP value.
     func test_getDisableAutoTotpCopy() async throws {
         stateService.activeAccount = .fixture()
@@ -225,6 +237,15 @@ class SettingsRepositoryTests: BitwardenTestCase {
         try await subject.updateAllowSyncOnRefresh(true)
         value = try await stateService.getAllowSyncOnRefresh()
         XCTAssertTrue(value)
+    }
+
+    /// `updateDefaultUriMatchType(_:)` updates the state service's default URI match type value.
+    func test_updateDefaultUriMatchType() async throws {
+        stateService.activeAccount = .fixture()
+
+        try await subject.updateDefaultUriMatchType(.exact)
+
+        XCTAssertEqual(stateService.defaultUriMatchTypeByUserId["1"], .exact)
     }
 
     /// `updateDisableAutoTotpCopy(_:)` updates the state service's disable auto-copy TOTP value.

--- a/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
@@ -16,12 +16,15 @@ class MockSettingsRepository: SettingsRepository {
     var fetchSyncCalled = false
     var fetchSyncResult: Result<Void, Error> = .success(())
     var foldersListError: Error?
+    var getDefaultUriMatchTypeResult: Result<BitwardenShared.UriMatchType, Error> = .success(.domain)
     var getDisableAutoTotpCopyResult: Result<Bool, Error> = .success(false)
     var isLockedResult: Result<Bool, VaultTimeoutServiceError> = .failure(.noAccountFound)
     var lastSyncTimeError: Error?
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lockVaultCalls = [String?]()
     var unlockVaultCalls = [String?]()
+    var updateDefaultUriMatchTypeValue: BitwardenShared.UriMatchType?
+    var updateDefaultUriMatchTypeResult: Result<Void, Error> = .success(())
     var updateDisableAutoTotpCopyValue: Bool?
     var updateDisableAutoTotpCopyResult: Result<Void, Error> = .success(())
     var validatePasswordPasswords = [String]()
@@ -56,6 +59,10 @@ class MockSettingsRepository: SettingsRepository {
         return allowSyncOnRefresh
     }
 
+    func getDefaultUriMatchType() async throws -> BitwardenShared.UriMatchType {
+        try getDefaultUriMatchTypeResult.get()
+    }
+
     func getDisableAutoTotpCopy() async throws -> Bool {
         try getDisableAutoTotpCopyResult.get()
     }
@@ -82,6 +89,11 @@ class MockSettingsRepository: SettingsRepository {
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
         self.allowSyncOnRefresh = allowSyncOnRefresh
         try allowSyncOnRefreshResult.get()
+    }
+
+    func updateDefaultUriMatchType(_ defaultUriMatchType: BitwardenShared.UriMatchType) async throws {
+        updateDefaultUriMatchTypeValue = defaultUriMatchType
+        try updateDefaultUriMatchTypeResult.get()
     }
 
     func updateDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -76,6 +76,13 @@ protocol StateService: AnyObject {
     ///
     func getClearClipboardValue(userId: String?) async throws -> ClearClipboardValue
 
+    /// Gets the default URI match type value for an account.
+    ///
+    /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
+    /// - Returns: The default URI match type value.
+    ///
+    func getDefaultUriMatchType(userId: String?) async throws -> UriMatchType
+
     /// Gets the disable auto-copy TOTP value for an account.
     ///
     /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
@@ -173,6 +180,14 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws
+
+    /// Sets the default URI match type value for an account.
+    ///
+    /// - Parameters:
+    ///   - defaultUriMatchType: The default URI match type.
+    ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
+    ///
+    func setDefaultUriMatchType(_ defaultUriMatchType: UriMatchType?, userId: String?) async throws
 
     /// Sets the disable auto-copy TOTP value for an account.
     ///
@@ -294,6 +309,14 @@ extension StateService {
         try await getClearClipboardValue(userId: nil)
     }
 
+    /// Gets the default URI match type value for the active account.
+    ///
+    /// - Returns: The default URI match type value.
+    ///
+    func getDefaultUriMatchType() async throws -> UriMatchType {
+        try await getDefaultUriMatchType(userId: nil)
+    }
+
     /// Gets the disable auto-copy TOTP value for the active account.
     ///
     /// - Returns: The disable auto-copy TOTP value.
@@ -373,6 +396,14 @@ extension StateService {
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?) async throws {
         try await setClearClipboardValue(clearClipboardValue, userId: nil)
+    }
+
+    /// Sets the default URI match type value the active account.
+    ///
+    /// - Parameter defaultUriMatchType: The default URI match type.
+    ///
+    func setDefaultUriMatchType(_ defaultUriMatchType: UriMatchType?) async throws {
+        try await setDefaultUriMatchType(defaultUriMatchType, userId: nil)
     }
 
     /// Sets the disable auto-copy TOTP value for an account.
@@ -570,6 +601,11 @@ actor DefaultStateService: StateService {
         return appSettingsStore.clearClipboardValue(userId: userId)
     }
 
+    func getDefaultUriMatchType(userId: String?) async throws -> UriMatchType {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.defaultUriMatchType(userId: userId) ?? .domain
+    }
+
     func getDisableAutoTotpCopy(userId: String?) async throws -> Bool {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.disableAutoTotpCopy(userId: userId)
@@ -619,6 +655,7 @@ actor DefaultStateService: StateService {
             state.activeUserId = state.accounts.first?.key
         }
 
+        appSettingsStore.setDefaultUriMatchType(nil, userId: userId)
         appSettingsStore.setDisableAutoTotpCopy(nil, userId: userId)
         appSettingsStore.setEncryptedPrivateKey(key: nil, userId: userId)
         appSettingsStore.setEncryptedUserKey(key: nil, userId: userId)
@@ -657,6 +694,11 @@ actor DefaultStateService: StateService {
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setClearClipboardValue(clearClipboardValue, userId: userId)
+    }
+
+    func setDefaultUriMatchType(_ defaultUriMatchType: UriMatchType?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setDefaultUriMatchType(defaultUriMatchType, userId: userId)
     }
 
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -49,6 +49,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func clearClipboardValue(userId: String) -> ClearClipboardValue
 
+    /// Gets the default URI match type.
+    ///
+    /// - Parameter userId: The user ID associated with the default URI match type.
+    /// - Returns: The default URI match type.
+    ///
+    func defaultUriMatchType(userId: String) -> UriMatchType?
+
     /// Gets the encrypted private key for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the encrypted private key.
@@ -118,6 +125,14 @@ protocol AppSettingsStore: AnyObject {
     /// - Returns: The time after which the clipboard should be cleared.
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String)
+
+    /// Sets the default URI match type.
+    ///
+    /// - Parameters:
+    ///   - uriMatchType: The default URI match type.
+    ///   - userId: The user ID associated with the default URI match type.
+    ///
+    func setDefaultUriMatchType(_ uriMatchType: UriMatchType?, userId: String)
 
     /// Sets the disable auto-copy TOTP value for a user ID.
     ///
@@ -307,6 +322,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case appLocale
         case appTheme
         case clearClipboardValue(userId: String)
+        case defaultUriMatch(userId: String)
         case disableWebIcons
         case encryptedPrivateKey(userId: String)
         case encryptedUserKey(userId: String)
@@ -335,6 +351,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "theme"
             case let .clearClipboardValue(userId):
                 key = "clearClipboard_\(userId)"
+            case let .defaultUriMatch(userId):
+                key = "defaultUriMatch_\(userId)"
             case .disableWebIcons:
                 key = "disableFavicon"
             case let .encryptedUserKey(userId):
@@ -429,6 +447,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .encryptedUserKey(userId: userId))
     }
 
+    func defaultUriMatchType(userId: String) -> UriMatchType? {
+        fetch(for: .defaultUriMatch(userId: userId))
+    }
+
     func disableAutoTotpCopy(userId: String) -> Bool {
         fetch(for: .disableAutoTotpCopy(userId: userId))
     }
@@ -459,6 +481,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String) {
         store(clearClipboardValue?.rawValue, for: .clearClipboardValue(userId: userId))
+    }
+
+    func setDefaultUriMatchType(_ uriMatchType: UriMatchType?, userId: String) {
+        store(uriMatchType, for: .defaultUriMatch(userId: userId))
     }
 
     func setEncryptedPrivateKey(key: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -120,6 +120,22 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:clearClipboard_2"), -1)
     }
 
+    /// `defaultUriMatchType(userId:)` returns `nil` if there isn't a previously stored value.
+    func test_defaultUriMatchType_isInitiallyNil() {
+        XCTAssertNil(subject.defaultUriMatchType(userId: "-1"))
+    }
+
+    /// `defaultUriMatchType(userId:)` can be used to get the default URI match type value for a user.
+    func test_defaultUriMatchType_withValue() {
+        subject.setDefaultUriMatchType(.exact, userId: "1")
+        subject.setDefaultUriMatchType(.host, userId: "2")
+
+        XCTAssertEqual(subject.defaultUriMatchType(userId: "1"), .exact)
+        XCTAssertEqual(subject.defaultUriMatchType(userId: "2"), .host)
+        XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:defaultUriMatch_1"), 3)
+        XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:defaultUriMatch_2"), 1)
+    }
+
     /// `disableAutoTotpCopy(userId:)` returns `false` if there isn't a previously stored value.
     func test_disableAutoTotpCopy_isInitiallyNil() {
         XCTAssertFalse(subject.disableAutoTotpCopy(userId: "-1"))

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -9,6 +9,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var appLocale: String?
     var appTheme: String?
     var clearClipboardValues = [String: ClearClipboardValue]()
+    var defaultUriMatchTypeByUserId = [String: UriMatchType]()
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var disableWebIcons: Bool = false
     var encryptedPrivateKeys = [String: String]()
@@ -36,6 +37,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func clearClipboardValue(userId: String) -> ClearClipboardValue {
         clearClipboardValues[userId] ?? .never
+    }
+
+    func defaultUriMatchType(userId: String) -> UriMatchType? {
+        defaultUriMatchTypeByUserId[userId]
     }
 
     func disableAutoTotpCopy(userId: String) -> Bool {
@@ -76,6 +81,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String) {
         clearClipboardValues[userId] = clearClipboardValue
+    }
+
+    func setDefaultUriMatchType(_ uriMatchType: UriMatchType?, userId: String) {
+        defaultUriMatchTypeByUserId[userId] = uriMatchType
     }
 
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -16,6 +16,7 @@ class MockStateService: StateService {
     var clearClipboardValues = [String: ClearClipboardValue]()
     var clearClipboardResult: Result<Void, Error> = .success(())
     var environmentUrls = [String: EnvironmentUrlData]()
+    var defaultUriMatchTypeByUserId = [String: UriMatchType]()
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var lastSyncTimeByUserId = [String: Date]()
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
@@ -94,6 +95,11 @@ class MockStateService: StateService {
         return clearClipboardValues[userId] ?? .never
     }
 
+    func getDefaultUriMatchType(userId: String?) async throws -> UriMatchType {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        return defaultUriMatchTypeByUserId[userId] ?? .domain
+    }
+
     func getDisableAutoTotpCopy(userId: String?) async throws -> Bool {
         let userId = try userId ?? getActiveAccount().profile.userId
         return disableAutoTotpCopyByUserId[userId] ?? false
@@ -163,6 +169,11 @@ class MockStateService: StateService {
         try clearClipboardResult.get()
         let userId = try userId ?? getActiveAccount().profile.userId
         clearClipboardValues[userId] = clearClipboardValue
+    }
+
+    func setDefaultUriMatchType(_ defaultUriMatchType: UriMatchType?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccount().profile.userId
+        defaultUriMatchTypeByUserId[userId] = defaultUriMatchType
     }
 
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool, userId: String?) async throws {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
@@ -6,6 +6,9 @@ enum AutoFillAction: Equatable {
     /// The app extension button was tapped.
     case appExtensionTapped
 
+    /// The default URI match type was changed.
+    case defaultUriMatchTypeChanged(UriMatchType)
+
     /// The password auto-fill button was tapped.
     case passwordAutoFillTapped
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
@@ -3,6 +3,9 @@
 /// An object that defines the current state of the `AutoFillView`.
 ///
 struct AutoFillState {
+    /// The default URI match type.
+    var defaultUriMatchType: UriMatchType = .domain
+
     /// Whether or not the copy TOTP automatically toggle is on.
     var isCopyTOTPToggleOn: Bool = false
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -49,12 +49,15 @@ struct AutoFillView: View {
             .padding(.bottom, 12)
 
             VStack(spacing: 2) {
-                SettingsListItem(
-                    Localizations.defaultUriMatchDetection,
-                    hasDivider: false
-                ) {} trailingContent: {
-                    Text(Localizations.baseDomain) // TODO: BIT-1185 Dynamic value
-                }
+                SettingsMenuField(
+                    title: Localizations.defaultUriMatchDetection,
+                    options: UriMatchType.allCases,
+                    hasDivider: false,
+                    selection: store.binding(
+                        get: \.defaultUriMatchType,
+                        send: AutoFillAction.defaultUriMatchTypeChanged
+                    )
+                )
                 .cornerRadius(10)
                 .padding(.bottom, 8)
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillViewTests.swift
@@ -36,6 +36,14 @@ class AutoFillViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .appExtensionTapped)
     }
 
+    /// Updating the value of the default URI match type sends the `.defaultUriMatchTypeChanged` action.
+    func test_defaultUriMatchTypeChanged_updateValue() throws {
+        processor.state.defaultUriMatchType = .host
+        let menuField = try subject.inspect().find(settingsMenuField: Localizations.defaultUriMatchDetection)
+        try menuField.select(newValue: UriMatchType.exact)
+        XCTAssertEqual(processor.dispatchedActions.last, .defaultUriMatchTypeChanged(.exact))
+    }
+
     /// Tapping the password auto-fill button dispatches the `.passwordAutoFillTapped` action.
     func test_passwordAutoFillButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.passwordAutofill)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1185](https://livefront.atlassian.net/browse/BIT-1185)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implements the menu and persistence of the default URI match type setting.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SettingsRepository.swift:** Adds methods for getting and setting the default URI match type.
- **StateService.swift:** Adds methods for getting and setting the default URI match type.
- **AppSettingsStore.swift:** Adds methods for getting and setting the default URI match type.
- **AutofillProcessor.swift:** Fetches the default URI match type and saves it when it changes.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/9531a9e5-5fdc-4263-aa1f-77002c087504


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
