### PR TITLE
BIT-1448: Attach from camera

### DIFF
--- a/BitwardenShared/Core/Platform/Services/CameraService.swift
+++ b/BitwardenShared/Core/Platform/Services/CameraService.swift
@@ -87,7 +87,7 @@ class DefaultCameraService: NSObject {
     }
 }
 
-// MARK: - DefaultCamerAuthorizationService
+// MARK: - DefaultCameraAuthorizationService
 
 extension DefaultCameraService: CameraService {
     func checkStatusOrRequestCameraAuthorization() async -> CameraAuthorizationStatus {

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsAction.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - AttachmentsAction
 
 /// Actions that can be processed by an `AttachmentsProcessor`.
@@ -8,4 +10,10 @@ enum AttachmentsAction: Equatable {
 
     /// The dismiss button was pressed.
     case dismissPressed
+
+    /// The camera view was dismissed.
+    case cameraViewPresentedChanged(Bool)
+
+    /// The user took a photo or selected an image.
+    case imageChanged(UIImage?)
 }

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -1,3 +1,4 @@
+import UIKit
 import XCTest
 
 @testable import BitwardenShared
@@ -5,6 +6,7 @@ import XCTest
 class AttachmentsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
+    var cameraService: MockCameraService!
     var coordinator: MockCoordinator<VaultItemRoute>!
     var errorReporter: MockErrorReporter!
     var subject: AttachmentsProcessor!
@@ -14,12 +16,14 @@ class AttachmentsProcessorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        cameraService = MockCameraService()
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
 
         subject = AttachmentsProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
+                cameraService: cameraService,
                 errorReporter: errorReporter
             ),
             state: AttachmentsState()
@@ -29,6 +33,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        cameraService = nil
         coordinator = nil
         errorReporter = nil
         subject = nil
@@ -36,17 +41,54 @@ class AttachmentsProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `receive(_:)` with `.cameraViewPresentedChanged` updates the camera view presentation status.
+    func test_receive_cameraViewPresentedChanged() throws {
+        XCTAssertFalse(subject.state.cameraViewPresented)
+        subject.receive(.cameraViewPresentedChanged(true))
+        XCTAssertTrue(subject.state.cameraViewPresented)
+    }
+
     /// `receive(_:)` with `.chooseFilePressed` shows the attachment options alert.
     func test_receive_chooseFilePressed() {
         subject.receive(.chooseFilePressed)
-
         XCTAssertEqual(coordinator.alertShown.last, .attachmentOptions(handler: { _ in }))
     }
 
     /// `receive(_:)` with `.dismissPressed` dismisses the view.
     func test_receive_dismissPressed() {
         subject.receive(.dismissPressed)
-
         XCTAssertEqual(coordinator.routes.last, .dismiss())
+    }
+
+    /// `receive(_:)` with `.imageChanged` updates the image in the state.
+    func test_receive_imageChanged() throws {
+        let testImage = UIImage(named: "AppIcon")
+        subject.receive(.imageChanged(testImage))
+        XCTAssertEqual(subject.state.image, testImage)
+    }
+
+    /// Selecting the camera option on the attachments alert checks for camera permissions and presents the camera view.
+    func test_showCamera() async throws {
+        cameraService.cameraAuthorizationStatus = .authorized
+
+        subject.receive(.chooseFilePressed)
+
+        let cameraAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions[1])
+        await cameraAction.handler?(cameraAction, [])
+
+        XCTAssertTrue(subject.state.cameraViewPresented)
+    }
+
+    /// Selecting the camera option on the attachments alert prompts the user to enable camera permissions if necessary.
+    func test_showCamera_noPermission() async throws {
+        cameraService.cameraAuthorizationStatus = .denied
+
+        subject.receive(.chooseFilePressed)
+
+        let cameraAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions[1])
+        await cameraAction.handler?(cameraAction, [])
+
+        XCTAssertFalse(subject.state.cameraViewPresented)
+        // TODO: BIT-1466 alert to prompt user to enable camera permissions shows
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsState.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 // MARK: - AttachmentsState
 
 /// An object that defines the current state of a `AttachmentsView`.
@@ -5,4 +7,10 @@
 struct AttachmentsState: Equatable {
     /// The attachments.
     var attachments: [String] = []
+
+    /// Whether to show the camera view.
+    var cameraViewPresented = false
+
+    /// The image captured from the device's camera or photo library.
+    var image: UIImage?
 }

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsView.swift
@@ -27,6 +27,15 @@ struct AttachmentsView: View {
                 store.send(.dismissPressed)
             }
         }
+        .fullScreenCover(isPresented: store.binding(
+            get: \.cameraViewPresented,
+            send: AttachmentsAction.cameraViewPresentedChanged
+        )) {
+            CameraView(selectedImage: store.binding(
+                get: \.image,
+                send: AttachmentsAction.imageChanged
+            ))
+        }
     }
 
     // MARK: Private Views

--- a/BitwardenShared/UI/Vault/Views/CameraView.swift
+++ b/BitwardenShared/UI/Vault/Views/CameraView.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+// MARK: - CameraView
+
+/// A view that allows the user to use the camera to capture images.
+///
+struct CameraView: UIViewControllerRepresentable {
+    // MARK: Properties
+
+    /// Whether the view is presented or not.
+    @Environment(\.presentationMode) var isPresented
+
+    /// The image result selected by the user
+    @Binding var selectedImage: UIImage?
+
+    // MARK: Methods
+
+    /// Create the camera picker view.
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let imagePicker = UIImagePickerController()
+        imagePicker.sourceType = .camera
+        imagePicker.delegate = context.coordinator
+        return imagePicker
+    }
+
+    /// Create the coordinator used to pass the selected image to the caller.
+    func makeCoordinator() -> Coordinator { Coordinator(cameraView: self) }
+
+    /// A required delegate method that isn't used.
+    func updateUIViewController(_: UIImagePickerController, context _: Context) {}
+}
+
+// MARK: - Coordinator
+
+extension CameraView {
+    class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+        // MARK: Properties
+
+        /// The camera view.
+        var cameraView: CameraView
+
+        // MARK: Initialization
+
+        /// Initializes a `CameraView.Coordinator`.
+        ///
+        /// - Parameter cameraView: The camera view.
+        ///
+        init(cameraView: CameraView) {
+            self.cameraView = cameraView
+        }
+
+        // MARK: Methods
+
+        /// Pass the captured image back to the caller and dismiss the camera view.
+        func imagePickerController(
+            _: UIImagePickerController,
+            didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]
+        ) {
+            guard let selectedImage = info[.originalImage] as? UIImage else { return }
+            cameraView.selectedImage = selectedImage
+            cameraView.isPresented.wrappedValue.dismiss()
+        }
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1448](https://livefront.atlassian.net/browse/BIT-1448)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Added a camera view to allow the user to take a photo to attach to a cipher.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AttachmentsProcessor.swift:** Added actions for showing/dismissing the camera view, for receiving the selected image, and for checking camera permissions before showing the camera view
-   **AttachmentsView.swift:** Added the camera view
-   **CameraView.swift:** A view for displaying the camera view and handling the selected image

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<video width="400px" src="https://github.com/bitwarden/ios/assets/125921730/4dc05851-3587-4f9b-b8c3-bb63b2bafb0b" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
