### PR TITLE
BIT-2299: Use numeric keyboard for delete account verification code

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -330,7 +330,8 @@ extension Alert {
                     id: "otp",
                     autocapitalizationType: .none,
                     autocorrectionType: .no,
-                    isSecureTextEntry: true
+                    isSecureTextEntry: true,
+                    keyboardType: .numberPad
                 ),
             ]
         )

--- a/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -227,6 +227,7 @@ class AlertSettingsTests: BitwardenTestCase {
         XCTAssertEqual(subject.alertActions.last?.style, .cancel)
 
         var textField = try XCTUnwrap(subject.alertTextFields.first)
+        XCTAssertEqual(textField.keyboardType, .numberPad)
         textField = AlertTextField(id: "otp", text: "otp")
 
         let action = try XCTUnwrap(subject.alertActions.first(where: { $0.title == Localizations.submit }))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2299](https://livefront.atlassian.net/browse/BIT-2299)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the delete account verification code alert to use the numeric/number pad keyboard.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="559" alt="Screenshot 2024-04-30 at 10 40 12 AM" src="https://github.com/bitwarden/ios/assets/126492398/ecd9f381-a5f2-484d-9c45-72ac751085d6">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
