### PR TITLE
BIT-425: Validate password before exporting vault

### DIFF
--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
@@ -65,6 +65,13 @@ protocol SettingsRepository: AnyObject {
     ///
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws
 
+    /// Validates the user's entered master password to determine if it matches the stored hash.
+    ///
+    /// - Parameter password: The user's master password.
+    /// - Returns: Whether the hash of the password matches the stored hash.
+    ///
+    func validatePassword(_ password: String) async throws -> Bool
+
     // MARK: Publishers
 
     /// The publisher to keep track of the list of the user's current folders.
@@ -77,6 +84,9 @@ protocol SettingsRepository: AnyObject {
 ///
 class DefaultSettingsRepository {
     // MARK: Properties
+
+    /// The client used by the application to handle auth related encryption and decryption tasks.
+    private let clientAuth: ClientAuthProtocol
 
     /// The client used by the application to handle vault encryption and decryption tasks.
     private let clientVault: ClientVaultService
@@ -101,6 +111,7 @@ class DefaultSettingsRepository {
     /// Initialize a `DefaultSettingsRepository`.
     ///
     /// - Parameters:
+    ///   - clientAuth: The client used by the application to handle auth related encryption and decryption tasks.
     ///   - clientVault: The client used by the application to handle vault encryption and decryption tasks.
     ///   - folderService: The service used to manage syncing and updates to the user's folders.
     ///   - pasteboardService: The service used to manage copy/pasting from the device's clipboard.
@@ -109,6 +120,7 @@ class DefaultSettingsRepository {
     ///   - vaultTimeoutService: The service used to manage vault access.
     ///
     init(
+        clientAuth: ClientAuthProtocol,
         clientVault: ClientVaultService,
         folderService: FolderService,
         pasteboardService: PasteboardService,
@@ -116,6 +128,7 @@ class DefaultSettingsRepository {
         syncService: SyncService,
         vaultTimeoutService: VaultTimeoutService
     ) {
+        self.clientAuth = clientAuth
         self.clientVault = clientVault
         self.folderService = folderService
         self.pasteboardService = pasteboardService
@@ -176,6 +189,11 @@ extension DefaultSettingsRepository: SettingsRepository {
 
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
         try await stateService.setAllowSyncOnRefresh(allowSyncOnRefresh)
+    }
+
+    func validatePassword(_ password: String) async throws -> Bool {
+        guard let passwordHash = try await stateService.getMasterPasswordHash() else { return false }
+        return try await clientAuth.validatePassword(password: password, passwordHash: passwordHash)
     }
 
     // MARK: Publishers

--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
@@ -6,6 +6,7 @@ import XCTest
 class SettingsRepositoryTests: BitwardenTestCase {
     // MARK: Properties
 
+    var clientAuth: MockClientAuth!
     var clientVault: MockClientVaultService!
     var folderService: MockFolderService!
     var pasteboardService: MockPasteboardService!
@@ -19,6 +20,7 @@ class SettingsRepositoryTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        clientAuth = MockClientAuth()
         clientVault = MockClientVaultService()
         folderService = MockFolderService()
         pasteboardService = MockPasteboardService()
@@ -27,6 +29,7 @@ class SettingsRepositoryTests: BitwardenTestCase {
         vaultTimeoutService = MockVaultTimeoutService()
 
         subject = DefaultSettingsRepository(
+            clientAuth: clientAuth,
             clientVault: clientVault,
             folderService: folderService,
             pasteboardService: pasteboardService,
@@ -39,6 +42,7 @@ class SettingsRepositoryTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        clientAuth = nil
         clientVault = nil
         folderService = nil
         pasteboardService = nil
@@ -209,5 +213,38 @@ class SettingsRepositoryTests: BitwardenTestCase {
         try await subject.updateAllowSyncOnRefresh(true)
         value = try await stateService.getAllowSyncOnRefresh()
         XCTAssertTrue(value)
+    }
+
+    /// `validatePassword(_:)` returns `true` if the master password matches the stored password hash.
+    func test_validatePassword() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+        stateService.masterPasswordHashes["1"] = "wxyz4321"
+        clientAuth.validatePasswordResult = true
+
+        let isValid = try await subject.validatePassword("test1234")
+
+        XCTAssertTrue(isValid)
+        XCTAssertEqual(clientAuth.validatePasswordPassword, "test1234")
+        XCTAssertEqual(clientAuth.validatePasswordPasswordHash, "wxyz4321")
+    }
+
+    /// `validatePassword(_:)` returns `false` if there's no stored password hash.
+    func test_validatePassword_noPasswordHash() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
+        let isValid = try await subject.validatePassword("not the password")
+
+        XCTAssertFalse(isValid)
+    }
+
+    /// `validatePassword(_:)` returns `false` if the master password doesn't match the stored password hash.
+    func test_validatePassword_notValid() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+        stateService.masterPasswordHashes["1"] = "wxyz4321"
+        clientAuth.validatePasswordResult = false
+
+        let isValid = try await subject.validatePassword("not the password")
+
+        XCTAssertFalse(isValid)
     }
 }

--- a/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
@@ -21,6 +21,8 @@ class MockSettingsRepository: SettingsRepository {
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lockVaultCalls = [String?]()
     var unlockVaultCalls = [String?]()
+    var validatePasswordPasswords = [String]()
+    var validatePasswordResult: Result<Bool, Error> = .success(true)
     var logoutResult: Result<Void, StateServiceError> = .failure(.noActiveAccount)
     var foldersListSubject = CurrentValueSubject<[FolderView], Error>([])
 
@@ -73,6 +75,11 @@ class MockSettingsRepository: SettingsRepository {
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
         self.allowSyncOnRefresh = allowSyncOnRefresh
         try allowSyncOnRefreshResult.get()
+    }
+
+    func validatePassword(_ password: String) async throws -> Bool {
+        validatePasswordPasswords.append(password)
+        return try validatePasswordResult.get()
     }
 
     func logout() async throws {

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -265,6 +265,7 @@ public class ServiceContainer: Services {
         )
 
         let settingsRepository = DefaultSettingsRepository(
+            clientAuth: clientService.clientAuth(),
             clientVault: clientService.clientVault(),
             folderService: folderService,
             pasteboardService: pasteboardService,

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
@@ -57,9 +57,28 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
 
         // She the alert to confirm exporting the vault.
         coordinator.showAlert(.confirmExportVault(encrypted: encrypted) {
+            // Validate the password before exporting the vault.
+            guard await self.validatePassword() else {
+                return self.coordinator.showAlert(.defaultAlert(title: Localizations.invalidMasterPassword))
+            }
+
             // TODO: BIT-429
             // TODO: BIT-447
             // TODO: BIT-449
         })
+    }
+
+    /// Validate the password.
+    ///
+    /// - Returns: `true` if the password is valid.
+    ///
+    @MainActor
+    private func validatePassword() async -> Bool {
+        do {
+            return try await services.settingsRepository.validatePassword(state.passwordText)
+        } catch {
+            services.errorReporter.log(error: error)
+            return false
+        }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-425](https://livefront.atlassian.net/browse/BIT-425)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Verify the user's password before allowing them to export their vault and show an alert if it's invalid.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SettingsRepository.swift:** Add a method to validate the password
-   **ExportVaultProcessor.swift:** Check the password and display an alert if it's invalid

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
<video width="400px" src="https://github.com/bitwarden/ios/assets/125921730/e204833f-bd44-43ff-a69f-0a098d52fb7c" />

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
