### PR TITLE
BIT-2007: Remove extra SendCell accessibility identifier

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -89,7 +89,6 @@ struct SendListItemRowView: View {
                     optionsMenu(for: sendView)
                 }
             }
-            .accessibilityIdentifier("SendCell")
             .padding(.horizontal, 16)
 
             if store.state.hasDivider {


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2007](https://livefront.atlassian.net/browse/BIT-2007) - Adding Element IDs to Send cells

## 🚧 Type of change

-   🚀 New feature development

## 📔 Objective

For UI testing, the options button on a Send cell needs to have its own `accessibilityIdentifier`. We were applying `SendCell` at a level where it was overriding the button. This reduces the scope of that ID.

## 📋 Code changes

**SendListItemRowView.swift**: Removed redundant `accessibilityIdentifier` application that was overriding the button's `accessibilityIdentifier`

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
