### PR TITLE
BIT-2204: Don't show an alert if syncing was cancelled

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -186,6 +186,8 @@ extension VaultListProcessor {
                 filter: state.vaultFilterType
             ) else { return }
             state.loadingState = .data(sections)
+        } catch URLError.cancelled {
+            // No-op: don't log or alert for cancellation errors.
         } catch {
             coordinator.showAlert(.networkResponseError(error))
             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -100,6 +100,19 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
     }
 
+    /// `perform(_:)` with `.appeared` doesn't show an alert or log an error if the request was cancelled.
+    func test_perform_appeared_cancelled() async {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .authorized
+        vaultRepository.fetchSyncResult = .failure(URLError(.cancelled))
+
+        await subject.perform(.appeared)
+
+        XCTAssertTrue(vaultRepository.fetchSyncCalled)
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `perform(_:)` with `.appeared` handles any pending login requests for the user to address.
     func test_perform_appeared_checkPendingLoginRequests() async {
         // Set up the mock data.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2204](https://livefront.atlassian.net/browse/BIT-2204)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the `VaultListProcessor` to not show or log an error if syncing fails because the request was cancelled. This fixes an issue during automated tests where navigating to another tab before syncing completes displays an error for the cancelled request.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
