### PR TITLE
BIT-1718: Self hosted toast and saved value

### DIFF
--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -137,8 +137,8 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             showLoginWithDevice(email: email)
         case let .masterPasswordHint(username):
             showMasterPasswordHint(for: username)
-        case .selfHosted:
-            showSelfHostedView(delegate: context as? SelfHostedProcessorDelegate)
+        case let .selfHosted(region):
+            showSelfHostedView(delegate: context as? SelfHostedProcessorDelegate, currentRegion: region)
         case let .singleSignOn(callbackUrlScheme, state, url):
             showSingleSignOn(
                 callbackUrlScheme: callbackUrlScheme,
@@ -349,13 +349,30 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     }
 
     /// Shows the self-hosted settings view.
-    private func showSelfHostedView(delegate: SelfHostedProcessorDelegate?) {
+    ///
+    /// - Parameters:
+    ///   - delegate: A delegate of `SelfHostedProcessor` that is notified
+    ///     when the user saves their environment settings.
+    ///   - currentRegion: The user's region prior to showing the self-hosted settings view.
+    ///
+    private func showSelfHostedView(delegate: SelfHostedProcessorDelegate?, currentRegion: RegionType) {
+        let preAuthEnvironmentUrls = services.appSettingsStore.preAuthEnvironmentUrls ?? EnvironmentUrlData()
+        var state = SelfHostedState()
+
+        if currentRegion == .selfHosted {
+            state = SelfHostedState(
+                apiServerUrl: preAuthEnvironmentUrls.api?.sanitized.description ?? "",
+                iconsServerUrl: preAuthEnvironmentUrls.icons?.sanitized.description ?? "",
+                identityServerUrl: preAuthEnvironmentUrls.identity?.sanitized.description ?? "",
+                serverUrl: preAuthEnvironmentUrls.base?.sanitized.description ?? "",
+                webVaultServerUrl: preAuthEnvironmentUrls.webVault?.sanitized.description ?? ""
+            )
+        }
+
         let processor = SelfHostedProcessor(
             coordinator: asAnyCoordinator(),
             delegate: delegate,
-            state: SelfHostedState(
-                serverUrl: services.appSettingsStore.preAuthEnvironmentUrls?.base?.sanitized.description ?? ""
-            )
+            state: state
         )
         let view = SelfHostedView(store: Store(processor: processor))
         let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -177,7 +177,7 @@ class AuthCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.selfHosted` pushes the self-hosted view onto the stack navigator.
     func test_navigate_selfHosted() throws {
-        subject.navigate(to: .selfHosted)
+        subject.navigate(to: .selfHosted(currentRegion: .unitedStates))
 
         let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
         XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)

--- a/BitwardenShared/UI/Auth/AuthRoute.swift
+++ b/BitwardenShared/UI/Auth/AuthRoute.swift
@@ -54,7 +54,9 @@ public enum AuthRoute: Equatable {
     case updateMasterPassword
 
     /// A route to the self-hosted settings view.
-    case selfHosted
+    ///
+    /// - Parameter currentRegion: The user's region type prior to navigating to the self-hosted view.
+    case selfHosted(currentRegion: RegionType)
 
     /// A route to the single sign on WebAuth screen.
     ///

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -218,7 +218,10 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
                 if let urls = region.defaultURLs {
                     await self?.setRegion(region, urls: urls)
                 } else {
-                    self?.coordinator.navigate(to: .selfHosted, context: self)
+                    self?.coordinator.navigate(
+                        to: .selfHosted(currentRegion: self?.state.region ?? .unitedStates),
+                        context: self
+                    )
                 }
             }
         }
@@ -242,7 +245,6 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
         guard !urls.isEmpty else { return }
         await services.environmentService.setPreAuthURLs(urls: urls)
         state.region = region
-        state.toast = Toast(text: Localizations.environmentSaved)
     }
 
     /// Updates the value of `rememberedEmail` in the app settings store with the `email` value in `state`.
@@ -261,5 +263,6 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
 extension LandingProcessor: SelfHostedProcessorDelegate {
     func didSaveEnvironment(urls: EnvironmentUrlData) async {
         await setRegion(.selfHosted, urls: urls)
+        state.toast = Toast(text: Localizations.environmentSaved)
     }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -388,7 +388,7 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
 
         XCTAssertEqual(alert.alertActions[2].title, Localizations.selfHosted)
         try await alert.tapAction(title: Localizations.selfHosted)
-        XCTAssertEqual(coordinator.routes.last, .selfHosted)
+        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .europe))
     }
 
     /// `receive(_:)` with `.rememberMeChanged(true)` updates the state to reflect the changes.


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1718](https://livefront.atlassian.net/browse/BIT-1718?atlOrigin=eyJpIjoiMzc5NjNlZDZmMjM5NDE0OGE2ZjM3YmZhNmJkOTcyMjciLCJwIjoiaiJ9)

## 🚧 Type of change
-   🐛 Bug fix

## 📔 Objective
- Shows a toast when the environment is saved
- Shows the saved server URL in the self hosted view upon presenting the view

## 📋 Code changes
-   **AuthCoordinator.swift:** Initializes the view with the server URL.
-   **LandingProcessor.swift:** Shows a toast when the environment has been saved.

## 📸 Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-02-12 at 16 41 13](https://github.com/bitwarden/ios/assets/125899965/ce03293e-f9ca-413c-962d-982c638f720e)

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
