### PR TITLE
BIT-1657: Import images as JPEGs if supported

### DIFF
--- a/BitwardenShared/UI/Platform/FileSelection/FileSelectionCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/FileSelection/FileSelectionCoordinatorTests.swift
@@ -73,8 +73,8 @@ class FileSelectionCoordinatorTests: BitwardenTestCase {
     }
 
     /// `imagePickerController(_:,didFinishPickingMediaWithInfo:)` creates a filename for the photo
-    /// and notifies the delegate.
-    func test_imagePickerViewControllerDidFinishPickingMediaWithInfo() throws {
+    /// and notifies the delegate for a JPG image.
+    func test_imagePickerViewControllerDidFinishPickingMedia_jpg() throws {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             throw XCTSkip("Unable to unit test UIImagePickerController with a camera input on CI")
         }
@@ -84,12 +84,36 @@ class FileSelectionCoordinatorTests: BitwardenTestCase {
         let viewController = UIImagePickerController()
         let image = UIImage(systemName: "doc.zipper")!
         subject.imagePickerController(viewController, didFinishPickingMediaWithInfo: [
+            .mediaType: UTType.image.identifier,
             .originalImage: image,
         ])
 
         XCTAssertTrue(errorReporter.errors.isEmpty)
         XCTAssertTrue(delegate.fileName!.hasPrefix("photo_"))
+        XCTAssertTrue(delegate.fileName!.hasSuffix(".jpg"))
         XCTAssertEqual(delegate.data, image.jpegData(compressionQuality: 1))
+    }
+
+    /// `imagePickerController(_:,didFinishPickingMediaWithInfo:)` creates a filename for the photo
+    /// and notifies the delegate for a PNG image.
+    func test_imagePickerViewControllerDidFinishPickingMedia_png() throws {
+        guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
+            throw XCTSkip("Unable to unit test UIImagePickerController with a camera input on CI")
+        }
+
+        subject.navigate(to: .camera)
+
+        let viewController = UIImagePickerController()
+        let image = UIImage(systemName: "doc.zipper")!
+        subject.imagePickerController(viewController, didFinishPickingMediaWithInfo: [
+            .mediaType: UTType.png.identifier,
+            .originalImage: image,
+        ])
+
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+        XCTAssertTrue(delegate.fileName!.hasPrefix("photo_"))
+        XCTAssertTrue(delegate.fileName!.hasSuffix(".png"))
+        XCTAssertEqual(delegate.data, image.pngData())
     }
 
     /// `navigate(to:)` with `.camera` and with camera authorization presents the camera screen.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1657](https://livefront.atlassian.net/browse/BIT-1657)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

We were relying on the file's extension to determine if the image should be exported as a PNG or JPEG file. Since `PHPickerViewController` doesn't provide the extension, this would result in exporting images as PNGs, which causes the image to be much larger in size compared to a JPEG.

This PR changes this to inspect the UTType provided from `PHPickerViewController` or `UIImagePickerControllerDelegate`. It will only save images as PNGs if the type is a PNG image, otherwise JPEG will be used.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **FileSelectionCoordinator.swift:** Updates logic to determine whether an images is a PNG or JPEG.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/ab49dd2f-7141-493b-9016-7a002859618c



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
