### PR TITLE
BIT-2227: Hide require master password alert when setting a pin for a user without a master password

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -36,6 +36,7 @@ class MockAuthRepository: AuthRepository {
     var setMasterPasswordOrganizationIdentifier: String?
     var setMasterPasswordResetPasswordAutoEnroll: Bool?
     var setMasterPasswordResult: Result<Void, Error> = .success(())
+    var setPinsResult: Result<Void, Error> = .success(())
     var setVaultTimeoutError: Error?
     var unlockVaultFromLoginWithDeviceKey: String?
     var unlockVaultFromLoginWithDeviceMasterPasswordHash: String? // swiftlint:disable:this identifier_name
@@ -176,6 +177,7 @@ class MockAuthRepository: AuthRepository {
     func setPins(_ pin: String, requirePasswordAfterRestart _: Bool) async throws {
         encryptedPin = pin
         pinProtectedUserKey = pin
+        try setPinsResult.get()
     }
 
     func sessionTimeoutValue(userId: String?) async throws -> BitwardenShared.SessionTimeoutValue {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -227,6 +227,13 @@ protocol StateService: AnyObject {
     ///
     func getUnsuccessfulUnlockAttempts(userId: String?) async throws -> Int
 
+    /// Gets whether a user has a master password.
+    ///
+    /// - Parameter userId: The user ID of the user to determine whether they have a master password.
+    /// - Returns: Whether the user has a master password.
+    ///
+    func getUserHasMasterPassword(userId: String?) async throws -> Bool
+
     /// Gets the username generation options for a user ID.
     ///
     /// - Parameter userId: The user ID associated with the username generation options.
@@ -662,6 +669,14 @@ extension StateService {
         return 0
     }
 
+    /// Gets whether a user has a master password.
+    ///
+    /// - Returns: Whether the user has a master password.
+    ///
+    func getUserHasMasterPassword() async throws -> Bool {
+        try await getUserHasMasterPassword(userId: nil)
+    }
+
     /// Gets the username generation options for the active account.
     ///
     /// - Returns: The username generation options for the user ID.
@@ -1074,6 +1089,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
     func getUnsuccessfulUnlockAttempts(userId: String?) async throws -> Int {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.unsuccessfulUnlockAttempts(userId: userId)
+    }
+
+    func getUserHasMasterPassword(userId: String?) async throws -> Bool {
+        try getAccount(userId: userId).profile.userDecryptionOptions?.hasMasterPassword ?? true
     }
 
     func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -547,6 +547,52 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(unsuccessfulUnlockAttempts, 4)
     }
 
+    /// `getUserHasMasterPassword(userId:)` gets whether a user has a master password for a user
+    /// with a master password.
+    func test_getUserHasMasterPassword() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+        let userHasMasterPassword = try await subject.getUserHasMasterPassword()
+        XCTAssertTrue(userHasMasterPassword)
+    }
+
+    /// `getUserHasMasterPassword(userId:)` gets whether a user has a master password for a TDE user
+    /// without a master password.
+    func test_getUserHasMasterPassword_tdeUserNoPassword() async throws {
+        await subject.addAccount(
+            .fixture(
+                profile: .fixture(
+                    userDecryptionOptions: UserDecryptionOptions(
+                        hasMasterPassword: false,
+                        keyConnectorOption: nil,
+                        trustedDeviceOption: nil
+                    ),
+                    userId: "2"
+                )
+            )
+        )
+        let userHasMasterPassword = try await subject.getUserHasMasterPassword()
+        XCTAssertFalse(userHasMasterPassword)
+    }
+
+    /// `getUserHasMasterPassword(userId:)` gets whether a user has a master password for a TDE user
+    /// with a master password.
+    func test_getUserHasMasterPassword_tdeUserWithPassword() async throws {
+        await subject.addAccount(
+            .fixture(
+                profile: .fixture(
+                    userDecryptionOptions: UserDecryptionOptions(
+                        hasMasterPassword: true,
+                        keyConnectorOption: nil,
+                        trustedDeviceOption: nil
+                    ),
+                    userId: "2"
+                )
+            )
+        )
+        let userHasMasterPassword = try await subject.getUserHasMasterPassword()
+        XCTAssertTrue(userHasMasterPassword)
+    }
+
     /// `getUsernameGenerationOptions()` gets the saved username generation options for the account.
     func test_getUsernameGenerationOptions() async throws {
         let options1 = UsernameGenerationOptions(plusAddressedEmail: "user@bitwarden.com")

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -53,6 +53,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var unsuccessfulUnlockAttempts = [String: Int]()
     var updateProfileResponse: ProfileResponseModel?
     var updateProfileUserId: String?
+    var userHasMasterPassword = [String: Bool]()
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
     var vaultTimeout = [String: SessionTimeoutValue]()
 
@@ -219,6 +220,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func getUnsuccessfulUnlockAttempts(userId: String?) async throws -> Int {
         let userId = try unwrapUserId(userId)
         return unsuccessfulUnlockAttempts[userId] ?? 0
+    }
+
+    func getUserHasMasterPassword(userId: String?) async throws -> Bool {
+        let userId = try unwrapUserId(userId)
+        return userHasMasterPassword[userId] ?? true
     }
 
     func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -265,6 +265,28 @@ final class AccountSecurityProcessor: StateProcessor<
         }
     }
 
+    /// Sets the user's pin.
+    ///
+    /// - Parameters:
+    ///   - pin: The user's pin.
+    ///   - requirePasswordAfterRestart: Whether the user's master password should be required after
+    ///     an app restart.
+    ///
+    private func setPin(_ pin: String, requirePasswordAfterRestart: Bool) async {
+        do {
+            try await services.authRepository.setPins(
+                pin,
+                requirePasswordAfterRestart: requirePasswordAfterRestart
+            )
+            state.isUnlockWithPINCodeOn = true
+        } catch {
+            services.errorReporter.log(error: error)
+            coordinator.showAlert(.defaultAlert(
+                title: Localizations.anErrorHasOccurred
+            ))
+        }
+    }
+
     /// Shows an alert prompting the user to enter their PIN. If set successfully, the toggle will be turned on.
     ///
     /// - Parameter isOn: Whether or not the toggle value is true or false.
@@ -272,19 +294,19 @@ final class AccountSecurityProcessor: StateProcessor<
     private func toggleUnlockWithPIN(_ isOn: Bool) {
         if isOn {
             coordinator.showAlert(.enterPINCode(completion: { pin in
-                self.coordinator.showAlert(.unlockWithPINCodeAlert { requirePassword in
-                    do {
-                        try await self.services.authRepository.setPins(
-                            pin,
-                            requirePasswordAfterRestart: requirePassword
-                        )
-                        self.state.isUnlockWithPINCodeOn = isOn
-                    } catch {
-                        self.coordinator.showAlert(.defaultAlert(
-                            title: Localizations.anErrorHasOccurred
-                        ))
+                do {
+                    let userHasMasterPassword = try await self.services.stateService.getUserHasMasterPassword()
+                    if userHasMasterPassword {
+                        self.coordinator.showAlert(.unlockWithPINCodeAlert { requirePassword in
+                            await self.setPin(pin, requirePasswordAfterRestart: requirePassword)
+                        })
+                    } else {
+                        await self.setPin(pin, requirePasswordAfterRestart: false)
                     }
-                })
+                } catch {
+                    self.services.errorReporter.log(error: error)
+                    self.coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+                }
             }))
         } else {
             Task {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2227](https://livefront.atlassian.net/browse/BIT-2227)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

For a TDE user without a master password, when setting a PIN don't show the "do you want to require your master password" alert.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/60111396-1e21-4242-b68d-d02b61c12dd8



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
