### PR TITLE
BIT-2020: Include key when updating a cipher

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
@@ -34,6 +34,9 @@ struct CipherRequestModel: JSONRequestBody {
     /// Login data if the cipher is a login.
     let login: CipherLoginModel?
 
+    /// The cipher's key.
+    let key: String?
+
     /// The name of the cipher.
     let name: String
 
@@ -75,6 +78,7 @@ extension CipherRequestModel {
             identity: cipher.identity.map(CipherIdentityModel.init),
             lastKnownRevisionDate: cipher.revisionDate,
             login: cipher.login.map(CipherLoginModel.init),
+            key: cipher.key,
             name: cipher.name,
             notes: cipher.notes,
             organizationID: cipher.organizationId,


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-2020](https://livefront.atlassian.net/browse/BIT-2020?atlOrigin=eyJpIjoiZGEyMjAyZWY1M2E1NDY1ZTk0MWZlYThhZjc1ZTc0NjkiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Includes the cipher key in the `CipherRequestModel`, which will be used for individual cipher encryption/decryption.

## 📋 Code changes
-   **CipherRequestModel.swift:** Adds a `key` parameter that will be used for individual cipher encryption/decryption.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
