### PR TITLE
BIT-1911: Add alert warning the user if their KDF memory setting is too high for extensions

### DIFF
--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -43,6 +43,10 @@ enum Constants {
     /// The maximum number of accounts permitted for a user.
     static let maxAccounts = 5
 
+    /// The maximum amount of KDF memory that can be used to unlock the user's vault in an app
+    /// extension before the app should warn the user that the extension may hit its memory limit.
+    static let maxArgon2IdMemoryBeforeExtensionCrashing = 48
+
     /// The value representing 100 MB of data.
     static let maxFileSize = 104_857_600
 

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -85,6 +85,27 @@ extension Alert {
         )
     }
 
+    /// An alert notifying the user that unlocking the user's vault may fail in an app extension
+    /// because their KDF settings use too much memory.
+    ///
+    /// - Parameter continueAction: A closure containing the action to take if the user wants to
+    ///     continue despite the warning.
+    /// - Returns: An alert notifying the user that unlocking the user's vault may fail in an app
+    ///     extension because their KDF settings use too much memory.
+    ///
+    static func extensionKdfMemoryWarning(continueAction: @escaping () async -> Void) -> Alert {
+        Alert(
+            title: Localizations.warning,
+            message: Localizations.unlockingMayFailDueToInsufficientMemoryDecreaseYourKDFMemorySettingsToResolve,
+            alertActions: [
+                AlertAction(title: Localizations.continue, style: .default) { _ in
+                    await continueAction()
+                },
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ]
+        )
+    }
+
     /// An alert that is displayed to confirm the user wants to log out of the account.
     ///
     /// - Parameter action: An action to perform when the user taps `Yes`, to confirm logout.

--- a/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
@@ -32,6 +32,22 @@ class AlertAuthTests: BitwardenTestCase {
         XCTAssertEqual(subject.alertActions[1].title, Localizations.yes)
     }
 
+    /// `extensionKdfMemoryWarning(continueAction:)` constructs an `Alert` used to warn the user
+    /// that their KDF memory setting may be too high to unlock the vault in an extension.
+    func test_extensionKdfMemoryWarning() async throws {
+        let subject = Alert.extensionKdfMemoryWarning {}
+
+        XCTAssertEqual(subject.title, Localizations.warning)
+        XCTAssertEqual(
+            subject.message,
+            Localizations.unlockingMayFailDueToInsufficientMemoryDecreaseYourKDFMemorySettingsToResolve
+        )
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.continue)
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.cancel)
+    }
+
     /// `logoutConfirmation(action:)` constructs an `Alert` used to confirm that the user wants to
     /// logout of the account.
     func test_logoutConfirmation() {

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
@@ -256,6 +256,24 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(coordinator.events.last, .didCompleteAuth)
     }
 
+    /// `perform(_:)` with `.unlockVault` shows the KDF warning in an extension if the KDF memory is
+    /// potentially too high.
+    func test_perform_unlockVault_extensionKdfWarning() async throws {
+        appExtensionDelegate.isInAppExtension = true
+        stateService.activeAccount = .fixture(profile: .fixture(kdfMemory: 50, kdfType: .argon2id))
+        subject.state.masterPassword = "password"
+
+        await subject.perform(.unlockVault)
+
+        XCTAssertEqual(coordinator.alertShown, [.extensionKdfMemoryWarning {}])
+
+        let alert = coordinator.alertShown.last
+        try await alert?.tapAction(title: Localizations.continue)
+
+        XCTAssertEqual(authRepository.unlockVaultPassword, "password")
+        XCTAssertEqual(coordinator.events.last, .didCompleteAuth)
+    }
+
     /// `perform(_:)` with `.unlockVault` shows an alert if the master password is empty.
     func test_perform_unlockVault_InputValidationError_noPassword() async throws {
         subject.state.unlockMethod = .password
@@ -411,6 +429,27 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(subject.state.unsuccessfulUnlockAttemptsCount, 0)
         attemptsInUserDefaults = await stateService.getUnsuccessfulUnlockAttempts()
         XCTAssertEqual(attemptsInUserDefaults, 0)
+    }
+
+    /// `perform(_:)` with `.unlockVaultWithBiometrics` shows the KDF warning in an extension if the
+    /// KDF memory is potentially too high.
+    func test_perform_unlockWithBiometrics_extensionKdfWarning() async throws {
+        appExtensionDelegate.isInAppExtension = true
+        authRepository.unlockVaultWithBiometricsResult = .success(())
+        biometricsRepository.biometricUnlockStatus = .success(
+            .available(.faceID, enabled: true, hasValidIntegrity: true)
+        )
+        stateService.activeAccount = .fixture(profile: .fixture(kdfMemory: 50, kdfType: .argon2id))
+        subject.state.biometricUnlockStatus = .available(.touchID, enabled: true, hasValidIntegrity: true)
+
+        await subject.perform(.unlockVaultWithBiometrics)
+
+        XCTAssertEqual(coordinator.alertShown, [.extensionKdfMemoryWarning {}])
+
+        let alert = coordinator.alertShown.last
+        try await alert?.tapAction(title: Localizations.continue)
+
+        XCTAssertEqual(coordinator.events.last, .didCompleteAuth)
     }
 
     /// `perform(_:)` with `.unlockWithBiometrics` requires a set user preference.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1911](https://livefront.atlassian.net/browse/BIT-1911)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Trying to unlock the vault in an app extension with KDF settings that use too much memory for the extension results in the extension hitting an out of memory condition and appearing to crash. This adds an alert warning the user that their settings might cause the extension to crash prior to unlocking the vault.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Constants.swift:** Adds a constant for the maximum amount of KDF memory before we show the alert.
- **VaultUnlockProcessor.swift:** When in an extension and if the user's KDF memory setting is above the threshold, show an alert warning the user.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="559" alt="Screenshot 2024-02-22 at 11 02 50 AM" src="https://github.com/bitwarden/ios/assets/126492398/b24790a1-f73f-498c-ba1f-8a411af8c924">

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
