### PR TITLE
BIT-1991: Settings IDs

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -36,36 +36,42 @@ struct SettingsView: View {
             } trailingContent: {
                 chevron
             }
+            .accessibilityIdentifier("AccountSecuritySettingsButton")
 
             SettingsListItem(Localizations.autofill) {
                 store.send(.autoFillPressed)
             } trailingContent: {
                 chevron
             }
+            .accessibilityIdentifier("AutofillSettingsButton")
 
             SettingsListItem(Localizations.vault) {
                 store.send(.vaultPressed)
             } trailingContent: {
                 chevron
             }
+            .accessibilityIdentifier("VaultSettingsButton")
 
             SettingsListItem(Localizations.appearance) {
                 store.send(.appearancePressed)
             } trailingContent: {
                 chevron
             }
+            .accessibilityIdentifier("AppearanceSettingsButton")
 
             SettingsListItem(Localizations.other) {
                 store.send(.otherPressed)
             } trailingContent: {
                 chevron
             }
+            .accessibilityIdentifier("OtherSettingsButton")
 
             SettingsListItem(Localizations.about, hasDivider: false) {
                 store.send(.aboutPressed)
             } trailingContent: {
                 chevron
             }
+            .accessibilityIdentifier("AboutSettingsButton")
         }
         .cornerRadius(10)
     }


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1991](https://livefront.atlassian.net/browse/BIT-1991?atlOrigin=eyJpIjoiM2M4YzBiYzAxYjE3NGNmNzg2YWQzMTMyZTFlZjIwOTQiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to the settings page.

## 📋 Code changes
-   **SettingsView.swift:** Adds accessibility IDs to elements within the view.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
