### PR TITLE
BIT-1964: Automatically send email on 2FA method switch to email.

### DIFF
--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
@@ -53,6 +53,7 @@ class MockAuthService: AuthService {
     var publicKey: String = ""
     var requirePasswordChangeResult: Result<Bool, Error> = .success(false)
     var resendVerificationCodeEmailResult: Result<Void, Error> = .success(())
+    var sentVerificationEmail = false
 
     func answerLoginRequest(_ request: LoginRequest, approve: Bool) async throws {
         answerLoginRequestRequest = request
@@ -140,6 +141,7 @@ class MockAuthService: AuthService {
     }
 
     func resendVerificationCodeEmail() async throws {
+        sentVerificationEmail = true
         try resendVerificationCodeEmailResult.get()
     }
 }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -94,9 +94,13 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
 
     /// Update the selected auth method or launch the web view for the recovery code.
     private func handleAuthMethodSelected(_ authMethod: TwoFactorAuthMethod) {
-        if authMethod == .recoveryCode {
+        switch authMethod {
+        case .recoveryCode:
             state.url = ExternalLinksConstants.recoveryCode
-        } else {
+        case .email:
+            Task { await resendEmail() }
+            state.authMethod = authMethod
+        default:
             state.authMethod = authMethod
         }
     }


### PR DESCRIPTION
Automatically send email on 2FA method switch to email.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[BIT-1964](https://livefront.atlassian.net/browse/BIT-1964)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
A user is logging in, has email and another form of 2FA enabled, and is on the 2FA screen.

- The 2FA screen is NOT for email 2FA
- Tap the kebab menu, then select “User another two-step login method”
- Tap the “Email” option

The user is delivered to the email 2FA screen and the code is sent to their email automatically without requiring the user to take any further actions.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **[TwoFactorAuthProcessor.swift](https://github.com/bitwarden/ios/compare/eliot/BIT-1964-Email-2FA-Switch?expand=1#diff-9141c713562d914ed94a58f24f6832509aff6239a2a97a04475aa07cc0369e51)** Adds logic to send the email when the user switches to email 2FA.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/148839008/e32cd454-62cf-4924-9b03-97ff2ef08069



## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
