### PR TITLE
BIT-1713 element id for declineAllRequests button

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsView.swift
@@ -62,6 +62,7 @@ struct PendingRequestsView: View {
             }
         }
         .buttonStyle(.secondary())
+        .accessibilityIdentifier("DeclineAllRequestsButton")
         .accessibilityLabel(Localizations.declineAllRequests)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1713](https://livefront.atlassian.net/browse/BIT-1713)
## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🎂 Other

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Added ```accessibilityIdentifier``` for declineAllRequests button in login with device screen.
## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **PendingRequestsView.swift:** Added accessibilityIdentifier.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
