### PR TITLE
BIT-2304: Fix pin unlock for new TDE accounts

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -394,6 +394,13 @@ extension DefaultAuthRepository: AuthRepository {
             publicKey: registrationKeys.publicKey
         ))
 
+        try await stateService.setAccountEncryptionKeys(
+            AccountEncryptionKeys(
+                encryptedPrivateKey: registrationKeys.privateKey,
+                encryptedUserKey: nil
+            )
+        )
+
         try await organizationUserAPIService.organizationUserResetPasswordEnrollment(
             organizationId: enrollStatus.id,
             requestModel: OrganizationUserResetPasswordEnrollmentRequestModel(

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -171,6 +171,10 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(clientService.mockAuth.makeRegisterTdeKeysEmail, "user@bitwarden.com")
         XCTAssertEqual(clientService.mockAuth.makeRegisterTdeKeysOrgPublicKey, "MIIBIjAN...2QIDAQAB")
         XCTAssertEqual(clientService.mockAuth.makeRegisterTdeKeysRememberDevice, true)
+        XCTAssertEqual(
+            stateService.accountEncryptionKeys["1"],
+            AccountEncryptionKeys(encryptedPrivateKey: "privateKey", encryptedUserKey: nil)
+        )
     }
 
     /// `createNewSsoUser()` creates a new account for sso JIT user and don't trust device.
@@ -200,6 +204,10 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertNil(trustDeviceService.trustDeviceWithExistingKeysValue)
         XCTAssertEqual(clientService.mockAuth.makeRegisterTdeKeysOrgPublicKey, "MIIBIjAN...2QIDAQAB")
         XCTAssertEqual(clientService.mockAuth.makeRegisterTdeKeysRememberDevice, false)
+        XCTAssertEqual(
+            stateService.accountEncryptionKeys["1"],
+            AccountEncryptionKeys(encryptedPrivateKey: "privateKey", encryptedUserKey: nil)
+        )
     }
 
     /// `deleteAccount()` deletes the active account and removes it from the state.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2304](https://livefront.atlassian.net/browse/BIT-2304)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an issue where pin unlock fails for new TDE accounts. The user's encrypted private key needs to be persisted after the account is created to enable pin unlock to work.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <video src="https://github.com/bitwarden/ios/assets/126492398/410d340d-8c7d-416f-b9dc-0a84f3197cb1" /> | <video src="https://github.com/bitwarden/ios/assets/126492398/d5db9b3e-e37e-43db-952c-85fb1202ae88" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
