### PR TITLE
BIT-1261: Reset stored date values when migrating to native app

### DIFF
--- a/BitwardenShared/Core/Platform/Services/MigrationService.swift
+++ b/BitwardenShared/Core/Platform/Services/MigrationService.swift
@@ -51,12 +51,19 @@ class DefaultMigrationService {
     ///
     /// Notes:
     /// - Migrates account tokens from UserDefaults to Keychain.
+    /// - Resets stored date values from Xamarin/Maui, which uses an incompatible format.
     ///
     private func performMigration1() async throws {
         guard var state = appSettingsStore.state else { return }
         defer { appSettingsStore.state = state }
 
         for (accountId, account) in state.accounts {
+            // Reset date values.
+            appSettingsStore.setLastActiveTime(nil, userId: accountId)
+            appSettingsStore.setLastSyncTime(nil, userId: accountId)
+            appSettingsStore.setNotificationsLastRegistrationDate(nil, userId: accountId)
+
+            // Migrate tokens to Keychain.
             let tokens = account._tokens
             state.accounts[accountId]?._tokens = nil
 

--- a/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
@@ -79,6 +79,11 @@ class MigrationServiceTests: BitwardenTestCase {
             ],
             activeUserId: "1"
         )
+        for userId in ["1", "2"] {
+            appSettingsStore.lastActiveTime[userId] = Date()
+            appSettingsStore.lastSyncTimeByUserId[userId] = Date()
+            appSettingsStore.notificationsLastRegistrationDates[userId] = Date()
+        }
 
         await subject.performMigrations()
 
@@ -93,6 +98,12 @@ class MigrationServiceTests: BitwardenTestCase {
         try XCTAssertEqual(keychainRepository.getValue(for: .refreshToken(userId: "1")), "REFRESH_TOKEN_1")
         try XCTAssertEqual(keychainRepository.getValue(for: .accessToken(userId: "2")), "ACCESS_TOKEN_2")
         try XCTAssertEqual(keychainRepository.getValue(for: .refreshToken(userId: "2")), "REFRESH_TOKEN_2")
+
+        for userId in ["1", "2"] {
+            XCTAssertNil(appSettingsStore.lastActiveTime(userId: userId))
+            XCTAssertNil(appSettingsStore.lastSyncTime(userId: userId))
+            XCTAssertNil(appSettingsStore.notificationsLastRegistrationDate(userId: userId))
+        }
     }
 
     /// `performMigrations()` for migration 1 handles no existing accounts.

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -23,7 +23,6 @@ class MockAppSettingsStore: AppSettingsStore {
     var clearClipboardValues = [String: ClearClipboardValue]()
     var connectToWatchByUserId = [String: Bool]()
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
-    var timeProvider = MockTimeProvider(.currentTime)
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var encryptedPrivateKeys = [String: String]()
     var encryptedUserKeys = [String: String]()
@@ -152,8 +151,8 @@ class MockAppSettingsStore: AppSettingsStore {
         encryptedUserKeys[userId] = key
     }
 
-    func setLastActiveTime(_: Date?, userId: String) {
-        lastActiveTime[userId] = timeProvider.presentTime
+    func setLastActiveTime(_ date: Date?, userId: String) {
+        lastActiveTime[userId] = date
     }
 
     func setLastSyncTime(_ date: Date?, userId: String) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1261](https://livefront.atlassian.net/browse/BIT-1261)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Resets the stored date values when migrating from Xamarin/Maui since that app uses a date format that is incompatible.

- Last active time
- Last sync time
- Last push notification registration time

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **MigrationService.swift:** Resets stored date values.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
