### PR TITLE
BIT-2049: Default owner and collection when adding a new item from within a collection

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -196,6 +196,11 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
                 .fetchCipherOwnershipOptions(includePersonal: !isPersonalOwnershipDisabled)
 
             state.collections = try await services.vaultRepository.fetchCollections(includeReadOnly: false)
+            // Filter out any collection IDs that aren't included in the fetched collections.
+            state.collectionIds = state.collectionIds.filter { collectionId in
+                state.collections.contains(where: { $0.id == collectionId })
+            }
+
             state.isPersonalOwnershipDisabled = isPersonalOwnershipDisabled
             state.ownershipOptions = ownershipOptions
             if isPersonalOwnershipDisabled, state.organizationId == nil {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2049](https://livefront.atlassian.net/browse/BIT-2049)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When adding a new cipher from within an organization group view, the cipher's owner and collection should default to the collection and organization for the group which was being shown.


## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **AddEditItemProcessor.swift:** Only overwrite the owner if personal ownership is disabled and there isn't already an organization ID set.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <video src="https://github.com/bitwarden/ios/assets/126492398/5124cb25-f924-4f3b-be64-70413013af7f" > | <video src="https://github.com/bitwarden/ios/assets/126492398/88407166-bb8c-42a9-9b50-09c8b328561f" > |

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
