### PR TITLE
BIT-1722: Open URIs for login items

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -218,11 +218,8 @@ struct ViewItemDetailsView: View {
             SectionView(Localizations.urIs) {
                 ForEach(store.state.loginState.uris, id: \.self) { uri in
                     BitwardenTextValueField(title: Localizations.uri, value: uri.uri) {
-                        if uri.uri.isValidURL {
+                        if let url = URL(string: uri.uri), uri.uri.isValidURL {
                             Button {
-                                guard let url = URL(string: uri.uri) else {
-                                    return
-                                }
                                 openURL(url.sanitized)
                             } label: {
                                 Asset.Images.externalLink.swiftUIImage


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1722](https://livefront.atlassian.net/browse/BIT-1722?atlOrigin=eyJpIjoiZWY0ZWM0MTk5YmZiNDEzOGJlZmU4Yzg5MjVlZTU1NGQiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
- When the URI is a website, the user can tap the launch button, redirecting them to the website
- The launch button is hidden if the URI doesn't contain `.com`

## 📋 Code changes
-   **ViewItemDetailsView.swift:** Conditionally shows the launch button.

## 📸 Screenshots
Launch button example        |  No launch button  example
:-------------------------:|:-------------------------:
![](https://github.com/bitwarden/ios/assets/125899965/9ffe7759-05a4-43a0-8fd7-5aff0f484fce)  |  ![](https://github.com/bitwarden/ios/assets/125899965/429249a0-7767-44be-9c82-42516b123e32)

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
