### PR TITLE
BIT-1552: Number pad for PIN unlock

### DIFF
--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -148,7 +148,7 @@ struct VaultUnlockView: View {
                     send: VaultUnlockAction.revealPinFieldPressed
                 )
             )
-            .textFieldConfiguration(.password)
+            .textFieldConfiguration(.pin)
         }
     }
 

--- a/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
@@ -46,6 +46,14 @@ extension TextFieldConfiguration {
         textInputAutocapitalization: .never
     )
 
+    /// A `TextFieldConfiguration` for applying common properties to PIN text fields.
+    static let pin = TextFieldConfiguration(
+        isAutocorrectionDisabled: true,
+        keyboardType: .numberPad,
+        textContentType: .password,
+        textInputAutocapitalization: .never
+    )
+
     /// A `TextFieldConfiguration` for applying common properties to URL text fields.
     static let url = TextFieldConfiguration(
         isAutocorrectionDisabled: true,


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1552](https://livefront.atlassian.net/browse/BIT-1552?atlOrigin=eyJpIjoiM2Y0NWZlYzA2Nzk4NDJjMzllNWY4Y2RmZTE4ZTE2OTMiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
When unlocking with PIN, the user will now see a number pad rather than a keyboard.

## 📋 Code changes
-   **TextFieldConfiguration.swift:** Adds a text field configuration for a PIN text field.

## 📸 Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-01-25 at 11 24 23](https://github.com/bitwarden/ios/assets/125899965/dd6bf285-d434-4f06-b669-4eef66c6c5df)

## ⏰ Reminders before review
-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
