### PR TITLE
BIT-689: Add locale to captcha service url

### DIFF
--- a/BitwardenShared/Core/Auth/Services/CaptchaService.swift
+++ b/BitwardenShared/Core/Auth/Services/CaptchaService.swift
@@ -38,19 +38,29 @@ protocol CaptchaService {
 class DefaultCaptchaService: CaptchaService {
     // MARK: Properties
 
-    /// The service used by the application to manage the environment settings.
-    let environmentService: EnvironmentService
-
+    /// The callback url scheme.
     let callbackUrlScheme: String
+
+    /// The service used by the application to manage the environment settings.
+    private let environmentService: EnvironmentService
+
+    /// The service used by the application to manage account state.
+    private let stateService: StateService
 
     // MARK: Initialization
 
     /// Creates a new `DefaultCaptchaService`.
     ///
-    /// - Parameter environmentService: The service used by the application to manage the environment settings.
+    /// - Parameters:
+    ///   - environmentService: The service used by the application to manage the environment settings.
+    ///   - stateService: The service used by the application to manage account state.
     ///
-    init(environmentService: EnvironmentService) {
+    init(
+        environmentService: EnvironmentService,
+        stateService: StateService
+    ) {
         self.environmentService = environmentService
+        self.stateService = stateService
         callbackUrlScheme = "bitwarden"
     }
 
@@ -58,8 +68,7 @@ class DefaultCaptchaService: CaptchaService {
 
     func generateCaptchaUrl(with siteKey: String) throws -> URL {
         let callbackUrl = "\(callbackUrlScheme)://captcha-callback"
-        // TODO: BIT-689 Dynamically retrieve the user's locale
-        let locale = "en"
+        let locale = stateService.appLanguage.value ?? Locale.current.identifier
         let request = CaptchaRequestModel(
             callbackUri: callbackUrl,
             captchaRequiredText: Localizations.captchaRequired,

--- a/BitwardenShared/Core/Auth/Services/CaptchaServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/CaptchaServiceTests.swift
@@ -7,19 +7,26 @@ import XCTest
 class CaptchaServiceTests: BitwardenTestCase {
     // MARK: Properties
 
+    var stateService: MockStateService!
     var subject: DefaultCaptchaService!
 
     // MARK: Setup & Teardown
 
     override func setUp() {
         super.setUp()
+
+        stateService = MockStateService()
+
         subject = DefaultCaptchaService(
-            environmentService: MockEnvironmentService()
+            environmentService: MockEnvironmentService(),
+            stateService: stateService
         )
     }
 
     override func tearDown() {
         super.tearDown()
+
+        stateService = nil
         subject = nil
     }
 
@@ -30,6 +37,8 @@ class CaptchaServiceTests: BitwardenTestCase {
     }
 
     func test_generateCaptchaUrl() throws {
+        stateService.appLanguage = .custom(languageCode: "en")
+
         CaptchaRequestModel.encoder.outputFormatting = .sortedKeys
         let url = try subject.generateCaptchaUrl(with: "12345")
 

--- a/BitwardenShared/Core/Platform/Models/Enum/LanguageOption.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/LanguageOption.swift
@@ -93,7 +93,7 @@ public enum LanguageOption: Equatable {
         }
     }
 
-    /// The value to cache to local storage.
+    /// The two letter language code representation of the language, or `nil` for the system default.
     var value: String? {
         switch self {
         case .default:

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -189,6 +189,7 @@ public class ServiceContainer: Services {
         let sendService = DefaultSendService(sendDataStore: dataStore, stateService: stateService)
         let tokenService = DefaultTokenService(stateService: stateService)
         let apiService = APIService(environmentService: environmentService, tokenService: tokenService)
+        let captchaService = DefaultCaptchaService(environmentService: environmentService, stateService: stateService)
 
         let cipherService = DefaultCipherService(
             cipherAPIService: apiService,
@@ -298,7 +299,7 @@ public class ServiceContainer: Services {
             authRepository: authRepository,
             authService: authService,
             biometricsService: biometricsService,
-            captchaService: DefaultCaptchaService(environmentService: environmentService),
+            captchaService: captchaService,
             cameraService: DefaultCameraService(),
             clientService: clientService,
             environmentService: environmentService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-689](https://livefront.atlassian.net/browse/BIT-689)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add the custom locale setting to the request body for the captcha url.

## 📋 Code changes
<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **CaptchaService.swift:** Dynamically get the locale setting to add to the captcha request

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
