### PR TITLE
BIT-1497: Fixes an empty state bug with SendRepository

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -138,6 +138,10 @@ class DefaultSendRepository: SendRepository {
             .asyncMap { try await clientVault.sends().decrypt(send: $0) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
 
+        guard !sends.isEmpty else {
+            return []
+        }
+
         let fileSendsCount = sends
             .filter { $0.type == .file }
             .count

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -182,6 +182,20 @@ class SendRepositoryTests: BitwardenTestCase {
 
     /// `sendListPublisher()` returns a publisher for the list of sections and items that are
     /// displayed in the sends tab.
+    func test_sendListPublisher_withoutValues() async throws {
+        sendService.sendsSubject.send([])
+
+        var iterator = try await subject.sendListPublisher().makeAsyncIterator()
+        let sections = try await iterator.next()
+
+        try assertInlineSnapshot(of: dumpSendListSections(XCTUnwrap(sections)), as: .lines) {
+            """
+            """
+        }
+    }
+
+    /// `sendListPublisher()` returns a publisher for the list of sections and items that are
+    /// displayed in the sends tab.
     func test_sendListPublisher_withValues() async throws {
         sendService.sendsSubject.send([
             .fixture(


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1497](https://livefront.atlassian.net/browse/BIT-1497)

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

This PR fixes a bug where the empty state for the Sends list would never be shown.

## 📋 Code changes

- **SendRepository:** Added a check for the list of sends being empty when creating the sections for the Sends list screen.

## 📸 Screenshots

https://github.com/bitwarden/ios/assets/125909022/bff30daf-ffb5-49db-84f3-3572d0628563

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
