### PR TITLE
BIT-2045: Display alert before cloning cipher without passkey

### DIFF
--- a/BitwardenShared/Core/Vault/Models/API/CipherLoginFido2Credential.swift
+++ b/BitwardenShared/Core/Vault/Models/API/CipherLoginFido2Credential.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+// MARK: - CipherLoginFido2Credential
+
 /// API model for a login cipher's FIDO2 credential.
 ///
 struct CipherLoginFido2Credential: Codable, Equatable {

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -4,6 +4,22 @@ import UIKit
 // MARK: - Alert+Vault
 
 extension Alert {
+    /// Returns an alert confirming whether to clone an item without the FIDO2 credential.
+    ///
+    /// - Parameter action: The action to perform if the user confirms.
+    /// - Returns: An alert confirming whether to clone an item without the FIDO2 credential.
+    ///
+    static func confirmCloneExcludesFido2Credential(action: @escaping () async -> Void) -> Alert {
+        Alert(
+            title: Localizations.passkeyWillNotBeCopied,
+            message: Localizations.thePasskeyWillNotBeCopiedToTheClonedItemDoYouWantToContinueCloningThisItem,
+            alertActions: [
+                AlertAction(title: Localizations.yes, style: .default) { _, _ in await action() },
+                AlertAction(title: Localizations.no, style: .cancel),
+            ]
+        )
+    }
+
     /// Present an alert confirming deleting an attachment.
     ///
     /// - Parameter action: The action to perform if the user confirms.

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -3,6 +3,31 @@ import XCTest
 @testable import BitwardenShared
 
 class AlertVaultTests: BitwardenTestCase {
+    /// `confirmCloneExcludesFido2Credential(action:)` constructs an alert to confirm whether to
+    /// clone the item without the FIDO2 credential.
+    func test_confirmCloneExcludesFido2Credential() async throws {
+        var actionCalled: Bool?
+        let subject = Alert.confirmCloneExcludesFido2Credential { actionCalled = true }
+
+        XCTAssertEqual(subject.title, Localizations.passkeyWillNotBeCopied)
+        XCTAssertEqual(
+            subject.message,
+            Localizations.thePasskeyWillNotBeCopiedToTheClonedItemDoYouWantToContinueCloningThisItem
+        )
+        XCTAssertEqual(subject.alertActions.count, 2)
+
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.yes)
+        XCTAssertEqual(subject.alertActions[0].style, .default)
+        try await subject.tapAction(title: Localizations.yes)
+        XCTAssertEqual(actionCalled, true)
+        actionCalled = nil
+
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.no)
+        XCTAssertEqual(subject.alertActions[1].style, .cancel)
+        try await subject.tapAction(title: Localizations.no)
+        XCTAssertNil(actionCalled)
+    }
+
     /// `confirmDeleteAttachment(action:)` shows an `Alert` that asks the user to confirm deleting
     /// an attachment.
     func test_confirmDeleteAttachment() {

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -238,7 +238,7 @@ struct CipherItemState: Equatable {
             isFavoriteOn: cipherView.favorite,
             isMasterPasswordRePromptOn: cipherView.reprompt == .password,
             isPersonalOwnershipDisabled: false,
-            loginState: cipherView.loginItemState(showTOTP: hasPremium),
+            loginState: cipherView.loginItemState(excludeFido2Credentials: true, showTOTP: hasPremium),
             name: "\(cipherView.name) - \(Localizations.clone)",
             notes: cipherView.notes ?? "",
             organizationId: cipherView.organizationId,

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -9,7 +9,7 @@ class CipherItemStateTests: BitwardenTestCase {
 
     /// `init(cloneItem: hasPremium)` returns a cloned CipherItemState.
     func test_init_clone() {
-        let cipher = CipherView.loginFixture()
+        let cipher = CipherView.loginFixture(login: .fixture(fido2Credentials: [.fixture()]))
         let state = CipherItemState(cloneItem: cipher, hasPremium: true)
         XCTAssertEqual(state.name, "\(cipher.name) - \(Localizations.clone)")
         XCTAssertNil(state.cipher.id)
@@ -22,7 +22,8 @@ class CipherItemStateTests: BitwardenTestCase {
         XCTAssertEqual(state.identityState, cipher.identityItemState())
         XCTAssertEqual(state.isFavoriteOn, cipher.favorite)
         XCTAssertEqual(state.isMasterPasswordRePromptOn, cipher.reprompt == .password)
-        XCTAssertEqual(state.loginState, cipher.loginItemState(showTOTP: true))
+        XCTAssertEqual(state.loginState, cipher.loginItemState(excludeFido2Credentials: true, showTOTP: true))
+        XCTAssertTrue(state.loginState.fido2Credentials.isEmpty)
         XCTAssertEqual(state.notes, cipher.notes ?? "")
         XCTAssertEqual(state.type, .init(type: cipher.type))
         XCTAssertEqual(state.updatedDate, cipher.revisionDate)

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
@@ -144,11 +144,9 @@ class VaultItemCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(view.store.state.folderId, "12345")
     }
 
-    /// `navigate(to:)` with `.cloneItem()`  triggers the show clone item flow.
+    /// `navigate(to:)` with `.cloneItem()` triggers the show clone item flow.
     func test_navigateTo_cloneItem_nonPremium() throws {
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
-        subject.navigate(to: .cloneItem(cipher: .loginFixture()), context: subject)
-        waitFor(!stackNavigator.actions.isEmpty)
+        subject.navigate(to: .cloneItem(cipher: .loginFixture(), hasPremium: false), context: subject)
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .replaced)

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemRoute.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemRoute.swift
@@ -34,9 +34,11 @@ enum VaultItemRoute: Equatable, Hashable {
 
     /// A route to the clone item screen.
     ///
-    /// - Parameter cipher: A  `CipherView` to be cloned.
+    /// - Parameters:
+    ///   - cipher: A `CipherView` to be cloned.
+    ///   - hasPremium: Whether the user has premium.
     ///
-    case cloneItem(cipher: CipherView)
+    case cloneItem(cipher: CipherView, hasPremium: Bool)
 
     /// A route to dismiss the screen currently presented modally.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
@@ -89,15 +89,20 @@ extension CipherView {
     /// which is used to manage and display login data in the UI.
     ///
     /// - Parameters:
+    ///   - excludeFido2Credentials: Whether to exclude copying any FIDO2 credentials from the login item.
     ///   - showPassword: A Boolean value indicating whether the password should be visible.
     ///   - showTOTP: A Boolean value indicating whether TOTP should be visible.
     ///
     /// - Returns: A `LoginItemState` representing the login information of the cipher.
     ///
-    func loginItemState(showPassword: Bool = false, showTOTP: Bool) -> LoginItemState {
+    func loginItemState(
+        excludeFido2Credentials: Bool = false,
+        showPassword: Bool = false,
+        showTOTP: Bool
+    ) -> LoginItemState {
         LoginItemState(
             canViewPassword: viewPassword,
-            fido2Credentials: login?.fido2Credentials ?? [],
+            fido2Credentials: excludeFido2Credentials ? [] : login?.fido2Credentials ?? [],
             isPasswordVisible: showPassword,
             isTOTPAvailable: showTOTP,
             password: login?.password ?? "",

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherViewUpdateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherViewUpdateTests.swift
@@ -25,6 +25,37 @@ final class CipherViewUpdateTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `loginItemState()` doesn't exclude the FIDO2 credential when `excludeFido2Credentials` is false.
+    func test_loginItemState_excludeFido2Credential_false() {
+        let cipherView = CipherView.fixture(
+            login: .fixture(
+                fido2Credentials: [
+                    .fixture(),
+                ]
+            )
+        )
+
+        let loginItemState = cipherView.loginItemState(excludeFido2Credentials: false, showTOTP: false)
+        XCTAssertEqual(
+            loginItemState.fido2Credentials,
+            [.fixture()]
+        )
+    }
+
+    /// `loginItemState()` excludes the FIDO2 credential when `excludeFido2Credentials` is true.
+    func test_loginItemState_excludeFido2Credential_true() {
+        let cipherView = CipherView.fixture(
+            login: .fixture(
+                fido2Credentials: [
+                    .fixture(),
+                ]
+            )
+        )
+
+        let loginItemState = cipherView.loginItemState(excludeFido2Credentials: true, showTOTP: false)
+        XCTAssertTrue(loginItemState.fido2Credentials.isEmpty)
+    }
+
     /// Tests that the update succeeds with new properties.
     func test_update_card_edits_succeeds() {
         cipherItemState.type = .card


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2045](https://livefront.atlassian.net/browse/BIT-2045)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Before cloning a login cipher with a passkey, present an alert notifying the user that cloning a cipher won't include the passkey and confirm they want to continue before cloning the cipher.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Alert+Vault.swift:** Adds the confirmation alert for cloning a cipher with a passkey.
- **CipherItemState.swift:** Exclude the passkey when cloning.
- **VaultItemCoordinator.swift:** Fixes a presentation glitch when cloning an item by removing the task prior to presenting the view.
- **ViewItemProcessor.swift:** Shows a confirmation alert prior to cloning a cipher with a passkey.
- **CipherView+Update.swift:** Excludes the passkey if needed when creating a login state.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/04f55c4d-d292-49c3-8718-47956e47ec06


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
