### PR TITLE
BIT-1585: Restrict Copy Password

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import XCTest
 
 @testable import BitwardenShared
@@ -111,5 +112,135 @@ class AlertTests: XCTestCase {
         XCTAssertEqual(subject, Alert(title: "🍎", message: "🥝", preferredStyle: .alert)
             .add(AlertAction(title: "Cancel", style: .cancel))
             .addPreferred(AlertAction(title: "OK", style: .default)))
+    }
+
+    @MainActor
+    func test_vault_moreOptions_login_canViewPassowrd() async throws { // swiftlint:disable:this function_body_length
+        var capturedAction: MoreOptionsAction?
+        let action: (MoreOptionsAction) -> Void = { action in
+            capturedAction = action
+        }
+        let cipher = CipherView.fixture(
+            edit: false,
+            id: "123",
+            login: .fixture(
+                password: "password",
+                username: "username"
+            ),
+            name: "Test Cipher",
+            type: .login,
+            viewPassword: true
+        )
+        let alert = Alert.moreOptions(
+            cipherView: cipher,
+            id: cipher.id!,
+            showEdit: true,
+            action: action
+        )
+        XCTAssertEqual(alert.title, cipher.name)
+        XCTAssertEqual(alert.preferredStyle, .actionSheet)
+        XCTAssertEqual(alert.alertActions.count, 5)
+
+        // Test the first action is a view action.
+        let first = try XCTUnwrap(alert.alertActions[0])
+        XCTAssertEqual(first.title, Localizations.view)
+        await first.handler?(first, [])
+        XCTAssertEqual(capturedAction, .view(id: "123"))
+        capturedAction = nil
+
+        // Test the second action is edit.
+        let second = try XCTUnwrap(alert.alertActions[1])
+        XCTAssertEqual(second.title, Localizations.edit)
+        await second.handler?(second, [])
+        XCTAssertEqual(
+            capturedAction,
+            .edit(cipherView: cipher)
+        )
+        capturedAction = nil
+
+        // Test the third action is copy username.
+        let third = try XCTUnwrap(alert.alertActions[2])
+        XCTAssertEqual(third.title, Localizations.copyUsername)
+        await third.handler?(third, [])
+        XCTAssertEqual(
+            capturedAction,
+            .copy(
+                toast: Localizations.username,
+                value: "username",
+                requiresMasterPasswordReprompt: false
+            )
+        )
+        capturedAction = nil
+
+        // Test the fourth action is copy password.
+        let fourth = try XCTUnwrap(alert.alertActions[3])
+        XCTAssertEqual(fourth.title, Localizations.copyPassword)
+        await fourth.handler?(fourth, [])
+        XCTAssertEqual(
+            capturedAction,
+            .copy(
+                toast: Localizations.password,
+                value: "password",
+                requiresMasterPasswordReprompt: false
+            )
+        )
+        capturedAction = nil
+
+        // Test the fifth action is a cancel action.
+        let fifth = try XCTUnwrap(alert.alertActions[4])
+        XCTAssertEqual(fifth.title, Localizations.cancel)
+        await fifth.handler?(fifth, [])
+        XCTAssertNil(capturedAction)
+    }
+
+    @MainActor
+    func test_vault_moreOptions_login_cannotViewPassword() async throws {
+        var capturedAction: MoreOptionsAction?
+        let action: (MoreOptionsAction) -> Void = { action in
+            capturedAction = action
+        }
+        let cipher = CipherView.fixture(
+            edit: false,
+            id: "123",
+            login: .fixture(
+                password: "password",
+                username: nil
+            ),
+            name: "Test Cipher",
+            type: .login,
+            viewPassword: false
+        )
+        let alert = Alert.moreOptions(
+            cipherView: cipher,
+            id: cipher.id!,
+            showEdit: true,
+            action: action
+        )
+        XCTAssertEqual(alert.title, cipher.name)
+        XCTAssertEqual(alert.preferredStyle, .actionSheet)
+        XCTAssertEqual(alert.alertActions.count, 3)
+
+        // Test the first action is a view action.
+        let first = try XCTUnwrap(alert.alertActions[0])
+        XCTAssertEqual(first.title, Localizations.view)
+        await first.handler?(first, [])
+        XCTAssertEqual(capturedAction, .view(id: "123"))
+        capturedAction = nil
+
+        // Test the second action is edit.
+        let second = try XCTUnwrap(alert.alertActions[1])
+        XCTAssertEqual(second.title, Localizations.edit)
+        await second.handler?(second, [])
+        XCTAssertEqual(
+            capturedAction,
+            .edit(cipherView: cipher)
+        )
+        capturedAction = nil
+
+        // Test the third action is a cancel action.
+        let third = try XCTUnwrap(alert.alertActions[2])
+        XCTAssertEqual(third.title, Localizations.cancel)
+        await third.handler?(third, [])
+        XCTAssertNil(capturedAction)
     }
 }

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -134,7 +134,8 @@ extension Alert {
                     ))
                 })
             }
-            if let password = cipherView.login?.password {
+            if let password = cipherView.login?.password,
+               cipherView.viewPassword {
                 alertActions.append(AlertAction(title: Localizations.copyPassword, style: .default) { _, _ in
                     action(.copy(
                         toast: Localizations.password,

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -437,7 +437,7 @@ extension VaultListProcessor: CipherItemOperationDelegate {
 // MARK: - MoreOptionsAction
 
 /// The actions available from the More Options alert.
-enum MoreOptionsAction {
+enum MoreOptionsAction: Equatable {
     /// Copy the `value` and show a toast with the `toast` string.
     case copy(toast: String, value: String, requiresMasterPasswordReprompt: Bool)
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1585](https://livefront.atlassian.net/browse/BIT-1585)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Restrict copy password for orgs that do not permit the action.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Alert+Vault.swift:** Adds a check for the cipher's `viewPassword` value.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/148839008/02954e2c-72e5-473c-95fe-1e7c4f252e44



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
