### PR TITLE
BIT-2116: Fix policy type decoding error for new policy

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyType.swift
@@ -33,4 +33,18 @@ enum PolicyType: Int, Codable {
 
     /// Disable personal vault export.
     case disablePersonalVaultExport = 10
+
+    /// Activates autofill with page load on the browser extension.
+    case activateAutofill = 11
+
+    /// An unknown policy type.
+    case unknown = -1
+
+    // MARK: Initialization
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(RawValue.self)
+        self = Self(rawValue: rawValue) ?? .unknown
+    }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyTypeTests.swift
@@ -1,0 +1,35 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class PolicyTypeTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `init(from:)` decodes an integer value to the `PolicyType` enum.
+    func test_init_decoder() {
+        XCTAssertEqual(
+            try JSONDecoder().decode(PolicyType.self, from: #"0"#.data(using: .utf8)!),
+            PolicyType.twoFactorAuthentication
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(PolicyType.self, from: #"1"#.data(using: .utf8)!),
+            PolicyType.masterPassword
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(PolicyType.self, from: #"10"#.data(using: .utf8)!),
+            PolicyType.disablePersonalVaultExport
+        )
+    }
+
+    /// `init(from:)` decodes an invalid or unknown value as `PolicyType.unknown`.
+    func test_init_decoder_invalidValue() {
+        XCTAssertEqual(
+            try JSONDecoder().decode(PolicyType.self, from: #"-1"#.data(using: .utf8)!),
+            PolicyType.unknown
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(PolicyType.self, from: #"9999"#.data(using: .utf8)!),
+            PolicyType.unknown
+        )
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2116](https://livefront.atlassian.net/browse/BIT-2116)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

There was a new policy type added which was causing a decoding error. This adds the new `PolicyType` and handles an unknown policy type without throwing a syncing error.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **PolicyType.swift:** Adds the new policy and handles an unknown policy.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
