### PR TITLE
BIT-1698: Screenshot share

### DIFF
--- a/BitwardenShared/Core/Tools/Utilities/ShareExtensionHelper.swift
+++ b/BitwardenShared/Core/Tools/Utilities/ShareExtensionHelper.swift
@@ -9,6 +9,8 @@ import UniformTypeIdentifiers
 ///
 @MainActor
 public class ShareExtensionHelper {
+    // MARK: Properties
+
     /// The service used to get the present time.
     let timeProvider: TimeProvider
 

--- a/BitwardenShared/Core/Tools/Utilities/ShareExtensionHelperTests.swift
+++ b/BitwardenShared/Core/Tools/Utilities/ShareExtensionHelperTests.swift
@@ -8,20 +8,17 @@ import XCTest
 class ShareExtensionHelperTests: BitwardenTestCase {
     // MARK: Properties
 
-    var timeProvider: MockTimeProvider!
     var subject: ShareExtensionHelper!
 
     // MARK: Setup & Teardown
 
     override func setUp() {
         super.setUp()
-        timeProvider = MockTimeProvider(.currentTime)
-        subject = ShareExtensionHelper()
+        subject = ShareExtensionHelper(timeProvider: MockTimeProvider(.mockTime(Date(year: 2024, month: 2, day: 1))))
     }
 
     override func tearDown() {
         super.tearDown()
-        timeProvider = nil
         subject = nil
     }
 
@@ -81,13 +78,9 @@ class ShareExtensionHelperTests: BitwardenTestCase {
             ),
         ]
 
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyyMMddHHmmss"
-        let fileName = "image_\(formatter.string(from: timeProvider.presentTime)).png"
-
         let content = await subject.processInputItems([extensionItem])
 
-        XCTAssertEqual(content, .file(fileName: fileName, fileData: data!.pngData()!))
+        XCTAssertEqual(content, .file(fileName: "image_20240201000000.png", fileData: data!.pngData()!))
     }
 
     /// `processInputItems(_:)` processes the input items for content but does not return anything.


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1698](https://livefront.atlassian.net/browse/BIT-1698?atlOrigin=eyJpIjoiMTMxNWYzMmZkZWFiNDM5NzkwODA5ZDMwYmZmY2VkYWUiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
Gives the user the ability to share a screenshot to the Bitwarden app, where the user can save the image as a new Send.

## 📋 Code changes
-   **ShareExtensionHelper.swift:** Checks if the input data is an image.

## 📸 Screenshots
https://github.com/bitwarden/ios/assets/125899965/425e2d69-f7cf-484f-9984-e18c7932b11b


## ⏰ Reminders before review
-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
