### PR TITLE
BIT-1163: Generate unset avatar colors based on user ID

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -610,11 +610,10 @@ extension DefaultAuthRepository: AuthRepository {
             .getVaultTimeout(userId: account.profile.userId)) == .never
         let displayAsUnlocked = !isLocked || hasNeverLock
 
-        var color: Color = .clear
-        if let avatarColor = account.profile.avatarColor {
-            color = Color(hex: avatarColor)
+        let color = if let avatarColor = account.profile.avatarColor {
+            Color(hex: avatarColor)
         } else {
-            color = Color(asset: Asset.Colors.primaryBitwardenLight)
+            account.profile.userId.hashColor
         }
 
         return ProfileSwitcherItem(

--- a/BitwardenShared/UI/Platform/Application/Extensions/String.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/String.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 // MARK: - URLDecodingError
 
@@ -29,6 +30,21 @@ extension String {
 
     // MARK: Properties
 
+    /// Returns a color that's generated from the hash of the characters in the string. This can be
+    /// used to create a consistent color based on the provided string.
+    var hashColor: Color {
+        let hash = unicodeScalars.reduce(into: 0) { result, scalar in
+            result = Int(scalar.value) + ((result << 5) &- result)
+        }
+
+        let color = (0 ..< 3).reduce(into: "#") { result, index in
+            let value = (hash >> (index * 8)) & 0xFF
+            result += String(value, radix: 16).leftPadding(toLength: 2, withPad: "0")
+        }
+
+        return Color(hex: color)
+    }
+
     /// A flag indicating if this string is considered a valid email address or not.
     ///
     /// An email is considered valid if it has at least one `@` symbol in it.
@@ -55,6 +71,23 @@ extension String {
     }
 
     // MARK: Methods
+
+    /// Returns a copy of the string, padded to the specified length on the left side with the
+    /// provided padding character.
+    ///
+    /// - Parameters:
+    ///   - toLength: The length of the string to return. If the string's length is less than this,
+    ///     it will be padded with the provided character on the left/leading side.
+    ///   - character: The character to use for padding.
+    /// - Returns: A copy of the string, padded to the specified length on the left side.
+    ///
+    func leftPadding(toLength: Int, withPad character: Character) -> String {
+        if count < toLength {
+            return String(repeatElement(character, count: toLength - count)) + self
+        } else {
+            return String(suffix(toLength))
+        }
+    }
 
     /// Creates a new string that has been encoded for use in a url or request header.
     ///

--- a/BitwardenShared/UI/Platform/Application/Extensions/StringTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/StringTests.swift
@@ -7,6 +7,13 @@ import XCTest
 class StringTests: BitwardenTestCase {
     // MARK: Tests
 
+    /// `hashColor` returns a color generated from a hash of the string's characters.
+    func test_hashColor() {
+        XCTAssertEqual("test".hashColor.description, "#924436FF")
+        XCTAssertEqual("0620ee30-91c3-40cb-8fad-b102005c35b0".hashColor.description, "#32F23FFF")
+        XCTAssertEqual("9c303aee-e636-4760-94b6-e4951d7b0abb".hashColor.description, "#C96CD2FF")
+    }
+
     /// `isValidEmail` with an invalid string returns `false`.
     func test_isValidEmail_withInvalidString() {
         let subjects = [
@@ -54,6 +61,14 @@ class StringTests: BitwardenTestCase {
         XCTAssertFalse("a b c".isValidURL)
         XCTAssertFalse("a<b>c".isValidURL)
         XCTAssertFalse("a[b]c".isValidURL)
+    }
+
+    /// `leftPadding(toLength:withPad:)` returns a string padded to the specified length.
+    func test_leftPadding() {
+        XCTAssertEqual("".leftPadding(toLength: 2, withPad: "0"), "00")
+        XCTAssertEqual("AB".leftPadding(toLength: 4, withPad: "0"), "00AB")
+        XCTAssertEqual("ABCD".leftPadding(toLength: 4, withPad: "0"), "ABCD")
+        XCTAssertEqual("ABCDEF".leftPadding(toLength: 4, withPad: "0"), "CDEF")
     }
 
     /// `urlDecoded()` with an invalid string throws an error.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1163](https://livefront.atlassian.net/browse/BIT-1163)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

For users that don't have an avatar color set on their profile, generate one based on their user ID to maintain a consistent avatar color across platforms.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AuthRepository.swift:** Default to color based on user ID hash if user has no avatar color set.
- **String.swift:** Generate a color based on the characters in a string.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <img width="559" alt="Screenshot 2024-03-08 at 9 47 40 AM" src="https://github.com/bitwarden/ios/assets/126492398/af64446f-d876-4a31-8930-fbbc76b0a35b"> | <img width="559" alt="Screenshot 2024-03-08 at 9 47 05 AM" src="https://github.com/bitwarden/ios/assets/126492398/87ab5d44-fe77-49a3-8193-8154c47d7301"> |

| Native | Xamarin |
| --- | --- |
| <img width="559" alt="Screenshot 2024-03-08 at 9 47 05 AM" src="https://github.com/bitwarden/ios/assets/126492398/87ab5d44-fe77-49a3-8193-8154c47d7301"> | <img width="559" src="https://github.com/bitwarden/ios/assets/126492398/4377501b-6e9a-4737-9b9f-9f3e7dc1ad5d"> |

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
