### PR TITLE
BIT-1258: Only generate a new value when the slider stops

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/FormFields/SliderFieldView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/FormFields/SliderFieldView.swift
@@ -44,11 +44,14 @@ struct SliderField<State>: Equatable, Identifiable {
 struct SliderFieldView<State>: View {
     // MARK: Properties
 
-    /// A closure containing the action to take when a new value is selected.
-    let action: (Double) -> Void
-
     /// The data for displaying the field.
     let field: SliderField<State>
+
+    /// A closure containing the action to take when the slider begins or ends editing.
+    let onEditingChanged: (Bool) -> Void
+
+    /// A closure containing the action to take when a new value is selected.
+    let onValueChanged: (Double) -> Void
 
     var body: some View {
         VStack(spacing: 8) {
@@ -69,9 +72,10 @@ struct SliderFieldView<State>: View {
             Divider()
 
             Slider(
-                value: Binding(get: { field.value }, set: action),
+                value: Binding(get: { field.value }, set: onValueChanged),
                 in: field.range,
-                step: field.step
+                step: field.step,
+                onEditingChanged: onEditingChanged
             )
             .tint(Asset.Colors.primaryBitwarden.swiftUIColor)
             .accessibilityLabel(field.title)
@@ -88,11 +92,17 @@ struct SliderFieldView<State>: View {
     /// Initialize a `SliderFieldView`.
     ///
     /// - Parameters:
-    ///   - field:  The data for displaying the field.
-    ///   - action: A closure containing the action to take when a new value is selected.
+    ///   - field: The data for displaying the field.
+    ///   - onEditingChanged: A closure containing the action to take when the slider begins or ends editing.
+    ///   - onValueChanged: A closure containing the action to take when a new value is selected.
     ///
-    init(field: SliderField<State>, action: @escaping (Double) -> Void) {
-        self.action = action
+    init(
+        field: SliderField<State>,
+        onEditingChanged: @escaping (Bool) -> Void = { _ in },
+        onValueChanged: @escaping (Double) -> Void
+    ) {
         self.field = field
+        self.onEditingChanged = onEditingChanged
+        self.onValueChanged = onValueChanged
     }
 }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorAction.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorAction.swift
@@ -25,6 +25,9 @@ enum GeneratorAction: Equatable {
     /// The show password history button was pressed.
     case showPasswordHistory
 
+    /// A slider field editing value was changed.
+    case sliderEditingChanged(field: SliderField<GeneratorState>, isEditing: Bool)
+
     /// A slider field value was changed.
     case sliderValueChanged(field: SliderField<GeneratorState>, value: Double)
 
@@ -63,13 +66,15 @@ extension GeneratorAction {
              .generatorTypeChanged,
              .passwordGeneratorTypeChanged,
              .refreshGeneratedValue,
-             .sliderValueChanged,
              .stepperValueChanged,
              .textValueChanged,
              .toggleValueChanged,
              .usernameForwardedEmailServiceChanged,
              .usernameGeneratorTypeChanged:
             return true
+        case let .sliderEditingChanged(_, isEditing):
+            // Only generate a new value when editing completes.
+            return !isEditing
         case let .textFieldFocusChanged(keyPath):
             // Only generate a new value when focus leaves the field (keyPath == nil).
             return keyPath == nil
@@ -77,6 +82,7 @@ extension GeneratorAction {
              .dismissPressed,
              .selectButtonPressed,
              .showPasswordHistory,
+             .sliderValueChanged,
              .textFieldIsPasswordVisibleChanged,
              .toastShown:
             return false

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -87,6 +87,10 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
             )
         case .showPasswordHistory:
             coordinator.navigate(to: .generatorHistory)
+        case .sliderEditingChanged:
+            // No-op: This action is just used to generate a value when the slider finishes
+            // editing, which happens below.
+            break
         case let .sliderValueChanged(field, value):
             guard state.shouldGenerateNewValueOnSliderValueChanged(value, keyPath: field.keyPath) else {
                 shouldGenerateNewValue = false

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -573,12 +573,15 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         )
 
         subject.receive(.sliderValueChanged(field: field, value: 10))
+        subject.receive(.sliderEditingChanged(field: field, isEditing: false))
         XCTAssertNil(generatorRepository.passwordGeneratorRequest)
 
         subject.receive(.sliderValueChanged(field: field, value: 19))
+        subject.receive(.sliderEditingChanged(field: field, isEditing: false))
         XCTAssertNil(generatorRepository.passwordGeneratorRequest)
 
         subject.receive(.sliderValueChanged(field: field, value: 20))
+        subject.receive(.sliderEditingChanged(field: field, isEditing: false))
         waitFor(generatorRepository.passwordGeneratorRequest != nil)
         XCTAssertEqual(generatorRepository.passwordGeneratorRequest?.length, 20)
     }
@@ -710,7 +713,7 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     }
 
     /// The user's password options are saved when any of the password options are changed.
-    func test_saveGeneratorOptions_password() { // swiftlint:disable:this function_body_length
+    func test_saveGeneratorOptions_password() {
         // Wait for the initial loading of the generation options to complete before making changes.
         waitFor { subject.didLoadGeneratorOptions }
 
@@ -736,16 +739,14 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
                 wordSeparator: "-"
             )
         )
-        subject.receive(
-            .sliderValueChanged(
-                field: sliderField(
-                    keyPath: \.passwordState.lengthDouble,
-                    sliderAccessibilityId: "PasswordLengthSlider",
-                    sliderValueAccessibilityId: "PasswordLengthLabel"
-                ),
-                value: 30
-            )
+
+        let sliderField = sliderField(
+            keyPath: \.passwordState.lengthDouble,
+            sliderAccessibilityId: "PasswordLengthSlider",
+            sliderValueAccessibilityId: "PasswordLengthLabel"
         )
+        subject.receive(.sliderValueChanged(field: sliderField, value: 30))
+        subject.receive(.sliderEditingChanged(field: sliderField, isEditing: false))
         waitFor { generatorRepository.passwordGenerationOptions.length == 30 }
         XCTAssertEqual(generatorRepository.passwordGenerationOptions.length, 30)
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
@@ -107,7 +107,9 @@ struct GeneratorView: View {
                 case let .menuUsernameGeneratorType(menuField):
                     menuUsernameGeneratorTypeView(field: menuField)
                 case let .slider(sliderField):
-                    SliderFieldView(field: sliderField) { newValue in
+                    SliderFieldView(field: sliderField) { isEditing in
+                        store.send(.sliderEditingChanged(field: sliderField, isEditing: isEditing))
+                    } onValueChanged: { newValue in
                         store.send(.sliderValueChanged(field: sliderField, value: newValue))
                     }
                 case let .stepper(stepperField):


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1258](https://livefront.atlassian.net/browse/BIT-1258)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

For the length slider in the generator, only generate a new password once the slider stops editing.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SliderFieldView.swift:** Adds a closure for when editing of the slider changes.
- **GeneratorAction.swift:** Only generate a new value when the slider finishes editing.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/00d2e290-8b69-4caf-9c61-2208644c3a8a



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
