### PR TITLE
BIT-273: Rename old unit tests to follow standard

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/ErrorResponseModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/ErrorResponseModelTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 class ErrorResponseModelTests: BitwardenTestCase {
     /// Tests that `singleMessage()` returns the validation error's message.
-    func testSingleMessage() throws {
+    func test_singleMessage() throws {
         let json = APITestData.createAccountAccountAlreadyExists.data
         let decoder = JSONDecoder()
         let subject = try decoder.decode(ErrorResponseModel.self, from: json)
@@ -14,7 +14,7 @@ class ErrorResponseModelTests: BitwardenTestCase {
     }
 
     /// Tests that `singleMessage()` returns an error message when there are no validation errors.
-    func testSingleMessageNilValidationErrors() throws {
+    func test_singleMessage_nilValidationErrors() throws {
         let json = APITestData.createAccountNilValidationErrors.data
         let decoder = JSONDecoder()
         let subject = try decoder.decode(ErrorResponseModel.self, from: json)

--- a/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModelTests.swift
@@ -8,7 +8,7 @@ class ResponseValidationErrorModelTests: BitwardenTestCase {
     // MARK: - Tests
 
     /// Tests that a response is initialized correctly.
-    func testInit() {
+    func test_init() {
         let subject = ResponseValidationErrorModel(
             error: "invalid_input",
             errorDescription: "invalid_username",

--- a/BitwardenShared/Core/Auth/Repositories/Extensions/SequenceAsyncTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/Extensions/SequenceAsyncTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class SequenceAsyncTests: BitwardenTestCase {
     /// `asyncMap` correctly maps each element.
-    func testAsyncMapSuccess() async {
+    func test_asyncMap_success() async {
         let input = [1, 2, 3]
         let output = await input.asyncMap { number in
             await asyncDouble(number)
@@ -13,7 +13,7 @@ final class SequenceAsyncTests: BitwardenTestCase {
     }
 
     /// `asyncMap` correctly propagates errors.
-    func testAsyncMapWithError() async {
+    func test_asyncMap_error() async {
         let input = [1, 2, 3]
         await assertAsyncThrows {
             _ = try await input.asyncMap { number in

--- a/BitwardenShared/Core/Platform/Utilities/AnyCodableTests.swift
+++ b/BitwardenShared/Core/Platform/Utilities/AnyCodableTests.swift
@@ -50,7 +50,7 @@ class AnyCodableTests: BitwardenTestCase {
     }
 
     /// `AnyCodable` can be used to encode JSON.
-    func testEncode() throws {
+    func test_encode() throws {
         let dictionary: [String: AnyCodable] = [
             "minComplexity": AnyCodable.null,
             "minLength": AnyCodable.int(12),

--- a/Networking/Tests/NetworkingTests/Extensions/URLSessionHTTPClientTests.swift
+++ b/Networking/Tests/NetworkingTests/Extensions/URLSessionHTTPClientTests.swift
@@ -22,7 +22,7 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
 
     /// `send(_:)` performs the request and returns the response for a 200 status request.
-    func testSendSuccess200() async throws {
+    func test_send_success200() async throws {
         let urlResponse = HTTPURLResponse(
             url: URL(string: "https://example.com")!,
             statusCode: 200,
@@ -47,7 +47,7 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
 
     /// `send(_:)` performs the request and returns the response for a 500 status request.
-    func testSendSuccess500() async throws {
+    func test_send_success500() async throws {
         let urlResponse = HTTPURLResponse(
             url: URL(string: "https://example.com")!,
             statusCode: 500,
@@ -69,7 +69,7 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
 
     /// `send(_:)` performs the request and throws an error if one occurs.
-    func testSendError() async throws {
+    func test_send_error() async throws {
         URLProtocolMocking.mock(
             HTTPRequest.default.url,
             with: .failure(NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil))

--- a/Networking/Tests/NetworkingTests/HTTPRequestTests.swift
+++ b/Networking/Tests/NetworkingTests/HTTPRequestTests.swift
@@ -13,7 +13,7 @@ class HTTPRequestTests: XCTestCase {
     }
 
     /// The initializer provides default values.
-    func testInitDefaultValues() {
+    func test_init_defaultValues() {
         let subject = HTTPRequest(url: URL(string: "https://example.com")!)
 
         XCTAssertNil(subject.body)
@@ -23,7 +23,7 @@ class HTTPRequestTests: XCTestCase {
     }
 
     /// The initializer sets the item's properties.
-    func testInit() throws {
+    func test_init() throws {
         let subject = HTTPRequest(
             url: URL(string: "https://example.com/json")!,
             method: .post,
@@ -50,7 +50,7 @@ class HTTPRequestTests: XCTestCase {
     }
 
     /// `init(request:baseURL)` builds a `HTTPRequest` from a `Request` object.
-    func testInitRequest() throws {
+    func test_init_request() throws {
         let subject = try HTTPRequest(
             request: TestRequest(),
             baseURL: URL(string: "https://example.com/")!

--- a/Networking/Tests/NetworkingTests/HTTPResponseTests.swift
+++ b/Networking/Tests/NetworkingTests/HTTPResponseTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class HTTPResponseTests: XCTestCase {
     /// The initializer sets the item's properties.
-    func testInit() {
+    func test_init() {
         let subject = HTTPResponse(
             url: URL(string: "https://example.com")!,
             statusCode: 200,
@@ -20,7 +20,7 @@ class HTTPResponseTests: XCTestCase {
     }
 
     /// The initializer sets the item's properties with a `HTTPURLResponse`.
-    func testInitResponse() throws {
+    func test_init_httpUrlResponse() throws {
         let subject = try HTTPResponse(
             data: "response body".data(using: .utf8)!,
             response: XCTUnwrap(HTTPURLResponse(
@@ -42,7 +42,7 @@ class HTTPResponseTests: XCTestCase {
     }
 
     /// Initializing an `HTTPResponse` with an `URLResponse` vs a `HTTPURLResponse` throws an error.
-    func testInitWithURLResponseThrowsError() {
+    func test_init_urlResponse_error() {
         let urlResponse = URLResponse(
             url: URL(string: "https://example.com")!,
             mimeType: nil,

--- a/Networking/Tests/NetworkingTests/RequestTests.swift
+++ b/Networking/Tests/NetworkingTests/RequestTests.swift
@@ -9,7 +9,7 @@ class RequestTests: XCTestCase {
     }
 
     /// `Request` default.
-    func testRequest() {
+    func test_request() {
         let request = DefaultRequest()
         XCTAssertEqual(request.method, .get)
         XCTAssertNil(request.body)

--- a/Networking/Tests/NetworkingTests/ResponseTests.swift
+++ b/Networking/Tests/NetworkingTests/ResponseTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ResponseTests: XCTestCase {
     /// Test creating a `Response` from JSON.
-    func testJSONResponse() throws {
+    func test_jsonresponse() throws {
         let httpResponse = HTTPResponse(
             url: URL(string: "http://example.com")!,
             statusCode: 200,
@@ -17,7 +17,7 @@ class ResponseTests: XCTestCase {
     }
 
     /// Test creating a `Response` from a JSON array.
-    func testJSONArray() throws {
+    func test_jsonresponse_array() throws {
         let httpResponse = HTTPResponse(
             url: URL(string: "http://example.com")!,
             statusCode: 200,


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-273](https://livefront.atlassian.net/browse/BIT-273) - Rename all of the unit tests in Networking to follow our new unit test naming scheme

## 🚧 Type of change

-   🧹 Tech debt (refactoring, code cleanup, dependency upgrades, etc.)

## 📔 Objective

Various unit tests were named with camel case (`testInit`), while the standard in the codebase is underscores between camel case components (`test_init`). This unifies all the old tests to that new standard

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
