### PR TITLE
BIT-2172: Hide TOTP seed

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -88,7 +88,7 @@ struct BitwardenTextField<TrailingContent: View>: View {
     private var textField: some View {
         HStack(spacing: 8) {
             ZStack {
-                let isPassword = isPasswordVisible != nil
+                let isPassword = isPasswordVisible != nil || canViewPassword == false
                 let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
 
                 TextField(placeholder, text: $text)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
@@ -99,15 +99,19 @@ struct AddEditLoginItemView: View {
                     send: AddEditItemAction.totpKeyChanged
                 ),
                 accessibilityIdentifier: "LoginTotpEntry",
+                canViewPassword: store.state.canViewPassword,
                 trailingContent: {
-                    AccessoryButton(asset: Asset.Images.copy, accessibilityLabel: Localizations.copyTotp) {
-                        await store.perform(.copyTotpPressed)
+                    if store.state.canViewPassword {
+                        AccessoryButton(asset: Asset.Images.copy, accessibilityLabel: Localizations.copyTotp) {
+                            await store.perform(.copyTotpPressed)
+                        }
                     }
                     AccessoryButton(asset: Asset.Images.camera, accessibilityLabel: Localizations.setupTotp) {
                         await store.perform(.setupTotpPressed)
                     }
                 }
             )
+            .disabled(!store.state.canViewPassword)
             .focused($focusedField, equals: .totp)
             .onSubmit {
                 store.send(.totpFieldLeftFocus)


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-2172](https://livefront.atlassian.net/browse/BIT-2172?atlOrigin=eyJpIjoiOGUxNmE3YWUzMDkzNDFlMGJmZWMzOGIxNWNmMmMyYzgiLCJwIjoiaiJ9)

## 📔 Objective
Hides the TOTP seed if the user has "Can view, except password" permissions.

## 📸 Screenshots
### Before
![Before](https://github.com/bitwarden/ios/assets/125899965/543b2515-b4f5-4474-ac3e-e50e0fd680e6)

### After
![After](https://github.com/bitwarden/ios/assets/125899965/0dfd3ea9-a58b-4a1e-81f9-179a1886680f)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
