### PR TITLE
BIT-2085: Add accessibility IDs to Move to Organization screen

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenMenuField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenMenuField.swift
@@ -70,7 +70,6 @@ struct BitwardenMenuField<T, TrailingContent: View>: View where T: Menuable {
             } label: {
                 Text("")
             }
-            .accessibilityIdentifier(accessibilityIdentifier ?? "")
         } label: {
             HStack {
                 Text(selection.localizedName)
@@ -85,6 +84,7 @@ struct BitwardenMenuField<T, TrailingContent: View>: View where T: Menuable {
         }
         .styleGuide(.body)
         .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 
     // MARK: Initialization

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationView.swift
@@ -45,6 +45,7 @@ struct MoveToOrganizationView: View {
                         Text(collection.name)
                     }
                     .toggleStyle(.bitwarden)
+                    .accessibilityIdentifier("CollectionItemCell")
                 }
             }
         }
@@ -72,6 +73,7 @@ struct MoveToOrganizationView: View {
             BitwardenMenuField(
                 title: Localizations.organization,
                 footer: Localizations.moveToOrgDesc,
+                accessibilityIdentifier: "OrganizationListDropdown",
                 options: store.state.ownershipOptions,
                 selection: store.binding(
                     get: { _ in owner },


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2085](https://livefront.atlassian.net/browse/BIT-2085)

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds requested accessibility IDs to the "Move to Organization" screen. As well, the `BitwardenMenuField` view had to be updated to move where the accessibility ID is applied in order for it to show up in the accessibility inspector

## 📋 Code changes

- **MoveToOrganizationView.swift**: Added IDs
- **BitwardenMenuField.swift**: Applied `accessibilityIdentifier` to the entire `Menu` instead of just the `Picker` because applying it to just the `Picker` wasn't working

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
