### PR TITLE
BIT-2081: Fix watch service error on user logout

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -502,7 +502,7 @@ protocol StateService: AnyObject {
     ///
     /// - Returns: A publisher for the connect to watch value.
     ///
-    func connectToWatchPublisher() async -> AnyPublisher<Bool, Never>
+    func connectToWatchPublisher() async -> AnyPublisher<(String?, Bool), Never>
 
     /// A publisher for the last sync time for the active account.
     ///
@@ -1321,16 +1321,17 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appThemeSubject.eraseToAnyPublisher()
     }
 
-    func connectToWatchPublisher() async -> AnyPublisher<Bool, Never> {
+    func connectToWatchPublisher() async -> AnyPublisher<(String?, Bool), Never> {
         activeAccountIdPublisher().flatMap { userId in
             self.connectToWatchByUserIdSubject.map { values in
-                if let userId {
+                let userValue = if let userId {
                     // Get the user's setting, if they're logged in.
                     values[userId] ?? self.appSettingsStore.connectToWatch(userId: userId)
                 } else {
                     // Otherwise, use the last known value for the previous user.
                     self.appSettingsStore.lastUserShouldConnectToWatch
                 }
+                return (userId, userValue)
             }
         }
         .eraseToAnyPublisher()

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -23,7 +23,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var clearClipboardResult: Result<Void, Error> = .success(())
     var connectToWatchByUserId = [String: Bool]()
     var connectToWatchResult: Result<Void, Error> = .success(())
-    var connectToWatchSubject = CurrentValueSubject<Bool, Never>(false)
+    var connectToWatchSubject = CurrentValueSubject<(String?, Bool), Never>((nil, false))
     var timeProvider = MockTimeProvider(.currentTime)
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
     var disableAutoTotpCopyByUserId = [String: Bool]()
@@ -458,7 +458,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         appThemeSubject.eraseToAnyPublisher()
     }
 
-    func connectToWatchPublisher() async -> AnyPublisher<Bool, Never> {
+    func connectToWatchPublisher() async -> AnyPublisher<(String?, Bool), Never> {
         connectToWatchSubject.eraseToAnyPublisher()
     }
 

--- a/BitwardenShared/Core/Platform/Services/WatchService.swift
+++ b/BitwardenShared/Core/Platform/Services/WatchService.swift
@@ -70,14 +70,8 @@ class DefaultWatchService: NSObject, WatchService {
 
         // Listen for changes in the settings and data that would require syncing with the watch.
         Task {
-            let jointPublisher = await Publishers.CombineLatest(
-                self.stateService.activeAccountIdPublisher(),
-                self.stateService.connectToWatchPublisher()
-            )
-            .values
-
-            for await values in jointPublisher {
-                syncWithWatch(userId: values.0, shouldConnect: values.1)
+            for await (userId, shouldConnect) in await self.stateService.connectToWatchPublisher().values {
+                syncWithWatch(userId: userId, shouldConnect: shouldConnect)
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2081](https://livefront.atlassian.net/browse/BIT-2081)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an intermittent logged error / crash in debug builds when there's only a single user on the device and that user logs out. 

The `WatchService` was previously subscribing to two publishers, the active account and connect to watch publishers. The connect to watch publisher is dependent on the active account publisher as well. This presented a race condition when the sole account on the device logs out. Each of these publishers would publish a new value - if the connect to watch publisher published a new value first, the `WatchService` would receive the updated connect to watch setting, but still have the previous account ID until the active account publisher publishes a value. This results in a short period of time when there isn't an active account, but the `WatchService` attempts to subscribe to an account's ciphers which ends up throwing an error. This updates the `WatchService` to only subscribe to a single publisher which contains both the active account ID and whether the app should connect to the watch.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

- **StateService.swift:** Updates the connect to watch publisher to publish the active user ID and the connect to watch setting.
-   **WatchService.swift:** Changes the subscription logic to only subscribe to the `connectToWatchPublisher` which contains both a user ID and should connect value.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
