### PR TITLE
BIT-1549: Verify pin header

### DIFF
--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -19,12 +19,19 @@ struct VaultUnlockView: View {
         """
     }
 
+    /// The view's navigation title.
+    var navigationTitle: String {
+        store.state.unlockMethod == .pin
+            ? Localizations.verifyPIN
+            : Localizations.verifyMasterPassword
+    }
+
     var body: some View {
         ZStack {
             scrollView
             profileSwitcher
         }
-        .navigationTitle(Localizations.verifyMasterPassword)
+        .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1549](https://livefront.atlassian.net/browse/BIT-1549?atlOrigin=eyJpIjoiMDQ1Y2ZkYTA2NzliNGM2ZjgxODY4MTJiNzY4YTM0MTIiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
Adds correct header for unlocking with PIN.

## 📋 Code changes
-   **UnlockVaultView.swiftt:** Conditional for the header text.

## 📸 Screenshots
Before: 
<img width="389" alt="Screenshot 2024-02-05 at 2 40 01 PM" src="https://github.com/bitwarden/ios/assets/125899965/ee4e5b30-0896-47b7-b41c-b5ee085b8d3b">

After:
![Simulator Screenshot - iPhone 15 Pro - 2024-02-05 at 14 39 27](https://github.com/bitwarden/ios/assets/125899965/2f0d8ffa-0847-4cb5-b2d8-0628665db274)

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
