### PR TITLE
BIT-2257: Remove alert if login with device request is denied

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/CheckLoginRequestRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/CheckLoginRequestRequest.swift
@@ -1,6 +1,12 @@
 import Foundation
 import Networking
 
+/// Errors thrown from validating a `CheckLoginRequestRequest` response.
+enum CheckLoginRequestError: Error {
+    /// The request has expired.
+    case expired
+}
+
 // MARK: - CheckLoginRequestRequest
 
 /// A request for checking the status of a login request for an unauthenticated user.
@@ -24,4 +30,12 @@ struct CheckLoginRequestRequest: Request {
 
     /// The query item for this request.
     var query: [URLQueryItem] { [URLQueryItem(name: "code", value: accessCode)] }
+
+    // MARK: Request
+
+    func validate(_ response: HTTPResponse) throws {
+        if response.statusCode == 404 {
+            throw CheckLoginRequestError.expired
+        }
+    }
 }

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/CheckLoginRequestRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/CheckLoginRequestRequestTests.swift
@@ -1,0 +1,50 @@
+import Networking
+import XCTest
+
+@testable import BitwardenShared
+
+class CheckLoginRequestRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: CheckLoginRequestRequest!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        subject = CheckLoginRequestRequest(accessCode: "ACCESS_CODE", id: "ID")
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `method` returns the method of the request.
+    func test_method() {
+        XCTAssertEqual(subject.method, .get)
+    }
+
+    /// `path` returns the path of the request.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/auth-requests/ID/response")
+    }
+
+    /// `query` returns the query items of the request.
+    func test_query() {
+        XCTAssertEqual(subject.query, [URLQueryItem(name: "code", value: "ACCESS_CODE")])
+    }
+
+    /// `validate(_:)` validates the response for the request and throws an error if the request is expired.
+    func test_validate() {
+        XCTAssertNoThrow(try subject.validate(.success()))
+        XCTAssertNoThrow(try subject.validate(.failure(statusCode: 400)))
+        XCTAssertNoThrow(try subject.validate(.failure(statusCode: 500)))
+
+        XCTAssertThrowsError(try subject.validate(.failure(statusCode: 404))) { error in
+            XCTAssertEqual(error as? CheckLoginRequestError, .expired)
+        }
+    }
+}

