### PR TITLE
BIT-1972: Accessibility IDs for header

### DIFF
--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
@@ -30,7 +30,7 @@ struct ProfileSwitcherToolbarView: View {
             }
             .frame(minWidth: 50)
         }
-        .accessibilityIdentifier("AccountIconButton")
+        .accessibilityIdentifier("CurrentActiveAccount")
         .accessibilityLabel(Localizations.account)
         .hidden(!store.state.showPlaceholderToolbarIcon && store.state.accounts.isEmpty)
     }

--- a/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
@@ -24,7 +24,7 @@ extension View {
     ///
     func cancelToolbarButton(action: @escaping () -> Void) -> some View {
         toolbarButton(asset: Asset.Images.cancel, label: Localizations.cancel, action: action)
-            .accessibilityIdentifier("CLOSE")
+            .accessibilityIdentifier("CancelButton")
     }
 
     /// Returns a toolbar button configured for closing a view.

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
@@ -31,6 +31,7 @@ struct GeneratorView: View {
                         store.send(.selectButtonPressed)
                     }
                     .buttonStyle(.primary())
+                    .accessibilityIdentifier("SelectButton")
                 }
             }
             .padding(16)


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-1972](https://livefront.atlassian.net/browse/BIT-1972?atlOrigin=eyJpIjoiMjI4YTNmYjYzOWI4NGRiMGE2ZWVhNGZjOGM1NjkzMzMiLCJwIjoiaiJ9)

## 📔 Objective
- Adds accessibility ID to select button in `GeneratorView.swift`.
- Updates accessibility IDs for cancel buttons & profile switcher account icon.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
