### PR TITLE
BIT-1970: Password history IDs

### DIFF
--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListView.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListView.swift
@@ -90,10 +90,12 @@ struct PasswordHistoryListView: View {
         HStack(spacing: 16) {
             VStack(alignment: .leading, spacing: 2) {
                 PasswordText(password: passwordHistory.password, isPasswordVisible: true)
+                    .accessibilityIdentifier("GeneratedPasswordValue")
 
                 FormattedDateTimeView(date: passwordHistory.lastUsedDate)
                     .styleGuide(.subheadline)
                     .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                    .accessibilityIdentifier("GeneratedPasswordDateLabel")
             }
             .padding(.vertical, 10)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -107,6 +109,7 @@ struct PasswordHistoryListView: View {
                     .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
             }
             .accessibilityLabel(Localizations.copyPassword)
+            .accessibilityIdentifier("CopyPasswordValueButton")
         }
         .accessibilityElement(children: .combine)
         .accessibilityAction(named: Localizations.copyPassword) {


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1970](https://livefront.atlassian.net/browse/BIT-1970?atlOrigin=eyJpIjoiMGExY2VkYTBiNzNiNDhkY2I3MjM4MTRjZTViZGU1Y2UiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to password history screen.

## 📋 Code changes
-   **PasswordHistoryListView.swift:** Adds accessibility IDs to password history row elements.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
