### PR TITLE
BIT-1778: Add the homebrew path for Apple silicon to build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,7 @@
     $ brew install mint
     ```
 
-    If you're using a Mac with Apple Silicon with Mint installed via Homebrew, you may see the SwiftGen build phase fail with the following error:
-
-    `line 2: mint: command not found`
-
-    If so, or if you just prefer to install Mint without `brew`, clone the Mint repo into a temporary directory and run `make`.
+    Alternatively, if you prefer to install Mint without `brew`, clone the Mint repo into a temporary directory and run `make`.
 
     ```sh
     $ git clone https://github.com/yonaskolb/Mint.git

--- a/Scripts/update_acknowledgements.sh
+++ b/Scripts/update_acknowledgements.sh
@@ -5,6 +5,11 @@
 set -euo pipefail
 
 if [ "$CONFIGURATION" = "Debug" ]; then
+    # Add the homebrew path for Apple silicon since it's not in Xcode's path.
+    if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then
+        PATH="/opt/homebrew/bin:$PATH"
+    fi
+
     mint run LicensePlist license-plist \
         --config-path .license_plist.yml
 fi

--- a/project.yml
+++ b/project.yml
@@ -151,14 +151,22 @@ targets:
           - $(SRCROOT)/Bitwarden/Application/Support/Settings.bundle/Acknowledgements.latest_results.txt
           - $(SRCROOT)/Bitwarden/Application/Support/Settings.bundle/Acknowledgements
     postCompileScripts:
-      - script: mint run swiftlint
+      - script: |
+          if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then
+            PATH="/opt/homebrew/bin:$PATH"
+          fi
+          mint run swiftlint
         name: Swiftlint
         basedOnDependencyAnalysis: false
-      - script: mint run swiftformat --lint --lenient .
+      - script: |
+          if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then
+            PATH="/opt/homebrew/bin:$PATH"
+          fi
+          mint run swiftformat --lint --lenient .
         name: SwiftFormat Lint
         basedOnDependencyAnalysis: false
     postBuildScripts:
-      - script: Scripts/update_settings_version_number.sh
+      - path: Scripts/update_settings_version_number.sh
         name: "Settings.bundle: Update Version Number"
         basedOnDependencyAnalysis: false
       - path: Scripts/firebase_crashlytics_run.sh
@@ -330,7 +338,10 @@ targets:
     preBuildScripts:
       - name: SwiftGen
         script: |
-            mint run swiftgen config run --config "swiftgen.yml"
+          if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then
+            PATH="/opt/homebrew/bin:$PATH"
+          fi
+          mint run swiftgen config run --config "swiftgen.yml"
         basedOnDependencyAnalysis: false
         outputFiles:
           - $(SRCROOT)/BitwardenShared/UI/Platform/Application/Support/Generated/Assets.swift


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1778](https://livefront.atlassian.net/browse/BIT-1778)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the homebrew path on Apple silicon to the build scripts so no special setup should be required to build and run the app after installing mint and bootstrapping.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
