### PR TITLE
BIT-2093 BIT-2095 BIT-2096 BIT-2098: Implemented password protected export

### DIFF
--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockExportVaultService.swift
@@ -5,6 +5,7 @@ import Foundation
 class MockExportVaultService: ExportVaultService {
     var didClearFiles = false
 
+    var exportVaultContentsFormat: ExportFileType?
     var exportVaultContentResult: Result<String, Error> = .failure(BitwardenTestError.example)
 
     var mockFileName: String = "mockExport.json"
@@ -16,7 +17,8 @@ class MockExportVaultService: ExportVaultService {
     }
 
     func exportVaultFileContents(format: BitwardenShared.ExportFileType) async throws -> String {
-        try exportVaultContentResult.get()
+        exportVaultContentsFormat = format
+        return try exportVaultContentResult.get()
     }
 
     func generateExportFileName(

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
@@ -57,11 +57,12 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
             services.exportVaultService.clearTemporaryFiles()
             coordinator.navigate(to: .dismiss)
         case .exportVaultTapped:
-            confirmExportVault()
+            validateFieldsAndExportVault()
         case let .fileFormatTypeChanged(fileFormat):
             state.fileFormat = fileFormat
         case let .filePasswordTextChanged(newValue):
             state.filePasswordText = newValue
+            updatePasswordStrength()
         case let .filePasswordConfirmationTextChanged(newValue):
             state.filePasswordConfirmationText = newValue
         case let .masterPasswordTextChanged(newValue):
@@ -79,9 +80,9 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
     private func confirmExportVault() {
         let encrypted = (state.fileFormat == .jsonEncrypted)
         let format = state.fileFormat
-        let password = state.masterPasswordText
+        let password = state.filePasswordText
 
-        // She the alert to confirm exporting the vault.
+        // Show the alert to confirm exporting the vault.
         coordinator.showAlert(.confirmExportVault(encrypted: encrypted) {
             // Validate the password before exporting the vault.
             guard await self.validatePassword() else {
@@ -129,11 +130,55 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
         )
     }
 
+    /// Updates state's password strength score based on the user's entered password.
+    ///
+    private func updatePasswordStrength() {
+        guard !state.filePasswordText.isEmpty else {
+            state.filePasswordStrengthScore = nil
+            return
+        }
+        Task {
+            state.filePasswordStrengthScore = await services.authRepository.passwordStrength(
+                email: "",
+                password: state.filePasswordText
+            )
+        }
+    }
+
+    /// Validates the input fields and if they are valid, shows the alert to confirm the vault export.
+    ///
+    private func validateFieldsAndExportVault() {
+        let isEncryptedExport = state.fileFormat == .jsonEncrypted
+
+        do {
+            if isEncryptedExport {
+                try EmptyInputValidator(fieldName: Localizations.filePassword)
+                    .validate(input: state.filePasswordText)
+                try EmptyInputValidator(fieldName: Localizations.confirmFilePassword)
+                    .validate(input: state.filePasswordConfirmationText)
+
+                guard state.filePasswordText == state.filePasswordConfirmationText else {
+                    coordinator.showAlert(.passwordsDontMatch)
+                    return
+                }
+            }
+
+            try EmptyInputValidator(fieldName: Localizations.masterPassword)
+                .validate(input: state.masterPasswordText)
+
+            confirmExportVault()
+        } catch let error as InputValidationError {
+            coordinator.showAlert(.inputValidationAlert(error: error))
+        } catch {
+            coordinator.showAlert(.networkResponseError(error))
+            services.errorReporter.log(error: error)
+        }
+    }
+
     /// Validate the password.
     ///
     /// - Returns: `true` if the password is valid.
     ///
-    @MainActor
     private func validatePassword() async -> Bool {
         do {
             return try await services.authRepository.validatePassword(state.masterPasswordText)

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultView.swift
@@ -24,6 +24,7 @@ struct ExportVaultView: View {
 
             exportVaultButton
         }
+        .animation(.default, value: store.state.filePasswordStrengthScore)
         .disabled(store.state.disableIndividualVaultExport)
         .scrollView()
         .navigationBar(title: Localizations.exportVault, titleDisplayMode: .inline)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2093](https://livefront.atlassian.net/browse/BIT-2093) - Require all password fields for password protected vault export
[BIT-2095](https://livefront.atlassian.net/browse/BIT-2095) - Implement password strength indicator
[BIT-2096](https://livefront.atlassian.net/browse/BIT-2096) - Confirm passwords and execute password-protected vault export 
[BIT-2098](https://livefront.atlassian.net/browse/BIT-2098) - Implement Password Protection for Exported Vault .json File

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implements the password protected export feature. This adds validation to the inputs (fields aren't empty, file passwords match), implements the password strength indicator, and uses the file password when encrypting the contents of the vault.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **ExportVaultProcessor.swift:** Adds input validation, implements password strength indicator and uses the file password for encryption.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/2d882f34-e8e0-4d70-8b37-09941d48e040


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
