### PR TITLE
BIT-2133: Clear master password after successful vault export

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
@@ -84,6 +84,10 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
 
             do {
                 try await self.exportVault(format: format, password: password)
+
+                // Clear the user's entered password so that it's required to be entered again for
+                // any subsequent exports.
+                self.state.passwordText = ""
             } catch {
                 self.services.errorReporter.log(error: error)
             }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessorTests.swift
@@ -156,6 +156,23 @@ class ExportVaultProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .shareExportedVault(testURL))
     }
 
+    /// `.receive()` with  `.exportVaultTapped` clears the user's master password after exporting
+    /// the vault successfully.
+    func test_receive_exportVaultTapped_success_clearsMasterPassword() async throws {
+        let testURL = URL(string: "www.bitwarden.com")!
+        exportService.exportVaultContentResult = .success("")
+        exportService.writeToFileResult = .success(testURL)
+        subject.state.fileFormat = .json
+
+        subject.receive(.exportVaultTapped)
+
+        XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: false, action: {}))
+        try await coordinator.alertShown.last?.tapAction(title: Localizations.exportVault)
+
+        XCTAssertEqual(coordinator.routes.last, .shareExportedVault(testURL))
+        XCTAssertTrue(subject.state.passwordText.isEmpty)
+    }
+
     /// `.receive()` with `.fileFormatTypeChanged()` updates the file format.
     func test_receive_fileFormatTypeChanged() {
         subject.receive(.fileFormatTypeChanged(.csv))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2133](https://livefront.atlassian.net/browse/BIT-2133)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

After a successful vault export, the user's master password should be cleared and required to be entered again for any subsequent exports.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **ExportVaultProcessor.swift:** Clear master password after a successful export.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/e39b2958-6a3e-4a0a-be19-40183b7f52fb


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
