### PR TITLE
BIT-1556: Update two factor request to use captcha bypass token

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenTwoFactorFailure.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenTwoFactorFailure.json
@@ -9,5 +9,6 @@
             "sh***@example.com"
         }
     },
-    "SsoEmail2faSessionToken": "exampleToken"
+    "SsoEmail2faSessionToken": "exampleToken",
+    "CaptchaBypassToken": "BWCaptchaBypass_ABCXYZ"
 }

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
@@ -21,8 +21,9 @@ enum IdentityTokenRequestError: Error, Equatable {
     /// - Parameters:
     ///   - authMethodsData: The information about the available auth methods.
     ///   - ssoToken: The sso token, which is non-nil if the user is using single sign on.
+    ///   - captchaBypassToken: A captcha bypass token, which allows the user to bypass the next captcha prompt.
     ///
-    case twoFactorRequired(_ authMethodsData: AuthMethodsData, _ ssoToken: String?)
+    case twoFactorRequired(_ authMethodsData: AuthMethodsData, _ ssoToken: String?, _ captchaBypassToken: String?)
 }
 
 // MARK: - IdentityTokenRequest
@@ -77,7 +78,8 @@ struct IdentityTokenRequest: Request {
 
             if let providersData = object["TwoFactorProviders2"] as? AuthMethodsData {
                 let ssoToken = object["SsoEmail2faSessionToken"] as? String
-                throw IdentityTokenRequestError.twoFactorRequired(providersData, ssoToken)
+                let captchaBypassToken = object["CaptchaBypassToken"] as? String
+                throw IdentityTokenRequestError.twoFactorRequired(providersData, ssoToken, captchaBypassToken)
             } else if let siteCode = object["HCaptcha_SiteKey"] as? String {
                 // Throw the captcha error if the captcha site key can be found.
                 throw IdentityTokenRequestError.captchaRequired(hCaptchaSiteCode: siteCode)

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
@@ -128,7 +128,7 @@ class IdentityTokenRequestTests: BitwardenTestCase {
         XCTAssertThrowsError(try subjectAuthorizationCode.validate(response)) { error in
             XCTAssertEqual(
                 error as? IdentityTokenRequestError,
-                .twoFactorRequired(["1": ["Email": "sh***@example.com"]], "exampleToken")
+                .twoFactorRequired(["1": ["Email": "sh***@example.com"]], "exampleToken", "BWCaptchaBypass_ABCXYZ")
             )
         }
     }

--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -407,10 +407,11 @@ class DefaultAuthService: AuthService {
             let encryptionKeys = AccountEncryptionKeys(identityTokenResponseModel: identityTokenResponse)
             try await stateService.setAccountEncryptionKeys(encryptionKeys)
         } catch let error as IdentityTokenRequestError {
-            if case let .twoFactorRequired(_, ssoToken) = error {
+            if case let .twoFactorRequired(_, ssoToken, captchaBypassToken) = error {
                 // If the token request require two-factor authentication, cache the request so that
                 // the token information can be added once the user inputs the code.
                 twoFactorRequest = request
+                twoFactorRequest?.captchaToken = captchaBypassToken
 
                 // Form the resend email request in case the user needs to resend the verification code email.
                 var passwordHash: String?

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -184,7 +184,13 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
 
         // Attempt to login.
         let authMethodsData = ["1": ["Email": "sh***@example.com"]]
-        await assertAsyncThrows(error: IdentityTokenRequestError.twoFactorRequired(authMethodsData, "exampleToken")) {
+        await assertAsyncThrows(
+            error: IdentityTokenRequestError.twoFactorRequired(
+                authMethodsData,
+                "exampleToken",
+                "BWCaptchaBypass_ABCXYZ"
+            )
+        ) {
             try await subject.loginWithMasterPassword(
                 "Password1234!",
                 username: "email@example.com",
@@ -259,7 +265,13 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
 
         // First login with the master password so that the request will be saved.
         let authMethodsData = ["1": ["Email": "sh***@example.com"]]
-        await assertAsyncThrows(error: IdentityTokenRequestError.twoFactorRequired(authMethodsData, "exampleToken")) {
+        await assertAsyncThrows(
+            error: IdentityTokenRequestError.twoFactorRequired(
+                authMethodsData,
+                "exampleToken",
+                "BWCaptchaBypass_ABCXYZ"
+            )
+        ) {
             try await subject.loginWithMasterPassword(
                 "Password1234!",
                 username: "email@example.com",
@@ -320,7 +332,13 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
 
         // First login with the master password so that the resend email request will be saved.
         let authMethodsData = ["1": ["Email": "sh***@example.com"]]
-        await assertAsyncThrows(error: IdentityTokenRequestError.twoFactorRequired(authMethodsData, "exampleToken")) {
+        await assertAsyncThrows(
+            error: IdentityTokenRequestError.twoFactorRequired(
+                authMethodsData,
+                "exampleToken",
+                "BWCaptchaBypass_ABCXYZ"
+            )
+        ) {
             try await subject.loginWithMasterPassword(
                 "Password1234!",
                 username: "email@example.com",

--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -150,7 +150,7 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
             switch error {
             case let .captchaRequired(hCaptchaSiteCode):
                 launchCaptchaFlow(with: hCaptchaSiteCode)
-            case let .twoFactorRequired(authMethodsData, _):
+            case let .twoFactorRequired(authMethodsData, _, _):
                 coordinator.navigate(to: .twoFactor(state.username, state.masterPassword, authMethodsData))
             }
         } catch {

--- a/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
@@ -214,7 +214,7 @@ class LoginProcessorTests: BitwardenTestCase {
     func test_perform_loginWithMasterPasswordPressed_twoFactorError() async {
         subject.state.masterPassword = "Test"
         authService.loginWithMasterPasswordResult = .failure(
-            IdentityTokenRequestError.twoFactorRequired(AuthMethodsData(), nil)
+            IdentityTokenRequestError.twoFactorRequired(AuthMethodsData(), nil, nil)
         )
 
         await subject.perform(.loginWithMasterPasswordPressed)

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -85,7 +85,7 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
     private func handleError(_ error: Error, _ tryAgain: (() async -> Void)? = nil) {
         coordinator.hideLoadingOverlay()
         if case ASWebAuthenticationSessionError.canceledLogin = error { return }
-        if case let .twoFactorRequired(authMethodsData, _) = error as? IdentityTokenRequestError {
+        if case let .twoFactorRequired(authMethodsData, _, _) = error as? IdentityTokenRequestError {
             return coordinator.navigate(to: .twoFactor(state.email, nil, authMethodsData))
         }
         coordinator.showAlert(.networkResponseError(error, tryAgain))

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
@@ -165,7 +165,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase {
     func test_singleSignOnCompleted_twoFactorError() async throws {
         // Set up the mock data.
         authService.generateSingleSignOnUrlResult = .failure(
-            IdentityTokenRequestError.twoFactorRequired(AuthMethodsData(), nil)
+            IdentityTokenRequestError.twoFactorRequired(AuthMethodsData(), nil, nil)
         )
         subject.state.identifierText = "BestOrganization"
 

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -164,7 +164,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase {
     func test_perform_continueTapped_twoFactorError() async {
         subject.state.verificationCode = "Test"
         authService.loginWithTwoFactorCodeResult = .failure(
-            IdentityTokenRequestError.twoFactorRequired(.init(), nil)
+            IdentityTokenRequestError.twoFactorRequired(.init(), nil, nil)
         )
 
         await subject.perform(.continueTapped)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1556](https://livefront.atlassian.net/browse/BIT-1556)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We're currently passing the captcha token returned from the login captcha to the two factor request, but this results in an error when this token is used: `Captcha is invalid. Please refresh and try again`. Instead, I think we need to save the captcha bypass token parsed from the identity token error response and include that as the captcha token when making subsequent identity token requests.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **IdentityTokenRequest.swift:** Parse the captcha bypass token from the error response.
- **AuthService.swift:** Apply the captcha bypass token to subsequent identity token requests.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
