### PR TITLE
BIT-1732: Profile Switcher Context

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -517,7 +517,8 @@ extension DefaultAuthRepository: AuthRepository {
             isUnlocked: displayAsUnlocked,
             userId: account.profile.userId,
             userInitials: account.initials()
-                ?? ".."
+                ?? "..",
+            webVault: account.settings.environmentUrls?.webVaultHost ?? ""
         )
     }
 

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -56,7 +56,7 @@ extension Alert {
         }
 
         return Alert(
-            title: item.email,
+            title: [item.email, item.webVault].joined(separator: "\n"),
             message: nil,
             preferredStyle: .actionSheet,
             alertActions: alertActions + [AlertAction(title: Localizations.cancel, style: .cancel)]
@@ -96,6 +96,28 @@ extension Alert {
         Alert(
             title: Localizations.logOut,
             message: Localizations.logoutConfirmation,
+            alertActions: [
+                AlertAction(title: Localizations.yes, style: .default) { _ in await action() },
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ]
+        )
+    }
+
+    /// An alert that is displayed to confirm the user wants to log out of the account.
+    ///
+    /// - Parameters:
+    ///   - profile: The profile switcher item to log out.
+    ///   - action: An action to perform when the user taps `Yes`, to confirm logout.
+    /// - Returns: An alert that is displayed to confirm the user wants to log out of the account.
+    ///
+    static func logoutConfirmation(
+        _ profile: ProfileSwitcherItem,
+        action: @escaping () async -> Void
+    ) -> Alert {
+        Alert(
+            title: Localizations.logOut,
+            message: Localizations.logoutConfirmation + "\n\n"
+                + [profile.email, profile.webVault].joined(separator: "\n"),
             alertActions: [
                 AlertAction(title: Localizations.yes, style: .default) { _ in await action() },
                 AlertAction(title: Localizations.cancel, style: .cancel),

--- a/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
@@ -6,12 +6,12 @@ class AlertAuthTests: BitwardenTestCase {
     /// `accountOptions(_:lockAction:logoutAction:)`
     func test_accountOptions() {
         let subject = Alert.accountOptions(
-            .fixture(email: "test@example.com", isUnlocked: true),
+            .fixture(email: "test@example.com", isUnlocked: true, webVault: "secureVault.example.com"),
             lockAction: {},
             logoutAction: {}
         )
 
-        XCTAssertEqual(subject.title, "test@example.com")
+        XCTAssertEqual(subject.title, "test@example.com\nsecureVault.example.com")
         XCTAssertNil(subject.message)
         XCTAssertEqual(subject.preferredStyle, .actionSheet)
         XCTAssertEqual(subject.alertActions.count, 3)

--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -185,7 +185,8 @@ struct LandingView_Previews: PreviewProvider {
                                         email: "max.protecc@bitwarden.com",
                                         isUnlocked: false,
                                         userId: "123",
-                                        userInitials: "MP"
+                                        userInitials: "MP",
+                                        webVault: ""
                                     ),
                                 ],
                                 activeAccountId: "123",
@@ -212,7 +213,8 @@ struct LandingView_Previews: PreviewProvider {
                                         email: "max.protecc@bitwarden.com",
                                         isUnlocked: false,
                                         userId: "123",
-                                        userInitials: "MP"
+                                        userInitials: "MP",
+                                        webVault: ""
                                     ),
                                 ],
                                 activeAccountId: "123",

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/Fixtures/ProfileSwitcherState+Fixtures.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/Fixtures/ProfileSwitcherState+Fixtures.swift
@@ -16,14 +16,16 @@ extension ProfileSwitcherItem {
         email: String = "",
         isUnlocked: Bool = false,
         userId: String = UUID().uuidString,
-        userInitials: String = ".."
+        userInitials: String = "..",
+        webVault: String = "vault.bitwarden.com"
     ) -> ProfileSwitcherItem {
         ProfileSwitcherItem(
             color: color,
             email: email,
             isUnlocked: isUnlocked,
             userId: userId,
-            userInitials: userInitials
+            userInitials: userInitials,
+            webVault: webVault
         )
     }
 }

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
@@ -108,14 +108,16 @@ extension ProfileSwitcherHandler {
 private extension ProfileSwitcherHandler {
     /// Confirms that the user would like to log out of an account by presenting an alert.
     ///
-    /// - Parameter account: The profile switcher item for the account to be logged out.
+    /// - Parameter profile: The profile switcher item for the account to be logged out.
     ///
-    func confirmLogout(_ account: ProfileSwitcherItem) {
+    func confirmLogout(_ profile: ProfileSwitcherItem) {
         // Confirm logging out.
-        showAlert(.logoutConfirmation { [weak self] in
-            guard let self else { return }
-            await logout(account)
-        })
+        showAlert(
+            .logoutConfirmation(profile) { [weak self] in
+                guard let self else { return }
+                await logout(profile)
+            }
+        )
     }
 
     /// Handles a long press of an account in the profile switcher.

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherItem.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherItem.swift
@@ -11,7 +11,8 @@ struct ProfileSwitcherItem: Equatable, Hashable {
             email: "",
             isUnlocked: false,
             userId: "",
-            userInitials: ".."
+            userInitials: "..",
+            webVault: ""
         )
     }
 
@@ -29,4 +30,7 @@ struct ProfileSwitcherItem: Equatable, Hashable {
 
     /// The user's initials.
     var userInitials: String
+
+    /// The account's email.
+    var webVault: String
 }

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRow.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRow.swift
@@ -229,7 +229,8 @@ struct ProfileSwitcherRow_Previews: PreviewProvider {
         email: "anne.account@bitwarden.com",
         isUnlocked: true,
         userId: "1",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     static var lockedAccount = ProfileSwitcherItem(
@@ -237,7 +238,8 @@ struct ProfileSwitcherRow_Previews: PreviewProvider {
         email: "anne.account@bitwarden.com",
         isUnlocked: false,
         userId: "2",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     static var previews: some View {

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRowTests.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRowTests.swift
@@ -13,7 +13,8 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
         email: "anne.account@bitwarden.com",
         isUnlocked: true,
         userId: "1",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     let lockedAccount = ProfileSwitcherItem(
@@ -21,7 +22,8 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
         email: "anne.account@bitwarden.com",
         isUnlocked: false,
         userId: "2",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     var processor: MockProcessor<ProfileSwitcherRowState, ProfileSwitcherRowAction, ProfileSwitcherRowEffect>!

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
@@ -50,7 +50,8 @@ struct ProfileSwitcherToolbarView_Previews: PreviewProvider {
         email: "anne.account@bitwarden.com",
         isUnlocked: true,
         userId: "1",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     static var previews: some View {
@@ -129,7 +130,8 @@ struct ProfileSwitcherToolbarView_Previews: PreviewProvider {
                                                 email: "bonus.bridge@bitwarde.com",
                                                 isUnlocked: true,
                                                 userId: "123",
-                                                userInitials: "BB"
+                                                userInitials: "BB",
+                                                webVault: ""
                                             ),
                                         ],
                                         activeAccountId: "123",

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarViewTests.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarViewTests.swift
@@ -71,7 +71,8 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
                     email: "",
                     isUnlocked: true,
                     userId: "123",
-                    userInitials: "OW"
+                    userInitials: "OW",
+                    webVault: ""
                 ),
             ],
             activeAccountId: "123",

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherView.swift
@@ -163,7 +163,8 @@ struct ProfileSwitcherView_Previews: PreviewProvider {
         email: "anne.account@bitwarden.com",
         isUnlocked: true,
         userId: "1",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     static var previews: some View {
@@ -197,7 +198,8 @@ struct ProfileSwitcherView_Previews: PreviewProvider {
                                     email: "bonus.bridge@bitwarde.com",
                                     isUnlocked: true,
                                     userId: "2",
-                                    userInitials: "BB"
+                                    userInitials: "BB",
+                                    webVault: ""
                                 ),
                             ],
                             activeAccountId: selectedAccount.userId,
@@ -222,21 +224,24 @@ struct ProfileSwitcherView_Previews: PreviewProvider {
                                     email: "bonus.bridge@bitwarden.com",
                                     isUnlocked: true,
                                     userId: "2",
-                                    userInitials: "BB"
+                                    userInitials: "BB",
+                                    webVault: ""
                                 ),
                                 ProfileSwitcherItem(
                                     color: .teal,
                                     email: "concurrent.claim@bitarden.com",
                                     isUnlocked: true,
                                     userId: "3",
-                                    userInitials: "CC"
+                                    userInitials: "CC",
+                                    webVault: ""
                                 ),
                                 ProfileSwitcherItem(
                                     color: .indigo,
                                     email: "double.dip@bitwarde.com",
                                     isUnlocked: true,
                                     userId: "4",
-                                    userInitials: "DD"
+                                    userInitials: "DD",
+                                    webVault: ""
                                 ),
                             ],
                             activeAccountId: "1",
@@ -261,28 +266,32 @@ struct ProfileSwitcherView_Previews: PreviewProvider {
                                     email: "bonus.bridge@bitwarden.com",
                                     isUnlocked: true,
                                     userId: "2",
-                                    userInitials: "BB"
+                                    userInitials: "BB",
+                                    webVault: ""
                                 ),
                                 ProfileSwitcherItem(
                                     color: .teal,
                                     email: "concurrent.claim@bitarden.com",
                                     isUnlocked: true,
                                     userId: "3",
-                                    userInitials: "CC"
+                                    userInitials: "CC",
+                                    webVault: ""
                                 ),
                                 ProfileSwitcherItem(
                                     color: .indigo,
                                     email: "double.dip@bitwarde.com",
                                     isUnlocked: true,
                                     userId: "4",
-                                    userInitials: "DD"
+                                    userInitials: "DD",
+                                    webVault: ""
                                 ),
                                 ProfileSwitcherItem(
                                     color: .green,
                                     email: "extra.edition@bitwarden.com",
                                     isUnlocked: false,
                                     userId: "5",
-                                    userInitials: "EE"
+                                    userInitials: "EE",
+                                    webVault: ""
                                 ),
                             ],
                             activeAccountId: "1",

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -211,7 +211,8 @@ struct UnlockVaultView_Previews: PreviewProvider {
                                         email: "max.protecc@bitwarden.com",
                                         isUnlocked: false,
                                         userId: "123",
-                                        userInitials: "MP"
+                                        userInitials: "MP",
+                                        webVault: ""
                                     ),
                                 ],
                                 activeAccountId: "123",
@@ -239,7 +240,8 @@ struct UnlockVaultView_Previews: PreviewProvider {
                                         email: "max.protecc@bitwarden.com",
                                         isUnlocked: false,
                                         userId: "123",
-                                        userInitials: "MP"
+                                        userInitials: "MP",
+                                        webVault: ""
                                     ),
                                 ],
                                 activeAccountId: "123",

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -371,7 +371,8 @@ struct VaultListView_Previews: PreviewProvider {
         email: "Anne.Account@bitwarden.com",
         isUnlocked: true,
         userId: "1",
-        userInitials: "AA"
+        userInitials: "AA",
+        webVault: ""
     )
 
     static let account2 = ProfileSwitcherItem(
@@ -379,7 +380,8 @@ struct VaultListView_Previews: PreviewProvider {
         email: "bonus.bridge@bitwarden.com",
         isUnlocked: true,
         userId: "2",
-        userInitials: "BB"
+        userInitials: "BB",
+        webVault: ""
     )
 
     static let singleAccountState = ProfileSwitcherState(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1723](https://livefront.atlassian.net/browse/BIT-1723)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add the user email and vault url to the logout/lock menu and logout alert when triggered by the profile switcher.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **[ProfileSwitcherItem.swift](https://github.com/bitwarden/ios/compare/eliot/BIT-1423-Vault-List-Accessibility...eliot/BIT-1732-Profile-Switcher-Logout-Context?expand=1#diff-63ca6111d9a4e35d1ec0ef50f4c8f87100fd6171c8203c6b52fa1987d425081d):** Adds the web vault host.
-  **[Alert+Auth.swift](https://github.com/bitwarden/ios/compare/eliot/BIT-1423-Vault-List-Accessibility...eliot/BIT-1732-Profile-Switcher-Logout-Context?expand=1#diff-f06d3ffca8df1cfe21c0b8b47ee2916442e539e4930e7581b4393cffb78af98f)** Adds the host url to the alerts.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/148839008/55298e31-e105-4ec7-a13c-160f079e7016

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
