### PR TITLE
BIT-1993: Folder list IDs

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsListItem.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsListItem.swift
@@ -19,6 +19,9 @@ struct SettingsListItem<Content: View>: View {
     /// The name of the list item.
     let name: String
 
+    /// The accessibility ID for the list item name.
+    let nameAccessibilityID: String?
+
     /// Content that appears on the trailing edge of the list item.
     let trailingContent: () -> Content?
 
@@ -32,6 +35,7 @@ struct SettingsListItem<Content: View>: View {
                 HStack {
                     Text(name)
                         .styleGuide(.body)
+                        .accessibilityIdentifier(nameAccessibilityID ?? "")
                         .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
                         .multilineTextAlignment(.leading)
                         .padding(.vertical, 19)
@@ -63,6 +67,7 @@ struct SettingsListItem<Content: View>: View {
     ///  - name: The name of the list item.
     ///  - hasDivider: Whether or not the list item should have a divider on the bottom.
     ///  - accessibilityIdentifier: The accessibility ID for the list item.
+    ///  - nameAccessibilityID: The accessibility ID for the list item name.
     ///  - action: The action to perform when the list item is tapped.
     ///  - trailingContent: Content that appears on the trailing edge of the list item.
     ///
@@ -72,12 +77,14 @@ struct SettingsListItem<Content: View>: View {
         _ name: String,
         hasDivider: Bool = true,
         accessibilityIdentifier: String? = nil,
+        nameAccessibilityID: String? = nil,
         action: @escaping () -> Void,
         @ViewBuilder trailingContent: @escaping () -> Content? = { EmptyView() }
     ) {
         self.accessibilityIdentifier = accessibilityIdentifier
         self.name = name
         self.hasDivider = hasDivider
+        self.nameAccessibilityID = nameAccessibilityID
         self.trailingContent = trailingContent
         self.action = action
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersView.swift
@@ -45,6 +45,7 @@ struct FoldersView: View {
             .styleGuide(.callout)
             .multilineTextAlignment(.center)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .accessibilityIdentifier("NoFoldersLabel")
     }
 
     /// The section listing all the user's folders.
@@ -60,10 +61,15 @@ struct FoldersView: View {
                 },
                 id: \.id
             ) { index, folder in
-                SettingsListItem(folder.name, hasDivider: index < (store.state.folders.count - 1)) {
+                SettingsListItem(
+                    folder.name,
+                    hasDivider: index < (store.state.folders.count - 1),
+                    nameAccessibilityID: "FolderName"
+                ) {
                     guard let id = folder.id else { return }
                     store.send(.folderTapped(id: id))
                 }
+                .accessibilityIdentifier("FolderCell")
             }
         }
         .clipShape(RoundedRectangle(cornerRadius: 10))


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1993](https://livefront.atlassian.net/browse/BIT-1993?atlOrigin=eyJpIjoiYmM2ZDZkZTBkMjg4NGY2M2IzMjBlOGUzZDhjOWVkZDgiLCJwIjoiaiJ9)

## 🚧 Type of change
-   🚀 New feature development

## 📔 Objective
Adds accessibility IDs to the folders view in settings.

## 📋 Code changes
-   **FoldersView.swift:** Adds accessibility IDs to the folder cell and the folder cell's name.
-   **SettingsListView.swift:** Adds `nameAccessibilityID` property.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
