### PR TITLE
BIT-1576: Add support for persisting policies

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -199,6 +199,7 @@ public class ServiceContainer: Services {
         let clientService = DefaultClientService()
         let environmentService = DefaultEnvironmentService(stateService: stateService)
         let collectionService = DefaultCollectionService(collectionDataStore: dataStore, stateService: stateService)
+        let policyService = DefaultPolicyService(policyDataStore: dataStore, stateService: stateService)
         let settingsService = DefaultSettingsService(settingsDataStore: dataStore, stateService: stateService)
         let tokenService = DefaultTokenService(stateService: stateService)
         let apiService = APIService(environmentService: environmentService, tokenService: tokenService)
@@ -244,6 +245,7 @@ public class ServiceContainer: Services {
             collectionService: collectionService,
             folderService: folderService,
             organizationService: organizationService,
+            policyService: policyService,
             sendService: sendService,
             settingsService: settingsService,
             stateService: stateService,

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -671,6 +671,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
                 folder: Folder(id: "1", name: "FOLDER1", revisionDate: Date())
             )
             _ = OrganizationData(context: context, userId: "1", organization: .fixture())
+            _ = PolicyData(context: context, userId: "1", policy: .fixture())
             _ = try SendData(context: context, userId: "1", send: .fixture())
         }
 
@@ -691,6 +692,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try XCTAssertEqual(context.count(for: FolderData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: OrganizationData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: PasswordHistoryData.fetchByUserIdRequest(userId: "1")), 0)
+        try XCTAssertEqual(context.count(for: PolicyData.fetchByUserIdRequest(userId: "1")), 0)
         try XCTAssertEqual(context.count(for: SendData.fetchByUserIdRequest(userId: "1")), 0)
     }
 

--- a/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
+++ b/BitwardenShared/Core/Platform/Services/Stores/Bitwarden.xcdatamodeld/Bitwarden.xcdatamodel/contents
@@ -58,6 +58,17 @@
         <attribute name="password" attributeType="String"/>
         <attribute name="userId" attributeType="String"/>
     </entity>
+    <entity name="PolicyData" representedClassName=".PolicyData" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="modelData" attributeType="Binary"/>
+        <attribute name="userId" attributeType="String"/>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="userId"/>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
     <entity name="SendData" representedClassName=".SendData" syncable="YES">
         <attribute name="id" attributeType="String"/>
         <attribute name="modelData" attributeType="Binary"/>

--- a/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
@@ -80,6 +80,7 @@ class DataStore {
         try await deleteAllFolders(userId: userId)
         try await deleteAllOrganizations(userId: userId)
         try await deleteAllPasswordHistory(userId: userId)
+        try await deleteAllPolicies(userId: userId)
         try await deleteAllSends(userId: userId)
         try await deleteEquivalentDomains(userId: userId)
     }

