### PR TITLE
BIT-1173 added element id for generator screen

### DIFF
--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
@@ -93,10 +93,12 @@ struct GeneratorView: View {
                     FormMenuFieldView(field: menuField) { newValue in
                         store.send(.generatorTypeChanged(newValue))
                     }
+                    .accessibilityIdentifier("GeneratorTypePicker")
                 case let .menuPasswordGeneratorType(menuField):
                     FormMenuFieldView(field: menuField) { newValue in
                         store.send(.passwordGeneratorTypeChanged(newValue))
                     }
+                    .accessibilityIdentifier("PasswordTypePicker")
                 case let .menuUsernameForwardedEmailService(menuField):
                     FormMenuFieldView(field: menuField) { newValue in
                         store.send(.usernameForwardedEmailServiceChanged(newValue))
@@ -148,6 +150,7 @@ struct GeneratorView: View {
     func generatedValueView(field: GeneratorState.GeneratedValueField<GeneratorState>) -> some View {
         BitwardenField {
             PasswordText(password: field.value, isPasswordVisible: true)
+                .accessibilityIdentifier("GeneratedPasswordLabel")
         } accessoryContent: {
             Button {
                 store.send(.copyGeneratedValue)
@@ -157,6 +160,7 @@ struct GeneratorView: View {
                     .frame(width: 16, height: 16)
             }
             .buttonStyle(.accessory)
+            .accessibilityIdentifier("CopyValueButton")
             .accessibilityLabel(Localizations.copyPassword)
 
             Button {
@@ -167,6 +171,7 @@ struct GeneratorView: View {
                     .frame(width: 16, height: 16)
             }
             .buttonStyle(.accessory)
+            .accessibilityIdentifier("RegenerateValueButton")
             .accessibilityLabel(Localizations.generatePassword)
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1173](https://livefront.atlassian.net/browse/BIT-1173)
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🎂 Other

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Added element ids for generator screen.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **GeneratorView.swift:** Added ```GeneratorTypePicker, PasswordTypePicker, GeneratedPasswordLabel, CopyValueButton, RegenerateValueButton``` element ids.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
