### PR TITLE
BIT-2130: Show folders when filtering on an org

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Enum/VaultFilterType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/VaultFilterType.swift
@@ -74,16 +74,18 @@ extension VaultFilterType {
         }
     }
 
-    /// A filter to determine if a `FolderView` should be included in the vault list with the
-    /// current filter.
+    /// A filter to determine if a `VaultListItem` should be included in the vault list with the
+    /// current filter. Filters out any empty folders on the my vault and organization vault filters.
     ///
-    /// - Parameter folder: The `FolderView` to determine if it should be in the vault list.
-    /// - Returns: Whether the folder should be displayed in the vault list.
+    /// - Parameter item: The `VaultListItem` to determine if it should be in the vault list.
+    /// - Returns: Whether the item should be displayed in the vault list.
     ///
-    func folderFilter(_ folder: FolderView) -> Bool {
-        if case .organization = self {
-            false
-        } else {
+    func folderFilter(_ item: VaultListItem) -> Bool {
+        switch (item.itemType, self) {
+        case (let .group(_, cipherCount), .myVault),
+             (let .group(_, cipherCount), .organization):
+            cipherCount > 0
+        default:
             true
         }
     }

--- a/BitwardenShared/Core/Vault/Models/Enum/VaultFilterTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/VaultFilterTypeTests.swift
@@ -67,19 +67,22 @@ class VaultFilterTypeTests: BitwardenTestCase {
         )
     }
 
-    /// `folderFilter(_:)` returns whether the folder should be included in the all vaults list.
+    /// `folderFilter(_:)` returns that folders are always included in the all vaults lists
     func test_folderFilter_allVaults() {
-        XCTAssertTrue(VaultFilterType.allVaults.folderFilter(.fixture()))
+        XCTAssertTrue(VaultFilterType.allVaults.folderFilter(.fixtureGroup(count: 0)))
+        XCTAssertTrue(VaultFilterType.allVaults.folderFilter(.fixtureGroup(count: 1)))
     }
 
-    /// `folderFilter(_:)` returns whether the folder should be included in the my vault list.
+    /// `folderFilter(_:)` returns that folders are included in the my vaults list if they aren't empty.
     func test_folderFilter_myVaults() {
-        XCTAssertTrue(VaultFilterType.myVault.folderFilter(.fixture()))
+        XCTAssertFalse(VaultFilterType.myVault.folderFilter(.fixtureGroup(count: 0)))
+        XCTAssertTrue(VaultFilterType.myVault.folderFilter(.fixtureGroup(count: 1)))
     }
 
-    /// `folderFilter(_:)` returns whether the folder should be included in the organization vault list.
+    /// `folderFilter(_:)` returns that folders are included in the organization vault list if they aren't empty.
     func test_folderFilter_organization() {
-        XCTAssertFalse(VaultFilterType.organization(.fixture()).folderFilter(.fixture()))
+        XCTAssertFalse(VaultFilterType.organization(.fixture()).folderFilter(.fixtureGroup(count: 0)))
+        XCTAssertTrue(VaultFilterType.organization(.fixture()).folderFilter(.fixtureGroup(count: 1)))
     }
 
     /// `title` returns the title of filter for displaying in the filter menu.

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -562,7 +562,6 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
 
         let folders = try await clientVault.folders()
             .decryptList(folders: folders)
-            .filter(filter.folderFilter)
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
 
         let folderItems = folderVaultListItems(
@@ -570,6 +569,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
             folderTree: folders.asNestedNodes(),
             nestedFolderId: folderId
         )
+        .filter(filter.folderFilter)
 
         return VaultListSection(
             id: "Folders",
@@ -669,7 +669,6 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
 
         let folders = try await clientVault.folders()
             .decryptList(folders: folders)
-            .filter(filter.folderFilter)
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
 
         let collections = try await clientVault.collections()
@@ -709,6 +708,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
             activeCiphers: activeCiphers,
             folderTree: folders.asNestedNodes()
         )
+        .filter(filter.folderFilter)
 
         // Add no folder to folders item if needed.
         if !showNoFolderCipherGroup {

--- a/BitwardenShared/Core/Vault/Services/API/Fixtures/syncWithCiphersCollections.json
+++ b/BitwardenShared/Core/Vault/Services/API/Fixtures/syncWithCiphersCollections.json
@@ -161,7 +161,64 @@
       ],
       "edit": true,
       "creationDate": "2023-12-01T15:49:55Z"
+    },
+    {
+      "favorite": false,
+      "id": "21b18415-caf2-44c7-8dee-9d28d69710d9",
+      "name": "Reddit",
+      "viewPassword": true,
+      "reprompt": 0,
+      "login": {
+        "password": "reddit1234asdf",
+        "uris": [
+          {
+            "match": 0,
+            "uri": "reddit.com"
+          }
+        ],
+        "username": "engineering@bitwarden.com",
+        "autofillOnPageLoad": true
+      },
+      "type": 1,
+      "folderId": "3270afb7-e3d7-495a-8867-c66cf272f795",
+      "organizationId": "ba756e34-4650-4e8a-8cbb-6e98bfae9abf",
+      "organizationUseTotp": false,
+      "revisionDate": "2023-12-01T15:49:55Z",
+      "collectionIds": [
+        "f96de98e-618a-4886-b396-66b92a385325"
+      ],
+      "edit": true,
+      "creationDate": "2023-12-01T15:49:55Z"
+    },
+    {
+      "favorite": false,
+      "id": "2febd4e6-3e74-42a6-bc7b-f4e0faffa5d2",
+      "name": "Zoom",
+      "viewPassword": true,
+      "reprompt": 0,
+      "login": {
+        "password": "zoom1234asdf",
+        "uris": [
+          {
+            "match": 0,
+            "uri": "zoom.com"
+          }
+        ],
+        "username": "zoom@bitwarden.com",
+        "autofillOnPageLoad": true
+      },
+      "type": 1,
+      "folderId": "2f6e9cda-b12a-4b16-8db1-c7c2e4dc32d5",
+      "organizationId": "ba756e34-4650-4e8a-8cbb-6e98bfae9abf",
+      "organizationUseTotp": false,
+      "revisionDate": "2023-12-01T15:49:55Z",
+      "collectionIds": [
+        "a468e453-7141-49cf-bb15-58448c2b27b9"
+      ],
+      "edit": true,
+      "creationDate": "2023-12-01T15:49:55Z"
     }
+
   ],
   "collections": [
     {
@@ -189,6 +246,11 @@
     {
       "id": "3270afb7-e3d7-495a-8867-c66cf272f795",
       "name": "Social",
+      "revisionDate": "2023-10-09T03:44:59Z"
+    },
+    {
+      "id": "2f6e9cda-b12a-4b16-8db1-c7c2e4dc32d5",
+      "name": "Internal",
       "revisionDate": "2023-10-09T03:44:59Z"
     }
   ]


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2130](https://livefront.atlassian.net/browse/BIT-2130) - Folders Containing Organization Ciphers Not Displayed When Filtering by Organization

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

When the user is filtering their vaults by an organization, they should still see items from that organization.

## 📋 Code changes

- **VaultFilterType**: changes how it filters out folders to be based not just on the kind of filter but also whether or not the item in question has ciphers in it
- **VaultRepository**: changes to use the new folder-filtering mechanism
- **syncWithCiphersCollections.json**: adds additional ciphers to allow tests to cover folder/collection scenarios
<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

## 📸 Screenshots

![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 13 40 05](https://github.com/bitwarden/ios/assets/159173170/22e2917d-c809-4562-ae5a-3f3a5b97e6c6)

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
