### PR TITLE
BIT-2274: Create account ID update

### DIFF
--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountView.swift
@@ -79,7 +79,7 @@ struct CreateAccountView: View {
                     get: \.emailText,
                     send: CreateAccountAction.emailTextChanged
                 ),
-                accessibilityIdentifier: "EmailAddressEntry"
+                accessibilityIdentifier: "CreateAccountEmailAddressEntry"
             )
             .textFieldConfiguration(.email)
 


### PR DESCRIPTION
## 🎟️ Tracking
[BIT-2274](https://livefront.atlassian.net/browse/BIT-2274?atlOrigin=eyJpIjoiNjI0YzZhNTQzOGM3NDliMmJjOGFjMzI0Yzc1MjA1M2UiLCJwIjoiaiJ9)

## 📔 Objective
Adds the `CreateAccount` prefix to the email field's accessibility ID, differentiating it from the email field on the landing screen.

## 📸 Screenshots
N/A

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
