### PR TITLE
BIT-2031: Don't require master password reprompt for copying a custom text field value

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -13,7 +13,7 @@ enum ViewItemAction: Equatable {
     ///   - value: The value to copy.
     ///   - field: The field being copied.
     ///
-    case copyPressed(value: String, field: CopyableField? = nil)
+    case copyPressed(value: String, field: CopyableField)
 
     /// The visibility button was pressed for the specified custom field.
     case customFieldVisibilityPressed(CustomFieldState)
@@ -45,14 +45,15 @@ enum ViewItemAction: Equatable {
     var requiresMasterPasswordReprompt: Bool {
         switch self {
         case .cardItemAction,
-             .copyPressed,
              .customFieldVisibilityPressed,
              .editPressed,
+             .morePressed,
              .passwordVisibilityPressed:
             true
+        case let .copyPressed(_, field):
+            field.requiresMasterPasswordReprompt
         case .dismissPressed,
              .downloadAttachment,
-             .morePressed,
              .passwordHistoryPressed,
              .toastShown:
             false
@@ -67,6 +68,12 @@ enum ViewItemAction: Equatable {
 enum CopyableField {
     /// The card number field.
     case cardNumber
+
+    /// A custom hidden field.
+    case customHiddenField
+
+    /// A custom text field.
+    case customTextField
 
     /// The password field.
     case password
@@ -83,11 +90,31 @@ enum CopyableField {
     /// The username field.
     case username
 
+    /// Whether copying the field requires the user to be reprompted for their master password, if
+    /// master password reprompt is enabled.
+    var requiresMasterPasswordReprompt: Bool {
+        switch self {
+        case .cardNumber,
+             .customHiddenField,
+             .password,
+             .securityCode,
+             .totp:
+            true
+        case .customTextField,
+             .uri,
+             .username:
+            false
+        }
+    }
+
     /// The localized name for each field.
-    var localizedName: String {
+    var localizedName: String? {
         switch self {
         case .cardNumber:
             Localizations.number
+        case .customHiddenField,
+             .customTextField:
+            nil
         case .password:
             Localizations.password
         case .securityCode:

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class ViewItemActionTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `requiresMasterPasswordReprompt` returns whether the user's master password needs to be
+    /// entered again before performing the action if master password reprompt is enabled.
+    func test_requiresMasterPasswordReprompt() {
+        XCTAssertTrue(ViewItemAction.cardItemAction(.toggleCodeVisibilityChanged(false)).requiresMasterPasswordReprompt)
+
+        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .cardNumber).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .customHiddenField).requiresMasterPasswordReprompt)
+        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .customTextField).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .password).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .securityCode).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .totp).requiresMasterPasswordReprompt)
+        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .uri).requiresMasterPasswordReprompt)
+        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .username).requiresMasterPasswordReprompt)
+
+        XCTAssertTrue(
+            ViewItemAction.customFieldVisibilityPressed(CustomFieldState(id: "1", type: .hidden))
+                .requiresMasterPasswordReprompt
+        )
+
+        XCTAssertFalse(ViewItemAction.dismissPressed.requiresMasterPasswordReprompt)
+
+        XCTAssertFalse(ViewItemAction.downloadAttachment(.fixture()).requiresMasterPasswordReprompt)
+
+        XCTAssertTrue(ViewItemAction.editPressed.requiresMasterPasswordReprompt)
+
+        XCTAssertTrue(ViewItemAction.morePressed(.attachments).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.morePressed(.clone).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.morePressed(.editCollections).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.morePressed(.moveToOrganization).requiresMasterPasswordReprompt)
+
+        XCTAssertFalse(ViewItemAction.passwordHistoryPressed.requiresMasterPasswordReprompt)
+
+        XCTAssertTrue(ViewItemAction.passwordVisibilityPressed.requiresMasterPasswordReprompt)
+
+        XCTAssertFalse(ViewItemAction.toastShown(nil).requiresMasterPasswordReprompt)
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -107,7 +107,7 @@ struct ViewItemDetailsView: View {
                                         store.send(.customFieldVisibilityPressed(customField))
                                     }
                                     Button {
-                                        store.send(.copyPressed(value: value))
+                                        store.send(.copyPressed(value: value, field: .customHiddenField))
                                     } label: {
                                         Asset.Images.copy.swiftUIImage
                                             .resizable()
@@ -115,7 +115,7 @@ struct ViewItemDetailsView: View {
                                     }
                                 case .text:
                                     Button {
-                                        store.send(.copyPressed(value: value))
+                                        store.send(.copyPressed(value: value, field: .customTextField))
                                     } label: {
                                         Asset.Images.copy.swiftUIImage
                                             .resizable()

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -88,6 +88,10 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
             }
         case .deletePressed:
             guard case let .data(cipherState) = state.loadingState else { return }
+            guard !state.isMasterPasswordRequired else {
+                presentMasterPasswordRepromptAlert { await self.perform(effect) }
+                return
+            }
             if cipherState.cipher.deletedDate == nil {
                 await showSoftDeleteConfirmation(cipherState.cipher)
             } else {
@@ -102,7 +106,7 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
 
     override func receive(_ action: ViewItemAction) {
         guard !state.isMasterPasswordRequired || !action.requiresMasterPasswordReprompt else {
-            presentMasterPasswordRepromptAlert(for: action)
+            presentMasterPasswordRepromptAlert { self.receive(action) }
             return
         }
         switch action {
@@ -180,7 +184,7 @@ private extension ViewItemProcessor {
     private func copyValue(_ value: String, _ field: CopyableField?) {
         services.pasteboardService.copy(value)
 
-        let localizedFieldName = if let field { field.localizedName } else { Localizations.value }
+        let localizedFieldName = field?.localizedName ?? Localizations.value
         state.toast = Toast(text: Localizations.valueHasBeenCopied(localizedFieldName))
     }
 
@@ -311,9 +315,10 @@ private extension ViewItemProcessor {
     /// Presents the master password re-prompt alert for the specified action. This method will
     /// process the action once the master password has been verified.
     ///
-    /// - Parameter action: The action to process once the password has been verified.
+    /// - Parameter completion: A closure containing the action to perform once the password has
+    ///     been verified.
     ///
-    private func presentMasterPasswordRepromptAlert(for action: ViewItemAction) {
+    private func presentMasterPasswordRepromptAlert(completion: @escaping () async -> Void) {
         let alert = Alert.masterPasswordPrompt { [weak self] password in
             guard let self else { return }
 
@@ -324,7 +329,7 @@ private extension ViewItemProcessor {
                     return
                 }
                 state.hasVerifiedMasterPassword = true
-                receive(action)
+                await completion()
             } catch {
                 services.errorReporter.log(error: error)
             }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2031](https://livefront.atlassian.net/browse/BIT-2031)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This removes the need to reprompt for a master password when copying a custom text field value which is already visible. 

This also requires master password reprompt for any of the options in the more/kebab menu (delete, attachments, clone, move to organization). This matches the Xamarin behavior.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **ViewItemAction.swift:** Break out requirements for master password reprompt when copying a field by the field type.
- **ViewItemProcessor.swift:** Require master password reprompt for the delete effect and actions that require it.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/39d73b07-44ce-40d7-852c-79a8ef6b6b0f


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
