### PR TITLE
BIT-1625: Search bar bug

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListAction.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListAction.swift
@@ -12,6 +12,12 @@ enum SendListAction: Equatable {
     /// The info button was pressed.
     case infoButtonPressed
 
+    /// The search bar focus changed.
+    ///
+    /// - Parameter isSearching: Whether the user is currently searching.
+    ///
+    case searchStateChanged(isSearching: Bool)
+
     /// The text in the search bar was changed.
     case searchTextChanged(String)
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -80,6 +80,11 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
             state.infoUrl = nil
         case .infoButtonPressed:
             state.infoUrl = ExternalLinksConstants.sendInfo
+        case let .searchStateChanged(isSearching):
+            guard isSearching else {
+                state.searchText = ""
+                return
+            }
         case let .searchTextChanged(newValue):
             state.searchText = newValue
         case let .sendListItemRow(rowAction):

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -223,6 +223,14 @@ class SendListProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.infoUrl, ExternalLinksConstants.sendInfo)
     }
 
+    /// `receive(_:)` with `.searchStateChanged` updates the state when the search state changes.
+    func test_receive_searchStateChanged() {
+        subject.receive(.searchStateChanged(isSearching: true))
+        subject.receive(.searchTextChanged("Send"))
+        subject.receive(.searchStateChanged(isSearching: false))
+        XCTAssertTrue(subject.state.searchText.isEmpty)
+    }
+
     /// `receive(_:)` with `.searchTextChanged` updates the state correctly.
     func test_receive_searchTextChanged() {
         subject.state.searchText = ""

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -39,6 +39,9 @@ private struct MainSendListView: View {
             search
                 .hidden(!isSearching)
         }
+        .onChange(of: isSearching) { newValue in
+            store.send(.searchStateChanged(isSearching: newValue))
+        }
     }
 
     // MARK: Private views

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListAction.swift
@@ -14,7 +14,10 @@ enum VaultAutofillListAction: Equatable {
     /// A forwarded profile switcher action.
     case profileSwitcherAction(ProfileSwitcherAction)
 
-    /// The text in the search bar was changed.
+    /// The search bar focus changed.
+    ///
+    /// - Parameter isSearching: Whether the user is currently searching.
+    ///
     case searchStateChanged(isSearching: Bool)
 
     /// The text in the search bar was changed.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
@@ -26,7 +26,10 @@ enum VaultListAction: Equatable {
     /// A forwarded profile switcher action
     case profileSwitcherAction(ProfileSwitcherAction)
 
-    /// The text in the search bar was changed.
+    /// The search bar focus changed.
+    ///
+    /// - Parameter isSearching: Whether the user is currently searching.
+    ///
     case searchStateChanged(isSearching: Bool)
 
     /// The text in the search bar was changed.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -113,7 +113,10 @@ final class VaultListProcessor: StateProcessor<// swiftlint:disable:this type_bo
         case let .morePressed(item):
             showMoreOptionsAlert(for: item)
         case let .searchStateChanged(isSearching: isSearching):
-            guard isSearching else { return }
+            guard isSearching else {
+                state.searchText = ""
+                return
+            }
             state.profileSwitcherState.isVisible = !isSearching
         case let .searchTextChanged(newValue):
             state.searchText = newValue

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -859,6 +859,14 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
     }
 
+    /// `receive(_:)` with `.searchStateChanged` updates the state when the search state changes.
+    func test_receive_searchStateChanged() {
+        subject.receive(.searchStateChanged(isSearching: true))
+        subject.receive(.searchTextChanged("File"))
+        subject.receive(.searchStateChanged(isSearching: false))
+        XCTAssertTrue(subject.state.searchText.isEmpty)
+    }
+
     /// `receive(_:)` with `.searchTextChanged` without a matching search term updates the state correctly.
     func test_receive_searchTextChanged_withoutResult() {
         subject.state.searchText = ""


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1625](https://livefront.atlassian.net/browse/BIT-1625?atlOrigin=eyJpIjoiMTJiMWMzODU1MmQxNDU3MWI3MGMyYzU1MGVjMTRkOTEiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
Sets search text in the state to `""` when the search bar becomes un-focused.

## 📋 Code changes
-  **SendListAction.swift:** Adds action that empties the search text in the state when the search bar becomes un-focused.
-  **VaultListProcessor.swift:** Empties the search text in the state when the search bar becomes un-focused.

## 📸 Screenshots
### Before
https://github.com/bitwarden/ios/assets/125899965/a0e085c2-d41c-4ed9-9a69-ed08bd159559

### After
https://github.com/bitwarden/ios/assets/125899965/e6d088f9-5ef0-4549-a6a2-68c4e5c46270

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
