### PR TITLE
BIT-2209: Clear file password after a successful vault export

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
@@ -94,6 +94,9 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
 
                 // Clear the user's entered password so that it's required to be entered again for
                 // any subsequent exports.
+                self.state.filePasswordText = ""
+                self.state.filePasswordConfirmationText = ""
+                self.state.filePasswordStrengthScore = nil
                 self.state.masterPasswordText = ""
             } catch {
                 self.services.errorReporter.log(error: error)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2209](https://livefront.atlassian.net/browse/BIT-2209)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Clear the file password in addition to the master password after a successful vault export.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/2f251bbd-9906-4d4f-bd6d-c53369bf03f6



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
