### PR TITLE
BIT-1168: added element id to self hosted env

### DIFF
--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
@@ -44,6 +44,7 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.webVaultUrlChanged
                     )
                 )
+                .accessibilityIdentifier("WebVaultUrlEntry")
 
                 BitwardenTextField(
                     title: Localizations.apiUrl,
@@ -52,6 +53,7 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.apiUrlChanged
                     )
                 )
+                .accessibilityIdentifier("ApiUrlEntry")
 
                 BitwardenTextField(
                     title: Localizations.identityUrl,
@@ -60,6 +62,7 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.identityUrlChanged
                     )
                 )
+                .accessibilityIdentifier("IdentityUrlEntry")
 
                 BitwardenTextField(
                     title: Localizations.iconsUrl,
@@ -68,6 +71,7 @@ struct SelfHostedView: View {
                         send: SelfHostedAction.iconsUrlChanged
                     )
                 )
+                .accessibilityIdentifier("IconsUrlEntry")
             }
         }
         .padding(.top, 8)
@@ -98,6 +102,7 @@ struct SelfHostedView: View {
                 ),
                 placeholder: "ex. https://bitwarden.company.com"
             )
+            .accessibilityIdentifier("ServerUrlEntry")
             .autocorrectionDisabled()
             .keyboardType(.URL)
             .textContentType(.URL)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1168](https://livefront.atlassian.net/browse/BIT-1168)
## 🚧 Type of change
-   🎂 Added added accessibility identifier to self hosted environment text fields.
<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix
-   🚀 New feature development
-   🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)
-   🤖 Build/deploy pipeline (DevOps)
-   🎂 Other

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SelfHostedView.swift:** Added  accessibility identifier for ```ServerUrlEntry```, ```WebVaultUrlEntry```,  ```ApiUrlEntry```, ```IdentityUrlEntry```, ```IconsUrlEntry```.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
