### PR TITLE
BIT-1887: Enable login with device with two factor authentication

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Domain/Fixtures/AuthRequestResponse+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Domain/Fixtures/AuthRequestResponse+Fixtures.swift
@@ -1,0 +1,17 @@
+import BitwardenSdk
+
+extension AuthRequestResponse {
+    static func fixture(
+        privateKey: String = "PRIVATE_KEY",
+        publicKey: String = "PUBLIC_KEY",
+        fingerprint: String = "FINGERPRINT",
+        accessCode: String = "ACCESS_CODE"
+    ) -> AuthRequestResponse {
+        AuthRequestResponse(
+            privateKey: privateKey,
+            publicKey: publicKey,
+            fingerprint: fingerprint,
+            accessCode: accessCode
+        )
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Enum/TwoFactorUnlockMethod.swift
+++ b/BitwardenShared/Core/Auth/Models/Enum/TwoFactorUnlockMethod.swift
@@ -1,0 +1,10 @@
+/// An enumeration of methods used to unlock the user's vault after two-factor authentication
+/// completes successfully.
+///
+public enum TwoFactorUnlockMethod: Equatable {
+    /// The vault should be unlocked with the response from logging in with another device.
+    case loginWithDevice(key: String, masterPasswordHash: String?, privateKey: String)
+
+    /// The vault should be unlocked with the user's master password.
+    case password(String)
+}

--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -85,10 +85,12 @@ protocol AuthService {
     ///
     /// - Parameters email: The user's email.
     ///
-    /// - Returns: The fingerprint associated with the new login request and the id of the login
-    ///   request, used to check for a response.
+    /// - Returns: The auth request response containing the fingerprint for the new login request
+    ///     and the id of the login request, used to check for a response.
     ///
-    func initiateLoginWithDevice(email: String) async throws -> (fingerprint: String, requestId: String)
+    func initiateLoginWithDevice(
+        email: String
+    ) async throws -> (authRequestResponse: AuthRequestResponse, requestId: String)
 
     /// Login with the response received from a login with device request.
     ///
@@ -371,7 +373,9 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         )
     }
 
-    func initiateLoginWithDevice(email: String) async throws -> (fingerprint: String, requestId: String) {
+    func initiateLoginWithDevice(
+        email: String
+    ) async throws -> (authRequestResponse: AuthRequestResponse, requestId: String) {
         // Get the app's id.
         let appId = await appIdService.getOrCreateAppId()
 
@@ -386,8 +390,11 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         )
         self.loginWithDeviceData = loginWithDeviceData
 
-        // Return the fingerprint and the request id.
-        return (fingerprint: loginWithDeviceData.fingerprint, requestId: loginRequest.id)
+        // Return the auth request response and the request id.
+        return (
+            authRequestResponse: loginWithDeviceData,
+            requestId: loginRequest.id
+        )
     }
 
     func loginWithDevice(

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -189,12 +189,8 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         // Set up the mock data.
         client.result = .httpSuccess(testData: .authRequestSuccess)
         appSettingsStore.appId = "App id"
-        clientAuth.newAuthRequestResult = .success(.init(
-            privateKey: "",
-            publicKey: "",
-            fingerprint: "fingerprint",
-            accessCode: ""
-        ))
+        let authRequestResponse = AuthRequestResponse.fixture()
+        clientAuth.newAuthRequestResult = .success(authRequestResponse)
 
         // Test.
         let result = try await subject.initiateLoginWithDevice(email: "email@example.com")
@@ -202,7 +198,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         // Verify the results.
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertEqual(clientAuth.newAuthRequestEmail, "email@example.com")
-        XCTAssertEqual(result.fingerprint, "fingerprint")
+        XCTAssertEqual(result.authRequestResponse, authRequestResponse)
         XCTAssertEqual(result.requestId, LoginRequest.fixture().id)
     }
 

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
@@ -27,7 +27,9 @@ class MockAuthService: AuthService {
     var hashPasswordResult: Result<String, Error> = .success("hashed")
 
     var initiateLoginWithDeviceEmail: String?
-    var initiateLoginWithDeviceResult: Result<(fingerprint: String, requestId: String), Error> = .success(("", ""))
+    var initiateLoginWithDeviceResult: Result<
+        (authRequestResponse: AuthRequestResponse, requestId: String), Error
+    > = .success((.fixture(), ""))
 
     var loginWithDeviceRequest: LoginRequest?
     var loginWithDeviceEmail: String?
@@ -84,7 +86,9 @@ class MockAuthService: AuthService {
         return try hashPasswordResult.get()
     }
 
-    func initiateLoginWithDevice(email: String) async throws -> (fingerprint: String, requestId: String) {
+    func initiateLoginWithDevice(
+        email: String
+    ) async throws -> (authRequestResponse: AuthRequestResponse, requestId: String) {
         initiateLoginWithDeviceEmail = email
         return try initiateLoginWithDeviceResult.get()
     }

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -146,8 +146,8 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 state: state,
                 url: url
             )
-        case let .twoFactor(email, password, authMethodsData):
-            showTwoFactorAuth(email: email, password: password, authMethodsData: authMethodsData)
+        case let .twoFactor(email, unlockMethod, authMethodsData):
+            showTwoFactorAuth(email: email, unlockMethod: unlockMethod, authMethodsData: authMethodsData)
         case let .vaultUnlock(
             account,
             animated,
@@ -405,13 +405,20 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
 
     /// Show the two factor authentication view.
     ///
-    /// - Parameter data: The data required for the two-factor flow.
+    /// - Parameters:
+    ///   - email: The user's email.
+    ///   - unlockMethod: The method used to unlock the vault after two-factor completes successfully.
+    ///   - authMethodsData: The data required for the two-factor flow.
     ///
-    private func showTwoFactorAuth(email: String, password: String?, authMethodsData: AuthMethodsData) {
+    private func showTwoFactorAuth(
+        email: String,
+        unlockMethod: TwoFactorUnlockMethod?,
+        authMethodsData: AuthMethodsData
+    ) {
         let state = TwoFactorAuthState(
             authMethodsData: authMethodsData,
             email: email,
-            password: password
+            unlockMethod: unlockMethod
         )
         let processor = TwoFactorAuthProcessor(
             coordinator: asAnyCoordinator(),

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -243,7 +243,7 @@ class AuthCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.twoFactor` shows the two factor auth view.
     func test_navigate_twoFactor() throws {
-        subject.navigate(to: .twoFactor("", "", ["": ["": ""]]))
+        subject.navigate(to: .twoFactor("", .password(""), ["": ["": ""]]))
 
         XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
         let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)

--- a/BitwardenShared/UI/Auth/AuthRoute.swift
+++ b/BitwardenShared/UI/Auth/AuthRoute.swift
@@ -69,12 +69,12 @@ public enum AuthRoute: Equatable {
     ///
     /// - Parameters:
     ///   - email: The user's email address.
-    ///   - password: The password, if the login method was password.
+    ///   - unlockMethod: The method used to unlock the vault after two-factor completes successfully.
     ///   - authMethodsData: The data on the available auth methods.
     ///
     case twoFactor(
         _ email: String,
-        _ password: String?,
+        _ unlockMethod: TwoFactorUnlockMethod?,
         _ authMethodsData: AuthMethodsData
     )
 

--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -149,7 +149,9 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
             case let .captchaRequired(hCaptchaSiteCode):
                 launchCaptchaFlow(with: hCaptchaSiteCode)
             case let .twoFactorRequired(authMethodsData, _, _):
-                coordinator.navigate(to: .twoFactor(state.username, state.masterPassword, authMethodsData))
+                coordinator.navigate(
+                    to: .twoFactor(state.username, .password(state.masterPassword), authMethodsData)
+                )
             }
         } catch {
             coordinator.showAlert(.networkResponseError(error))

--- a/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
@@ -251,7 +251,7 @@ class LoginProcessorTests: BitwardenTestCase {
 
         await subject.perform(.loginWithMasterPasswordPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .twoFactor("", "Test", AuthMethodsData()))
+        XCTAssertEqual(coordinator.routes.last, .twoFactor("", .password("Test"), AuthMethodsData()))
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.loggingIn)])
     }

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import Foundation
 
 // MARK: - LoginWithDeviceProcessor
@@ -20,6 +21,9 @@ final class LoginWithDeviceProcessor: StateProcessor<
 
     /// The approved login request (stored in case the login flow is interrupted by a captcha request).
     private var approvedRequest: LoginRequest?
+
+    /// The response from creating an auth request for logging in with another device.
+    private var authRequestResponse: AuthRequestResponse?
 
     /// The coordinator used for navigation.
     private let coordinator: AnyCoordinator<AuthRoute, AuthEvent>
@@ -80,8 +84,9 @@ final class LoginWithDeviceProcessor: StateProcessor<
             coordinator.showLoadingOverlay(title: Localizations.loading)
 
             let result = try await services.authService.initiateLoginWithDevice(email: state.email)
-            state.fingerprintPhrase = result.fingerprint
+            state.fingerprintPhrase = result.authRequestResponse.fingerprint
             state.requestId = result.requestId
+            authRequestResponse = result.authRequestResponse
 
             // Start checking for a response every few seconds.
             setCheckTimer()
@@ -170,7 +175,16 @@ final class LoginWithDeviceProcessor: StateProcessor<
             case let .captchaRequired(token):
                 launchCaptchaFlow(with: token)
             case let .twoFactorRequired(authMethodsData, _, _):
-                coordinator.navigate(to: .twoFactor(state.email, nil, authMethodsData))
+                let unlockMethod: TwoFactorUnlockMethod? = if let key = approvedRequest?.key, let authRequestResponse {
+                    TwoFactorUnlockMethod.loginWithDevice(
+                        key: key,
+                        masterPasswordHash: approvedRequest?.masterPasswordHash,
+                        privateKey: authRequestResponse.privateKey
+                    )
+                } else {
+                    nil
+                }
+                coordinator.navigate(to: .twoFactor(state.email, unlockMethod, authMethodsData))
             }
             return
         }

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessorTests.swift
@@ -48,7 +48,7 @@ class LoginWithDeviceProcessorTests: BitwardenTestCase {
     /// completes login for an approved response.
     func test_attemptLogin() {
         let approvedLoginRequest = LoginRequest.fixture(requestApproved: true, responseDate: .now)
-        authService.initiateLoginWithDeviceResult = .success(("fingerprint", "id"))
+        authService.initiateLoginWithDeviceResult = .success((.fixture(fingerprint: "fingerprint"), "id"))
         authService.checkPendingLoginRequestResult = .success(approvedLoginRequest)
         authService.loginWithDeviceResult = .success(("PRIVATE_KEY", "KEY"))
         subject.state.email = "user@bitwarden.com"
@@ -123,9 +123,39 @@ class LoginWithDeviceProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes, [.dismiss])
     }
 
+    /// `checkForResponse()` navigates the user to the two factor flow if it's required to complete login.
+    func test_checkForResponse_twoFactorRequired() {
+        let approvedLoginRequest = LoginRequest.fixture(requestApproved: true, responseDate: .now)
+        authService.initiateLoginWithDeviceResult = .success((.fixture(fingerprint: "fingerprint"), "id"))
+        authService.checkPendingLoginRequestResult = .success(approvedLoginRequest)
+        authService.loginWithDeviceResult = .failure(
+            IdentityTokenRequestError.twoFactorRequired(AuthMethodsData(), nil, nil)
+        )
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+
+        waitFor(!coordinator.routes.isEmpty)
+        task.cancel()
+
+        XCTAssertEqual(
+            coordinator.routes.last,
+            .twoFactor(
+                "",
+                .loginWithDevice(
+                    key: "reallyLongKey",
+                    masterPasswordHash: "reallyLongMasterPasswordHash",
+                    privateKey: "PRIVATE_KEY"
+                ),
+                AuthMethodsData()
+            )
+        )
+    }
+
     /// `perform(_:)` with `.appeared` sets the fingerprint phrase in the state.
     func test_perform_appeared() async {
-        authService.initiateLoginWithDeviceResult = .success(("fingerprint", "id"))
+        authService.initiateLoginWithDeviceResult = .success((.fixture(fingerprint: "fingerprint"), "id"))
         subject.state.email = "user@bitwarden.com"
 
         await subject.perform(.appeared)
@@ -147,7 +177,7 @@ class LoginWithDeviceProcessorTests: BitwardenTestCase {
 
     /// `perform(_:)` with `.resendNotification` updates the fingerprint phrase in the state.
     func test_perform_resendNotification() async {
-        authService.initiateLoginWithDeviceResult = .success(("fingerprint2", "id"))
+        authService.initiateLoginWithDeviceResult = .success((.fixture(fingerprint: "fingerprint2"), "id"))
 
         await subject.perform(.appeared)
 

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -150,14 +150,34 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase {
         )
     }
 
-    /// `perform(_:)` with `.continueTapped` logs in and unlocks the vault successfully.
+    /// `perform(_:)` with `.continueTapped` logs in and unlocks the vault successfully when using
+    /// a password.
     func test_perform_continueTapped_success() async {
-        subject.state.password = "password123"
+        subject.state.unlockMethod = .password("password123")
         subject.state.verificationCode = "Test"
 
         await subject.perform(.continueTapped)
 
         XCTAssertEqual(coordinator.events, [.didCompleteAuth])
+        XCTAssertEqual(authRepository.unlockVaultPassword, "password123")
+    }
+
+    /// `perform(_:)` with `.continueTapped` logs in and unlocks the vault successfully when using
+    /// login with device.
+    func test_perform_continueTapped_loginWithDevice_success() async {
+        subject.state.unlockMethod = .loginWithDevice(
+            key: "KEY",
+            masterPasswordHash: "MASTER_PASSWORD_HASH",
+            privateKey: "PRIVATE_KEY"
+        )
+        subject.state.verificationCode = "Test"
+
+        await subject.perform(.continueTapped)
+
+        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
+        XCTAssertEqual(authRepository.unlockVaultFromLoginWithDeviceKey, "KEY")
+        XCTAssertEqual(authRepository.unlockVaultFromLoginWithDevicePrivateKey, "PRIVATE_KEY")
+        XCTAssertEqual(authRepository.unlockVaultFromLoginWithDeviceMasterPasswordHash, "MASTER_PASSWORD_HASH")
     }
 
     /// `perform(_:)` with `.continueTapped` handles a two-factor error correctly.

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
@@ -28,11 +28,11 @@ struct TwoFactorAuthState: Equatable {
     /// Whether the remember me toggle is on.
     var isRememberMeOn = false
 
-    /// The master password used to unlock the vault if the login method is password.
-    var password: String?
-
     /// A toast message to show in the view.
     var toast: Toast?
+
+    /// The method used to unlock the vault after two-factor completes successfully.
+    var unlockMethod: TwoFactorUnlockMethod?
 
     /// The url to open in the device's web browser.
     var url: URL?


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1887](https://livefront.atlassian.net/browse/BIT-1887)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

After completing two factor auth when logging in with another device, the user’s vault should be unlocked using the login with device details and not require a manual master password entry.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **TwoFactorUnlockMethod.swift:** An enum for the method used to unlock the vault after two-factor authentication.
- **AuthRoute.swift:** The two-factor route now includes the unlock method, instead of just the user's password.
- **LoginWithDeviceProcessor.swift:** Passes the login with device unlock method to the two-factor route.
- **TwoFactorAuthProcessor.swift:** Unlocks the user's vault with either their password or login with device details.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/c02332c8-efa4-4082-a4d9-6f4538a74d6a



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