--- a/BitwardenShared/Core/Vault/Models/Data/PolicyData.swift
+++ b/BitwardenShared/Core/Vault/Models/Data/PolicyData.swift
@@ -1,0 +1,70 @@
+import BitwardenSdk
+import CoreData
+import Foundation
+
+/// A data model for persisting policies.
+///
+class PolicyData: NSManagedObject, ManagedUserObject, CodableModelData {
+    typealias Model = PolicyResponseModel
+
+    // MARK: Properties
+
+    /// The policy's identifier.
+    @NSManaged var id: String?
+
+    /// The data model encoded as JSON data.
+    @NSManaged var modelData: Data?
+
+    /// The ID of the user who owns the policy.
+    @NSManaged var userId: String?
+
+    // MARK: Initialization
+
+    /// Initialize a `PolicyData` object for insertion into the managed object context.
+    ///
+    /// - Parameters:
+    ///   - context: The managed object context to insert the initialized object.
+    ///   - userId: The user ID associated with the policy.
+    ///   - policy: The `PolicyResponseModel` object used to create the object.
+    ///
+    convenience init(
+        context: NSManagedObjectContext,
+        userId: String,
+        policy: PolicyResponseModel
+    ) {
+        self.init(context: context)
+        id = policy.id
+        model = policy
+        self.userId = userId
+    }
+
+    // MARK: Methods
+
+    /// Updates the `PolicyData` object from a `Policy` and user ID.
+    ///
+    /// - Parameters:
+    ///   - policy: The `PolicyResponseModel` object used to update the `PolicyData` instance.
+    ///   - userId: The user ID associated with the policy.
+    ///
+    func update(with policy: PolicyResponseModel, userId: String) {
+        id = policy.id
+        model = policy
+        self.userId = userId
+    }
+}
+
+extension PolicyData {
+    static func userIdPredicate(userId: String) -> NSPredicate {
+        NSPredicate(format: "%K == %@", #keyPath(PolicyData.userId), userId)
+    }
+
+    static func userIdAndIdPredicate(userId: String, id: String) -> NSPredicate {
+        NSPredicate(
+            format: "%K == %@ AND %K == %@",
+            #keyPath(PolicyData.userId),
+            userId,
+            #keyPath(PolicyData.id),
+            id
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Domain/Policy.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Policy.swift
@@ -1,0 +1,39 @@
+/// A domain model containing the details of a policy.
+///
+struct Policy: Equatable {
+    // MARK: Properties
+
+    /// Custom policy key value pairs.
+    let data: [String: AnyCodable]?
+
+    /// Whether the policy is enabled.
+    let enabled: Bool
+
+    /// The policy's identifier.
+    let id: String
+
+    /// The organization identifier for the policy.
+    let organizationId: String
+
+    /// The policy type.
+    let type: PolicyType
+}
+
+extension Policy {
+    init(responseModel: PolicyResponseModel) {
+        self.init(
+            data: responseModel.data,
+            enabled: responseModel.enabled,
+            id: responseModel.id,
+            organizationId: responseModel.organizationId,
+            type: responseModel.type
+        )
+    }
+
+    init?(policyData: PolicyData) throws {
+        guard let model = policyData.model else {
+            throw DataMappingError.invalidData
+        }
+        self.init(responseModel: model)
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Response/Fixtures/PolicyResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/Fixtures/PolicyResponseModel+Fixtures.swift
@@ -1,0 +1,19 @@
+@testable import BitwardenShared
+
+extension PolicyResponseModel {
+    static func fixture(
+        data: [String: AnyCodable]? = nil,
+        enabled: Bool = true,
+        id: String = "policy-1",
+        organizationId: String = "org-1",
+        type: PolicyType = .twoFactorAuthentication
+    ) -> PolicyResponseModel {
+        PolicyResponseModel(
+            data: data,
+            enabled: enabled,
+            id: id,
+            organizationId: organizationId,
+            type: type
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -1,0 +1,47 @@
+// MARK: - PolicyService
+
+/// A protocol for a `PolicyService` which manages syncing and updates to the user's policies.
+///
+protocol PolicyService: AnyObject {
+    /// Replaces the list of policies for the user.
+    ///
+    /// - Parameters:
+    ///   - domains: The list of policies.
+    ///   - userId: The user ID associated with the policies.
+    ///
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws
+}
+
+// MARK: - DefaultPolicyService
+
+/// A default implementation of a `PolicyService` which manages syncing and updates to the user's
+/// policies.
+///
+class DefaultPolicyService: PolicyService {
+    // MARK: Properties
+
+    /// The data store for managing the persisted policies for the user.
+    let policyDataStore: PolicyDataStore
+
+    /// The service used by the application to manage account state.
+    let stateService: StateService
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultPolicyService`.
+    ///
+    /// - Parameters:
+    ///   - policyDataStore: The data store for managing the persisted policies for the user.
+    ///   - stateService: The service used by the application to manage account state.
+    ///
+    init(policyDataStore: PolicyDataStore, stateService: StateService) {
+        self.policyDataStore = policyDataStore
+        self.stateService = stateService
+    }
+}
+
+extension DefaultPolicyService {
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws {
+        try await policyDataStore.replacePolicies(policies, userId: userId)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class PolicyServiceTests: XCTestCase {
+    // MARK: Properties
+
+    var policyDataStore: MockPolicyDataStore!
+    var stateService: MockStateService!
+    var subject: DefaultPolicyService!
+
+    let policies: [PolicyResponseModel] = [
+        .fixture(id: "1"),
+        .fixture(id: "2"),
+    ]
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        policyDataStore = MockPolicyDataStore()
+        stateService = MockStateService()
+
+        subject = DefaultPolicyService(
+            policyDataStore: policyDataStore,
+            stateService: stateService
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        policyDataStore = nil
+        stateService = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `replacePolicies(_:userId:)` replaces the persisted policies in the data store.
+    func test_replacePolicies() async throws {
+        try await subject.replacePolicies(policies, userId: "1")
+
+        XCTAssertEqual(policyDataStore.replacePoliciesPolicies, policies)
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/SettingsServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SettingsServiceTests.swift
@@ -64,14 +64,14 @@ class SettingsServiceTests: XCTestCase {
         )
     }
 
-    /// `replaceCiphers(_:userId:)` replaces the persisted domains in the data store.
+    /// `replaceEquivalentDomains(_:userId:)` replaces the persisted domains in the data store.
     func test_replaceEquivalentDomains() async throws {
         try await subject.replaceEquivalentDomains(domains, userId: "1")
 
         XCTAssertEqual(settingsDataStore.replaceDomainsDomains, domains)
     }
 
-    /// `replaceCiphers(_:userId:)` deletes the persisted domains in the data store if the data is `nil`.
+    /// `replaceEquivalentDomains(_:userId:)` deletes the persisted domains in the data store if the data is `nil`.
     func test_replaceEquivalentDomains_nil() async throws {
         try await subject.replaceEquivalentDomains(nil, userId: "1")
 

--- a/BitwardenShared/Core/Vault/Services/Stores/PolicyDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/PolicyDataStore.swift
@@ -1,0 +1,49 @@
+import CoreData
+
+/// A protocol for a data store that handles performing data requests for policies.
+///
+protocol PolicyDataStore: AnyObject {
+    /// Deletes all policies for the user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the policies.
+    ///
+    func deleteAllPolicies(userId: String) async throws
+
+    /// Fetches all policies for the user.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the policies.
+    /// - Returns: The list of policies.
+    ///
+    func fetchAllPolicies(userId: String) async throws -> [Policy]
+
+    /// Replaces the list of policies for the user.
+    ///
+    /// - Parameters:
+    ///   - domains: The list of policies.
+    ///   - userId: The user ID of the user associated with the policies.
+    ///
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws
+}
+
+extension DataStore: PolicyDataStore {
+    func deleteAllPolicies(userId: String) async throws {
+        let fetchRequest = PolicyData.fetchResultRequest(predicate: PolicyData.userIdPredicate(userId: userId))
+        try await executeBatchDelete(NSBatchDeleteRequest(fetchRequest: fetchRequest))
+    }
+
+    func fetchAllPolicies(userId: String) async throws -> [Policy] {
+        try await backgroundContext.perform {
+            let fetchRequest = PolicyData.fetchByUserIdRequest(userId: userId)
+            return try self.backgroundContext.fetch(fetchRequest).compactMap(Policy.init)
+        }
+    }
+
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws {
+        let deleteRequest = PolicyData.deleteByUserIdRequest(userId: userId)
+        let insertRequest = try PolicyData.batchInsertRequest(objects: policies, userId: userId)
+        try await executeBatchReplace(
+            deleteRequest: deleteRequest,
+            insertRequest: insertRequest
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/PolicyDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/PolicyDataStoreTests.swift
@@ -1,0 +1,91 @@
+import CoreData
+import XCTest
+
+@testable import BitwardenShared
+
+class PolicyDataStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DataStore!
+
+    let policies: [PolicyResponseModel] = [
+        PolicyResponseModel(
+            data: nil,
+            enabled: true,
+            id: "1",
+            organizationId: "org-1",
+            type: .twoFactorAuthentication
+        ),
+        PolicyResponseModel(
+            data: nil,
+            enabled: true,
+            id: "2",
+            organizationId: "org-1",
+            type: .masterPassword
+        ),
+    ]
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `deleteAllPolicies(user:)` removes all objects for the user.
+    func test_deleteAllPolicies() async throws {
+        try await insertPolicies(policies, userId: "1")
+        try await insertPolicies(policies, userId: "2")
+
+        try await subject.deleteAllPolicies(userId: "1")
+
+        try XCTAssertTrue(fetchPolicies(userId: "1").isEmpty)
+        try XCTAssertEqual(fetchPolicies(userId: "2").count, 2)
+    }
+
+    /// `fetchAllPolicies(userId:)` fetches all policies for a user.
+    func test_fetchAllPolicies() async throws {
+        try await insertPolicies(policies, userId: "1")
+
+        let fetchedPolicies = try await subject.fetchAllPolicies(userId: "1")
+        XCTAssertEqual(fetchedPolicies, policies.map(Policy.init))
+
+        let emptyPolicies = try await subject.fetchAllPolicies(userId: "-1")
+        XCTAssertEqual(emptyPolicies, [])
+    }
+
+    /// `replacePolicies(_:userId:)` replaces the list of policies for the user.
+    func test_replacePolicies() async throws {
+        try await subject.replacePolicies(policies, userId: "1")
+
+        let fetchedPolicies = try await subject.fetchAllPolicies(userId: "1")
+        XCTAssertEqual(fetchedPolicies, policies.map(Policy.init))
+    }
+
+    // MARK: Test Helpers
+
+    /// A test helper to fetch all policies for a user.
+    private func fetchPolicies(userId: String) throws -> [Policy] {
+        let fetchRequest = PolicyData.fetchByUserIdRequest(userId: userId)
+        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \PolicyData.id, ascending: true)]
+        return try subject.backgroundContext.fetch(fetchRequest).compactMap(Policy.init)
+    }
+
+    /// A test helper for inserting a list of policies for a user.
+    private func insertPolicies(_ policies: [PolicyResponseModel], userId: String) async throws {
+        try await subject.backgroundContext.performAndSave {
+            for policy in policies {
+                _ = PolicyData(context: self.subject.backgroundContext, userId: userId, policy: policy)
+            }
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/SettingsDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/SettingsDataStoreTests.swift
@@ -15,6 +15,23 @@ class SettingsDataStoreTests: BitwardenTestCase {
         ]
     )
 
+    let policies: [PolicyResponseModel] = [
+        PolicyResponseModel(
+            data: nil,
+            enabled: true,
+            id: "1",
+            organizationId: "org-1",
+            type: .twoFactorAuthentication
+        ),
+        PolicyResponseModel(
+            data: nil,
+            enabled: true,
+            id: "2",
+            organizationId: "org-1",
+            type: .masterPassword
+        ),
+    ]
+
     // MARK: Setup & Teardown
 
     override func setUp() {

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockPolicyDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockPolicyDataStore.swift
@@ -1,0 +1,29 @@
+@testable import BitwardenShared
+
+class MockPolicyDataStore: PolicyDataStore {
+    var deleteAllPoliciesCalled = false
+    var deleteAllPoliciesUserId: String?
+    var deleteAllPoliciesResult: Result<Void, Error> = .success(())
+
+    var fetchPoliciesResult: Result<[Policy], Error> = .success([])
+
+    var replacePoliciesPolicies = [PolicyResponseModel]()
+    var replacePoliciesUserId: String?
+    var replacePoliciesResult: Result<Void, Error> = .success(())
+
+    func deleteAllPolicies(userId: String) async throws {
+        deleteAllPoliciesCalled = true
+        deleteAllPoliciesUserId = userId
+        try deleteAllPoliciesResult.get()
+    }
+
+    func fetchAllPolicies(userId: String) async throws -> [Policy] {
+        try fetchPoliciesResult.get()
+    }
+
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws {
+        replacePoliciesPolicies = policies
+        replacePoliciesUserId = userId
+        try replacePoliciesResult.get()
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockSettingsDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockSettingsDataStore.swift
@@ -5,16 +5,36 @@ class MockSettingsDataStore: SettingsDataStore {
     var deleteEquivalentDomainsUserId: String?
     var deleteEquivalentDomainsResult: Result<Void, Error> = .success(())
 
+    var deleteAllPoliciesCalled = false
+    var deleteAllPoliciesUserId: String?
+    var deleteAllPoliciesResult: Result<Void, Error> = .success(())
+
     var fetchDomainsResult: Result<DomainsResponseModel?, Error> = .success(nil)
+
+    var fetchPoliciesResult: Result<[Policy], Error> = .success([])
 
     var replaceDomainsDomains: DomainsResponseModel?
     var replaceDomainsUserId: String?
     var replaceDomainsResult: Result<Void, Error> = .success(())
 
+    var replacePoliciesPolicies = [PolicyResponseModel]()
+    var replacePoliciesUserId: String?
+    var replacePoliciesResult: Result<Void, Error> = .success(())
+
     func deleteEquivalentDomains(userId: String) async throws {
         deleteEquivalentDomainsCalled = true
         deleteEquivalentDomainsUserId = userId
         try deleteEquivalentDomainsResult.get()
+    }
+
+    func deleteAllPolicies(userId: String) async throws {
+        deleteAllPoliciesCalled = true
+        deleteAllPoliciesUserId = userId
+        try deleteAllPoliciesResult.get()
+    }
+
+    func fetchAllPolicies(userId: String) async throws -> [Policy] {
+        try fetchPoliciesResult.get()
     }
 
     func fetchEquivalentDomains(userId: String) async throws -> DomainsResponseModel? {
@@ -25,5 +45,11 @@ class MockSettingsDataStore: SettingsDataStore {
         replaceDomainsDomains = domains
         replaceDomainsUserId = userId
         try replaceDomainsResult.get()
+    }
+
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws {
+        replacePoliciesPolicies = policies
+        replacePoliciesUserId = userId
+        try replacePoliciesResult.get()
     }
 }

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -33,6 +33,9 @@ class DefaultSyncService: SyncService {
     /// The service for managing the organizations for the user.
     private let organizationService: OrganizationService
 
+    /// The service for managing the polices for the user.
+    private let policyService: PolicyService
+
     /// The service for managing the sends for the user.
     private let sendService: SendService
 
@@ -54,6 +57,7 @@ class DefaultSyncService: SyncService {
     ///   - collectionService: The service for managing the collections for the user.
     ///   - folderService: The service for managing the folders for the user.
     ///   - organizationService: The service for managing the organizations for the user.
+    ///   - policyService: The service for managing the polices for the user.
     ///   - sendService: The service for managing the sends for the user.
     ///   - settingsService: The service for managing the organizations for the user.
     ///   - stateService: The service used by the application to manage account state.
@@ -64,6 +68,7 @@ class DefaultSyncService: SyncService {
         collectionService: CollectionService,
         folderService: FolderService,
         organizationService: OrganizationService,
+        policyService: PolicyService,
         sendService: SendService,
         settingsService: SettingsService,
         stateService: StateService,
@@ -73,6 +78,7 @@ class DefaultSyncService: SyncService {
         self.collectionService = collectionService
         self.folderService = folderService
         self.organizationService = organizationService
+        self.policyService = policyService
         self.sendService = sendService
         self.settingsService = settingsService
         self.stateService = stateService
@@ -98,6 +104,7 @@ extension DefaultSyncService {
         try await folderService.replaceFolders(response.folders, userId: userId)
         try await sendService.replaceSends(response.sends, userId: userId)
         try await settingsService.replaceEquivalentDomains(response.domains, userId: userId)
+        try await policyService.replacePolicies(response.policies, userId: userId)
 
         try await stateService.setLastSyncTime(Date(), userId: userId)
     }

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockPolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockPolicyService.swift
@@ -1,0 +1,13 @@
+@testable import BitwardenShared
+
+class MockPolicyService: PolicyService {
+    var replacePoliciesPolicies = [PolicyResponseModel]()
+    var replacePoliciesUserId: String?
+    var replacePoliciesResult: Result<Void, Error> = .success(())
+
+    func replacePolicies(_ policies: [PolicyResponseModel], userId: String) async throws {
+        replacePoliciesPolicies = policies
+        replacePoliciesUserId = userId
+        try replacePoliciesResult.get()
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1576](https://livefront.atlassian.net/browse/BIT-1576)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the PolicyDataStore used to persist collections to the database along with the main operations for delete, delete all, and replace.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

- **DataStore.swift:** Clears policy data for the user on logout.
- **PolicyData.swift:** The data model for persisting policies.
- **PolicyService.swift:** The service for managing syncing and updating the user's policies.
- **PolicyDataService.swift:** The data store for persisting policies.
- **SyncService.swift:** Updates policies after receiving a sync response.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
