### PR TITLE
BIT-1697: Reset never lock timeout to policy max if policy is enabled

### DIFF
--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -218,7 +218,7 @@ extension DefaultSyncService {
 
         // Only update the user's stored vault timeout value if
         // their stored timeout value is > the policy's timeout value.
-        if timeoutValue.rawValue > value {
+        if timeoutValue.rawValue > value || timeoutValue.rawValue < 0 {
             try await stateService.setVaultTimeout(
                 value: SessionTimeoutValue(rawValue: value)
             )

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -97,6 +97,21 @@ class SyncServiceTests: BitwardenTestCase {
         XCTAssertEqual(stateService.vaultTimeout["1"], SessionTimeoutValue(rawValue: 60))
     }
 
+    /// `fetchSync()` updates the user's timeout action and value - if the timeout value is set to
+    /// never, it is set to the maximum timeout allowed by the policy.
+    func test_checkVaultTimeoutPolicy_valueNever() async throws {
+        client.result = .httpSuccess(testData: .syncWithCiphers)
+        stateService.activeAccount = .fixture()
+        stateService.vaultTimeout["1"] = .never
+
+        policyService.fetchTimeoutPolicyValuesResult = .success((.lock, 15 * 60))
+
+        try await subject.fetchSync(forceSync: false)
+
+        XCTAssertEqual(stateService.timeoutAction["1"], .lock)
+        XCTAssertEqual(stateService.vaultTimeout["1"], SessionTimeoutValue.fifteenMinutes)
+    }
+
     /// `fetchSync()` performs the sync API request.
     func test_fetchSync() async throws {
         client.result = .httpSuccess(testData: .syncWithCiphers)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1697](https://livefront.atlassian.net/browse/BIT-1697)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If the user has their vault timeout set to never or on app restart, when a vault timeout policy is enabled, the policy should reset the timeout to the maximum timeout allowed by the policy.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **SyncService.swift:** When applying the vault policy, ensure that a timeout of never or on app restart are considered to be greater than the vault timeout policy.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
