### PR TITLE
BIT-1674: Add autofill information alert

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -61,6 +61,12 @@ protocol StateService: AnyObject {
     ///
     func getActiveAccountId() async throws -> String
 
+    /// Gets whether the autofill info prompt has been shown.
+    ///
+    /// - Returns: Whether the autofill info prompt has been shown.
+    ///
+    func getAddSitePromptShown() async -> Bool
+
     /// Gets the allow sync on refresh value for an account.
     ///
     /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
@@ -257,6 +263,12 @@ protocol StateService: AnyObject {
     /// - Parameter userId: The user Id of the account to set as active.
     ///
     func setActiveAccount(userId: String) async throws
+
+    /// Sets whether the autofill info prompt has been shown.
+    ///
+    /// - Parameter shown: Whether the autofill info prompt has been shown.
+    ///
+    func setAddSitePromptShown(_ shown: Bool) async
 
     /// Sets the allow sync on refresh value for an account.
     ///
@@ -938,6 +950,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         return activeAccount
     }
 
+    func getAddSitePromptShown() async -> Bool {
+        appSettingsStore.addSitePromptShown
+    }
+
     func getAllowSyncOnRefresh(userId: String?) async throws -> Bool {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.allowSyncOnRefresh(userId: userId)
@@ -1091,6 +1107,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         guard state.accounts
             .contains(where: { $0.key == userId }) else { throw StateServiceError.noAccounts }
         state.activeUserId = userId
+    }
+
+    func setAddSitePromptShown(_ shown: Bool) async {
+        appSettingsStore.addSitePromptShown = shown
     }
 
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -264,6 +264,16 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(accountId, account.profile.userId)
     }
 
