### PR TITLE
BIT-2195: Add support for nested collections

### DIFF
--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -534,7 +534,7 @@ extension BitwardenSdk.Collection {
     }
 }
 
-extension BitwardenSdk.CollectionView: @unchecked Sendable {}
+extension BitwardenSdk.CollectionView: @unchecked Sendable, TreeNodeModel {}
 
 // MARK: - Folders (BitwardenSdk)
 

--- a/BitwardenShared/Core/Vault/Services/API/Fixtures/syncWithCiphersCollections.json
+++ b/BitwardenShared/Core/Vault/Services/API/Fixtures/syncWithCiphersCollections.json
@@ -262,6 +262,16 @@
       "readOnly": false,
       "hidePasswords": false,
       "manage": false,
+      "id": "1a102336-fbfd-4d63-bd7b-8a953a1bcdb3",
+      "organizationId": "ba756e34-4650-4e8a-8cbb-6e98bfae9abf",
+      "name": "Engineering/Apple",
+      "externalId": null,
+      "object": "collectionDetails"
+    },
+    {
+      "readOnly": false,
+      "hidePasswords": false,
+      "manage": false,
       "id": "a468e453-7141-49cf-bb15-58448c2b27b9",
       "organizationId": "ba756e34-4650-4e8a-8cbb-6e98bfae9abf",
       "name": "Design",

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -351,6 +351,11 @@ class SyncServiceTests: BitwardenTestCase {
                     organizationId: "ba756e34-4650-4e8a-8cbb-6e98bfae9abf"
                 ),
                 CollectionDetailsResponseModel.fixture(
+                    id: "1a102336-fbfd-4d63-bd7b-8a953a1bcdb3",
+                    name: "Engineering/Apple",
+                    organizationId: "ba756e34-4650-4e8a-8cbb-6e98bfae9abf"
+                ),
+                CollectionDetailsResponseModel.fixture(
                     id: "a468e453-7141-49cf-bb15-58448c2b27b9",
                     name: "Design",
                     organizationId: "ba756e34-4650-4e8a-8cbb-6e98bfae9abf"


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2195](https://livefront.atlassian.net/browse/BIT-2195)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for displaying nested collections within the vault.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/7718e5ac-00ff-4aeb-829d-181b925d47e8



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
