### PR TITLE
BIT-1696: Fix account recovery screen bypassed if no policy exists

### DIFF
--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -108,7 +108,13 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 delegate: context as? CaptchaFlowDelegate
             )
         case .complete:
-            delegate?.didCompleteAuth()
+            if stackNavigator?.isPresenting == true {
+                stackNavigator?.dismiss {
+                    self.delegate?.didCompleteAuth()
+                }
+            } else {
+                delegate?.didCompleteAuth()
+            }
         case .createAccount:
             showCreateAccount()
         case .dismiss:

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -84,6 +84,15 @@ class AuthCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(authDelegate.didCompleteAuthCalled)
     }
 
+    /// `navigate(to:)` with `.complete` dismisses a presented view and notifies the delegate that
+    /// auth has completed.
+    func test_navigate_complete_withPresented() {
+        subject.navigate(to: .updateMasterPassword)
+        subject.navigate(to: .complete)
+        XCTAssertTrue(authDelegate.didCompleteAuthCalled)
+        XCTAssertEqual(stackNavigator.actions.last?.type, .dismissedWithCompletionHandler)
+    }
+
     /// `navigate(to:)` with `.createAccount` pushes the create account view onto the stack navigator.
     func test_navigate_createAccount() throws {
         subject.navigate(to: .createAccount)

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
@@ -103,7 +103,9 @@ class UpdateMasterPasswordProcessor: StateProcessor<
 
             if let policy = try await services.policyService.getMasterPasswordPolicyOptions() {
                 state.masterPasswordPolicy = policy
-            } else {
+            } else if state.forcePasswordResetReason == .weakMasterPasswordOnLogin {
+                // If the reset reason is because of a weak password, but there's no policy don't
+                // require a master password update.
                 coordinator.hideLoadingOverlay()
                 coordinator.navigate(to: .complete)
             }

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessorTests.swift
@@ -93,12 +93,25 @@ class UpdateMasterPasswordProcessorTests: BitwardenTestCase {
     /// `perform()` with `.appeared` succeeds to sync but master password policy fails to load,
     /// and move to main vault screen.
     func test_perform_appeared_succeeds_policyNil() async throws {
-        authRepository.activeAccount = .fixture()
+        authRepository.activeAccount = .fixture(
+            profile: .fixture(forcePasswordResetReason: .weakMasterPasswordOnLogin)
+        )
         policyService.getMasterPasswordPolicyOptionsResult = .success(nil)
         XCTAssertNil(subject.state.masterPasswordPolicy)
         await subject.perform(.appeared)
         XCTAssertNil(subject.state.masterPasswordPolicy)
         XCTAssertEqual(coordinator.routes.last, .complete)
+    }
+
+    /// `perform()` with `.appeared` succeeds to sync but master password policy fails to load,
+    /// and move to main vault screen.
+    func test_perform_appeared_succeeds_policyNilAccountRecovery() async throws {
+        authRepository.activeAccount = .fixture()
+        policyService.getMasterPasswordPolicyOptionsResult = .success(nil)
+        XCTAssertNil(subject.state.masterPasswordPolicy)
+        await subject.perform(.appeared)
+        XCTAssertNil(subject.state.masterPasswordPolicy)
+        XCTAssertTrue(coordinator.routes.isEmpty)
     }
 
     /// `perform()` with `.logoutPressed` logs the user out.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1696](https://livefront.atlassian.net/browse/BIT-1696)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an issue where the account recovery update password screen is bypassed if there's no password policy enabled for the organization.

The update password screen is used for two cases: account recovery and the user's password doesn't meet the organization's policy. For the latter, if policy doesn't exist after syncing, we complete the auth flow and navigate the user to the vault. For account recovery, we need to allow the user to update their password even though there's no policy.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **UpdateMasterPasswordProcessor.swift:** Remove the check to dismiss the view if there's no policy.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
