### PR TITLE
BIT-1804: Delete all keychain items on app reinstall

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1225,6 +1225,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertEqual([account.profile.userId], stateService.accountsLoggedOut)
         XCTAssertNil(biometricsRepository.capturedUserAuthKey)
+        XCTAssertEqual(keychainService.deleteItemsForUserIds, ["1"])
     }
 
     /// `unlockVault(password:)` throws an error if the vault is unable to be unlocked.

--- a/BitwardenShared/Core/Auth/Services/KeychainService.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainService.swift
@@ -85,7 +85,10 @@ class DefaultKeychainService: KeychainService {
     }
 
     func delete(query: CFDictionary) throws {
-        try resolve(SecItemDelete(query))
+        let status = SecItemDelete(query)
+        guard [errSecSuccess, errSecItemNotFound].contains(status) else {
+            throw KeychainServiceError.osStatusError(status)
+        }
     }
 
     func search(query: CFDictionary) throws -> AnyObject? {

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockKeychainRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockKeychainRepository.swift
@@ -6,6 +6,10 @@ class MockKeychainRepository: KeychainRepository {
     var appId: String = "mockAppId"
     var mockStorage = [String: String]()
     var securityType: SecAccessControlCreateFlags?
+    var deleteAllItemsCalled = false
+    var deleteAllItemsResult: Result<Void, Error> = .success(())
+    var deleteItemsForUserIds = [String]()
+    var deleteItemsForUserResult: Result<Void, Error> = .success(())
     var deleteResult: Result<Void, Error> = .success(())
     var getResult: Result<String, Error>?
     var setResult: Result<Void, Error> = .success(())
@@ -25,6 +29,18 @@ class MockKeychainRepository: KeychainRepository {
     var setRefreshTokenResult: Result<Void, Error> = .success(())
 
     var setPendingAdminLoginRequestResult: Result<Void, Error> = .success(())
+
+    func deleteAllItems() async throws {
+        deleteAllItemsCalled = true
+        mockStorage.removeAll()
+        try deleteAllItemsResult.get()
+    }
+
+    func deleteItems(for userId: String) async throws {
+        deleteItemsForUserIds.append(userId)
+        mockStorage = mockStorage.filter { !$0.key.contains(userId) }
+        try deleteItemsForUserResult.get()
+    }
 
     func deleteDeviceKey(userId: String) async throws {
         let formattedKey = formattedKey(for: .deviceKey(userId: userId))

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockKeychainService.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockKeychainService.swift
@@ -9,7 +9,7 @@ class MockKeychainService {
     var accessControlResult: Result<SecAccessControl, KeychainServiceError> = .failure(.accessControlFailed(nil))
     var addAttributes: CFDictionary?
     var addResult: Result<Void, KeychainServiceError> = .success(())
-    var deleteQuery: CFDictionary?
+    var deleteQueries = [CFDictionary]()
     var deleteResult: Result<Void, KeychainServiceError> = .success(())
     var searchQuery: CFDictionary?
     var searchResult: Result<AnyObject?, KeychainServiceError> = .success(nil)
@@ -29,7 +29,7 @@ extension MockKeychainService: KeychainService {
     }
 
     func delete(query: CFDictionary) throws {
-        deleteQuery = query
+        deleteQueries.append(query)
         try deleteResult.get()
     }
 

--- a/BitwardenShared/Core/Platform/Services/MigrationService.swift
+++ b/BitwardenShared/Core/Platform/Services/MigrationService.swift
@@ -52,9 +52,15 @@ class DefaultMigrationService {
     /// Notes:
     /// - Migrates account tokens from UserDefaults to Keychain.
     /// - Resets stored date values from Xamarin/Maui, which uses an incompatible format.
+    /// - Clears all keychain values on a fresh app install.
     ///
     private func performMigration1() async throws {
-        guard var state = appSettingsStore.state else { return }
+        guard var state = appSettingsStore.state else {
+            // If state doesn't exist, this is a fresh install. Remove any persisted values in the
+            // keychain from the previous install.
+            try await keychainRepository.deleteAllItems()
+            return
+        }
         defer { appSettingsStore.state = state }
 
         for (accountId, account) in state.accounts {

--- a/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
@@ -104,6 +104,8 @@ class MigrationServiceTests: BitwardenTestCase {
             XCTAssertNil(appSettingsStore.lastSyncTime(userId: userId))
             XCTAssertNil(appSettingsStore.notificationsLastRegistrationDate(userId: userId))
         }
+
+        XCTAssertFalse(keychainRepository.deleteAllItemsCalled)
     }
 
     /// `performMigrations()` for migration 1 handles no existing accounts.
@@ -115,5 +117,6 @@ class MigrationServiceTests: BitwardenTestCase {
 
         XCTAssertEqual(appSettingsStore.migrationVersion, 1)
         XCTAssertNil(appSettingsStore.state)
+        XCTAssertTrue(keychainRepository.deleteAllItemsCalled)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-1804](https://livefront.atlassian.net/browse/BIT-1804)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Deletes all keychain values when the app is reinstalled. Also, this clears all keychain values (other than the device key) for a user when they logout.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
