### PR TITLE
BIT-1940: Add accessibility ID to current vault information

### DIFF
--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -64,7 +64,14 @@ struct VaultUnlockView: View {
     @ViewBuilder var scrollView: some View {
         ScrollView {
             VStack(spacing: 24) {
-                textField
+                VStack(alignment: .leading, spacing: 8) {
+                    textField
+
+                    Text(footerText)
+                        .styleGuide(.footnote)
+                        .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                        .accessibilityIdentifier("UserAndEnvironmentDataLabel")
+                }
 
                 biometricAuthButton
 
@@ -137,7 +144,7 @@ struct VaultUnlockView: View {
                     get: \.masterPassword,
                     send: VaultUnlockAction.masterPasswordChanged
                 ),
-                footer: footerText,
+                footer: nil,
                 accessibilityIdentifier: "MasterPasswordEntry",
                 passwordVisibilityAccessibilityId: "PasswordVisibilityToggle",
                 isPasswordVisible: store.binding(
@@ -159,7 +166,7 @@ struct VaultUnlockView: View {
                     get: \.pin,
                     send: VaultUnlockAction.pinChanged
                 ),
-                footer: footerText,
+                footer: nil,
                 accessibilityIdentifier: "PinEntry",
                 passwordVisibilityAccessibilityId: "PinVisibilityToggle",
                 isPasswordVisible: store.binding(


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1940](https://livefront.atlassian.net/browse/BIT-1940) - Adding missing element IDs to Unlock Page

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

This adds an ID to the "logged in as [user] on [server]" text on the Vault Unlock Screen. This did require pulling that text from being a footer of the password/pin entry fields and into a separate Text element itself.

## 📋 Code changes

- **VaultUnlockView.swift**: Text broken out and ID added

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