+    /// `getAddSitePromptShown()` returns whether the autofill info prompt has been shown
+    func test_getAddSitePromptShown() async {
+        var hasShownPrompt = await subject.getAddSitePromptShown()
+        XCTAssertFalse(hasShownPrompt)
+
+        appSettingsStore.addSitePromptShown = true
+        hasShownPrompt = await subject.getAddSitePromptShown()
+        XCTAssertTrue(hasShownPrompt)
+    }
+
     /// `allowSyncOnRefreshes()` returns the allow sync on refresh value for the active account.
     func test_getAllowSyncOnRefresh() async throws {
         await subject.addAccount(.fixture())
@@ -944,6 +954,15 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try await subject.setActiveAccount(userId: "1")
         active = try await subject.getActiveAccount()
         XCTAssertEqual(active, account1)
+    }
+
+    /// `setAddSitePromptShown(_:)` sets whether the autofill info prompt has been shown.
+    func test_setAddSitePromptShown() async {
+        await subject.setAddSitePromptShown(true)
+        XCTAssertTrue(appSettingsStore.addSitePromptShown)
+
+        await subject.setAddSitePromptShown(false)
+        XCTAssertFalse(appSettingsStore.addSitePromptShown)
     }
 
     /// `setAllowSyncOnRefresh(_:userId:)` sets the allow sync on refresh value for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -9,6 +9,9 @@ import OSLog
 /// A protocol for an object that persists app setting values.
 ///
 protocol AppSettingsStore: AnyObject {
+    /// Whether the autofill info prompt has been shown.
+    var addSitePromptShown: Bool { get set }
+
     /// The app's unique identifier.
     var appId: String? { get set }
 
@@ -498,6 +501,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     /// The keys used to store their associated values.
     ///
     enum Keys {
+        case addSitePromptShown
         case allowSyncOnRefresh(userId: String)
         case appId
         case appLocale
@@ -535,6 +539,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         var storageKey: String {
             let key: String
             switch self {
+            case .addSitePromptShown:
+                key = "addSitePromptShown"
             case let .allowSyncOnRefresh(userId):
                 key = "syncOnRefresh_\(userId)"
             case .appId:
@@ -602,6 +608,11 @@ extension DefaultAppSettingsStore: AppSettingsStore {
             }
             return "bwPreferencesStorage:\(key)"
         }
+    }
+
+    var addSitePromptShown: Bool {
+        get { fetch(for: .addSitePromptShown) }
+        set { store(newValue, for: .addSitePromptShown) }
     }
 
     var appId: String? {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -38,6 +38,22 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     // MARK: Tests
 
+    /// `addSitePromptShown` returns `false` if there isn't a previously stored value.
+    func test_addSitePromptShown_isInitiallyFalse() {
+        XCTAssertFalse(subject.addSitePromptShown)
+    }
+
+    /// `addSitePromptShown` can be used to get and set the persisted value in user defaults.
+    func test_addSitePromptShown_withValue() {
+        subject.addSitePromptShown = true
+        XCTAssertTrue(subject.addSitePromptShown)
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:addSitePromptShown"))
+
+        subject.addSitePromptShown = false
+        XCTAssertFalse(subject.addSitePromptShown)
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:addSitePromptShown"))
+    }
+
     /// `appId` returns `nil` if there isn't a previously stored value.
     func test_appId_isInitiallyNil() {
         XCTAssertNil(subject.appId)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -4,6 +4,7 @@ import Foundation
 @testable import BitwardenShared
 
 class MockAppSettingsStore: AppSettingsStore {
+    var addSitePromptShown = false
     var allowSyncOnRefreshes = [String: Bool]()
     var appId: String?
     var appLocale: String?

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -11,6 +11,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var accountsLoggedOut = [String]()
     var activeAccount: Account?
     var accounts: [Account]?
+    var addSitePromptShown = false
     var allowSyncOnRefresh = [String: Bool]()
     var appLanguage: LanguageOption = .default
     var approveLoginRequestsByUserId = [String: Bool]()
@@ -118,6 +119,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func getActiveAccountId() async throws -> String {
         try getActiveAccount().profile.userId
+    }
+
+    func getAddSitePromptShown() async -> Bool {
+        addSitePromptShown
     }
 
     func getApproveLoginRequests(userId: String?) async throws -> Bool {
@@ -243,6 +248,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
                   account.profile.userId == userId
               }) else { throw StateServiceError.noAccounts }
         activeAccount = match
+    }
+
+    func setAddSitePromptShown(_ shown: Bool) async {
+        addSitePromptShown = shown
     }
 
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool, userId: String?) async throws {

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -174,6 +174,17 @@ extension Alert {
         )
     }
 
+    /// An alert that informs the user about password autofill.
+    ///
+    /// - Returns: An alert that informs the user about password autofill.
+    ///
+    static func passwordAutofillInformation() -> Alert {
+        Alert.defaultAlert(
+            title: Localizations.passwordAutofill,
+            message: Localizations.bitwardenAutofillAlert2
+        )
+    }
+
     /// An alert that informs the user about receiving push notifications.
     ///
     /// - Parameter action: The action to perform when the user clicks through.

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -36,6 +36,17 @@ class AlertVaultTests: BitwardenTestCase {
         XCTAssertEqual(subject.alertActions[3].style, .cancel)
     }
 
+    /// `passwordAutofillInformation()` constructs an `Alert` that informs the user about password
+    /// autofill.
+    func test_passwordAutofillInformation() {
+        let subject = Alert.passwordAutofillInformation()
+
+        XCTAssertEqual(subject.title, Localizations.passwordAutofill)
+        XCTAssertEqual(subject.message, Localizations.bitwardenAutofillAlert2)
+        XCTAssertEqual(subject.alertActions.first?.title, Localizations.ok)
+        XCTAssertEqual(subject.alertActions.first?.style, .cancel)
+    }
+
     /// `pushNotificationsInformation(action:)` constructs an `Alert` that informs the
     ///  user about receiving push notifications.
     func test_pushNotificationsInformation() {

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemEffect.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemEffect.swift
@@ -4,6 +4,9 @@ import Foundation
 
 /// Effects that can be processed by an `AddEditItemProcessor`.
 enum AddEditItemEffect {
+    /// The view appeared.
+    case appeared
+
     /// The check password button was pressed.
     case checkPasswordPressed
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -25,6 +25,7 @@ struct AddEditItemView: View {
                 existing
             }
         }
+        .task { await store.perform(.appeared) }
         .task { await store.perform(.fetchCipherOptions) }
         .toast(store.binding(
             get: \.toast,

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
@@ -16,6 +16,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     typealias Services = AuthenticatorKeyCaptureCoordinator.Services
         & GeneratorCoordinator.Services
         & HasAPIService
+        & HasStateService
         & HasTOTPService
         & HasTimeProvider
         & HasVaultRepository


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1674](https://livefront.atlassian.net/browse/BIT-1674)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Displays an alert informing the user of the autofill capabilities the first time that they open the add cipher view. This isn't shown if the user is in an extension or if they are adding a non-login item.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AppSettingStore.swift, StateService.swift:** Adds methods for getting and setting whether the alert has been shown.
- **Alert+Vault.swift:** Adds an extension for creating the alert.
- **AddEditItemProcessor.swift:** Checks to see if the alert needs to be shown when the view appears.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/eaa8f6b1-8295-4e2b-8da9-2e7af3a9e7ab


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
