### PR TITLE
BIT-1495: View item view toasts

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/LoginItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/LoginItemState.swift
@@ -25,6 +25,9 @@ struct LoginItemState: Equatable {
     /// The date the password was last updated.
     var passwordUpdatedDate: Date?
 
+    /// A toast message to show in the view.
+    var toast: Toast?
+
     /// The TOTP key/code state.
     var totpState: LoginTOTPState
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemView.swift
@@ -49,7 +49,7 @@ struct ViewCardItemView: View {
                 }
 
                 Button {
-                    store.send(.copyPressed(value: number))
+                    store.send(.copyPressed(value: number, field: .cardNumber))
                 } label: {
                     Asset.Images.copy.swiftUIImage
                         .resizable()

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -9,9 +9,11 @@ enum ViewItemAction: Equatable {
 
     /// A copy button was pressed for the given value.
     ///
-    /// - Parameter value: The value to copy.
+    /// - Parameters:
+    ///   - value: The value to copy.
+    ///   - field: The field being copied.
     ///
-    case copyPressed(value: String)
+    case copyPressed(value: String, field: CopyableField? = nil)
 
     /// The visibility button was pressed for the specified custom field.
     case customFieldVisibilityPressed(CustomFieldState)
@@ -54,6 +56,43 @@ enum ViewItemAction: Equatable {
              .passwordHistoryPressed,
              .toastShown:
             false
+        }
+    }
+}
+
+// MARK: CopyableField
+
+/// The text fields within the `ViewItemView` that can be copied.
+///
+enum CopyableField {
+    /// The card number field.
+    case cardNumber
+
+    /// The password field.
+    case password
+
+    /// The uri field.
+    case uri
+
+    /// The username field.
+    case username
+
+    /// The totp field.
+    case totp
+
+    /// The localized name for each field.
+    var localizedName: String {
+        switch self {
+        case .cardNumber:
+            Localizations.number
+        case .password:
+            Localizations.password
+        case .uri:
+            Localizations.uri
+        case .username:
+            Localizations.username
+        case .totp:
+            Localizations.totp
         }
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -231,7 +231,7 @@ struct ViewItemDetailsView: View {
                         .accessibilityLabel(Localizations.launch)
 
                         Button {
-                            store.send(.copyPressed(value: uri.uri))
+                            store.send(.copyPressed(value: uri.uri, field: .uri))
                         } label: {
                             Asset.Images.copy.swiftUIImage
                                 .resizable()

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -108,8 +108,8 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
         switch action {
         case let .cardItemAction(cardAction):
             handleCardAction(cardAction)
-        case let .copyPressed(value):
-            copyValue(value)
+        case let .copyPressed(value, field):
+            copyValue(value, field)
         case let .customFieldVisibilityPressed(customFieldState):
             guard case var .data(cipherState) = state.loadingState else {
                 services.errorReporter.log(
@@ -171,12 +171,18 @@ private extension ViewItemProcessor {
         }
     }
 
-    /// Copies a value to the pasteboard.
+    /// Copies a value to the pasteboard and shows a toast for the field that was copied.
     ///
-    /// - Parameter value: The string to be copied.
+    /// - Parameters:
+    ///   - value: The string to be copied.
+    ///   - field: The field being copied.
     ///
-    private func copyValue(_ value: String) {
+    private func copyValue(_ value: String, _ field: CopyableField?) {
         services.pasteboardService.copy(value)
+
+        if let field {
+            state.toast = Toast(text: Localizations.valueHasBeenCopied(field.localizedName))
+        }
     }
 
     /// Download the attachment.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -333,10 +333,23 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(subject.state.loadingState, .data(cipherState))
     }
 
-    /// `receive` with `.copyPressed` copies the value with the pasteboard service.
+    /// `receive` with `.copyPressed` copies the value with the pasteboard service and shows a toast.
     func test_receive_copyPressed() {
-        subject.receive(.copyPressed(value: "value"))
+        subject.receive(.copyPressed(value: "value", field: .cardNumber))
         XCTAssertEqual(pasteboardService.copiedString, "value")
+        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.number))
+
+        subject.receive(.copyPressed(value: "value", field: .password))
+        XCTAssertEqual(pasteboardService.copiedString, "value")
+        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.password))
+
+        subject.receive(.copyPressed(value: "value", field: .totp))
+        XCTAssertEqual(pasteboardService.copiedString, "value")
+        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.totp))
+
+        subject.receive(.copyPressed(value: "value", field: .username))
+        XCTAssertEqual(pasteboardService.copiedString, "value")
+        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.username))
     }
 
     /// `receive` with `.customFieldVisibilityPressed()` toggles custom field visibility.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemViewTests.swift
