### PR TITLE
BIT-597 BIT-539 BIT-532: Implement autofill exact, starts with and never URI matching

### DIFF
--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -300,6 +300,7 @@ extension BitwardenSdk.Cipher {
 }
 
 extension BitwardenSdk.CipherListView: Identifiable {}
+extension BitwardenSdk.CipherView: Identifiable {}
 
 extension BitwardenSdk.CipherType {
     init(_ cipherType: CipherType) {

--- a/BitwardenShared/Core/Vault/Extensions/TestHelpers/BitwardenSdk+VaultFixtures.swift
+++ b/BitwardenShared/Core/Vault/Extensions/TestHelpers/BitwardenSdk+VaultFixtures.swift
@@ -277,6 +277,26 @@ extension CollectionView {
     }
 }
 
+extension BitwardenSdk.Login {
+    static func fixture(
+        autofillOnPageLoad: Bool? = nil,
+        password: String? = nil,
+        passwordRevisionDate: Date? = nil,
+        uris: [LoginUri]? = nil,
+        username: String? = nil,
+        totp: String? = nil
+    ) -> BitwardenSdk.Login {
+        BitwardenSdk.Login(
+            username: username,
+            password: password,
+            passwordRevisionDate: passwordRevisionDate,
+            uris: uris,
+            totp: totp,
+            autofillOnPageLoad: autofillOnPageLoad
+        )
+    }
+}
+
 extension BitwardenSdk.LoginView {
     static func fixture(
         password: String? = nil,

--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
@@ -1,0 +1,97 @@
+import BitwardenSdk
+
+/// A helper object to handle filtering a list of ciphers that match a URI.
+///
+enum CipherMatchingHelper {
+    // MARK: Types
+
+    /// An enum describing the strength that a cipher matches a URI.
+    ///
+    enum MatchResult {
+        /// The cipher is an exact match for the URI.
+        case exact
+
+        /// The cipher is a close match for the URI.
+        case fuzzy
+
+        /// The cipher doesn't match the URI.
+        case none
+    }
+
+    // MARK: Methods
+
+    /// Returns the list of ciphers that match the URI.
+    ///
+    /// - Parameters:
+    ///   - uri: The URI used to filter the list of ciphers.
+    ///   - ciphers: The list of ciphers to filter.
+    /// - Returns: The list of ciphers that match the URI.
+    ///
+    static func ciphersMatching(uri: String?, ciphers: [CipherView]) -> [CipherView] {
+        guard let uri else { return [] }
+
+        let matchingCiphers = ciphers.reduce(
+            into: (exact: [CipherView], fuzzy: [CipherView])([], [])
+        ) { result, cipher in
+            switch checkForCipherMatch(cipher: cipher, matchUri: uri) {
+            case .exact:
+                result.exact.append(cipher)
+            case .fuzzy:
+                result.fuzzy.append(cipher)
+            case .none:
+                // No-op: don't add non-matching ciphers.
+                break
+            }
+        }
+
+        return matchingCiphers.exact + matchingCiphers.fuzzy
+    }
+
+    // MARK: Private
+
+    /// Returns the result of checking if a cipher matches a URI.
+    ///
+    /// - Parameters:
+    ///   - cipher: The cipher to check if it matches the URI.
+    ///   - matchUri: The URI used to check if the cipher matches.
+    /// - Returns: The result of the match for the cipher and URI.
+    ///
+    private static func checkForCipherMatch(cipher: CipherView, matchUri: String) -> MatchResult {
+        guard cipher.type == .login,
+              let login = cipher.login,
+              let loginUris = login.uris,
+              cipher.deletedDate == nil else {
+            return .none
+        }
+
+        var matchResult = MatchResult.none
+        for loginUri in loginUris {
+            guard let uri = loginUri.uri, !uri.isEmpty else { continue }
+            let uriMatchType = loginUri.match ?? .domain
+
+            matchResult = switch uriMatchType {
+            case .domain:
+                // TODO: BIT-1097
+                MatchResult.none
+            case .host:
+                // TODO: BIT-596
+                MatchResult.none
+            case .startsWith:
+                uri.starts(with: matchUri) ? MatchResult.exact : MatchResult.none
+            case .exact:
+                uri == matchUri ? MatchResult.exact : MatchResult.none
+            case .regularExpression:
+                // TODO: BIT-538
+                MatchResult.none
+            case .never:
+                MatchResult.none
+            }
+
+            if matchResult != .none {
+                break
+            }
+        }
+
+        return matchResult
+    }
+}

--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelperTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelperTests.swift
@@ -1,0 +1,133 @@
+import BitwardenSdk
+import InlineSnapshotTesting
+import XCTest
+
+@testable import BitwardenShared
+
+class CipherMatchingHelperTests: BitwardenTestCase {
+    let ciphers: [CipherView] = [
+        .fixture(
+            login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com", match: .exact)]),
+            name: "Bitwarden (Exact)"
+        ),
+        .fixture(
+            login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com", match: .startsWith)]),
+            name: "Bitwarden (Starts With)"
+        ),
+        .fixture(
+            login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com", match: .never)]),
+            name: "Bitwarden (Never)"
+        ),
+
+        .fixture(
+            login: .fixture(uris: [LoginUriView(uri: "https://example.com", match: .startsWith)]),
+            name: "Example (Starts With)"
+        ),
+
+        .fixture(login: .fixture(), name: "No URIs"),
+        .fixture(login: .fixture(uris: []), name: "Empty URIs"),
+    ]
+
+    // MARK: Tests
+
+    /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the exact
+    /// match type.
+    func test_ciphersMatching_exact() {
+        let ciphers: [CipherView] = [
+            .fixture(
+                login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com", match: .exact)]),
+                name: "Bitwarden Vault"
+            ),
+            .fixture(
+                login: .fixture(uris: [LoginUriView(uri: "https://bitwarden.com", match: .exact)]),
+                name: "Bitwarden"
+            ),
+            .fixture(
+                login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com/login", match: .exact)]),
+                name: "Bitwarden Login"
+            ),
+            .fixture(
+                login: .fixture(uris: [
+                    LoginUriView(uri: "https://bitwarden.com", match: .exact),
+                    LoginUriView(uri: "https://vault.bitwarden.com", match: .exact),
+                ]),
+                name: "Bitwarden Multiple"
+            ),
+        ]
+
+        assertInlineSnapshot(
+            of: dumpMatching(uri: "https://vault.bitwarden.com", ciphers: ciphers),
+            as: .lines
+        ) {
+            """
+            Bitwarden Vault
+            Bitwarden Multiple
+            """
+        }
+
+        assertInlineSnapshot(
+            of: dumpMatching(uri: "https://bitwarden.com", ciphers: ciphers),
+            as: .lines
+        ) {
+            """
+            Bitwarden
+            Bitwarden Multiple
+            """
+        }
+
+        XCTAssertTrue(CipherMatchingHelper.ciphersMatching(uri: "http://bitwarden.com", ciphers: ciphers).isEmpty)
+    }
+
+    /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the never
+    /// match type.
+    func test_ciphersMatching_never() {
+        let ciphers: [CipherView] = [
+            .fixture(
+                login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com", match: .never)]),
+                name: "Bitwarden Never"
+            ),
+            .fixture(
+                login: .fixture(uris: [LoginUriView(uri: "https://vault.bitwarden.com", match: .exact)]),
+                name: "Bitwarden Exact"
+            ),
+        ]
+
+        assertInlineSnapshot(
+            of: dumpMatching(uri: "https://vault.bitwarden.com", ciphers: ciphers),
+            as: .lines
+        ) {
+            """
+            Bitwarden Exact
+            """
+        }
+
+        XCTAssertTrue(CipherMatchingHelper.ciphersMatching(uri: "http://bitwarden.com", ciphers: ciphers).isEmpty)
+    }
+
+    /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the starts
+    /// with match type.
+    func test_ciphersMatching_startsWith() {
+        assertInlineSnapshot(
+            of: dumpMatching(uri: "https://vault.bitwarden.com", ciphers: ciphers),
+            as: .lines
+        ) {
+            """
+            Bitwarden (Exact)
+            Bitwarden (Starts With)
+            """
+        }
+    }
+
+    // MARK: Private
+
+    /// Returns a string containing a description of the matching ciphers.
+    func dumpMatchingCiphers(_ ciphers: [CipherView]) -> String {
+        ciphers.map(\.name).joined(separator: "\n")
+    }
+
+    /// Filters the ciphers that match the URI and returns a string containing the description of
+    ///  the matching ciphers.
+    func dumpMatching(uri: String, ciphers: [CipherView]) -> String {
+        dumpMatchingCiphers(CipherMatchingHelper.ciphersMatching(uri: uri, ciphers: ciphers))
+    }
+}

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -10,6 +10,7 @@ class MockVaultRepository: VaultRepository {
     var addCipherCiphers = [BitwardenSdk.CipherView]()
     var addCipherResult: Result<Void, Error> = .success(())
     var ciphersSubject = CurrentValueSubject<[CipherListView], Error>([])
+    var ciphersAutofillSubject = CurrentValueSubject<[CipherView], Error>([])
     var cipherDetailsSubject = CurrentValueSubject<BitwardenSdk.CipherView, Never>(.fixture())
     var deletedCipher = [String]()
     var deleteCipherResult: Result<Void, Error> = .success(())
@@ -71,6 +72,12 @@ class MockVaultRepository: VaultRepository {
 
     func cipherDetailsPublisher(id _: String) -> AsyncPublisher<AnyPublisher<BitwardenSdk.CipherView, Never>> {
         cipherDetailsSubject.eraseToAnyPublisher().values
+    }
+
+    func ciphersAutofillPublisher(
+        uri: String?
+    ) async throws -> AsyncThrowingPublisher<AnyPublisher<[CipherView], Error>> {
+        ciphersAutofillSubject.eraseToAnyPublisher().values
     }
 
     func deleteCipher(_ id: String) async throws {

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListEffect.swift
@@ -6,7 +6,7 @@ import BitwardenSdk
 ///
 enum VaultAutofillListEffect: Equatable {
     /// A cipher in the list was tapped
-    case cipherTapped(CipherListView)
+    case cipherTapped(CipherView)
 
     /// Stream the autofill items for the user.
     case streamAutofillItems

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -59,7 +59,7 @@ class VaultAutofillListProcessor: StateProcessor<
     override func perform(_ effect: VaultAutofillListEffect) async {
         switch effect {
         case let .cipherTapped(cipher):
-            await autofillHelper.handleCipherForAutofill(cipherListView: cipher) { [weak self] toastText in
+            await autofillHelper.handleCipherForAutofill(cipherView: cipher) { [weak self] toastText in
                 self?.state.toast = Toast(text: toastText)
             }
         case .streamAutofillItems:
@@ -90,7 +90,9 @@ class VaultAutofillListProcessor: StateProcessor<
     ///
     private func streamAutofillItems() async {
         do {
-            for try await ciphers in try await services.vaultRepository.cipherPublisher() {
+            for try await ciphers in try await services.vaultRepository.ciphersAutofillPublisher(
+                uri: appExtensionDelegate?.uri
+            ) {
                 state.ciphersForAutofill = ciphers
             }
         } catch {

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
@@ -48,11 +48,7 @@ class VaultAutofillListProcessorTests: BitwardenTestCase {
     /// `cipherTapped(_:)` has the autofill helper handle autofill for the cipher and completes the
     /// autofill request.
     func test_perform_cipherTapped() async {
-        vaultRepository.fetchCipherResult = .success(.fixture(
-            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com")
-        ))
-
-        let cipher = CipherListView.fixture()
+        let cipher = CipherView.fixture(login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"))
         await subject.perform(.cipherTapped(cipher))
 
         XCTAssertEqual(appExtensionDelegate.didCompleteAutofillRequest?.username, "user@bitwarden.com")
@@ -62,11 +58,7 @@ class VaultAutofillListProcessorTests: BitwardenTestCase {
     /// `cipherTapped(_:)` has the autofill helper handle autofill for the cipher and shows a toast
     /// if a cipher value was copied instead of autofilled.
     func test_perform_cipherTapped_showToast() async throws {
-        vaultRepository.fetchCipherResult = .success(.fixture(
-            login: .fixture(password: "PASSWORD", username: nil)
-        ))
-
-        let cipher = CipherListView.fixture()
+        let cipher = CipherView.fixture(login: .fixture(password: "PASSWORD", username: nil))
         await subject.perform(.cipherTapped(cipher))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListState.swift
@@ -8,7 +8,7 @@ struct VaultAutofillListState: Equatable {
     // MARK: Properties
 
     /// The list of matching ciphers that can be used for autofill.
-    var ciphersForAutofill: [CipherListView] = []
+    var ciphersForAutofill: [CipherView] = []
 
     /// A toast message to show in the view.
     var toast: Toast?

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -65,7 +65,7 @@ struct VaultAutofillListView: View {
 
     /// Returns the view for displaying a cipher in a row in a list.
     @ViewBuilder
-    private func cipherRowView(_ cipher: CipherListView, hasDivider: Bool) -> some View {
+    private func cipherRowView(_ cipher: CipherView, hasDivider: Bool) -> some View {
         VStack(spacing: 0) {
             VStack(spacing: 0) {
                 Text(cipher.name)
@@ -73,8 +73,8 @@ struct VaultAutofillListView: View {
                     .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
                     .styleGuide(.body)
 
-                if !cipher.subTitle.isEmpty {
-                    Text(cipher.subTitle)
+                if let username = cipher.login?.username, !username.isEmpty {
+                    Text(username)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
                         .styleGuide(.subheadline)
@@ -108,53 +108,94 @@ struct VaultAutofillListView: View {
                 processor: StateProcessor(
                     state: VaultAutofillListState(
                         ciphersForAutofill: [
-                            CipherListView(
+                            CipherView(
                                 id: "1",
                                 organizationId: nil,
                                 folderId: nil,
                                 collectionIds: [],
+                                key: nil,
                                 name: "Apple",
-                                subTitle: "user@bitwarden.com",
+                                notes: nil,
                                 type: .login,
+                                login: BitwardenSdk.LoginView(
+                                    username: "user@bitwarden.com",
+                                    password: nil,
+                                    passwordRevisionDate: nil,
+                                    uris: nil,
+                                    totp: nil,
+                                    autofillOnPageLoad: nil
+                                ),
+                                identity: nil,
+                                card: nil,
+                                secureNote: nil,
                                 favorite: false,
                                 reprompt: .none,
+                                organizationUseTotp: false,
                                 edit: true,
                                 viewPassword: true,
-                                attachments: 0,
+                                localData: nil,
+                                attachments: nil,
+                                fields: nil,
+                                passwordHistory: nil,
                                 creationDate: Date(),
                                 deletedDate: nil,
                                 revisionDate: Date()
                             ),
-                            CipherListView(
+                            CipherView(
                                 id: "2",
                                 organizationId: nil,
                                 folderId: nil,
                                 collectionIds: [],
+                                key: nil,
                                 name: "Bitwarden",
-                                subTitle: "user@bitwarden.com",
+                                notes: nil,
                                 type: .login,
+                                login: BitwardenSdk.LoginView(
+                                    username: "user@bitwarden.com",
+                                    password: nil,
+                                    passwordRevisionDate: nil,
+                                    uris: nil,
+                                    totp: nil,
+                                    autofillOnPageLoad: nil
+                                ),
+                                identity: nil,
+                                card: nil,
+                                secureNote: nil,
                                 favorite: false,
                                 reprompt: .none,
+                                organizationUseTotp: false,
                                 edit: true,
                                 viewPassword: true,
-                                attachments: 0,
+                                localData: nil,
+                                attachments: nil,
+                                fields: nil,
+                                passwordHistory: nil,
                                 creationDate: Date(),
                                 deletedDate: nil,
                                 revisionDate: Date()
                             ),
-                            CipherListView(
+                            CipherView(
                                 id: "3",
                                 organizationId: nil,
                                 folderId: nil,
                                 collectionIds: [],
+                                key: nil,
                                 name: "Company XYZ",
-                                subTitle: "",
+                                notes: nil,
                                 type: .login,
+                                login: nil,
+                                identity: nil,
+                                card: nil,
+                                secureNote: nil,
                                 favorite: false,
                                 reprompt: .none,
+                                organizationUseTotp: false,
                                 edit: true,
                                 viewPassword: true,
-                                attachments: 0,
+                                localData: nil,
+                                attachments: nil,
+                                fields: nil,
+                                passwordHistory: nil,
                                 creationDate: Date(),
                                 deletedDate: nil,
                                 revisionDate: Date()

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListViewTests.swift
@@ -56,9 +56,9 @@ class VaultAutofillListViewTests: BitwardenTestCase {
     /// The populated view renders correctly.
     func test_snapshot_vaultAutofillList_populated() {
         processor.state.ciphersForAutofill = [
-            .fixture(id: "1", name: "Apple", subTitle: "user@bitwarden.com"),
-            .fixture(id: "2", name: "Bitwarden", subTitle: "user@bitwarden.com"),
-            .fixture(id: "3", name: "Company XYZ", subTitle: ""),
+            .fixture(id: "1", login: .fixture(username: "user@bitwarden.com"), name: "Apple"),
+            .fixture(id: "2", login: .fixture(username: "user@bitwarden.com"), name: "Bitwarden"),
+            .fixture(id: "3", login: .fixture(username: ""), name: "Company XYZ"),
         ]
         assertSnapshots(
             of: subject.navStackWrapped,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-597 - Implement Exact Match Detection for Auto-Fill](https://livefront.atlassian.net/browse/BIT-597)
[BIT-539 - Implement Starts With Match Detection for Auto-Fill](https://livefront.atlassian.net/browse/BIT-539)
[BIT-532 - Implement Never Option for Auto-Fill](https://livefront.atlassian.net/browse/BIT-532)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This implements exact, starts with and never URI match detection for ciphers that match the URL that autofill was requested for.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **CipherMatchingHelper.swift:** A helper object for determine which ciphers match a URI.
- **VaultRepository.swift:** Exposes a publisher for the ciphers that match a URI.
- **VaultAutofillList\*.swift:** Updates the view to use a `CipherView` to enable URI matching.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
