### PR TITLE
BIT-2154: Keep actual value of date-time picker in sync with proxy value

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenDatePicker.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenDatePicker.swift
@@ -95,7 +95,14 @@ struct BitwardenDatePicker: View {
             }
         }
         .onChange(of: nonNilSelection, perform: { newValue in
-            selection = newValue
+            if selection != newValue {
+                selection = newValue
+            }
+        })
+        .onChange(of: selection, perform: { newValue in
+            if let newValue, newValue != nonNilSelection {
+                nonNilSelection = newValue
+            }
         })
     }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -206,7 +206,8 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                             get: \.customDeletionDate,
                             send: AddEditSendItemAction.customDeletionDateChanged
                         ),
-                        displayComponents: .hourAndMinute
+                        displayComponents: .hourAndMinute,
+                        accessibilityIdentifier: "SendCustomDeletionTimePicker"
                     )
                 }
             }
@@ -255,7 +256,8 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                             get: \.customExpirationDate,
                             send: AddEditSendItemAction.customExpirationDateChanged
                         ),
-                        displayComponents: .hourAndMinute
+                        displayComponents: .hourAndMinute,
+                        accessibilityIdentifier: "SendCustomDeletionTimePicker"
                     )
                 }
             }


### PR DESCRIPTION
## 🎟️ Tracking

[BIT-2154](https://livefront.atlassian.net/browse/BIT-2154) - Issue with Selecting Same Day Deletion for New Send

## 🚧 Type of change

-   🐛 Bug fix

## 📔 Objective

There was an issue with the `BitwardenDatePicker` where external changes to its date weren't updating the actual state that tracked the selected date/time. This meant when two of these were linked to each other (one with date, the other with time), updating one wouldn't _actually_ update the other's internal state. This fixes that to make sure both values stay in sync.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📋 Code changes

- **BitwardenDatePicker.swift**: Added change listener on `selection` to also update `nonNilSelection`, which is the actual value used when making further changes to this picker. Additional checks to avoid unnecessary updates that send redundant update events
- **AddEditSendItemView.swift**: Added additional accessibility identifier for completeness

<!-- Explain the changes you've made to each file or major component. This should help the reviewer understand your changes. -->
<!-- Also refer to any related changes or PRs in other repositories. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

-   Contributor guidelines followed
-   All formatters and local linters executed and passed
-   Written new unit and / or integration tests where applicable
-   Used internationalization (i18n) for all UI strings
-   CI builds passed
-   Communicated to DevOps any deployment requirements
-   Updated any necessary documentation or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

-   👍 (`:+1:`) or similar for great changes
-   📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
-   ❓ (`:question:`) for questions
-   🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
-   🎨 (`:art:`) for suggestions / improvements
-   ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
-   🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
-   ⛏ (`:pick:`) for minor or nitpick changes
