### PR TITLE
BIT-2155: Handle action extension provider types that don't support autofill

### DIFF
--- a/BitwardenActionExtension/ActionViewController.swift
+++ b/BitwardenActionExtension/ActionViewController.swift
@@ -75,6 +75,10 @@ extension ActionViewController: AppExtensionDelegate {
         actionExtensionHelper.authCompletionRoute
     }
 
+    var canAutofill: Bool {
+        actionExtensionHelper.canAutofill
+    }
+
     var isInAppExtension: Bool { true }
 
     var isInAppExtensionSaveLoginFlow: Bool {

--- a/BitwardenAutoFillExtension/CredentialProviderViewController.swift
+++ b/BitwardenAutoFillExtension/CredentialProviderViewController.swift
@@ -94,8 +94,6 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
 // MARK: - AppExtensionDelegate
 
 extension CredentialProviderViewController: AppExtensionDelegate {
-    var isInAppExtension: Bool { true }
-
     var authCompletionRoute: AppRoute {
         if isConfiguring {
             AppRoute.extensionSetup(.extensionActivation(type: .autofillExtension))
@@ -103,6 +101,10 @@ extension CredentialProviderViewController: AppExtensionDelegate {
             AppRoute.vault(.autofillList)
         }
     }
+
+    var canAutofill: Bool { true }
+
+    var isInAppExtension: Bool { true }
 
     var uri: String? {
         guard let serviceIdentifier = serviceIdentifiers.first else { return nil }

--- a/BitwardenShared/Core/Autofill/Utilities/ActionExtensionHelper.swift
+++ b/BitwardenShared/Core/Autofill/Utilities/ActionExtensionHelper.swift
@@ -2,6 +2,8 @@ import Foundation
 import OSLog
 import UniformTypeIdentifiers
 
+// swiftlint:disable file_length
+
 // MARK: - ActionExtensionHelper
 
 /// A helper class for processing the input items of the action extension.
@@ -29,6 +31,18 @@ public class ActionExtensionHelper { // swiftlint:disable:this type_body_length
         } else {
             AppRoute.vault(.autofillList)
         }
+    }
+
+    /// Whether the app extension can autofill credentials.
+    public var canAutofill: Bool {
+        guard context.providerType == Constants.UTType.appExtensionFillBrowserAction ||
+            context.providerType == Constants.UTType.appExtensionFillWebViewAction ||
+            context.providerType == UTType.propertyList.identifier ||
+            context.providerType == UTType.url.identifier
+        else {
+            return false
+        }
+        return context.pageDetails?.hasPasswordField ?? false
     }
 
     /// Whether the app extension setup provider was included in the input items.

--- a/BitwardenShared/Core/Autofill/Utilities/ActionExtensionHelperTests.swift
+++ b/BitwardenShared/Core/Autofill/Utilities/ActionExtensionHelperTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-class ActionExtensionHelperTests: BitwardenTestCase {
+class ActionExtensionHelperTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var subject: ActionExtensionHelper!
@@ -25,6 +25,69 @@ class ActionExtensionHelperTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `canAutofill` returns true if the provider type is supported and the page details contains a
+    /// password field.
+    func test_canAutofill() throws {
+        let pageDetailsJsonData = APITestData.loadFromJsonBundle(resource: "pageDetails").data
+        let pageDetailsJson = try XCTUnwrap(String(data: pageDetailsJsonData, encoding: .utf8))
+
+        let extensionItem = NSExtensionItem()
+        extensionItem.attachments = [
+            NSItemProvider(
+                item: [
+                    NSExtensionJavaScriptPreprocessingResultsKey: [
+                        Constants.appExtensionUrlStringKey: "https://vault.bitwarden.com",
+                        Constants.appExtensionWebViewPageDetails: pageDetailsJson,
+                    ],
+                ] as NSSecureCoding,
+                typeIdentifier: UTType.propertyList.identifier
+            ),
+        ]
+
+        subject.processInputItems([extensionItem])
+        waitFor(subject.context.didFinishLoadingItem)
+
+        XCTAssertTrue(subject.canAutofill)
+    }
+
+    /// `canAutofill` returns false if the provider type is supported but no page details exist.
+    func test_canAutofill_missingPageDetails() throws {
+        let extensionItem = NSExtensionItem()
+        extensionItem.attachments = [
+            NSItemProvider(
+                item: URL(string: "https://vault.bitwarden.com")! as NSSecureCoding,
+                typeIdentifier: UTType.url.identifier
+            ),
+        ]
+
+        subject.processInputItems([extensionItem])
+        waitFor(subject.context.didFinishLoadingItem)
+
+        XCTAssertFalse(subject.canAutofill)
+    }
+
+    /// `canAutofill` returns false if the page details doesn't contain a password field.
+    func test_canAutofill_noPasswordField() throws {
+        let pageDetailsJsonData = APITestData.loadFromJsonBundle(resource: "pageDetailsWithoutPassword").data
+        let pageDetailsJson = String(data: pageDetailsJsonData, encoding: .utf8)
+
+        let extensionItem = NSExtensionItem()
+        extensionItem.attachments = [
+            NSItemProvider(
+                item: [
+                    Constants.appExtensionUrlStringKey: "https://vault.bitwarden.com",
+                    Constants.appExtensionWebViewPageDetails: pageDetailsJson,
+                ] as NSSecureCoding,
+                typeIdentifier: Constants.UTType.appExtensionFillBrowserAction
+            ),
+        ]
+
+        subject.processInputItems([extensionItem])
+        waitFor(subject.context.didFinishLoadingItem)
+
+        XCTAssertFalse(subject.canAutofill)
+    }
+
     /// `processInputItems(_:)` processes the input items for the extension setup and sets the
     /// `isAppExtensionSetup` if the type identifier is for extension setup.
     func test_processInputItems_extensionSetup() {
@@ -39,6 +102,7 @@ class ActionExtensionHelperTests: BitwardenTestCase {
         subject.processInputItems([extensionItem])
 
         XCTAssertTrue(subject.isAppExtensionSetup)
+        XCTAssertFalse(subject.canAutofill)
     }
 
     /// `processInputItems(_:)` processes the input items for the extension setup, but doesn't set
@@ -78,6 +142,7 @@ class ActionExtensionHelperTests: BitwardenTestCase {
         subject.processInputItems([extensionItem])
         waitFor(subject.context.didFinishLoadingItem)
 
+        XCTAssertFalse(subject.canAutofill)
         XCTAssertEqual(subject.context.loginTitle, "Bitwarden")
         XCTAssertEqual(subject.context.notes, "My Bitwarden Login")
         XCTAssertEqual(subject.context.oldPassword, "Old Password")
@@ -119,6 +184,7 @@ class ActionExtensionHelperTests: BitwardenTestCase {
         subject.processInputItems([extensionItem])
         waitFor(subject.context.didFinishLoadingItem)
 
+        XCTAssertTrue(subject.canAutofill)
         XCTAssertEqual(subject.context.pageDetails, pageDetails)
         XCTAssertEqual(subject.context.urlString, "https://vault.bitwarden.com")
 
@@ -181,6 +247,7 @@ class ActionExtensionHelperTests: BitwardenTestCase {
         subject.processInputItems([extensionItem])
         waitFor(subject.context.didFinishLoadingItem)
 
+        XCTAssertFalse(subject.canAutofill)
         XCTAssertEqual(subject.context.urlString, "https://vault.bitwarden.com")
 
         // Output
@@ -218,6 +285,7 @@ class ActionExtensionHelperTests: BitwardenTestCase {
         subject.processInputItems([extensionItem])
         waitFor(subject.context.didFinishLoadingItem)
 
+        XCTAssertFalse(subject.canAutofill)
         XCTAssertEqual(subject.context.loginTitle, "Bitwarden")
         XCTAssertEqual(subject.context.notes, "My Bitwarden Login")
         XCTAssertEqual(subject.context.password, "Password")
@@ -262,6 +330,7 @@ class ActionExtensionHelperTests: BitwardenTestCase {
         subject.processInputItems([extensionItem])
         waitFor(subject.context.didFinishLoadingItem)
 
+        XCTAssertTrue(subject.canAutofill)
         XCTAssertEqual(subject.uri, "https://vault.bitwarden.com")
 
         let pageDetails = try XCTUnwrap(subject.context.pageDetails)

--- a/BitwardenShared/Core/Autofill/Utilities/Fixtures/pageDetailsWithoutPassword.json
+++ b/BitwardenShared/Core/Autofill/Utilities/Fixtures/pageDetailsWithoutPassword.json
@@ -1,0 +1,18 @@
+{
+  "documentUUID": "oneshotUUID",
+  "title": "Bitwarden Web vault",
+  "url": "https://vault.bitwarden.com/#/lock",
+  "documentUrl": "https://vault.bitwarden.com/#/lock",
+  "tabUrl": "https://vault.bitwarden.com/#/lock",
+  "forms": {
+    "__form__0": {
+      "opid": "__form__0",
+      "htmlName": "",
+      "htmlID": "",
+      "htmlAction": "https://vault.bitwarden.com/#/lock",
+      "htmlMethod": "get"
+    }
+  },
+  "fields": [],
+  "collectedTimestamp": 1705986374348
+}

--- a/BitwardenShared/UI/Platform/Application/AppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Platform/Application/AppExtensionDelegate.swift
@@ -7,6 +7,9 @@ public protocol AppExtensionDelegate: AnyObject {
     /// The app's route that the app should navigate to after auth has been completed.
     var authCompletionRoute: AppRoute { get }
 
+    /// Whether the app extension can autofill credentials.
+    var canAutofill: Bool { get }
+
     /// Whether the app is running within an extension.
     var isInAppExtension: Bool { get }
 
@@ -32,6 +35,9 @@ public protocol AppExtensionDelegate: AnyObject {
 }
 
 public extension AppExtensionDelegate {
+    /// Whether the app extension can autofill credentials.
+    var canAutofill: Bool { false }
+
     /// Whether the app is running the save login flow in the action extension. This flow opens the
     /// add vault item view and completes the extension request when the item has been added.
     var isInAppExtensionSaveLoginFlow: Bool { false }

--- a/BitwardenShared/UI/Platform/Application/TestHelpers/MockAppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Platform/Application/TestHelpers/MockAppExtensionDelegate.swift
@@ -2,6 +2,7 @@
 
 class MockAppExtensionDelegate: AppExtensionDelegate {
     var authCompletionRoute = AppRoute.vault(.autofillList)
+    var canAutofill = true
     var didCancelCalled = false
     var didCompleteAutofillRequestFields: [(String, String)]?
     var didCompleteAutofillRequestPassword: String?

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -95,7 +95,8 @@ class AutofillHelper {
         cipherView: CipherView,
         showToast: @escaping (String) -> Void
     ) async {
-        guard let username = cipherView.login?.username, !username.isEmpty,
+        guard appExtensionDelegate?.canAutofill ?? false,
+              let username = cipherView.login?.username, !username.isEmpty,
               let password = cipherView.login?.password, !password.isEmpty else {
             handleMissingValueForAutofill(cipherView: cipherView, showToast: showToast)
             return


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2155](https://livefront.atlassian.net/browse/BIT-2155)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🐛 Bug fix

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes a bug when the action extension is unable to fill the user's credentials into a web view that isn't Safari (e.g. Chrome). Apps other than Safari are unable to run the extension's javascript file to parse and fill the page, so in this case we show an alert allowing the user to select the username, password or TOTP code to copy when they return to the web view.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **ActionViewController/CredentailProviderViewController.swift:** Support new `canAutofill` delegate method.
- **ActionExtensionHelper.swift:** Only support autofill for the whitelisted providers types and if the page contains a password field.
- **AppExtensionDelegate.swift:** Add a method to determine if the extension can autofill the user's credentials.
- **AutofillHelper.swift:** Ensure the extension supports autofill, otherwise show an action sheet giving the user additional options.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/678bef91-6709-49ee-a2db-dc862ef24f7a


## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
