### PR TITLE
BIT-2162: Add device identifier header to login with device request

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/LoginWithDeviceRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/LoginWithDeviceRequest.swift
@@ -10,11 +10,14 @@ struct LoginWithDeviceRequest: Request {
     /// The body of this request.
     let body: LoginWithDeviceRequestModel?
 
-    /// The URL path for this request.
-    var path: String = "auth-requests"
+    /// A dictionary of HTTP headers to be sent in the request.
+    let headers: [String: String]
 
     /// The HTTP method for this request.
     let method: HTTPMethod = .post
+
+    /// The URL path for this request.
+    let path: String = "/auth-requests"
 
     /// Creates a new `LoginWithDeviceRequest`.
     ///
@@ -22,5 +25,6 @@ struct LoginWithDeviceRequest: Request {
     ///
     init(body: LoginWithDeviceRequestModel) {
         self.body = body
+        headers = ["Device-Identifier": body.deviceIdentifier]
     }
 }

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/LoginWithDeviceRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/LoginWithDeviceRequestTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class LoginWithDeviceRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: LoginWithDeviceRequest!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = LoginWithDeviceRequest(
+            body: LoginWithDeviceRequestModel(
+                email: "email",
+                publicKey: "public key",
+                deviceIdentifier: "device identifier",
+                accessCode: "access code",
+                type: 0,
+                fingerprintPhrase: "fingerprint phrase"
+            )
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `body` is the JSON encoded request model.
+    func test_body() throws {
+        let bodyData = try XCTUnwrap(subject.body?.encode())
+        XCTAssertEqual(
+            bodyData.prettyPrintedJson,
+            """
+            {
+              "accessCode" : "access code",
+              "deviceIdentifier" : "device identifier",
+              "email" : "email",
+              "fingerprintPhrase" : "fingerprint phrase",
+              "publicKey" : "public key",
+              "type" : 0
+            }
+            """
+        )
+    }
+
+    /// `headers` contains the device device identifier header.
+    func test_headers() {
+        XCTAssertEqual(subject.headers, ["Device-Identifier": "device identifier"])
+    }
+
+    /// `method` is `.post`.
+    func test_method() {
+        XCTAssertEqual(subject.method, .post)
+    }
+
+    /// `path` is the correct value.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/auth-requests")
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2162](https://livefront.atlassian.net/browse/BIT-2162)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the device's identifier to the login with device request (`POST /auth-requests`). This prevents the server from sending a push notification to the initiating device.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **LoginWithDeviceRequest.swift:** Adds the device identifier header.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
