### PR TITLE
BIT-1691: Cancel timer after login with device request is expired or denied

### DIFF
--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -28,7 +28,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
     private let services: Services
 
     /// The timer used to automatically check for a response to the login request.
-    private var checkTimer: Timer?
+    private(set) var checkTimer: Timer?
 
     // MARK: Initialization
 
@@ -132,6 +132,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
 
                 // Show an alert and dismiss the view if the request has expired.
                 guard !request.isExpired else {
+                    self.checkTimer?.invalidate()
                     return coordinator.showAlert(.requestExpired {
                         self.coordinator.navigate(to: .dismiss)
                     })
@@ -142,6 +143,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
 
                 // If the request has been denied, show an alert and dismiss the view.
                 if request.requestApproved == false {
+                    self.checkTimer?.invalidate()
                     coordinator.showAlert(.requestDenied {
                         self.coordinator.navigate(to: .dismiss)
                     })
@@ -204,8 +206,8 @@ final class LoginWithDeviceProcessor: StateProcessor<
         checkTimer?.invalidate()
 
         // Set the timer to auto-check for a response every four seconds.
-        checkTimer = Timer.scheduledTimer(withTimeInterval: UI.duration(4), repeats: true) { _ in
-            self.checkForResponse()
+        checkTimer = Timer.scheduledTimer(withTimeInterval: UI.duration(4), repeats: true) { [weak self] _ in
+            self?.checkForResponse()
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1691](https://livefront.atlassian.net/browse/BIT-1691)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a bug where if the login with device request is denied, a new denied alert pops up every four seconds as polling continues. If the request is denied or expires, we should stop polling prior to showing the alert.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **LoginWithDeviceProcessor.swift:** Cancels the timer if the request is denied or expires.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
