### PR TITLE
BIT-1649: Vault IDs

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -41,4 +41,28 @@ struct VaultGroupState: Equatable {
 
     /// The vault filter used to display a single or all vaults for the user.
     var vaultFilterType: VaultFilterType
+
+    // MARK: Computed Properties
+
+    /// The accessibility ID for the filter row.
+    var filterAccessibilityID: String {
+        switch group {
+        case .card:
+            return "CardFilter"
+        case .identity:
+            return "IdentityFilter"
+        case .login:
+            return "LoginFilter"
+        case .secureNote:
+            return "SecureNoteFilter"
+        case .totp:
+            return ""
+        case .collection:
+            return "CollectionFilter"
+        case .folder:
+            return "FolderFilter"
+        case .trash:
+            return "TrashFilter"
+        }
+    }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -81,7 +81,7 @@ struct VaultGroupView: View {
         GeometryReader { reader in
             ScrollView {
                 VStack(spacing: 24) {
-                    vaultFilterRow()
+                    vaultFilterRow
                         .padding(.top, 16)
 
                     Spacer()
@@ -157,7 +157,8 @@ struct VaultGroupView: View {
         }
     }
 
-    /// Displays the vault filter for search row if the user is a member of any org
+    /// Displays the vault filter for search row if the user is a member of any org.
+    ///
     private var searchVaultFilterRow: some View {
         SearchVaultFilterRowView(
             hasDivider: true, store: store.child(
@@ -178,11 +179,13 @@ struct VaultGroupView: View {
         )
     }
 
-    /// Displays the vault filter row if the user is a member of any
-    @ViewBuilder
-    private func vaultFilterRow() -> some View {
+    /// Displays the vault filter row if the user is a member of any.
+    ///
+    private var vaultFilterRow: some View {
         SearchVaultFilterRowView(
-            hasDivider: false, store: store.child(
+            hasDivider: false,
+            accessibilityID: store.state.filterAccessibilityID,
+            store: store.child(
                 state: { state in
                     SearchVaultFilterRowState(
                         organizations: state.organizations,
@@ -204,11 +207,12 @@ struct VaultGroupView: View {
     // MARK: Private Methods
 
     /// A view that displays a list of the contents of this vault group.
+    ///
     @ViewBuilder
     private func groupView(with items: [VaultListItem]) -> some View {
         ScrollView {
             VStack(spacing: 20.0) {
-                vaultFilterRow()
+                vaultFilterRow
 
                 VStack(alignment: .leading, spacing: 7) {
                     HStack(alignment: .firstTextBaseline) {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/SearchVaultFilterRowView/SearchVaultFilterRowView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/SearchVaultFilterRowView/SearchVaultFilterRowView.swift
@@ -10,6 +10,9 @@ struct SearchVaultFilterRowView: View {
     /// Whether the row should have a bottom divider.
     let hasDivider: Bool
 
+    /// The accessibility ID for the row.
+    let accessibilityID: String?
+
     /// The `Store` for this view.
     @ObservedObject var store: Store<SearchVaultFilterRowState, SearchVaultFilterRowAction, Void>
 
@@ -38,11 +41,13 @@ struct SearchVaultFilterRowView: View {
                             .frame(width: 44, height: 44, alignment: .trailing)
                             .contentShape(Rectangle())
                     }
+                    .accessibilityIdentifier("OpenOrgFilter")
                     .accessibilityLabel(Localizations.filterByVault)
                     .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
                 }
                 .padding(.horizontal, 16)
                 .frame(minHeight: 60)
+                .accessibilityIdentifier(accessibilityID ?? "")
                 .background(Asset.Colors.backgroundPrimary.swiftUIColor)
 
                 if hasDivider {
@@ -50,5 +55,24 @@ struct SearchVaultFilterRowView: View {
                 }
             }
         }
+    }
+
+    // MARK: Initialization
+
+    /// Initialize a `SearchVaultFilterRowView`.
+    ///
+    /// - Parameters:
+    ///   - hasDivider: Whether the row has a divider.
+    ///   - accessibilityID: The accessibility ID for the row.
+    ///   - store: The store used to render the view.
+    ///
+    init(
+        hasDivider: Bool,
+        accessibilityID: String? = nil,
+        store: Store<SearchVaultFilterRowState, SearchVaultFilterRowAction, Void>
+    ) {
+        self.hasDivider = hasDivider
+        self.accessibilityID = accessibilityID
+        self.store = store
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -72,7 +72,7 @@ private struct SearchableVaultListView: View {
         GeometryReader { reader in
             ScrollView {
                 VStack(spacing: 24) {
-                    vaultFilterRow()
+                    vaultFilterRow
                         .padding(.top, 16)
 
                     Spacer()
@@ -156,32 +156,12 @@ private struct SearchableVaultListView: View {
         }
     }
 
-    // MARK: Private Methods
-
-    /// A view that displays the main vault interface, including sections for groups and
-    /// vault items.
-    ///
-    /// - Parameter sections: The sections of the vault list to display.
-    ///
-    @ViewBuilder
-    private func vaultContents(with sections: [VaultListSection]) -> some View {
-        ScrollView {
-            VStack(spacing: 20) {
-                vaultFilterRow()
-
-                ForEach(sections) { section in
-                    vaultItemSectionView(title: section.name, items: section.items)
-                }
-            }
-            .padding(16)
-        }
-    }
-
-    /// Displays the vault filter row if the user is a member of any
-    @ViewBuilder
-    private func vaultFilterRow() -> some View {
+    /// Displays the vault filter row if the user is a member of any.
+    private var vaultFilterRow: some View {
         SearchVaultFilterRowView(
-            hasDivider: false, store: store.child(
+            hasDivider: false,
+            accessibilityID: "ActiveFilterRow",
+            store: store.child(
                 state: { state in
                     SearchVaultFilterRowState(
                         organizations: state.organizations,
@@ -198,6 +178,27 @@ private struct SearchableVaultListView: View {
             )
         )
         .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+
+    // MARK: Private Methods
+
+    /// A view that displays the main vault interface, including sections for groups and
+    /// vault items.
+    ///
+    /// - Parameter sections: The sections of the vault list to display.
+    ///
+    @ViewBuilder
+    private func vaultContents(with sections: [VaultListSection]) -> some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                vaultFilterRow
+
+                ForEach(sections) { section in
+                    vaultItemSectionView(title: section.name, items: section.items)
+                }
+            }
+            .padding(16)
+        }
     }
 
     /// Creates a row in the list for the provided item.
@@ -230,6 +231,7 @@ private struct SearchableVaultListView: View {
             ),
             timeProvider: timeProvider
         )
+        .accessibilityIdentifier("CipherCell")
     }
 
     /// Creates a section that appears in the vault.
@@ -289,7 +291,6 @@ struct VaultListView: View {
                 placement: .navigationBarDrawer(displayMode: .always),
                 prompt: Localizations.search
             )
-            .accessibilityIdentifier("SearchFieldEntry")
             .task(id: store.state.searchText) {
                 await store.perform(.search(store.state.searchText))
             }


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1649](https://livefront.atlassian.net/browse/BIT-1649?atlOrigin=eyJpIjoiMjQ1NDIzZjNjYjYxNGNhNTlhNDMzNjZjMDlmZWRlYzAiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to Vault elements.

## 📋 Code changes
-   **VaultGroupState.swift:** Adds accessibility ID computed property for the group's filter row.
-   **SearchVaultFilterRowView.swift:** Adds property for the accessibility ID.
-   **VaultListView.swift:** Adds `CipherCell` accessibility ID. Removes unneeded `SearchFieldEntry` accessibility ID. Bitwarden's automated tests are searching for the Search Field type rather than the ID.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
