### PR TITLE
BIT-1721: Add Copy TOTP option to login options

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
@@ -133,6 +133,7 @@ class AlertTests: BitwardenTestCase {
         )
         let alert = Alert.moreOptions(
             cipherView: cipher,
+            hasPremium: false,
             id: cipher.id!,
             showEdit: true,
             action: action
@@ -211,6 +212,7 @@ class AlertTests: BitwardenTestCase {
         )
         let alert = Alert.moreOptions(
             cipherView: cipher,
+            hasPremium: false,
             id: cipher.id!,
             showEdit: true,
             action: action

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -95,6 +95,7 @@ extension Alert {
     ///
     /// - Parameters:
     ///   - cipherView: The cipher view to show.
+    ///   - hasPremium: Whether the user has a premium account.
     ///   - id: The id of the item.
     ///   - showEdit: Whether to show the edit option (should be `false` for items in the trash).
     ///   - action: The action to perform after selecting an option.
@@ -103,6 +104,7 @@ extension Alert {
     @MainActor
     static func moreOptions( // swiftlint:disable:this function_body_length
         cipherView: CipherView,
+        hasPremium: Bool,
         id: String,
         showEdit: Bool,
         action: @escaping (_ action: MoreOptionsAction) async -> Void
@@ -160,7 +162,7 @@ extension Alert {
                     ))
                 })
             }
-            if let totp = cipherView.login?.totp, let totpKey = TOTPKeyModel(authenticatorKey: totp) {
+            if hasPremium, let totp = cipherView.login?.totp, let totpKey = TOTPKeyModel(authenticatorKey: totp) {
                 alertActions.append(AlertAction(title: Localizations.copyTotp, style: .default) { _, _ in
                     await action(.copyTotp(
                         totpKey: totpKey,

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
@@ -19,12 +19,6 @@ enum VaultGroupAction: Equatable {
     ///
     case itemPressed(_ item: VaultListItem)
 
-    /// The more button on an item in the vault group was tapped.
-    ///
-    /// - Parameter item: The item associated with the more button that was tapped.
-    ///
-    case morePressed(_ item: VaultListItem)
-
     /// The user has started or stopped searching.
     case searchStateChanged(isSearching: Bool)
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
@@ -5,6 +5,12 @@ enum VaultGroupEffect: Equatable {
     /// The vault group view appeared on screen.
     case appeared
 
+    /// The more button on an item in the vault group was tapped.
+    ///
+    /// - Parameter item: The item associated with the more button that was tapped.
+    ///
+    case morePressed(_ item: VaultListItem)
+
     /// The refresh control was triggered.
     case refresh
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -139,6 +139,405 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertTrue(subject.state.isPersonalOwnershipDisabled)
     }
 
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
+    func test_perform_morePressed_card() async throws {
+        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .card)))
+
+        // If the card item has no number or code, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.cardFixture())
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // If the item is in the trash, the edit option should not display.
+        subject.state.group = .trash
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+
+        // A card with data should show the copy actions.
+        let cardWithData = CipherView.cardFixture(card: .fixture(
+            code: "123",
+            number: "123456789"
+        ))
+        item = try XCTUnwrap(VaultListItem(cipherView: cardWithData))
+        subject.state.group = .card
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 5)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNumber)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copySecurityCode)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(cardWithData))
+
+        // Copy number copies the card's number.
+        let copyNumberAction = try XCTUnwrap(alert.alertActions[2])
+        await copyNumberAction.handler?(copyNumberAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123456789")
+
+        // Copy security code copies the card's security code.
+        let copyCodeAction = try XCTUnwrap(alert.alertActions[3])
+        await copyCodeAction.handler?(copyCodeAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123")
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert.
+    func test_perform_morePressed_copyPassword_rePromptMasterPassword() async throws {
+        // A login with data should show the copy and launch actions.
+        let loginWithData = CipherView.loginFixture(
+            login: .fixture(
+                password: "secretPassword",
+                uris: [.init(uri: URL.example.relativeString, match: nil)],
+                username: "username"
+            ),
+            reprompt: .password
+        )
+        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 6)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+
+        // Test the functionality of the copy user name and password buttons.
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's password.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+
+        // mock the master password
+        authRepository.validatePasswordResult = .success(true)
+
+        // Validate master password re-prompt is shown
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
+        var textField = try XCTUnwrap(alert.alertTextFields.first)
+        textField = AlertTextField(id: "password", text: "password")
+        let submitAction = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
+        await submitAction.handler?(submitAction, [textField])
+
+        XCTAssertEqual(pasteboardService.copiedString, "secretPassword")
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert,
+    ///  entering wrong password should not allow to copy password.
+    func test_perform_morePressed_copyPassword_passwordReprompt_invalidPassword() async throws {
+        // A login with data should show the copy and launch actions.
+        let loginWithData = CipherView.loginFixture(
+            login: .fixture(
+                password: "password",
+                uris: [.init(uri: URL.example.relativeString, match: nil)],
+                username: "username"
+            ),
+            reprompt: .password
+        )
+        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 6)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+
+        // Test the functionality of the copy user name and password buttons.
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's password.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+
+        // mock the master password
+        authRepository.validatePasswordResult = .success(false)
+
+        // Validate master password re-prompt is shown
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
+        try await alert.tapAction(title: Localizations.submit)
+
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .defaultAlert(title: Localizations.invalidMasterPassword))
+
+        XCTAssertNotEqual(pasteboardService.copiedString, "secretPassword")
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
+    /// alert and copies the TOTP code when the master password is confirmed.
+    func test_perform_morePressed_copyTotp_passwordReprompt() async throws {
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let item = try XCTUnwrap(
+            VaultListItem(
+                cipherView: .fixture(
+                    login: .fixture(totp: "totpKey"),
+                    reprompt: .password
+                )
+            )
+        )
+
+        await subject.perform(.morePressed(item))
+
+        authRepository.validatePasswordResult = .success(true)
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.copyTotp)
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertEqual(pasteboardService.copiedString, "123321")
+        XCTAssertEqual(
+            subject.state.toast?.text,
+            Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp)
+        )
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
+    /// alert and displays an alert if the entered master password doesn't match.
+    func test_perform_morePressed_copyTotp_passwordReprompt_invalidPassword() async throws {
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let item = try XCTUnwrap(
+            VaultListItem(
+                cipherView: .fixture(
+                    login: .fixture(totp: "totpKey"),
+                    reprompt: .password
+                )
+            )
+        )
+
+        await subject.perform(.morePressed(item))
+
+        authRepository.validatePasswordResult = .success(false)
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.copyTotp)
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
+    func test_perform_morePressed_login_full() async throws {
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let loginWithData = CipherView.loginFixture(login: .fixture(
+            password: "password",
+            uris: [.init(uri: URL.example.relativeString, match: nil)],
+            username: "username",
+            totp: "totpKey"
+        ))
+        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
+        subject.state.group = .login
+        await subject.perform(.morePressed(item))
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 7)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyUsername)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.copyTotp)
+        XCTAssertEqual(alert.alertActions[5].title, Localizations.launch)
+        XCTAssertEqual(alert.alertActions[6].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(loginWithData))
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's username.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "password")
+
+        // Copy TOTP copies the user's TOTP code.
+        let copyTotpAction = try XCTUnwrap(alert.alertActions[4])
+        await copyTotpAction.handler?(copyPasswordAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123321")
+
+        // Launch action set's the url to open.
+        let launchAction = try XCTUnwrap(alert.alertActions[5])
+        await launchAction.handler?(launchAction, [])
+        XCTAssertEqual(subject.state.url, .example)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
+    func test_perform_morePressed_login_minimal() async throws {
+        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .login)))
+
+        // If the login item has no username, password, or url, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.loginFixture())
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // If the item is in the trash, the edit option should not display.
+        subject.state.group = .trash
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for an identity cipher.
+    func test_perform_morePressed_identity() async throws {
+        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .identity)))
+
+        // If the item is in the trash, the edit option should not display.
+        vaultRepository.fetchCipherResult = .success(.fixture())
+        subject.state.group = .trash
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+
+        // An identity option can be viewed or edited.
+        subject.state.group = .identity
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(.fixture(type: .identity)))
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a secure note cipher.
+    func test_perform_morePressed_secureNote() async throws {
+        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .secureNote)))
+
+        // If the secure note has no value, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.fixture(type: .secureNote))
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // If the item is in the trash, the edit option should not display.
+        subject.state.group = .trash
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+
+        // A note with data should show the copy action.
+        let noteWithData = CipherView.fixture(notes: "Test Note", type: .secureNote)
+        item = try XCTUnwrap(VaultListItem(cipherView: noteWithData))
+        subject.state.group = .secureNote
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNotes)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(noteWithData))
+
+        // Copy copies the items notes.
+        let copyNoteAction = try XCTUnwrap(alert.alertActions[2])
+        await copyNoteAction.handler?(copyNoteAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "Test Note")
+    }
+
     /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository.
     func test_perform_refreshed() async {
         await subject.perform(.refresh)
@@ -591,405 +990,6 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         let totpItem = VaultListItem.fixtureTOTP(totp: .fixture())
         subject.receive(.itemPressed(totpItem))
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: totpItem.id))
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
-    func test_receive_morePressed_card() async throws {
-        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .card)))
-
-        // If the card item has no number or code, only the view and add buttons should display.
-        vaultRepository.fetchCipherResult = .success(.cardFixture())
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // If the item is in the trash, the edit option should not display.
-        subject.state.group = .trash
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 2)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
-
-        // A card with data should show the copy actions.
-        let cardWithData = CipherView.cardFixture(card: .fixture(
-            code: "123",
-            number: "123456789"
-        ))
-        item = try XCTUnwrap(VaultListItem(cipherView: cardWithData))
-        subject.state.group = .card
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 5)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNumber)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copySecurityCode)
-        XCTAssertEqual(alert.alertActions[4].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(cardWithData))
-
-        // Copy number copies the card's number.
-        let copyNumberAction = try XCTUnwrap(alert.alertActions[2])
-        await copyNumberAction.handler?(copyNumberAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "123456789")
-
-        // Copy security code copies the card's security code.
-        let copyCodeAction = try XCTUnwrap(alert.alertActions[3])
-        await copyCodeAction.handler?(copyCodeAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "123")
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert.
-    func test_receive_morePressed_copyPassword_rePromptMasterPassword() async throws {
-        // A login with data should show the copy and launch actions.
-        let loginWithData = CipherView.loginFixture(
-            login: .fixture(
-                password: "secretPassword",
-                uris: [.init(uri: URL.example.relativeString, match: nil)],
-                username: "username"
-            ),
-            reprompt: .password
-        )
-        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 6)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-
-        // Test the functionality of the copy user name and password buttons.
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's password.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-
-        // mock the master password
-        authRepository.validatePasswordResult = .success(true)
-
-        // Validate master password re-prompt is shown
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
-        var textField = try XCTUnwrap(alert.alertTextFields.first)
-        textField = AlertTextField(id: "password", text: "password")
-        let submitAction = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
-        await submitAction.handler?(submitAction, [textField])
-
-        XCTAssertEqual(pasteboardService.copiedString, "secretPassword")
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert,
-    ///  entering wrong password should not allow to copy password.
-    func test_receive_morePressed_copyPassword_passwordReprompt_invalidPassword() async throws {
-        // A login with data should show the copy and launch actions.
-        let loginWithData = CipherView.loginFixture(
-            login: .fixture(
-                password: "password",
-                uris: [.init(uri: URL.example.relativeString, match: nil)],
-                username: "username"
-            ),
-            reprompt: .password
-        )
-        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 6)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-
-        // Test the functionality of the copy user name and password buttons.
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's password.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-
-        // mock the master password
-        authRepository.validatePasswordResult = .success(false)
-
-        // Validate master password re-prompt is shown
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
-        try await alert.tapAction(title: Localizations.submit)
-
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .defaultAlert(title: Localizations.invalidMasterPassword))
-
-        XCTAssertNotEqual(pasteboardService.copiedString, "secretPassword")
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
-    /// alert and copies the TOTP code when the master password is confirmed.
-    func test_receive_morePressed_copyTotp_passwordReprompt() async throws {
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-
-        let item = try XCTUnwrap(
-            VaultListItem(
-                cipherView: .fixture(
-                    login: .fixture(totp: "totpKey"),
-                    reprompt: .password
-                )
-            )
-        )
-
-        subject.receive(.morePressed(item))
-
-        authRepository.validatePasswordResult = .success(true)
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.copyTotp)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        XCTAssertEqual(pasteboardService.copiedString, "123321")
-        XCTAssertEqual(
-            subject.state.toast?.text,
-            Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp)
-        )
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
-    /// alert and displays an alert if the entered master password doesn't match.
-    func test_receive_morePressed_copyTotp_passwordReprompt_invalidPassword() async throws {
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-
-        let item = try XCTUnwrap(
-            VaultListItem(
-                cipherView: .fixture(
-                    login: .fixture(totp: "totpKey"),
-                    reprompt: .password
-                )
-            )
-        )
-
-        subject.receive(.morePressed(item))
-
-        authRepository.validatePasswordResult = .success(false)
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.copyTotp)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
-    func test_receive_morePressed_login_full() async throws {
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-
-        let loginWithData = CipherView.loginFixture(login: .fixture(
-            password: "password",
-            uris: [.init(uri: URL.example.relativeString, match: nil)],
-            username: "username",
-            totp: "totpKey"
-        ))
-        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
-        subject.state.group = .login
-        subject.receive(.morePressed(item))
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 7)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyUsername)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-        XCTAssertEqual(alert.alertActions[4].title, Localizations.copyTotp)
-        XCTAssertEqual(alert.alertActions[5].title, Localizations.launch)
-        XCTAssertEqual(alert.alertActions[6].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(loginWithData))
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's username.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "password")
-
-        // Copy TOTP copies the user's TOTP code.
-        let copyTotpAction = try XCTUnwrap(alert.alertActions[4])
-        await copyTotpAction.handler?(copyPasswordAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "123321")
-
-        // Launch action set's the url to open.
-        let launchAction = try XCTUnwrap(alert.alertActions[5])
-        await launchAction.handler?(launchAction, [])
-        XCTAssertEqual(subject.state.url, .example)
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
-    func test_receive_morePressed_login_minimal() async throws {
-        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .login)))
-
-        // If the login item has no username, password, or url, only the view and add buttons should display.
-        vaultRepository.fetchCipherResult = .success(.loginFixture())
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // If the item is in the trash, the edit option should not display.
-        subject.state.group = .trash
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 2)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for an identity cipher.
-    func test_receive_morePressed_identity() async throws {
-        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .identity)))
-
-        // If the item is in the trash, the edit option should not display.
-        vaultRepository.fetchCipherResult = .success(.fixture())
-        subject.state.group = .trash
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 2)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
-
-        // An identity option can be viewed or edited.
-        subject.state.group = .identity
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(.fixture(type: .identity)))
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a secure note cipher.
-    func test_receive_morePressed_secureNote() async throws {
-        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .secureNote)))
-
-        // If the secure note has no value, only the view and add buttons should display.
-        vaultRepository.fetchCipherResult = .success(.fixture(type: .secureNote))
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // If the item is in the trash, the edit option should not display.
-        subject.state.group = .trash
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 2)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
-
-        // A note with data should show the copy action.
-        let noteWithData = CipherView.fixture(notes: "Test Note", type: .secureNote)
-        item = try XCTUnwrap(VaultListItem(cipherView: noteWithData))
-        subject.state.group = .secureNote
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 4)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNotes)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(noteWithData))
-
-        // Copy copies the items notes.
-        let copyNoteAction = try XCTUnwrap(alert.alertActions[2])
-        await copyNoteAction.handler?(copyNoteAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "Test Note")
     }
 
     /// `receive(_:)` with `.searchTextChanged` and no value sets the state correctly.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -233,11 +233,14 @@ struct VaultGroupView: View {
                     switch action {
                     case let .copyTOTPCode(code):
                         return .copyTOTPCode(code)
+                    }
+                },
+                mapEffect: { effect in
+                    switch effect {
                     case .morePressed:
                         return .morePressed(item)
                     }
-                },
-                mapEffect: nil
+                }
             ),
             timeProvider: timeProvider
         )

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupViewTests.swift
@@ -89,13 +89,13 @@ class VaultGroupViewTests: BitwardenTestCase {
     }
 
     /// Tapping the more button on a vault item dispatches the `.morePressed` action.
