### PR TITLE
BIT-1495: View item view toast

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemView.swift
@@ -107,7 +107,7 @@ struct ViewCardItemView: View {
                 }
 
                 Button {
-                    store.send(.copyPressed(value: code))
+                    store.send(.copyPressed(value: code, field: .securityCode))
                 } label: {
                     Asset.Images.copy.swiftUIImage
                         .resizable()

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -71,14 +71,17 @@ enum CopyableField {
     /// The password field.
     case password
 
+    /// The security code field.
+    case securityCode
+
+    /// The totp field.
+    case totp
+
     /// The uri field.
     case uri
 
     /// The username field.
     case username
-
-    /// The totp field.
-    case totp
 
     /// The localized name for each field.
     var localizedName: String {
@@ -87,12 +90,14 @@ enum CopyableField {
             Localizations.number
         case .password:
             Localizations.password
+        case .securityCode:
+            Localizations.securityCode
+        case .totp:
+            Localizations.totp
         case .uri:
             Localizations.uri
         case .username:
             Localizations.username
-        case .totp:
-            Localizations.totp
         }
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -343,6 +343,10 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(pasteboardService.copiedString, "value")
         XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.password))
 
+        subject.receive(.copyPressed(value: "value", field: .securityCode))
+        XCTAssertEqual(pasteboardService.copiedString, "value")
+        XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.securityCode))
+
         subject.receive(.copyPressed(value: "value", field: .totp))
         XCTAssertEqual(pasteboardService.copiedString, "value")
         XCTAssertEqual(subject.state.toast?.text, Localizations.valueHasBeenCopied(Localizations.totp))


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1495](https://livefront.atlassian.net/browse/BIT-1495?atlOrigin=eyJpIjoiYWUxNTFkYTk3NmJkNDIzMzlkM2RlNDk2NDM1OGU3MDgiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Show toast when security code is copied.

## 📋 Code changes
-   **ViewCardItemView.swift:** Show toast when security code is copied.

## 📸 Screenshots
![Simulator Screenshot - iPhone 15 Pro - 2024-02-13 at 16 53 50](https://github.com/bitwarden/ios/assets/125899965/fdf02314-e4f2-4975-9462-376396a8290b)

## ⏰ Reminders before review
-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