--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/Alert.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/Alert.swift
@@ -94,11 +94,13 @@ public class Alert {
 
     /// Creates a `UIAlertController` from the `Alert` that can be presented in the view.
     ///
+    /// - Parameter onDismissed: An optional closure that is called when the alert is dismissed.
     /// - Returns An initialized `UIAlertController` that has the `AlertAction`s added.
     ///
     @MainActor
-    func createAlertController() -> UIAlertController {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: preferredStyle)
+    func createAlertController(onDismissed: (() -> Void)? = nil) -> UIAlertController {
+        let alert = AlertController(title: title, message: message, preferredStyle: preferredStyle)
+        alert.onDismissed = onDismissed
         alertTextFields.forEach { alertTextField in
             alert.addTextField { textField in
                 textField.placeholder = alertTextField.placeholder
@@ -164,5 +166,24 @@ extension Alert: Hashable {
         hasher.combine(preferredAction)
         hasher.combine(preferredStyle)
         hasher.combine(title)
+    }
+}
+
+// MARK: - AlertController
+
+/// An `UIAlertController` subclass that allows for setting a closure to be notified when the alert
+/// controller is dismissed.
+///
+private class AlertController: UIAlertController {
+    // MARK: Properties
+
+    /// A closure that is called when the alert controller has been dismissed.
+    var onDismissed: (() -> Void)?
+
+    // MARK: UIViewController
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        onDismissed?()
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertPresentable.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertPresentable.swift
@@ -1,3 +1,4 @@
+import OSLog
 import UIKit
 
 // MARK: - AlertPresentable
@@ -14,6 +15,14 @@ public protocol AlertPresentable {
     /// - Parameter alert: The `Alert` used to create a `UIAlertController` to present.
     ///
     func present(_ alert: Alert)
+
+    /// Presents a `UIAlertController` created from the `Alert` on the provided `rootViewController`.
+    ///
+    /// - Parameters:
+    ///   - alert: The `Alert` used to create a `UIAlertController` to present.
+    ///   - onDismissed: An optional closure that is called when the alert is dismissed.
+    ///
+    func present(_ alert: Alert, onDismissed: (() -> Void)?)
 }
 
 public extension AlertPresentable {
@@ -22,9 +31,25 @@ public extension AlertPresentable {
     /// - Parameter alert: The `Alert` used to create a `UIAlertController` to present.
     ///
     func present(_ alert: Alert) {
-        let alertController = alert.createAlertController()
+        present(alert, onDismissed: nil)
+    }
+
+    /// Presents a `UIAlertController` created from the `Alert` on the provided `rootViewController`.
+    ///
+    /// - Parameters:
+    ///   - alert: The `Alert` used to create a `UIAlertController` to present.
+    ///   - onDismissed: An optional closure that is called when the alert is dismissed.
+    ///
+    func present(_ alert: Alert, onDismissed: (() -> Void)?) {
         guard let parent = rootViewController?.topmostViewController() else { return }
 
+        // Prevent presenting alerts on alerts.
+        guard !(parent is UIAlertController) else {
+            Logger.application.error("⛔️ Error: attempted to present an alert on top of another alert!")
+            return
+        }
+
+        let alertController = alert.createAlertController(onDismissed: onDismissed)
         if alert.preferredStyle == .actionSheet {
             // iPadOS requires an anchor for action sheets. This solution keeps the iPad app from crashing, and centers
             // the presentation of the action sheet.

--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertPresentableTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertPresentableTests.swift
@@ -33,6 +33,17 @@ class AlertPresentableTests: BitwardenTestCase {
         subject.present(Alert(title: "🍎", message: "🥝", preferredStyle: .alert))
         XCTAssertNotNil(rootViewController.presentedViewController as? UIAlertController)
     }
+
+    /// `present(_:)` presents a `UIAlertController` and calls the `onDismissed` closure when it's been dismissed.
+    func test_present_onDismissed() {
+        var onDismissedCalled = false
+        subject.present(Alert(title: "🍎", message: "🥝", preferredStyle: .alert)) {
+            onDismissedCalled = true
+        }
+        rootViewController.dismiss(animated: false)
+        waitFor(rootViewController.presentedViewController == nil)
+        XCTAssertTrue(onDismissedCalled)
+    }
 }
 
 class AlertPresentableSubject: AlertPresentable {

--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
@@ -61,6 +61,20 @@ class AlertTests: BitwardenTestCase {
         XCTAssertEqual(alertController.preferredAction?.title, "OK")
     }
 
+    /// `createAlertController` sets an `onDismissed` closure that's called when the alert is dismissed.
+    func test_createAlertController_onDismissed() {
+        var dismissedCalled = false
+        let alertController = subject.createAlertController { dismissedCalled = true }
+        let rootViewController = UIViewController()
+        setKeyWindowRoot(viewController: rootViewController)
+
+        rootViewController.present(alertController, animated: false)
+        XCTAssertFalse(dismissedCalled)
+        rootViewController.dismiss(animated: false)
+        waitFor(rootViewController.presentedViewController == nil)
+        XCTAssertTrue(dismissedCalled)
+    }
+
     /// `debugDescription` contains the alert's properties
     func test_debugDescription() {
         XCTAssertEqual(

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
@@ -15,7 +15,7 @@ open class AnyCoordinator<Route, Event>: Coordinator {
     private let doNavigate: (Route, AnyObject?) -> Void
 
     /// A closure that wraps the `showAlert(_:)` method.
-    private let doShowAlert: (Alert) -> Void
+    private let doShowAlert: (Alert, (() -> Void)?) -> Void
 
     /// A closure that wraps the `showLoadingOverlay(_:)` method.
     private let doShowLoadingOverlay: (LoadingOverlayState) -> Void
@@ -42,7 +42,7 @@ open class AnyCoordinator<Route, Event>: Coordinator {
         doNavigate = { route, context in
             coordinator.navigate(to: route, context: context)
         }
-        doShowAlert = { coordinator.showAlert($0) }
+        doShowAlert = { coordinator.showAlert($0, onDismissed: $1) }
         doShowLoadingOverlay = { coordinator.showLoadingOverlay($0) }
         doShowToast = { coordinator.showToast($0) }
         doStart = { coordinator.start() }
@@ -58,8 +58,8 @@ open class AnyCoordinator<Route, Event>: Coordinator {
         doNavigate(route, context)
     }
 
-    open func showAlert(_ alert: Alert) {
-        doShowAlert(alert)
+    open func showAlert(_ alert: Alert, onDismissed: (() -> Void)?) {
+        doShowAlert(alert, onDismissed)
     }
 
     open func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
@@ -34,6 +34,14 @@ public protocol Coordinator<Route, Event>: AnyObject {
     ///
     func showAlert(_ alert: Alert)
 
+    /// Shows the alert.
+    ///
+    /// - Parameters:
+    ///   - alert: The alert to show.
+    ///   - onDismissed: An optional closure that is called when the alert is dismissed.
+    ///
+    func showAlert(_ alert: Alert, onDismissed: (() -> Void)?)
+
     /// Shows the loading overlay view.
     ///
     /// - Parameter state: The state for configuring the loading overlay.
@@ -118,6 +126,14 @@ public extension Coordinator {
     func navigate(to route: Route) {
         navigate(to: route, context: nil)
     }
+
+    /// Shows the provided alert on the `stackNavigator`.
+    ///
+    /// - Parameter alert: The alert to show.
+    ///
+    func showAlert(_ alert: Alert) {
+        showAlert(alert, onDismissed: nil)
+    }
 }
 
 extension Coordinator where Self.Event == Void {
@@ -137,10 +153,12 @@ extension Coordinator where Self: HasNavigator {
 
     /// Shows the provided alert on the `stackNavigator`.
     ///
-    /// - Parameter alert: The alert to show.
+    /// - Parameters:
+    ///   - alert: The alert to show.
+    ///   - onDismissed: An optional closure that is called when the alert is dismissed.
     ///
-    func showAlert(_ alert: Alert) {
-        navigator?.present(alert)
+    func showAlert(_ alert: Alert, onDismissed: (() -> Void)? = nil) {
+        navigator?.present(alert, onDismissed: onDismissed)
     }
 
     /// Shows the loading overlay view.

--- a/BitwardenShared/UI/Platform/Extensions/Alert+Account.swift
+++ b/BitwardenShared/UI/Platform/Extensions/Alert+Account.swift
@@ -29,22 +29,6 @@ extension Alert {
         )
     }
 
-    /// An alert notifying the user that a pending login request has been denied.
-    ///
-    /// - Parameter action: The action to perform when the user exits the alert.
-    ///
-    /// - Returns: An alert notifying the user that a pending login request has been denied.
-    ///
-    static func requestDenied(action: @escaping () async -> Void) -> Alert {
-        Alert(
-            title: Localizations.logInDenied,
-            message: nil,
-            alertActions: [
-                AlertAction(title: Localizations.ok, style: .default) { _, _ in await action() },
-            ]
-        )
-    }
-
     /// An alert notifying the user that a pending login request has expired.
     ///
     /// - Parameter action: The action to perform when the user exits the alert.

--- a/GlobalTestHelpers/MockCoordinator.swift
+++ b/GlobalTestHelpers/MockCoordinator.swift
@@ -8,6 +8,7 @@ enum MockCoordinatorError: Error {
 
 class MockCoordinator<Route, Event>: Coordinator {
     var alertShown = [Alert]()
+    var alertOnDismissed: (() -> Void)?
     var contexts: [AnyObject?] = []
     var events = [Event]()
     var isLoadingOverlayShowing = false
@@ -30,8 +31,9 @@ class MockCoordinator<Route, Event>: Coordinator {
         contexts.append(context)
     }
 
-    func showAlert(_ alert: Alert) {
+    func showAlert(_ alert: BitwardenShared.Alert, onDismissed: (() -> Void)?) {
         alertShown.append(alert)
+        alertOnDismissed = onDismissed
     }
 
     func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/GlobalTestHelpers/MockStackNavigator.swift
+++ b/GlobalTestHelpers/MockStackNavigator.swift
@@ -71,6 +71,10 @@ final class MockStackNavigator: StackNavigator {
         alerts.append(alert)
     }
 
+    func present(_ alert: BitwardenShared.Alert, onDismissed: (() -> Void)?) {
+        alerts.append(alert)
+    }
+
     func present<Content: View>(
         _ view: Content,
         animated: Bool,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2257](https://livefront.atlassian.net/browse/BIT-2257)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the "Login denied" alert if a user's login with device request is denied by the approving device (or admin).

I also refactored some logic around polling:

- If the login with device request expires (and the API returns 404), the app stops polling and doesn't show an alert.
- If the request results in an error, the app stops polling while the error alert is visible and resumes when it's dismissed, to prevent stacked error alerts.
- Instead of polling every four seconds, it polls four seconds after the last response. This prevents requests from stacking up if the requests are taking a while to go through.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
