### PR TITLE
BIT-1911: Increase KDF memory warning threshold to 64MB

### DIFF
--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -45,7 +45,7 @@ enum Constants {
 
     /// The maximum amount of KDF memory that can be used to unlock the user's vault in an app
     /// extension before the app should warn the user that the extension may hit its memory limit.
-    static let maxArgon2IdMemoryBeforeExtensionCrashing = 48
+    static let maxArgon2IdMemoryBeforeExtensionCrashing = 64
 
     /// The value representing 100 MB of data.
     static let maxFileSize = 104_857_600
@@ -64,6 +64,7 @@ enum Constants {
 
     /// The minimum number of cipher items without folder
     static let noFolderListSize = 100
+
     /// The default number of KDF iterations to perform.
     static let pbkdf2Iterations = 600_000
 

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
@@ -260,7 +260,7 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
     /// potentially too high.
     func test_perform_unlockVault_extensionKdfWarning() async throws {
         appExtensionDelegate.isInAppExtension = true
-        stateService.activeAccount = .fixture(profile: .fixture(kdfMemory: 50, kdfType: .argon2id))
+        stateService.activeAccount = .fixture(profile: .fixture(kdfMemory: 65, kdfType: .argon2id))
         subject.state.masterPassword = "password"
 
         await subject.perform(.unlockVault)
@@ -439,7 +439,7 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: true)
         )
-        stateService.activeAccount = .fixture(profile: .fixture(kdfMemory: 50, kdfType: .argon2id))
+        stateService.activeAccount = .fixture(profile: .fixture(kdfMemory: 65, kdfType: .argon2id))
         subject.state.biometricUnlockStatus = .available(.touchID, enabled: true, hasValidIntegrity: true)
 
         await subject.perform(.unlockVaultWithBiometrics)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1911](https://livefront.atlassian.net/browse/BIT-1911)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the KDF memory warning threshold to 64MB. 64MB is the default Argon2 memory setting and this still seems to give the app enough headroom to be fine.

https://github.com/bitwarden/ios/pull/491#issuecomment-1962062833

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Constants.swift:** Updates the KDF memory warning threshold to 64MB.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
