### PR TITLE
BIT-1942: Apply accessibilityIdentifier to stepper proper rather than its label

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/FormFields/StepperFieldView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/FormFields/StepperFieldView.swift
@@ -59,11 +59,11 @@ struct StepperFieldView<State>: View {
                     Text(String(field.value))
                         .styleGuide(.body, monoSpacedDigit: true)
                         .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
-                        .accessibilityIdentifier(field.accessibilityId ?? field.id)
                 }
                 .padding(.trailing, 4)
             }
             .padding(.top, 4)
+            .accessibilityIdentifier(field.accessibilityId ?? field.id)
 
             Divider()
         }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -197,7 +197,7 @@ extension GeneratorState {
             [
                 passwordGeneratorTypeField(),
                 stepperField(
-                    accessibilityId: "NumberOfWordsLabel",
+                    accessibilityId: "NumberOfWordsStepper",
                     keyPath: \.passwordState.numberOfWords,
                     range: 3 ... 20,
                     title: Localizations.numberOfWords


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-1942](https://livefront.atlassian.net/browse/BIT-1942) - Adding missing element IDs to Generator Page

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

In order to give the stepper the accessibility ID given, where the accessibilityIdentifier gets applied has been shifted to the stepper itself, rather than its label.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

**StepperFieldView.swift**: Adjust where accessibilityIdentifier is being applied

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
