### PR TITLE
BIT-1590, BIT-1613, BIT-1644: Accessibility IDs

### DIFF
--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -455,7 +455,7 @@ class DefaultAuthService: AuthService {
         fingerPrint: String,
         publicKey: String
     ) async throws {
-        try await authAPIService.initiateLoginWithDevice(
+        _ = try await authAPIService.initiateLoginWithDevice(
             accessCode: accessCode,
             deviceIdentifier: deviceIdentifier,
             email: email,

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -93,11 +93,11 @@ struct CreateAccountView: View {
                     send: CreateAccountAction.passwordTextChanged
                 ),
                 accessibilityIdentifier: "MasterPasswordEntry",
+                passwordVisibilityAccessibilityId: "PasswordVisibilityToggle",
                 isPasswordVisible: store.binding(
                     get: \.arePasswordsVisible,
                     send: CreateAccountAction.togglePasswordVisibility
-                ),
-                passwordVisibilityAccessibilityId: "PasswordVisibilityToggle"
+                )
             )
             .textFieldConfiguration(.password)
         }
@@ -130,11 +130,11 @@ struct CreateAccountView: View {
                 send: CreateAccountAction.retypePasswordTextChanged
             ),
             accessibilityIdentifier: "ConfirmMasterPasswordEntry",
+            passwordVisibilityAccessibilityId: "ConfirmPasswordVisibilityToggle",
             isPasswordVisible: store.binding(
                 get: \.arePasswordsVisible,
                 send: CreateAccountAction.togglePasswordVisibility
-            ),
-            passwordVisibilityAccessibilityId: "ConfirmPasswordVisibilityToggle"
+            )
         )
         .textFieldConfiguration(.password)
     }

--- a/BitwardenShared/UI/Auth/Login/LoginView.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginView.swift
@@ -51,19 +51,19 @@ struct LoginView: View {
                     send: LoginAction.masterPasswordChanged
                 ),
                 accessibilityIdentifier: "MasterPasswordEntry",
+                passwordVisibilityAccessibilityId: "PasswordVisibilityToggle",
                 isPasswordVisible: store.binding(
                     get: \.isMasterPasswordRevealed,
                     send: LoginAction.revealMasterPasswordFieldPressed
-                ),
-                passwordVisibilityAccessibilityId: "PasswordVisibilityToggle"
+                )
             )
             .textFieldConfiguration(.password)
 
             Button(Localizations.getMasterPasswordwordHint) {
                 store.send(.getMasterPasswordHintPressed)
             }
-            .accessibilityIdentifier("GetMasterPasswordHintLabel")
             .styleGuide(.subheadline)
+            .accessibilityIdentifier("GetMasterPasswordHintLabel")
             .foregroundColor(Asset.Colors.primaryBitwarden.swiftUIColor)
         }
     }

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -62,12 +62,13 @@ struct VaultUnlockView: View {
 
                 biometricAuthButton
 
-                Button {
-                    Task { await store.perform(.unlockVault) }
+                AsyncButton {
+                    await store.perform(.unlockVault)
                 } label: {
                     Text(Localizations.unlock)
                 }
                 .buttonStyle(.primary(shouldFillWidth: true))
+                .accessibilityIdentifier("UnlockVaultButton")
             }
             .padding(16)
         }
@@ -129,6 +130,8 @@ struct VaultUnlockView: View {
                     send: VaultUnlockAction.masterPasswordChanged
                 ),
                 footer: footerText,
