### PR TITLE
BIT-538: Implement autofill regular expression URI matching

### DIFF
--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
@@ -69,22 +69,22 @@ enum CipherMatchingHelper {
             guard let uri = loginUri.uri, !uri.isEmpty else { continue }
             let uriMatchType = loginUri.match ?? .domain
 
-            matchResult = switch uriMatchType {
+            switch uriMatchType {
             case .domain:
                 // TODO: BIT-1097
-                MatchResult.none
+                matchResult = .none
             case .host:
                 // TODO: BIT-596
-                MatchResult.none
+                matchResult = .none
             case .startsWith:
-                uri.starts(with: matchUri) ? MatchResult.exact : MatchResult.none
+                matchResult = uri.starts(with: matchUri) ? .exact : .none
             case .exact:
-                uri == matchUri ? MatchResult.exact : MatchResult.none
+                matchResult = uri == matchUri ? .exact : .none
             case .regularExpression:
-                // TODO: BIT-538
-                MatchResult.none
+                let range = uri.range(of: matchUri, options: [.caseInsensitive, .regularExpression])
+                matchResult = range != nil ? .exact : .none
             case .never:
-                MatchResult.none
+                matchResult = .none
             }
 
             if matchResult != .none {

--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelperTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelperTests.swift
@@ -104,6 +104,35 @@ class CipherMatchingHelperTests: BitwardenTestCase {
         XCTAssertTrue(CipherMatchingHelper.ciphersMatching(uri: "http://bitwarden.com", ciphers: ciphers).isEmpty)
     }
 
+    /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the
+    /// regular expression match type.
+    func test_ciphersMatching_regularExpression() {
+        let uris: [(String, String)] = [
+            ("Wikipedia Special", "https://en.wikipedia.org/w/index.php?title=Special:UserLogin&returnto=Bitwarden"),
+            ("Wikipedia Specjalna", "https://pl.wikipedia.org/w/index.php?title=Specjalna:Zaloguj&returnto=Bitwarden"),
+            ("Wikipedia", "https://en.wikipedia.org/w/index.php"),
+            ("Malicious", "https://malicious-site.com"),
+            ("Bitwarden Wikipedia", "https://en.wikipedia.org/wiki/Bitwarden"),
+        ]
+        let ciphers = uris.map { name, uri in
+            CipherView.fixture(
+                login: .fixture(uris: [LoginUriView(uri: uri, match: .regularExpression)]),
+                name: name
+            )
+        }
+
+        assertInlineSnapshot(
+            of: dumpMatching(uri: #"^https://[a-z]+\.wikipedia\.org/w/index\.php"#, ciphers: ciphers),
+            as: .lines
+        ) {
+            """
+            Wikipedia Special
+            Wikipedia Specjalna
+            Wikipedia
+            """
+        }
+    }
+
     /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the starts
     /// with match type.
     func test_ciphersMatching_startsWith() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-538](https://livefront.atlassian.net/browse/BIT-538)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This implements regular expression URI match detection for ciphers that match the URL that autofill was requested for.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **CipherMatchingHelper.swift:** Implements regular expression UR matching.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