-    func test_vaultItem_moreButton_tap() throws {
+    func test_vaultItem_moreButton_tap() async throws {
         let item = VaultListItem.fixture()
         let section = VaultListSection(id: "Items", items: [item], name: Localizations.items)
         processor.state.loadingState = .data([section])
-        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.more)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed(item))
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .morePressed(item))
     }
 
     // MARK: Snapshots

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
@@ -17,12 +17,6 @@ enum VaultListAction: Equatable {
     /// An item in the vault was pressed.
     case itemPressed(item: VaultListItem)
 
-    /// The more button on an item in the vault group was tapped.
-    ///
-    /// - Parameter item: The item associated with the more button that was tapped.
-    ///
-    case morePressed(_ item: VaultListItem)
-
     /// A forwarded profile switcher action
     case profileSwitcher(ProfileSwitcherAction)
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
@@ -5,6 +5,12 @@ enum VaultListEffect: Equatable {
     /// The vault list appeared on screen.
     case appeared
 
+    /// The more button on an item in the vault group was tapped.
+    ///
+    /// - Parameter item: The item associated with the more button that was tapped.
+    ///
+    case morePressed(_ item: VaultListItem)
+
     /// A Profile Switcher Effect.
     case profileSwitcher(ProfileSwitcherEffect)
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -164,6 +164,367 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         )
     }
 
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
+    func test_perform_morePressed_card() async throws {
+        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .card)))
+
+        // If the card item has no number or code, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.cardFixture())
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // A card with data should show the copy actions.
+        let cardWithData = CipherView.cardFixture(card: .fixture(
+            code: "123",
+            number: "123456789"
+        ))
+        item = try XCTUnwrap(VaultListItem(cipherView: cardWithData))
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 5)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNumber)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copySecurityCode)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(cardWithData))
+
+        // Copy number copies the card's number.
+        let copyNumberAction = try XCTUnwrap(alert.alertActions[2])
+        await copyNumberAction.handler?(copyNumberAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123456789")
+
+        // Copy security code copies the card's security code.
+        let copyCodeAction = try XCTUnwrap(alert.alertActions[3])
+        await copyCodeAction.handler?(copyCodeAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123")
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert.
+    func test_perform_morePressed_copyPassword_rePromptMasterPassword() async throws {
+        // A login with data should show the copy and launch actions.
+        let loginWithData = CipherView.loginFixture(
+            login: .fixture(
+                password: "secretPassword",
+                uris: [.init(uri: URL.example.relativeString, match: nil)],
+                username: "username"
+            ),
+            reprompt: .password
+        )
+        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 6)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+
+        // Test the functionality of the copy user name and password buttons.
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's password.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+
+        // mock the master password
+        authRepository.validatePasswordResult = .success(true)
+
+        // Validate master password re-prompt is shown
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
+        var textField = try XCTUnwrap(alert.alertTextFields.first)
+        textField = AlertTextField(id: "password", text: "password")
+        let submitAction = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
+        await submitAction.handler?(submitAction, [textField])
+
+        XCTAssertEqual(pasteboardService.copiedString, "secretPassword")
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert,
+    ///  entering wrong password should not allow to copy password.
+    func test_perform_morePressed_copyPassword_passwordReprompt_invalidPassword() async throws {
+        // A login with data should show the copy and launch actions.
+        let loginWithData = CipherView.loginFixture(
+            login: .fixture(
+                password: "password",
+                uris: [.init(uri: URL.example.relativeString, match: nil)],
+                username: "username"
+            ),
+            reprompt: .password
+        )
+        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 6)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+
+        // Test the functionality of the copy user name and password buttons.
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's password.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+
+        // mock the master password
+        authRepository.validatePasswordResult = .success(false)
+
+        // Validate master password re-prompt is shown
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
+        try await alert.tapAction(title: Localizations.submit)
+
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .defaultAlert(title: Localizations.invalidMasterPassword))
+
+        XCTAssertNotEqual(pasteboardService.copiedString, "secretPassword")
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
+    /// alert and copies the TOTP code when the master password is confirmed.
+    func test_perform_morePressed_copyTotp_passwordReprompt() async throws {
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let item = try XCTUnwrap(
+            VaultListItem(
+                cipherView: .fixture(
+                    login: .fixture(totp: "totpKey"),
+                    reprompt: .password
+                )
+            )
+        )
+
+        await subject.perform(.morePressed(item))
+
+        authRepository.validatePasswordResult = .success(true)
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.copyTotp)
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertEqual(pasteboardService.copiedString, "123321")
+        XCTAssertEqual(
+            subject.state.toast?.text,
+            Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp)
+        )
+    }
+
+    /// `perform(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
+    /// alert and displays an alert if the entered master password doesn't match.
+    func test_perform_morePressed_copyTotp_passwordReprompt_invalidPassword() async throws {
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let item = try XCTUnwrap(
+            VaultListItem(
+                cipherView: .fixture(
+                    login: .fixture(totp: "totpKey"),
+                    reprompt: .password
+                )
+            )
+        )
+
+        await subject.perform(.morePressed(item))
+
+        authRepository.validatePasswordResult = .success(false)
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.copyTotp)
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
+    func test_perform_morePressed_login_full() async throws {
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let loginWithData = CipherView.loginFixture(login: .fixture(
+            password: "password",
+            uris: [.init(uri: URL.example.relativeString, match: nil)],
+            username: "username",
+            totp: "totpKey"
+        ))
+        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
+
+        await subject.perform(.morePressed(item))
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 7)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyUsername)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
+        XCTAssertEqual(alert.alertActions[4].title, Localizations.copyTotp)
+        XCTAssertEqual(alert.alertActions[5].title, Localizations.launch)
+        XCTAssertEqual(alert.alertActions[6].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(loginWithData))
+
+        // Copy username copies the username.
+        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
+        await copyUsernameAction.handler?(copyUsernameAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+
+        // Copy password copies the user's username.
+        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
+        await copyPasswordAction.handler?(copyPasswordAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "password")
+
+        // Copy TOTP copies the user's TOTP code.
+        let copyTotpAction = try XCTUnwrap(alert.alertActions[4])
+        await copyTotpAction.handler?(copyPasswordAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "123321")
+
+        // Launch action set's the url to open.
+        let launchAction = try XCTUnwrap(alert.alertActions[5])
+        await launchAction.handler?(launchAction, [])
+        XCTAssertEqual(subject.state.url, .example)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
+    func test_perform_morePressed_login_minimal() async throws {
+        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .login)))
+
+        // If the login item has no username, password, or url, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.loginFixture())
+        await subject.perform(.morePressed(item))
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for an identity cipher.
+    func test_perform_morePressed_identity() async throws {
+        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .identity)))
+
+        // An identity option can be viewed or edited.
+        vaultRepository.fetchCipherResult = .success(.fixture(type: .identity))
+        await subject.perform(.morePressed(item))
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(.fixture(type: .identity)))
+    }
+
+    /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a secure note cipher.
+    func test_perform_morePressed_secureNote() async throws {
+        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .secureNote)))
+
+        // If the secure note has no value, only the view and add buttons should display.
+        vaultRepository.fetchCipherResult = .success(.fixture(type: .secureNote))
+        await subject.perform(.morePressed(item))
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 3)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
+
+        // A note with data should show the copy action.
+        let noteWithData = CipherView.fixture(notes: "Test Note", type: .secureNote)
+        item = try XCTUnwrap(VaultListItem(cipherView: noteWithData))
+        await subject.perform(.morePressed(item))
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNotes)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.cancel)
+
+        // Test the functionality of the buttons.
+
+        // View navigates to the view item view.
+        let viewAction = try XCTUnwrap(alert.alertActions[0])
+        await viewAction.handler?(viewAction, [])
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+
+        // Edit navigates to the edit view.
+        let editAction = try XCTUnwrap(alert.alertActions[1])
+        await editAction.handler?(editAction, [])
+        XCTAssertEqual(coordinator.routes.last, .editItem(noteWithData))
+
+        // Copy copies the items notes.
+        let copyNoteAction = try XCTUnwrap(alert.alertActions[2])
+        await copyNoteAction.handler?(copyNoteAction, [])
+        XCTAssertEqual(pasteboardService.copiedString, "Test Note")
+    }
+
     /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository.
     func test_perform_refresh() async {
         await subject.perform(.refreshVault)
@@ -699,367 +1060,6 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         subject.receive(.itemPressed(item: .fixtureTOTP(totp: .fixture())))
 
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: "123"))
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a card cipher.
-    func test_receive_morePressed_card() async throws {
-        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .card)))
-
-        // If the card item has no number or code, only the view and add buttons should display.
-        vaultRepository.fetchCipherResult = .success(.cardFixture())
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // A card with data should show the copy actions.
-        let cardWithData = CipherView.cardFixture(card: .fixture(
-            code: "123",
-            number: "123456789"
-        ))
-        item = try XCTUnwrap(VaultListItem(cipherView: cardWithData))
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 5)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNumber)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copySecurityCode)
-        XCTAssertEqual(alert.alertActions[4].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(cardWithData))
-
-        // Copy number copies the card's number.
-        let copyNumberAction = try XCTUnwrap(alert.alertActions[2])
-        await copyNumberAction.handler?(copyNumberAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "123456789")
-
-        // Copy security code copies the card's security code.
-        let copyCodeAction = try XCTUnwrap(alert.alertActions[3])
-        await copyCodeAction.handler?(copyCodeAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "123")
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert.
-    func test_receive_morePressed_copyPassword_rePromptMasterPassword() async throws {
-        // A login with data should show the copy and launch actions.
-        let loginWithData = CipherView.loginFixture(
-            login: .fixture(
-                password: "secretPassword",
-                uris: [.init(uri: URL.example.relativeString, match: nil)],
-                username: "username"
-            ),
-            reprompt: .password
-        )
-        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 6)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-
-        // Test the functionality of the copy user name and password buttons.
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's password.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-
-        // mock the master password
-        authRepository.validatePasswordResult = .success(true)
-
-        // Validate master password re-prompt is shown
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
-        var textField = try XCTUnwrap(alert.alertTextFields.first)
-        textField = AlertTextField(id: "password", text: "password")
-        let submitAction = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
-        await submitAction.handler?(submitAction, [textField])
-
-        XCTAssertEqual(pasteboardService.copiedString, "secretPassword")
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyPassword` presents master password re-prompt alert,
-    ///  entering wrong password should not allow to copy password.
-    func test_receive_morePressed_copyPassword_passwordReprompt_invalidPassword() async throws {
-        // A login with data should show the copy and launch actions.
-        let loginWithData = CipherView.loginFixture(
-            login: .fixture(
-                password: "password",
-                uris: [.init(uri: URL.example.relativeString, match: nil)],
-                username: "username"
-            ),
-            reprompt: .password
-        )
-        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 6)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-
-        // Test the functionality of the copy user name and password buttons.
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's password.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-
-        // mock the master password
-        authRepository.validatePasswordResult = .success(false)
-
-        // Validate master password re-prompt is shown
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
-        try await alert.tapAction(title: Localizations.submit)
-
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .defaultAlert(title: Localizations.invalidMasterPassword))
-
-        XCTAssertNotEqual(pasteboardService.copiedString, "secretPassword")
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
-    /// alert and copies the TOTP code when the master password is confirmed.
-    func test_receive_morePressed_copyTotp_passwordReprompt() async throws {
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-
-        let item = try XCTUnwrap(
-            VaultListItem(
-                cipherView: .fixture(
-                    login: .fixture(totp: "totpKey"),
-                    reprompt: .password
-                )
-            )
-        )
-
-        subject.receive(.morePressed(item))
-
-        authRepository.validatePasswordResult = .success(true)
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.copyTotp)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        XCTAssertEqual(pasteboardService.copiedString, "123321")
-        XCTAssertEqual(
-            subject.state.toast?.text,
-            Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp)
-        )
-    }
-
-    /// `receive(_:)` with `.morePressed` and press `copyTotp` presents master password re-prompt
-    /// alert and displays an alert if the entered master password doesn't match.
-    func test_receive_morePressed_copyTotp_passwordReprompt_invalidPassword() async throws {
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-
-        let item = try XCTUnwrap(
-            VaultListItem(
-                cipherView: .fixture(
-                    login: .fixture(totp: "totpKey"),
-                    reprompt: .password
-                )
-            )
-        )
-
-        subject.receive(.morePressed(item))
-
-        authRepository.validatePasswordResult = .success(false)
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.copyTotp)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
-    func test_receive_morePressed_login_full() async throws {
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-
-        let loginWithData = CipherView.loginFixture(login: .fixture(
-            password: "password",
-            uris: [.init(uri: URL.example.relativeString, match: nil)],
-            username: "username",
-            totp: "totpKey"
-        ))
-        let item = try XCTUnwrap(VaultListItem(cipherView: loginWithData))
-
-        subject.receive(.morePressed(item))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 7)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyUsername)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-        XCTAssertEqual(alert.alertActions[4].title, Localizations.copyTotp)
-        XCTAssertEqual(alert.alertActions[5].title, Localizations.launch)
-        XCTAssertEqual(alert.alertActions[6].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(loginWithData))
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's username.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "password")
-
-        // Copy TOTP copies the user's TOTP code.
-        let copyTotpAction = try XCTUnwrap(alert.alertActions[4])
-        await copyTotpAction.handler?(copyPasswordAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "123321")
-
-        // Launch action set's the url to open.
-        let launchAction = try XCTUnwrap(alert.alertActions[5])
-        await launchAction.handler?(launchAction, [])
-        XCTAssertEqual(subject.state.url, .example)
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
-    func test_receive_morePressed_login_minimal() async throws {
-        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .login)))
-
-        // If the login item has no username, password, or url, only the view and add buttons should display.
-        vaultRepository.fetchCipherResult = .success(.loginFixture())
-        subject.receive(.morePressed(item))
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for an identity cipher.
-    func test_receive_morePressed_identity() async throws {
-        let item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .identity)))
-
-        // An identity option can be viewed or edited.
-        vaultRepository.fetchCipherResult = .success(.fixture(type: .identity))
-        subject.receive(.morePressed(item))
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(.fixture(type: .identity)))
-    }
-
-    /// `receive(_:)` with `.morePressed` shows the appropriate more options alert for a secure note cipher.
-    func test_receive_morePressed_secureNote() async throws {
-        var item = try XCTUnwrap(VaultListItem(cipherView: .fixture(type: .secureNote)))
-
-        // If the secure note has no value, only the view and add buttons should display.
-        vaultRepository.fetchCipherResult = .success(.fixture(type: .secureNote))
-        subject.receive(.morePressed(item))
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 3)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.cancel)
-
-        // A note with data should show the copy action.
-        let noteWithData = CipherView.fixture(notes: "Test Note", type: .secureNote)
-        item = try XCTUnwrap(VaultListItem(cipherView: noteWithData))
-        subject.receive(.morePressed(item))
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 4)
-        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
-        XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.copyNotes)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
-
-        // View navigates to the view item view.
-        let viewAction = try XCTUnwrap(alert.alertActions[0])
-        await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
-
-        // Edit navigates to the edit view.
-        let editAction = try XCTUnwrap(alert.alertActions[1])
-        await editAction.handler?(editAction, [])
-        XCTAssertEqual(coordinator.routes.last, .editItem(noteWithData))
-
-        // Copy copies the items notes.
-        let copyNoteAction = try XCTUnwrap(alert.alertActions[2])
-        await copyNoteAction.handler?(copyNoteAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "Test Note")
     }
 
     /// `receive(_:)` with `ProfileSwitcherAction.backgroundPressed` turns off the Profile Switcher Visibility.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -225,11 +225,14 @@ private struct SearchableVaultListView: View {
                     switch action {
                     case let .copyTOTPCode(code):
                         return .copyTOTPCode(code)
+                    }
+                },
+                mapEffect: { effect in
+                    switch effect {
                     case .morePressed:
                         return .morePressed(item)
                     }
-                },
-                mapEffect: nil
+                }
             ),
             timeProvider: timeProvider
         )

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
@@ -150,12 +150,12 @@ class VaultListViewTests: BitwardenTestCase {
     }
 
     /// Tapping the vault item more button dispatches the `.morePressed` action.
-    func test_vaultItem_moreButton_tap() throws {
+    func test_vaultItem_moreButton_tap() async throws {
         let item = VaultListItem.fixture()
         processor.state.loadingState = .data([VaultListSection(id: "1", items: [item], name: "Group")])
-        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.more)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed(item))
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .morePressed(item))
     }
 
     // MARK: Snapshots

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowAction.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowAction.swift
@@ -4,7 +4,4 @@
 enum VaultListItemRowAction: Equatable {
     /// The copy TOTP Code button was pressed.
     case copyTOTPCode(_ code: String)
-
-    /// The more button was pressed.
-    case morePressed
 }

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowEffect.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowEffect.swift
@@ -1,0 +1,7 @@
+// MARK: - VaultListItemRowEffect
+
+/// Effects that can be performed from a `VaultListItemRowView`.
+enum VaultListItemRowEffect: Equatable {
+    /// The more button was pressed.
+    case morePressed
+}

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
@@ -8,7 +8,7 @@ struct VaultListItemRowView: View {
     // MARK: Properties
 
     /// The `Store` for this view.
-    var store: Store<VaultListItemRowState, VaultListItemRowAction, Void>
+    var store: Store<VaultListItemRowState, VaultListItemRowAction, VaultListItemRowEffect>
 
     /// The `TimeProvider` used to calculate TOTP expiration.
     var timeProvider: any TimeProvider
@@ -64,8 +64,8 @@ struct VaultListItemRowView: View {
 
                         Spacer()
 
-                        Button {
-                            store.send(.morePressed)
+                        AsyncButton {
+                            await store.perform(.morePressed)
                         } label: {
                             Asset.Images.horizontalKabob.swiftUIImage
                         }

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowViewTests.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowViewTests.swift
@@ -8,7 +8,7 @@ import XCTest
 class VaultListItemRowViewTests: BitwardenTestCase {
     // MARK: Properties
 
-    var processor: MockProcessor<VaultListItemRowState, VaultListItemRowAction, Void>!
+    var processor: MockProcessor<VaultListItemRowState, VaultListItemRowAction, VaultListItemRowEffect>!
     var subject: VaultListItemRowView!
     var timeProvider: MockTimeProvider!
 
@@ -33,10 +33,10 @@ class VaultListItemRowViewTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Test that tapping the more button dispatches the `.morePressed` action.
-    func test_moreButton_tap() throws {
-        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.more)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed)
+    func test_moreButton_tap() async throws {
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .morePressed)
     }
 
     /// Test that tapping the totp copy button dispatches the `.copyTOTPCode` action.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1721](https://livefront.atlassian.net/browse/BIT-1721)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the "Copy TOTP" option to the login option's menu in the vault list or group views for logins with TOTP.

> [!NOTE]  
> Most of the changes here are in the first commit (6294b0d4277bbb024f981364bc99dfecc19ad97e). I added the premium check and converted an action to an effect in the second commit (8a04089c6595066cc02f975215848512bc7c8058) and rearranged a bunch of tests as a result.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **Alert+Vault.swift:** Shows a copy TOTP option if a login cipher has a TOTP and the user has premium access.
- **VaultList/VaultGroupProcessor.swift:** Handles generating and copying a login's TOTP code in response to the copy TOTP option.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/00ddc0fa-c42b-4a74-a23b-c29e8ed8ad72


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
