### PR TITLE
BIT-2157: Submit button IDs

### DIFF
--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -148,7 +148,7 @@ struct CreateAccountView: View {
         } label: {
             Text(Localizations.submit)
         }
-        .accessibilityIdentifier("CreateAccountLabel")
+        .accessibilityIdentifier("SubmitButton")
         .buttonStyle(.primary())
     }
 

--- a/BitwardenShared/UI/Auth/PasswordHint/PasswordHintView.swift
+++ b/BitwardenShared/UI/Auth/PasswordHint/PasswordHintView.swift
@@ -26,6 +26,7 @@ struct PasswordHintView: View {
                 AsyncButton(Localizations.submit) {
                     await store.perform(.submitPressed)
                 }
+                .accessibilityIdentifier("SubmitButton")
                 .buttonStyle(.primary())
                 .disabled(!store.state.isSubmitButtonEnabled)
             }

--- a/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordView.swift
+++ b/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordView.swift
@@ -72,6 +72,7 @@ struct SetMasterPasswordView: View {
                 AsyncButton(Localizations.submit) {
                     await store.perform(.submitPressed)
                 }
+                .accessibilityIdentifier("SubmitButton")
                 .buttonStyle(.primary())
             }
             .padding(16)

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordView.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordView.swift
@@ -83,6 +83,7 @@ struct UpdateMasterPasswordView: View {
                 AsyncButton(Localizations.submit) {
                     await store.perform(.submitPressed)
                 }
+                .accessibilityIdentifier("SubmitButton")
                 .buttonStyle(.primary())
             }
             .padding(16)


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-2157](https://livefront.atlassian.net/browse/BIT-2157?atlOrigin=eyJpIjoiNWEzMmFmMzdjNDE3NDJiZGFmNWJkMTU0MTExMDZlZjQiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to submit buttons.

## 📋 Code changes
-   **CreateAccountView.swift:** Adds accessibility ID to submit button.
-   **PasswordHintView.swift:** Adds accessibility ID to submit button.
-   **SetMasterPasswordView.swift:** Adds accessibility ID to submit button.
-   **UpdateMasterPasswordView.swift:** Adds accessibility ID to submit button.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