@@ -68,7 +68,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
         processor.state.loadingState = .data(loginState)
         let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.copy)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "username"))
+        XCTAssertTrue(processor.dispatchedActions.contains(.copyPressed(value: "username", field: .username)))
     }
 
     /// Tapping the copy password button dispatches the `.copyPressed` action along with the
@@ -84,7 +84,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
         processor.state.loadingState = .data(loginState)
         let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.copy)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "password"))
+        XCTAssertTrue(processor.dispatchedActions.contains(.copyPressed(value: "password", field: .password)))
     }
 
     /// Tapping the copy uri button dispatches the `.copyPressed` action along with the uri.
@@ -104,7 +104,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
         processor.state.loadingState = .data(loginState)
         let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.copy)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "www.example.com"))
+        XCTAssertTrue(processor.dispatchedActions.contains(.copyPressed(value: "www.example.com", field: .uri)))
     }
 
     /// Tapping the dismiss button dispatches the `.dismissPressed` action.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/ViewLoginItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/ViewLoginItemView.swift
@@ -16,12 +16,14 @@ struct ViewLoginItemView: View {
     /// The `TimeProvider` used to calculate TOTP expiration.
     var timeProvider: any TimeProvider
 
+    // MARK: View
+
     var body: some View {
         if !store.state.username.isEmpty {
             let username = store.state.username
             BitwardenTextValueField(title: Localizations.username, value: username) {
                 Button {
-                    store.send(.copyPressed(value: username))
+                    store.send(.copyPressed(value: username, field: .username))
                 } label: {
                     Asset.Images.copy.swiftUIImage
                         .resizable()
@@ -53,7 +55,7 @@ struct ViewLoginItemView: View {
                     .accessibilityLabel(Localizations.checkPassword)
 
                     Button {
-                        store.send(.copyPressed(value: password))
+                        store.send(.copyPressed(value: password, field: .password))
                     } label: {
                         Asset.Images.copy.swiftUIImage
                             .resizable()
@@ -92,7 +94,7 @@ struct ViewLoginItemView: View {
                         }
                     )
                     Button {
-                        store.send(.copyPressed(value: totpModel.code))
+                        store.send(.copyPressed(value: totpModel.code, field: .totp))
                     } label: {
                         Asset.Images.copy.swiftUIImage
                             .resizable()


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1495](https://livefront.atlassian.net/browse/BIT-1495?atlOrigin=eyJpIjoiNTFiODdlOGFhNmVkNGJiYmJmZTJmMWE3ZGE4ODRiNDAiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
Shows a toast when the following fields are copied in the `ViewItemView`:
- Username
- Password
- TOTP
- URI

## 📋 Code changes
-   **ViewItemAction.swift:** Adds associated value to `copyPressed` action. Adds enum for the fields that can be copied.

## 📸 Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 06 51](https://github.com/bitwarden/ios/assets/125899965/d74b0009-588d-4172-b672-8368b5139d66)
![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 06 57](https://github.com/bitwarden/ios/assets/125899965/1703b251-d1d8-452d-813d-d67d13a59c3b)
![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 07 02](https://github.com/bitwarden/ios/assets/125899965/0c85a8f6-1363-45ab-a9d6-011c6a514b25)
![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 16 07 06](https://github.com/bitwarden/ios/assets/125899965/2b31160d-5dc6-4dd0-8c79-1b5e9ac9865b)


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
