### PR TITLE
BIT-1588: Update last active time storage

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -209,11 +209,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
 
         let timeProvider = CurrentTime()
 
-        let stateService = DefaultStateService(
-            appSettingsStore: appSettingsStore,
-            dataStore: dataStore,
-            timeProvider: timeProvider
-        )
+        let stateService = DefaultStateService(appSettingsStore: appSettingsStore, dataStore: dataStore)
 
         let biometricsService = DefaultBiometricsService(stateService: stateService)
         let environmentService = DefaultEnvironmentService(stateService: stateService)
@@ -290,7 +286,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         let totpService = DefaultTOTPService()
 
         let twoStepLoginService = DefaultTwoStepLoginService(environmentService: environmentService)
-        let vaultTimeoutService = DefaultVaultTimeoutService(stateService: stateService, timeProvider: timeProvider)
+        let vaultTimeoutService = DefaultVaultTimeoutService(stateService: stateService)
 
         let pasteboardService = DefaultPasteboardService(
             errorReporter: errorReporter,

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -9,7 +9,6 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     var appSettingsStore: MockAppSettingsStore!
     var dataStore: DataStore!
     var subject: DefaultStateService!
-    var timeProvider: MockTimeProvider!
 
     // MARK: Setup & Teardown
 
@@ -18,13 +17,8 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         appSettingsStore = MockAppSettingsStore()
         dataStore = DataStore(errorReporter: MockErrorReporter(), storeType: .memory)
-        timeProvider = MockTimeProvider(.currentTime)
 
-        subject = DefaultStateService(
-            appSettingsStore: appSettingsStore,
-            dataStore: dataStore,
-            timeProvider: timeProvider
-        )
+        subject = DefaultStateService(appSettingsStore: appSettingsStore, dataStore: dataStore)
     }
 
     override func tearDown() {
@@ -33,7 +27,6 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         appSettingsStore = nil
         dataStore = nil
         subject = nil
-        timeProvider = nil
     }
 
     // MARK: Tests
@@ -417,11 +410,11 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_getLastActiveTime() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
 
-        try await subject.setLastActiveTime(userId: "1")
+        try await subject.setLastActiveTime(Date(), userId: "1")
         let lastActiveTime = try await subject.getLastActiveTime(userId: "1")
         XCTAssertEqual(
             lastActiveTime!.timeIntervalSince1970,
-            timeProvider.presentTime.timeIntervalSince1970,
+            Date().timeIntervalSince1970,
             accuracy: 1.0
         )
     }
@@ -1068,10 +1061,10 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_setLastActiveTime() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
 
-        try await subject.setLastActiveTime(userId: "1")
+        try await subject.setLastActiveTime(Date(), userId: "1")
         XCTAssertEqual(
             appSettingsStore.lastActiveTime["1"]!.timeIntervalSince1970,
-            timeProvider.presentTime.timeIntervalSince1970,
+            Date().timeIntervalSince1970,
             accuracy: 1.0
         )
     }

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -248,7 +248,7 @@ protocol AppSettingsStore: AnyObject {
     /// Sets the last active time within the app.
     ///
     /// - Parameters:
-    ///   - date: The date of the last active time.
+    ///   - date: The current time.
     ///   - userId: The user ID associated with the last active time within the app.
     ///
     func setLastActiveTime(_ date: Date?, userId: String)
@@ -687,7 +687,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     }
 
     func lastActiveTime(userId: String) -> Date? {
-        fetch(for: .lastActiveTime(userId: userId))
+        fetch(for: .lastActiveTime(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
 
     func isBiometricAuthenticationEnabled(userId: String) -> Bool {
@@ -759,7 +759,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     }
 
     func setLastActiveTime(_ date: Date?, userId: String) {
-        store(date, for: .lastActiveTime(userId: userId))
+        store(date?.timeIntervalSince1970, for: .lastActiveTime(userId: userId))
     }
 
     func setLastSyncTime(_ date: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -284,7 +284,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         accountEncryptionKeys["1"] = .init(encryptedPrivateKey: "", encryptedUserKey: "")
     }
 
-    func setLastActiveTime(userId: String?) async throws {
+    func setLastActiveTime(_ date: Date?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccount().profile.userId
         lastActiveTime[userId] = timeProvider.presentTime
     }

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -75,9 +75,6 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     /// The state service used by this Default Service.
     private var stateService: StateService
 
-    /// Provides the current time.
-    private var timeProvider: TimeProvider
-
     /// The store of locked status for known accounts
     var timeoutStore = [String: Bool]()
 
@@ -88,13 +85,10 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
 
     /// Creates a new `DefaultVaultTimeoutService`.
     ///
-    /// - Parameters:
-    ///  - stateService: The StateService used by DefaultVaultTimeoutService.
-    ///  - timeProvider: Provides the current time.
+    /// - Parameter stateService: The StateService used by DefaultVaultTimeoutService.
     ///
-    init(stateService: StateService, timeProvider: TimeProvider) {
+    init(stateService: StateService) {
         self.stateService = stateService
-        self.timeProvider = timeProvider
     }
 
     // MARK: Methods
@@ -117,7 +111,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     }
 
     func setLastActiveTime(userId: String) async throws {
-        try await stateService.setLastActiveTime(userId: userId)
+        try await stateService.setLastActiveTime(Date(), userId: userId)
     }
 
     func setVaultTimeout(value: SessionTimeoutValue, userId: String?) async throws {
@@ -131,7 +125,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         if vaultTimeout == .onAppRestart { return true }
         if vaultTimeout == .never { return false }
 
-        if timeProvider.presentTime.timeIntervalSince(lastActiveTime) >= TimeInterval(vaultTimeout.rawValue) {
+        if Date().timeIntervalSince(lastActiveTime) >= TimeInterval(vaultTimeout.rawValue) {
             return true
         }
         return false


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1588](https://livefront.atlassian.net/browse/BIT-1588?atlOrigin=eyJpIjoiMDg3MGY0MjE2ZmYyNDM2OGE1NDM2M2FiNWI4NGQ1MGYiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
Updates how the last active time is being stored.

## 📋 Code changes
-   **AppSettingsStore.swift:** Stores `date?.timeIntervalSince1970` rather than `TimeProvider.presentTime`

## ⏰ Reminders before review
-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
