### PR TITLE
BIT-1257: Add error handling for master password hint

### DIFF
--- a/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessor.swift
+++ b/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessor.swift
@@ -6,6 +6,7 @@ class PasswordHintProcessor: StateProcessor<PasswordHintState, PasswordHintActio
     // MARK: Types
 
     typealias Services = HasAccountAPIService
+        & HasErrorReporter
 
     // MARK: Private Properties
 
@@ -76,8 +77,8 @@ class PasswordHintProcessor: StateProcessor<PasswordHintState, PasswordHintActio
             coordinator.hideLoadingOverlay()
             coordinator.showAlert(alert)
         } catch {
-            // TODO: BIT-1257 Add error handling
-            print(error)
+            coordinator.showAlert(.networkResponseError(error))
+            services.errorReporter.log(error: error)
         }
     }
 }

--- a/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessorTests.swift
@@ -1,3 +1,4 @@
+import Networking
 import XCTest
 
 @testable import BitwardenShared
@@ -7,6 +8,7 @@ import XCTest
 class PasswordHintProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
+    var errorReporter: MockErrorReporter!
     var httpClient: MockHTTPClient!
     var coordinator: MockCoordinator<AuthRoute, AuthEvent>!
     var subject: PasswordHintProcessor!
@@ -16,8 +18,9 @@ class PasswordHintProcessorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
         coordinator = MockCoordinator()
+        errorReporter = MockErrorReporter()
         httpClient = MockHTTPClient()
-        let services = ServiceContainer.withMocks(httpClient: httpClient)
+        let services = ServiceContainer.withMocks(errorReporter: errorReporter, httpClient: httpClient)
         let state = PasswordHintState()
         subject = PasswordHintProcessor(
             coordinator: coordinator.asAnyCoordinator(),
@@ -29,11 +32,25 @@ class PasswordHintProcessorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
         coordinator = nil
+        errorReporter = nil
         httpClient = nil
         subject = nil
     }
 
     // MARK: Tests
+
+    /// `perform()` with `.submitPressed` shows an alert and logs an error if the request fails.
+    func test_perform_submitPressed_error() async throws {
+        subject.state.emailAddress = "email@example.com"
+        let errorResponse = HTTPResponse.failure(statusCode: 500)
+        httpClient.result = .success(errorResponse)
+
+        await subject.perform(.submitPressed)
+
+        let responseError = ResponseValidationError(response: errorResponse)
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(responseError))
+        XCTAssertEqual(errorReporter.errors.last as? ResponseValidationError, responseError)
+    }
 
     /// `perform()` with `.submitPressed` submits the request for the master password hint.
     func test_perform_submitPressed_success() async throws {
@@ -41,7 +58,6 @@ class PasswordHintProcessorTests: BitwardenTestCase {
         httpClient.results = [.success(.success(statusCode: 200))]
         await subject.perform(.submitPressed)
 
-        // TODO: BIT-733 Assert password hint service calls
         XCTAssertEqual(httpClient.requests.count, 1)
         let request = try XCTUnwrap(httpClient.requests.first)
         XCTAssertEqual(request.url, URL(string: "https://example.com/api/accounts/password-hint"))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1257](https://livefront.atlassian.net/browse/BIT-1257)

## 🚧 Type of change

<!-- Choose those applicable and remove the others. -->

-   🚀 New feature development

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add error handling if master password hint API call fails.

## 📋 Code changes

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

-   **PasswordHintProcessor.swift:** Add error handling for API request.

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
