### PR TITLE
BIT-1720:  logout user when password changed

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -68,10 +68,6 @@ protocol AuthRepository: AnyObject {
     ///
     func logout(userId: String?) async throws
 
-    /// Logs out all users.
-    ///
-    func logoutAllUsers() async throws
-
     /// Calculates the password strength of a password.
     ///
     /// - Parameters:
@@ -376,15 +372,6 @@ extension DefaultAuthRepository: AuthRepository {
         try? await biometricsRepository.setBiometricUnlockKey(authKey: nil)
         await vaultTimeoutService.remove(userId: userId)
         try await stateService.logoutAccount(userId: userId)
-    }
-
-    func logoutAllUsers() async throws {
-        try? await biometricsRepository.setBiometricUnlockKey(authKey: nil)
-        let accounts = try await getAccounts()
-        for account in accounts {
-            await vaultTimeoutService.remove(userId: account.userId)
-            try await stateService.logoutAccount(userId: account.userId)
-        }
     }
 
     func passwordStrength(email: String, password: String) async -> UInt8 {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -842,22 +842,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         }
     }
 
-    /// `logoutAllUsers` successfully logs out all users .
-    func test_logout_allUsers_success() async {
-        let account = Account.fixture()
-        let account2 = Account.fixture(profile: .fixture(userId: "2"))
-        stateService.accounts = [account, account2]
-        stateService.activeAccount = account
-        vaultTimeoutService.timeoutStore = [account.profile.userId: false]
-        biometricsRepository.capturedUserAuthKey = "Value"
-        biometricsRepository.setBiometricUnlockKeyError = nil
-
-        try? await subject.logoutAllUsers()
-        XCTAssertEqual(vaultTimeoutService.removedIds.count, stateService.accounts?.count)
-        XCTAssertEqual([account.profile.userId, account2.profile.userId], stateService.accountsLoggedOut)
-        XCTAssertNil(biometricsRepository.capturedUserAuthKey)
-    }
-
     /// `logout` throws an error with no accounts.
     func test_logout_noAccounts() async {
         stateService.accounts = []

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -19,8 +19,6 @@ class MockAuthRepository: AuthRepository {
     var logoutCalled = false
     var logoutUserId: String?
     var logoutResult: Result<Void, Error> = .success(())
-    var logoutAllUsersCalled = false
-    var logoutAllUsersResult: Result<Void, Error> = .success(())
     var passwordStrengthEmail: String?
     var passwordStrengthPassword: String?
     var passwordStrengthResult: UInt8 = 0
@@ -137,11 +135,6 @@ class MockAuthRepository: AuthRepository {
     func logout() async throws {
         logoutCalled = true
         try logoutResult.get()
-    }
-
-    func logoutAllUsers() async throws {
-        logoutAllUsersCalled = true
-        try logoutAllUsersResult.get()
     }
 
     func setActiveAccount(userId: String) async throws -> Account {

--- a/BitwardenShared/Core/Platform/Services/NotificationService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationService.swift
@@ -195,8 +195,12 @@ class DefaultNotificationService: NotificationService {
             case .syncOrgKeys:
                 try await syncService.fetchSync(forceSync: true)
             case .logOut:
-                try await authRepository.logoutAllUsers()
-                await delegate?.routeToLanding()
+                guard let data: UserNotification = notificationData.data() else { return }
+                try await authRepository.logout(userId: data.userId)
+                // Only route to landing page if the current active user was logged out.
+                if data.userId == userId {
+                    await delegate?.routeToLanding()
+                }
             case .syncSendCreate,
                  .syncSendUpdate:
                 if let data: SyncSendNotification = notificationData.data(), data.userId == userId {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1720](https://livefront.atlassian.net/browse/BIT-1720)
## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- it looks like server side sends push notification to the user's device when the user changed password from web portal,
 this PR will make sure to handle this push notification and log out all users.
it looks like Xamarin app [logout all the users](https://github.com/bitwarden/mobile/blob/c6a086fe62e81a1098308fcbc80d25cd48c1c78c/src/iOS/AppDelegate.cs#L155-L161).

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AuthRepository.swift:** added new method to logout all users.
-   **NotificationService.swift:** added handler for logout push notification.

## 📸 Screenshots

<!-- Required for 
![logout_users2](https://github.com/bitwarden/ios/assets/148797477/9130ea20-a04b-4aa2-a7f2-92fb71427e61)
any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