+                accessibilityIdentifier: "MasterPasswordEntry",
+                passwordVisibilityAccessibilityId: "PasswordVisibilityToggle",
                 isPasswordVisible: store.binding(
                     get: \.isMasterPasswordRevealed,
                     send: VaultUnlockAction.revealMasterPasswordFieldPressed
@@ -143,6 +146,8 @@ struct VaultUnlockView: View {
                     send: VaultUnlockAction.pinChanged
                 ),
                 footer: footerText,
+                accessibilityIdentifier: "PinEntry",
+                passwordVisibilityAccessibilityId: "PinVisibilityToggle",
                 isPasswordVisible: store.binding(
                     get: \.isPinRevealed,
                     send: VaultUnlockAction.revealPinFieldPressed

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
@@ -87,9 +87,9 @@ class VaultUnlockViewTests: BitwardenTestCase {
     }
 
     /// Tapping the vault unlock button dispatches the `.unlockVault` action.
-    func test_vaultUnlockButton_tap() throws {
-        let button = try subject.inspect().find(button: Localizations.unlock)
-        try button.tap()
+    func test_vaultUnlockButton_tap() async throws {
+        let button = try subject.inspect().find(asyncButton: Localizations.unlock)
+        try await button.tap()
         waitFor(!processor.effects.isEmpty)
         XCTAssertEqual(processor.effects.last, .unlockVault)
     }

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -128,10 +128,9 @@ struct BitwardenTextField<TrailingContent: View>: View {
     ///   - footer: The footer text displayed below the text field.
     ///   - text: The text entered into the text field.
     ///   - accessibilityIdentifier: The accessibility identifier for the text field.
+    ///   - passwordVisibilityAccessibilityId: The accessibility ID for the button to toggle password visibility.
     ///   - canViewPassword: Whether the password can be viewed.
     ///   - isPasswordVisible: Whether the password is visible.
-    ///   - passwordVisibilityAccessibilityId: The accessibility identifier for the
-    ///     button to toggle password visibility.
     ///   - placeholder: An optional placeholder to display in the text field.
     ///
     init(
@@ -139,9 +138,9 @@ struct BitwardenTextField<TrailingContent: View>: View {
         text: Binding<String>,
         footer: String? = nil,
         accessibilityIdentifier: String? = nil,
+        passwordVisibilityAccessibilityId: String? = nil,
         canViewPassword: Bool = true,
         isPasswordVisible: Binding<Bool>? = nil,
-        passwordVisibilityAccessibilityId: String? = nil,
         placeholder: String? = nil,
         @ViewBuilder trailingContent: () -> TrailingContent
     ) {
@@ -165,10 +164,9 @@ extension BitwardenTextField where TrailingContent == EmptyView {
     ///   - footer: The footer text displayed below the text field.
     ///   - text: The text entered into the text field.
     ///   - accessibilityIdentifier: The accessibility identifier for the text field.
+    ///   - passwordVisibilityAccessibilityId: The accessibility ID for the button to toggle password visibility.
     ///   - canViewPassword: Whether the password can be viewed.
     ///   - isPasswordVisible: Whether the password is visible.
-    ///   - passwordVisibilityAccessibilityId: The accessibility identifier for the
-    ///     button to toggle password visibility.
     ///   - placeholder: An optional placeholder to display in the text field.
     ///
     init(
@@ -176,9 +174,9 @@ extension BitwardenTextField where TrailingContent == EmptyView {
         text: Binding<String>,
         footer: String? = nil,
         accessibilityIdentifier: String? = nil,
+        passwordVisibilityAccessibilityId: String? = nil,
         canViewPassword: Bool = true,
         isPasswordVisible: Binding<Bool>? = nil,
-        passwordVisibilityAccessibilityId: String? = nil,
         placeholder: String? = nil
     ) {
         self.accessibilityIdentifier = accessibilityIdentifier

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultView.swift
@@ -69,11 +69,11 @@ struct ExportVaultView: View {
             ),
             footer: Localizations.exportVaultMasterPasswordDescription,
             accessibilityIdentifier: "MasterPasswordEntry",
+            passwordVisibilityAccessibilityId: "PasswordVisibilityToggle",
             isPasswordVisible: store.binding(
                 get: \.isPasswordVisible,
                 send: ExportVaultAction.togglePasswordVisibility
-            ),
-            passwordVisibilityAccessibilityId: "PasswordVisibilityToggle"
+            )
         )
         .textFieldConfiguration(.password)
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsView.swift
@@ -36,10 +36,12 @@ struct VaultSettingsView: View {
             SettingsListItem(Localizations.folders) {
                 store.send(.foldersTapped)
             }
+            .accessibilityIdentifier("FoldersLabel")
 
             SettingsListItem(Localizations.exportVault) {
                 store.send(.exportVaultTapped)
             }
+            .accessibilityIdentifier("ExportVaultLabel")
 
             SettingsListItem(Localizations.importItems, hasDivider: false) {
                 store.send(.importItemsTapped)
@@ -48,6 +50,7 @@ struct VaultSettingsView: View {
                     .resizable()
                     .frame(width: 22, height: 22)
             }
+            .accessibilityIdentifier("ImportItemsLinkItemView")
         }
         .clipShape(RoundedRectangle(cornerRadius: 10))
     }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
@@ -19,6 +19,7 @@ struct GeneratorView: View {
             VStack(alignment: .leading, spacing: 20) {
                 if store.state.isPolicyInEffect {
                     InfoContainer(Localizations.passwordGeneratorPolicyInEffect)
+                        .accessibilityIdentifier("PasswordGeneratorPolicyInEffectLabel")
                 }
 
                 ForEach(store.state.formSections) { section in


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1590](https://livefront.atlassian.net/browse/BIT-1590?atlOrigin=eyJpIjoiNjgxMTY1ZTc2ZWIxNDljN2EwMGM5ZDdmNGI0MGFmOTAiLCJwIjoiaiJ9), [BIT-1613](https://livefront.atlassian.net/browse/BIT-1613?atlOrigin=eyJpIjoiOTVjMDBmMmFkY2Y0NGY1ZWFiODU5ZGE2MjRhNTc0MGQiLCJwIjoiaiJ9), [BIT-1644](https://livefront.atlassian.net/browse/BIT-1644?atlOrigin=eyJpIjoiMTYyMjhhM2Q5ODI4NGNlOTlhN2VkN2EwMWM5MWM0YmQiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to the following screens:
- Generator
- Vault unlock 
- Vault menu in settings

## 📋 Code changes
-   **GeneratorView.swift:** Adds accessibility ID.
-   **VaultSettingsView.swift:** Adds accessibility IDs.
-   **VaultUnlockView.swift:** Adds accessibility IDs.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
