### PR TITLE
BIT-1097: Add support for persisting equivalent domains

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -186,6 +186,7 @@ public class ServiceContainer: Services {
         let stateService = DefaultStateService(appSettingsStore: appSettingsStore, dataStore: dataStore)
         let environmentService = DefaultEnvironmentService(stateService: stateService)
         let collectionService = DefaultCollectionService(collectionDataStore: dataStore, stateService: stateService)
+        let settingsService = DefaultSettingsService(settingsDataStore: dataStore, stateService: stateService)
         let tokenService = DefaultTokenService(stateService: stateService)
         let apiService = APIService(environmentService: environmentService, tokenService: tokenService)
         let captchaService = DefaultCaptchaService(environmentService: environmentService, stateService: stateService)
@@ -221,6 +222,7 @@ public class ServiceContainer: Services {
             folderService: folderService,
             organizationService: organizationService,
             sendService: sendService,
+            settingsService: settingsService,
             stateService: stateService,
             syncAPIService: apiService
         )

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -481,6 +481,14 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
             let context = self.dataStore.persistentContainer.viewContext
             _ = try CipherData(context: context, userId: "1", cipher: .fixture(id: UUID().uuidString))
             _ = try CollectionData(context: context, userId: "1", collection: .fixture())
+            _ = try DomainData(
+                context: context,
+                userId: "1",
+                domains: DomainsResponseModel(
+                    equivalentDomains: nil,
+                    globalEquivalentDomains: nil
+                )
+            )
             _ = FolderData(
                 context: context,
                 userId: "1",
@@ -501,6 +509,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let context = dataStore.persistentContainer.viewContext
         try XCTAssertEqual(context.count(for: CipherData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: CollectionData.fetchByUserIdRequest(userId: "1")), 0)
+        try XCTAssertEqual(context.count(for: DomainData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: FolderData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: OrganizationData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")), 0)

--- a/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
+++ b/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
@@ -22,6 +22,15 @@
             </uniquenessConstraint>
         </uniquenessConstraints>
     </entity>
+    <entity name="DomainData" representedClassName=".DomainData" syncable="YES">
+        <attribute name="modelData" attributeType="Binary"/>
+        <attribute name="userId" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userId"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="FolderData" representedClassName=".FolderData" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="modelData" optional="YES" attributeType="Binary"/>
@@ -37,6 +46,12 @@
         <attribute name="id" attributeType="String"/>
         <attribute name="modelData" attributeType="Binary"/>
         <attribute name="userId" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userId"/>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
     </entity>
     <entity name="PasswordHistoryData" representedClassName=".PasswordHistoryData" syncable="YES">
         <attribute name="lastUsedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
@@ -81,6 +81,7 @@ class DataStore {
         try await deleteAllOrganizations(userId: userId)
         try await deleteAllPasswordHistory(userId: userId)
         try await deleteAllSends(userId: userId)
+        try await deleteEquivalentDomains(userId: userId)
     }
 
     /// Executes a batch delete request and merges the changes into the background and view contexts.

--- a/BitwardenShared/Core/Vault/Models/Data/DomainData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/DomainData.swift
@@ -1,0 +1,55 @@
+import CoreData
+import Foundation
+
+/// A data model for persisting domains.
+///
+class DomainData: NSManagedObject, ManagedObject, CodableModelData {
+    typealias Model = DomainsResponseModel
+
+    // MARK: Properties
+
+    /// The data model encoded as JSON data.
+    @NSManaged var modelData: Data?
+
+    /// The ID of the user associated with the domains.
+    @NSManaged var userId: String?
+
+    // MARK: Initialization
+
+    /// Initialize a `DomainData` object for insertion into the managed object context.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context to insert the initialized object.
+    ///   - userId: The user ID associated with the domains.
+    ///   - domains: The `DomainsResponseModel` object used to create the object.
+    ///
+    convenience init(
+        context: NSManagedObjectContext,
+        userId: String,
+        domains: DomainsResponseModel
+    ) throws {
+        self.init(context: context)
+        model = domains
+        self.userId = userId
+    }
+}
+
+extension DomainData {
+    /// A `NSFetchRequest` that fetches all objects for the specified user.
+    ///
+    /// - Parameter userId: The user associated with the objects to delete.
+    /// - Returns: A `NSFetchRequest` that fetches all objects for the user.
+    ///
+    static func fetchByUserIdRequest(userId: String) -> NSFetchRequest<DomainData> {
+        fetchRequest(predicate: userIdPredicate(userId: userId))
+    }
+
+    /// A `NSPredicate` that constrains a search for `DomainData` objects to the specified user.
+    ///
+    /// - Parameter userId: The user associated with the `DomainData` objects.
+    /// - Returns: A `NSPredicate` that can be used to fetch `DomainData` objects for the user.
+    ///
+    static func userIdPredicate(userId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(DomainData.userId), userId)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/API/Fixtures/APITestData+Vault.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Fixtures/APITestData+Vault.swift
@@ -4,6 +4,7 @@ extension APITestData {
     static let syncWithCipher = loadFromJsonBundle(resource: "syncWithCipher")
     static let syncWithCiphers = loadFromJsonBundle(resource: "syncWithCiphers")
     static let syncWithCiphersCollections = loadFromJsonBundle(resource: "syncWithCiphersCollections")
+    static let syncWithDomains = loadFromJsonBundle(resource: "syncWithDomains")
     static let syncWithProfile = loadFromJsonBundle(resource: "syncWithProfile")
     static let syncWithProfileOrganizations = loadFromJsonBundle(resource: "syncWithProfileOrganizations")
     static let syncWithSends = loadFromJsonBundle(resource: "syncWithSends")

--- a/BitwardenShared/Core/Vault/Services/API/Fixtures/syncWithDomains.json
+++ b/BitwardenShared/Core/Vault/Services/API/Fixtures/syncWithDomains.json
@@ -1,0 +1,27 @@
+{
+  "profile": null,
+  "folders": [],
+  "collections": [],
+  "ciphers": [],
+  "domains": {
+    "equivalentDomains": [
+      [
+        "example.com",
+        "test.com"
+      ]
+    ],
+    "globalEquivalentDomains": [
+      {
+        "type": 1,
+        "domains": [
+          "apple.com",
+          "icloud.com"
+        ],
+        "excluded": false
+      }
+    ]
+  },
+  "policies": [],
+  "sends": [],
+  "object": "sync"
+}

--- a/BitwardenShared/Core/Vault/Services/SettingsService.swift
+++ b/BitwardenShared/Core/Vault/Services/SettingsService.swift
@@ -1,0 +1,67 @@
+// MARK: - SettingsService
+
+/// A protocol for a `SettingsService` which manages syncing and updates to the user's settings.
+///
+protocol SettingsService: AnyObject {
+    /// Fetches the list of equivalent domains for the current user.
+    ///
+    /// - Returns: The list of equivalent domains.
+    ///
+    func fetchEquivalentDomains() async throws -> [[String]]
+
+    /// Replaces the list of domains for the user.
+    ///
+    /// - Parameters:
+    ///   - domains: The list of domains.
+    ///   - userId: The user ID associated with the domains.
+    ///
+    func replaceEquivalentDomains(_ domains: DomainsResponseModel?, userId: String) async throws
+}
+
+// MARK: - DefaultSettingsService
+
+/// A default implementation of a `SettingsService` which manages syncing and updates to the user's
+/// settings.
+///
+class DefaultSettingsService: SettingsService {
+    // MARK: Properties
+
+    /// The data store for managing the persisted settings for the user.
+    let settingsDataStore: SettingsDataStore
+
+    /// The service used by the application to manage account state.
+    let stateService: StateService
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultSettingsService`.
+    ///
+    /// - Parameters:
+    ///   - settingsDataStore: The data store for managing the persisted settings for the user.
+    ///   - stateService: The service used by the application to manage account state.
+    ///
+    init(settingsDataStore: SettingsDataStore, stateService: StateService) {
+        self.settingsDataStore = settingsDataStore
+        self.stateService = stateService
+    }
+}
+
+extension DefaultSettingsService {
+    func fetchEquivalentDomains() async throws -> [[String]] {
+        let userId = try await stateService.getActiveAccountId()
+        guard let domains = try await settingsDataStore.fetchEquivalentDomains(userId: userId) else {
+            return []
+        }
+        let equivalentDomains = domains.equivalentDomains ?? []
+        let globalEquivalentDomains = domains.globalEquivalentDomains?.compactMap(\.domains) ?? []
+        return equivalentDomains + globalEquivalentDomains
+    }
+
+    func replaceEquivalentDomains(_ domains: DomainsResponseModel?, userId: String) async throws {
+        guard let domains else {
+            try await settingsDataStore.deleteEquivalentDomains(userId: userId)
+            return
+        }
+        try await settingsDataStore.replaceEquivalentDomains(domains, userId: userId)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/SettingsServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SettingsServiceTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class SettingsServiceTests: XCTestCase {
+    // MARK: Properties
+
+    var settingsDataStore: MockSettingsDataStore!
+    var stateService: MockStateService!
+    var subject: DefaultSettingsService!
+
+    let domains = DomainsResponseModel(
+        equivalentDomains: [["google.com", "youtube.com"]],
+        globalEquivalentDomains: [
+            GlobalDomains(domains: ["apple.com", "icloud.com"], excluded: false, type: 0),
+        ]
+    )
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        settingsDataStore = MockSettingsDataStore()
+        stateService = MockStateService()
+
+        subject = DefaultSettingsService(
+            settingsDataStore: settingsDataStore,
+            stateService: stateService
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        settingsDataStore = nil
+        stateService = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `fetchEquivalentDomains()` returns the list of persisted equivalent domains.
+    func test_fetchEquivalentDomains() async throws {
+        stateService.activeAccount = .fixture()
+
+        var fetchedDomains = try await subject.fetchEquivalentDomains()
+        XCTAssertEqual(fetchedDomains, [])
+
+        settingsDataStore.fetchDomainsResult = .success(
+            DomainsResponseModel(equivalentDomains: nil, globalEquivalentDomains: nil)
+        )
+        fetchedDomains = try await subject.fetchEquivalentDomains()
+        XCTAssertEqual(fetchedDomains, [])
+
+        settingsDataStore.fetchDomainsResult = .success(domains)
+        fetchedDomains = try await subject.fetchEquivalentDomains()
+        XCTAssertEqual(
+            fetchedDomains,
+            [
+                ["google.com", "youtube.com"],
+                ["apple.com", "icloud.com"],
+            ]
+        )
+    }
+
+    /// `replaceCiphers(_:userId:)` replaces the persisted domains in the data store.
+    func test_replaceEquivalentDomains() async throws {
+        try await subject.replaceEquivalentDomains(domains, userId: "1")
+
+        XCTAssertEqual(settingsDataStore.replaceDomainsDomains, domains)
+    }
+
+    /// `replaceCiphers(_:userId:)` deletes the persisted domains in the data store if the data is `nil`.
+    func test_replaceEquivalentDomains_nil() async throws {
+        try await subject.replaceEquivalentDomains(nil, userId: "1")
+
+        XCTAssertTrue(settingsDataStore.deleteEquivalentDomainsCalled)
+        XCTAssertEqual(settingsDataStore.deleteEquivalentDomainsUserId, "1")
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/SettingsDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/SettingsDataStore.swift
@@ -1,0 +1,47 @@
+import CoreData
+
+/// A protocol for a data store that handles performing data requests for settings.
+///
+protocol SettingsDataStore: AnyObject {
+    /// Deletes the list of equivalent domains for the user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the domains.
+    ///
+    func deleteEquivalentDomains(userId: String) async throws
+
+    /// Fetches the list of equivalent domains for the user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the domains.
+    /// - Returns: The list of equivalent domains.
+    ///
+    func fetchEquivalentDomains(userId: String) async throws -> DomainsResponseModel?
+
+    /// Replaces the list of equivalent domains for the user.
+    ///
+    /// - Parameters:
+    ///   - domains: The list of equivalent domains.
+    ///   - userId: The user ID of the user associated with the domains.
+    ///
+    func replaceEquivalentDomains(_ domains: DomainsResponseModel, userId: String) async throws
+}
+
+extension DataStore: SettingsDataStore {
+    func deleteEquivalentDomains(userId: String) async throws {
+        let fetchRequest = DomainData.fetchResultRequest(predicate: DomainData.userIdPredicate(userId: userId))
+        try await executeBatchDelete(NSBatchDeleteRequest(fetchRequest: fetchRequest))
+    }
+
+    func fetchEquivalentDomains(userId: String) async throws -> DomainsResponseModel? {
+        try await backgroundContext.perform {
+            try self.backgroundContext.fetch(DomainData.fetchByUserIdRequest(userId: userId))
+                .compactMap(\.model)
+                .first
+        }
+    }
+
+    func replaceEquivalentDomains(_ domains: DomainsResponseModel, userId: String) async throws {
+        try await backgroundContext.performAndSave {
+            _ = try DomainData(context: self.backgroundContext, userId: userId, domains: domains)
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/SettingsDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/SettingsDataStoreTests.swift
@@ -1,0 +1,66 @@
+import CoreData
+import XCTest
+
+@testable import BitwardenShared
+
+class SettingsDataStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DataStore!
+
+    let domains = DomainsResponseModel(
+        equivalentDomains: [["google.com", "youtube.com"]],
+        globalEquivalentDomains: [
+            GlobalDomains(domains: ["apple.com", "icloud.com"], excluded: false, type: 0),
+        ]
+    )
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `deleteEquivalentDomains(userId:)` removes the domains for the user.
+    func test_deleteEquivalentDomains() async throws {
+        try await subject.replaceEquivalentDomains(domains, userId: "1")
+        try await subject.replaceEquivalentDomains(domains, userId: "2")
+
+        try await subject.deleteEquivalentDomains(userId: "1")
+
+        var fetchedDomains = try await subject.fetchEquivalentDomains(userId: "1")
+        XCTAssertNil(fetchedDomains)
+        fetchedDomains = try await subject.fetchEquivalentDomains(userId: "2")
+        XCTAssertEqual(fetchedDomains, domains)
+    }
+
+    /// `fetchDomains(userId:` fetches the domains for the user.
+    func test_fetchEquivalentDomains() async throws {
+        try await subject.replaceEquivalentDomains(domains, userId: "1")
+        let fetchedDomains = try await subject.fetchEquivalentDomains(userId: "1")
+        XCTAssertEqual(fetchedDomains, domains)
+    }
+
+    /// `replaceEquivalentDomains(_:userId:)` replaces the list of domains for the user.
+    func test_replaceEquivalentDomains() async throws {
+        try await subject.replaceEquivalentDomains(
+            DomainsResponseModel(equivalentDomains: nil, globalEquivalentDomains: nil),
+            userId: "1"
+        )
+
+        try await subject.replaceEquivalentDomains(domains, userId: "1")
+
+        let fetchedDomains = try await subject.fetchEquivalentDomains(userId: "1")
+        XCTAssertEqual(fetchedDomains, domains)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockSettingsDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockSettingsDataStore.swift
@@ -1,0 +1,29 @@
+@testable import BitwardenShared
+
+class MockSettingsDataStore: SettingsDataStore {
+    var deleteEquivalentDomainsCalled = false
+    var deleteEquivalentDomainsUserId: String?
+    var deleteEquivalentDomainsResult: Result<Void, Error> = .success(())
+
+    var fetchDomainsResult: Result<DomainsResponseModel?, Error> = .success(nil)
+
+    var replaceDomainsDomains: DomainsResponseModel?
+    var replaceDomainsUserId: String?
+    var replaceDomainsResult: Result<Void, Error> = .success(())
+
+    func deleteEquivalentDomains(userId: String) async throws {
+        deleteEquivalentDomainsCalled = true
+        deleteEquivalentDomainsUserId = userId
+        try deleteEquivalentDomainsResult.get()
+    }
+
+    func fetchEquivalentDomains(userId: String) async throws -> DomainsResponseModel? {
+        try fetchDomainsResult.get()
+    }
+
+    func replaceEquivalentDomains(_ domains: DomainsResponseModel, userId: String) async throws {
+        replaceDomainsDomains = domains
+        replaceDomainsUserId = userId
+        try replaceDomainsResult.get()
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -46,6 +46,9 @@ class DefaultSyncService: SyncService {
     /// The service for managing the sends for the user.
     let sendService: SendService
 
+    /// The service for managing the settings for the user.
+    let settingsService: SettingsService
+
     /// The service used by the application to manage account state.
     let stateService: StateService
 
@@ -65,6 +68,7 @@ class DefaultSyncService: SyncService {
     ///   - folderService: The service for managing the folders for the user.
     ///   - organizationService: The service for managing the organizations for the user.
     ///   - sendService: The service for managing the sends for the user.
+    ///   - settingsService: The service for managing the organizations for the user.
     ///   - stateService: The service used by the application to manage account state.
     ///   - syncAPIService: The API service used to perform sync API requests.
     ///
@@ -74,6 +78,7 @@ class DefaultSyncService: SyncService {
         folderService: FolderService,
         organizationService: OrganizationService,
         sendService: SendService,
+        settingsService: SettingsService,
         stateService: StateService,
         syncAPIService: SyncAPIService
     ) {
@@ -82,6 +87,7 @@ class DefaultSyncService: SyncService {
         self.folderService = folderService
         self.organizationService = organizationService
         self.sendService = sendService
+        self.settingsService = settingsService
         self.stateService = stateService
         self.syncAPIService = syncAPIService
     }
@@ -108,6 +114,7 @@ extension DefaultSyncService {
         try await collectionService.replaceCollections(response.collections, userId: userId)
         try await folderService.replaceFolders(response.folders, userId: userId)
         try await sendService.replaceSends(response.sends, userId: userId)
+        try await settingsService.replaceEquivalentDomains(response.domains, userId: userId)
 
         syncResponseSubject.value = response
 

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -13,6 +13,7 @@ class SyncServiceTests: BitwardenTestCase {
     var folderService: MockFolderService!
     var organizationService: MockOrganizationService!
     var sendService: MockSendService!
+    var settingsService: MockSettingsService!
     var stateService: MockStateService!
     var subject: SyncService!
 
@@ -27,6 +28,7 @@ class SyncServiceTests: BitwardenTestCase {
         folderService = MockFolderService()
         organizationService = MockOrganizationService()
         sendService = MockSendService()
+        settingsService = MockSettingsService()
         stateService = MockStateService()
 
         subject = DefaultSyncService(
@@ -35,6 +37,7 @@ class SyncServiceTests: BitwardenTestCase {
             folderService: folderService,
             organizationService: organizationService,
             sendService: sendService,
+            settingsService: settingsService,
             stateService: stateService,
             syncAPIService: APIService(client: client)
         )
@@ -49,6 +52,7 @@ class SyncServiceTests: BitwardenTestCase {
         folderService = nil
         organizationService = nil
         sendService = nil
+        settingsService = nil
         stateService = nil
         subject = nil
     }
@@ -191,6 +195,24 @@ class SyncServiceTests: BitwardenTestCase {
             ]
         )
         XCTAssertEqual(sendService.replaceSendsUserId, "1")
+    }
+
+    /// `fetchSync()` replaces the list of the user's equivalent domains.
+    func test_fetchSync_domains() async throws {
+        client.result = .httpSuccess(testData: .syncWithDomains)
+        stateService.activeAccount = .fixture()
+
+        try await subject.fetchSync()
+
+        XCTAssertEqual(
+            settingsService.replaceEquivalentDomainsDomains,
+            DomainsResponseModel(
+                equivalentDomains: [["example.com", "test.com"]],
+                globalEquivalentDomains: [
+                    GlobalDomains(domains: ["apple.com", "icloud.com"], excluded: false, type: 1),
+                ]
+            )
+        )
     }
 
     /// `fetchSync()` replaces the list of the user's folders.

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockSettingsService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockSettingsService.swift
@@ -1,0 +1,19 @@
+@testable import BitwardenShared
+
+class MockSettingsService: SettingsService {
+    var fetchEquivalentDomainsResult: Result<[[String]], Error> = .success([[]])
+
+    var replaceEquivalentDomainsDomains: DomainsResponseModel?
+    var replaceEquivalentDomainsUserId: String?
+    var replaceEquivalentDomainsResult: Result<Void, Error> = .success(())
+
+    func fetchEquivalentDomains() async throws -> [[String]] {
+        try fetchEquivalentDomainsResult.get()
+    }
+
+    func replaceEquivalentDomains(_ domains: DomainsResponseModel?, userId: String) async throws {
+        replaceEquivalentDomainsDomains = domains
+        replaceEquivalentDomainsUserId = userId
+        try replaceEquivalentDomainsResult.get()
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1097](https://livefront.atlassian.net/browse/BIT-1097)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds support for persisting the equivalent domains contained in the sync response.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **ServiceContainer.swift:** Adds `SettingsService` for managing syncing of user settings.
- **Bitwarden.xcdatamodel:** Adds `DomainData` entity to the database.
- **DataStore.swift:** Clears domains when removing data for a user.
- **DomainData.swift:** Data model for persisting domains.
- **SettingsService.swift:** Service to managing syncing user settings.
- **SettingsDataStore.swift:** Data store for persisting domains.
- **SyncService.swift:** Replaces the user's list of domains on sync.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
