### PR TITLE
BIT-1651: Add Items IDs

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -120,6 +120,7 @@ struct AddEditItemView: View {
             if case .add = store.state.configuration, store.state.allowTypeSelection {
                 BitwardenMenuField(
                     title: Localizations.type,
+                    accessibilityIdentifier: "ItemTypePicker",
                     options: CipherType.allCases,
                     selection: store.binding(
                         get: \.type,
@@ -230,6 +231,7 @@ private extension AddEditItemView {
             SectionView(Localizations.ownership) {
                 BitwardenMenuField(
                     title: Localizations.whoOwnsThisItem,
+                    accessibilityIdentifier: "ItemOwnershipPicker",
                     options: store.state.ownershipOptions,
                     selection: store.binding(
                         get: { _ in owner },
@@ -255,6 +257,7 @@ private extension AddEditItemView {
                                     Text(collection.name)
                                 }
                                 .toggleStyle(.bitwarden)
+                                .accessibilityIdentifier("CollectionItemCell")
                             }
                         }
                     }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
@@ -36,6 +36,7 @@ struct AddEditLoginItemView: View {
             ) {
                 store.send(.generateUsernamePressed)
             }
+            .accessibilityIdentifier("GenerateUsernameButton")
         }
         .textFieldConfiguration(.username)
         .focused($focusedField, equals: .userName)


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1651](https://livefront.atlassian.net/browse/BIT-1292?atlOrigin=eyJpIjoiNDg0Y2E5MzYzM2UxNDM4ZWJmMTM4NDUzM2NlYjc5MWYiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to the Add Items view.

## 📋 Code changes
-   **AddEditLoginItemView.swift:** Adds accessibility ID to the generate username button.
-   **AddEditItemView.swift:** Adds accessibility IDs to pickers and collection item cells.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
