### PR TITLE
BIT-2326: Fix pin unlock failure after migration

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -621,7 +621,7 @@ extension DefaultAuthRepository: AuthRepository {
     func setPins(_ pin: String, requirePasswordAfterRestart: Bool) async throws {
         let pinKey = try await clientService.crypto().derivePinKey(pin: pin)
         try await stateService.setPinKeys(
-            pinKeyEncryptedUserKey: pinKey.encryptedPin,
+            encryptedPin: pinKey.encryptedPin,
             pinProtectedUserKey: pinKey.pinProtectedUserKey,
             requirePasswordAfterRestart: requirePasswordAfterRestart
         )
@@ -822,9 +822,9 @@ extension DefaultAuthRepository: AuthRepository {
 
             // If the user has a pin, but requires master password after restart, set the pin
             // protected user key in memory for future unlocks prior to app restart.
-            if let pinKeyEncryptedUserKey = try await stateService.pinKeyEncryptedUserKey() {
+            if let encryptedPin = try await stateService.getEncryptedPin() {
                 let pinProtectedUserKey = try await clientService.crypto().derivePinUserKey(
-                    encryptedPin: pinKeyEncryptedUserKey
+                    encryptedPin: encryptedPin
                 )
                 try await stateService.setPinProtectedUserKeyToMemory(pinProtectedUserKey)
             }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -137,12 +137,12 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let userId = Account.fixture().profile.userId
 
         stateService.pinProtectedUserKeyValue[userId] = "123"
-        stateService.pinKeyEncryptedUserKeyValue[userId] = "123"
+        stateService.encryptedPinByUserId[userId] = "123"
         stateService.accountVolatileData[userId]?.pinProtectedUserKey = "123"
 
         try await subject.clearPins()
         XCTAssertNil(stateService.pinProtectedUserKeyValue[userId])
-        XCTAssertNil(stateService.pinKeyEncryptedUserKeyValue[userId])
+        XCTAssertNil(stateService.encryptedPinByUserId[userId])
         XCTAssertNil(stateService.accountVolatileData[userId]?.pinProtectedUserKey)
     }
 
@@ -1041,7 +1041,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let userId = account.profile.userId
         try await subject.setPins("123", requirePasswordAfterRestart: true)
         XCTAssertEqual(stateService.pinProtectedUserKeyValue[userId], "12")
-        XCTAssertEqual(stateService.pinKeyEncryptedUserKeyValue[userId], "34")
+        XCTAssertEqual(stateService.encryptedPinByUserId[userId], "34")
         XCTAssertEqual(stateService.accountVolatileData[
             userId,
             default: AccountVolatileData()
@@ -1311,7 +1311,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
         ]
 
-        stateService.pinKeyEncryptedUserKeyValue[account.profile.userId] = "123"
+        stateService.encryptedPinByUserId[account.profile.userId] = "123"
         stateService.pinProtectedUserKeyValue[account.profile.userId] = "123"
 
         await assertAsyncDoesNotThrow {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -99,10 +99,10 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.clearPins()
         let pinProtectedUserKey = try await subject.pinProtectedUserKey()
-        let pinKeyEncryptedUserKey = try await subject.pinKeyEncryptedUserKey()
+        let encryptedPin = try await subject.getEncryptedPin()
 
         XCTAssertNil(pinProtectedUserKey)
-        XCTAssertNil(pinKeyEncryptedUserKey)
+        XCTAssertNil(encryptedPin)
     }
 
     /// `deleteAccount()` deletes the active user's account, removing it from the state.
@@ -378,6 +378,24 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         let value = try await subject.getDisableAutoTotpCopy()
         XCTAssertTrue(value)
+    }
+
+    /// `getEncryptedPin()` returns the user's pin encrypted by their user key.
+    func test_getEncryptedPin() async throws {
+        let account = Account.fixture()
+        await subject.addAccount(account)
+
+        try await subject.setPinKeys(
+            encryptedPin: "123",
+            pinProtectedUserKey: "321",
+            requirePasswordAfterRestart: true
+        )
+
+        let encryptedPin = try await subject.getEncryptedPin()
+        let pinProtectedUserKey = await subject.accountVolatileData["1"]?.pinProtectedUserKey
+
+        XCTAssertEqual(encryptedPin, "123")
+        XCTAssertEqual(pinProtectedUserKey, "321")
     }
 
     /// `getEnvironmentUrls()` returns the environment URLs for the active account.
@@ -903,24 +921,6 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, ["2": "2:USER_KEY"])
     }
 
-    /// `pinKeyEncryptedUserKey()` returns the pin key encrypted user key.
-    func test_pinKeyEncryptedUserKey() async throws {
-        let account = Account.fixture()
-        await subject.addAccount(account)
-
-        try await subject.setPinKeys(
-            pinKeyEncryptedUserKey: "123",
-            pinProtectedUserKey: "321",
-            requirePasswordAfterRestart: true
-        )
-
-        let pinKeyEncryptedUserKey = try await subject.pinKeyEncryptedUserKey()
-        let pinProtectedUserKey = await subject.accountVolatileData["1"]?.pinProtectedUserKey
-
-        XCTAssertEqual(pinKeyEncryptedUserKey, "123")
-        XCTAssertEqual(pinProtectedUserKey, "321")
-    }
-
     /// `pinProtectedUserKey(userId:)` returns the pin protected user key.
     func test_pinProtectedUserKey() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
@@ -1202,12 +1202,12 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
 
         try await subject.setPinKeys(
-            pinKeyEncryptedUserKey: "123",
-            pinProtectedUserKey: "123",
+            encryptedPin: "encryptedPin",
+            pinProtectedUserKey: "pinProtectedUserKey",
             requirePasswordAfterRestart: false
         )
-        XCTAssertEqual(appSettingsStore.pinProtectedUserKey["1"], "123")
-        XCTAssertEqual(appSettingsStore.pinKeyEncryptedUserKey["1"], "123")
+        XCTAssertEqual(appSettingsStore.pinProtectedUserKey["1"], "pinProtectedUserKey")
+        XCTAssertEqual(appSettingsStore.encryptedPinByUserId["1"], "encryptedPin")
     }
 
     /// `setPreAuthEnvironmentUrls` saves the pre-auth URLs.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -91,6 +91,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func disableAutoTotpCopy(userId: String) -> Bool
 
+    /// The user's pin protected by their user key.
+    ///
+    /// - Parameter userId: The user ID associated with the encrypted pin.
+    /// - Returns: The user's pin protected by their user key.
+    ///
+    func encryptedPin(userId: String) -> String?
+
     /// Gets the encrypted private key for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the encrypted private key.
@@ -147,13 +154,6 @@ protocol AppSettingsStore: AnyObject {
     /// - Returns: The password generation options for the user ID.
     ///
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions?
-
-    /// The user's pin protected user key.
-    ///
-    /// - Parameter userId: The user ID associated with the pin key encrypted user key.
-    /// - Returns: The pin protected user key.
-    ///
-    func pinKeyEncryptedUserKey(userId: String) -> String?
 
     /// The pin protected user key.
     ///
@@ -228,6 +228,14 @@ protocol AppSettingsStore: AnyObject {
     ///
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool?, userId: String)
 
+    /// Sets the user's pin protected by their user key.
+    ///
+    /// - Parameters:
+    ///   - encryptedPin: The user's pin protected by their user key.
+    ///   - userId: The user ID.
+    ///
+    func setEncryptedPin(_ encryptedPin: String?, userId: String)
+
     /// Sets the encrypted private key for a user ID.
     ///
     /// - Parameters:
@@ -283,14 +291,6 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the password generation options.
     ///
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String)
-
-    /// Sets the pin key encrypted user key.
-    ///
-    /// - Parameters:
-    ///   - key: A pin key encrypted user key derived from the user's pin.
-    ///   - userId: The user ID.
-    ///
-    func setPinKeyEncryptedUserKey(key: String?, userId: String)
 
     /// Sets the pin protected user key.
     ///
@@ -531,6 +531,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case defaultUriMatch(userId: String)
         case disableAutoTotpCopy(userId: String)
         case disableWebIcons
+        case encryptedPin(userId: String)
         case encryptedPrivateKey(userId: String)
         case encryptedUserKey(userId: String)
         case lastActiveTime(userId: String)
@@ -541,7 +542,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case migrationVersion
         case notificationsLastRegistrationDate(userId: String)
         case passwordGenerationOptions(userId: String)
-        case pinKeyEncryptedUserKey(userId: String)
         case pinProtectedUserKey(userId: String)
         case preAuthEnvironmentUrls
         case rememberedEmail
@@ -585,6 +585,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "disableFavicon"
             case let .encryptedUserKey(userId):
                 key = "masterKeyEncryptedUserKey_\(userId)"
+            case let .encryptedPin(userId):
+                key = "protectedPin_\(userId)"
             case let .encryptedPrivateKey(userId):
                 key = "encPrivateKey_\(userId)"
             case let .lastActiveTime(userId):
@@ -603,10 +605,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "pushLastRegistrationDate_\(userId)"
             case let .passwordGenerationOptions(userId):
                 key = "passwordGenerationOptions_\(userId)"
-            case let .pinKeyEncryptedUserKey(userId):
-                key = "pinKeyEncryptedUserKey_\(userId)"
             case let .pinProtectedUserKey(userId):
-                key = "pinProtectedUserKey_\(userId)"
+                key = "pinKeyEncryptedUserKey_\(userId)"
             case .preAuthEnvironmentUrls:
                 key = "preAuthEnvironmentUrls"
             case .rememberedEmail:
@@ -730,6 +730,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .disableAutoTotpCopy(userId: userId))
     }
 
+    func encryptedPin(userId: String) -> String? {
+        fetch(for: .encryptedPin(userId: userId))
+    }
+
     func encryptedPrivateKey(userId: String) -> String? {
         fetch(for: .encryptedPrivateKey(userId: userId))
     }
@@ -760,10 +764,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions? {
         fetch(for: .passwordGenerationOptions(userId: userId))
-    }
-
-    func pinKeyEncryptedUserKey(userId: String) -> String? {
-        fetch(for: .pinKeyEncryptedUserKey(userId: userId))
     }
 
     func pinProtectedUserKey(userId: String) -> String? {
@@ -808,6 +808,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         store(disableAutoTotpCopy, for: .disableAutoTotpCopy(userId: userId))
     }
 
+    func setEncryptedPin(_ encryptedPin: String?, userId: String) {
+        store(encryptedPin, for: .encryptedPin(userId: userId))
+    }
+
     func setEncryptedPrivateKey(key: String?, userId: String) {
         store(key, for: .encryptedPrivateKey(userId: userId))
     }
@@ -834,10 +838,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String) {
         store(options, for: .passwordGenerationOptions(userId: userId))
-    }
-
-    func setPinKeyEncryptedUserKey(key: String?, userId: String) {
-        store(key, for: .pinKeyEncryptedUserKey(userId: userId))
     }
 
     func setPinProtectedUserKey(key: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -222,6 +222,14 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:disableFavicon"))
     }
 
+    /// `.encryptedPin(_:userId:)` can be used to get the user's encrypted pin.
+    func test_encryptedPin() {
+        let userId = Account.fixture().profile.userId
+        subject.setEncryptedPin("123", userId: userId)
+        let pin = subject.encryptedPin(userId: userId)
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:protectedPin_1"), pin)
+    }
+
     /// `encryptedPrivateKey(userId:)` returns `nil` if there isn't a previously stored value.
     func test_encryptedPrivateKey_isInitiallyNil() {
         XCTAssertNil(subject.encryptedPrivateKey(userId: "-1"))
@@ -500,20 +508,12 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(subject.passwordGenerationOptions(userId: "2"), options2)
     }
 
-    /// `.pinKeyEncryptedUserKey(userId:)` can be used to get the pin key encrypted user key.
-    func test_pinKeyEncryptedUserKey() {
-        let userId = Account.fixture().profile.userId
-        subject.setPinKeyEncryptedUserKey(key: "123", userId: userId)
-        let pin = subject.pinKeyEncryptedUserKey(userId: userId)
-        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:pinKeyEncryptedUserKey_1"), pin)
-    }
-
     /// `.pinProtectedUserKey(userId:)` can be used to get the pin protected user key for a user.
     func test_pinProtectedUserKey() {
         let userId = Account.fixture().profile.userId
         subject.setPinProtectedUserKey(key: "123", userId: userId)
         let pin = subject.pinProtectedUserKey(userId: userId)
-        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:pinProtectedUserKey_1"), pin)
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:pinKeyEncryptedUserKey_1"), pin)
     }
 
     /// `preAuthEnvironmentUrls` returns `nil` if there isn't a previously stored value.

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -23,6 +23,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var connectToWatchByUserId = [String: Bool]()
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
     var disableAutoTotpCopyByUserId = [String: Bool]()
+    var encryptedPinByUserId = [String: String]()
     var encryptedPrivateKeys = [String: String]()
     var encryptedUserKeys = [String: String]()
     var lastActiveTime = [String: Date]()
@@ -30,7 +31,6 @@ class MockAppSettingsStore: AppSettingsStore {
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
-    var pinKeyEncryptedUserKey = [String: String]()
     var pinProtectedUserKey = [String: String]()
     var serverConfig = [String: ServerConfig]()
     var shouldTrustDevice = [String: Bool?]()
@@ -68,6 +68,10 @@ class MockAppSettingsStore: AppSettingsStore {
         disableAutoTotpCopyByUserId[userId] ?? false
     }
 
+    func encryptedPin(userId: String) -> String? {
+        encryptedPinByUserId[userId]
+    }
+
     func encryptedPrivateKey(userId: String) -> String? {
         encryptedPrivateKeys[userId]
     }
@@ -94,10 +98,6 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func passwordGenerationOptions(userId: String) -> PasswordGenerationOptions? {
         passwordGenerationOptions[userId]
-    }
-
-    func pinKeyEncryptedUserKey(userId: String) -> String? {
-        pinKeyEncryptedUserKey[userId]
     }
 
     func pinProtectedUserKey(userId: String) -> String? {
@@ -130,6 +130,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool?, userId: String) {
         disableAutoTotpCopyByUserId[userId] = disableAutoTotpCopy
+    }
+
+    func setEncryptedPin(_ encryptedPin: String?, userId: String) {
+        encryptedPinByUserId[userId] = encryptedPin
     }
 
     func setEncryptedPrivateKey(key: String?, userId: String) {
@@ -170,10 +174,6 @@ class MockAppSettingsStore: AppSettingsStore {
             return
         }
         passwordGenerationOptions[userId] = options
-    }
-
-    func setPinKeyEncryptedUserKey(key: String?, userId: String) {
-        pinKeyEncryptedUserKey[userId] = key
     }
 
     func setPinProtectedUserKey(key: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -26,6 +26,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var timeProvider = MockTimeProvider(.currentTime)
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
     var disableAutoTotpCopyByUserId = [String: Bool]()
+    var encryptedPinByUserId = [String: String]()
     var environmentUrls = [String: EnvironmentUrlData]()
     var forcePasswordResetReason = [String: ForcePasswordResetReason]()
     var lastActiveTime = [String: Date]()
@@ -39,7 +40,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
-    var pinKeyEncryptedUserKeyValue = [String: String]()
     var pinProtectedUserKeyValue = [String: String]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
     var rememberedOrgIdentifier: String?
@@ -70,7 +70,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         let userId = try unwrapUserId(nil)
         accountVolatileData.removeValue(forKey: userId)
         pinProtectedUserKeyValue[userId] = nil
-        pinKeyEncryptedUserKeyValue[userId] = nil
+        encryptedPinByUserId[userId] = nil
     }
 
     func updateProfile(from response: ProfileResponseModel, userId: String) async {
@@ -163,6 +163,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         return disableAutoTotpCopyByUserId[userId] ?? false
     }
 
+    func getEncryptedPin(userId: String?) async throws -> String? {
+        let userId = try unwrapUserId(userId)
+        return encryptedPinByUserId[userId] ?? nil
+    }
+
     func getEnvironmentUrls(userId: String?) async throws -> EnvironmentUrlData? {
         let userId = try unwrapUserId(userId)
         return environmentUrls[userId]
@@ -246,11 +251,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func logoutAccount(userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         accountsLoggedOut.append(userId)
-    }
-
-    func pinKeyEncryptedUserKey(userId: String?) async throws -> String? {
-        let userId = try unwrapUserId(userId)
-        return pinKeyEncryptedUserKeyValue[userId] ?? nil
     }
 
     func pinProtectedUserKey(userId: String?) async throws -> String? {
@@ -362,13 +362,13 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     }
 
     func setPinKeys(
-        pinKeyEncryptedUserKey: String,
+        encryptedPin: String,
         pinProtectedUserKey: String,
         requirePasswordAfterRestart: Bool
     ) async throws {
         let userId = try unwrapUserId(nil)
         pinProtectedUserKeyValue[userId] = pinProtectedUserKey
-        pinKeyEncryptedUserKeyValue[userId] = pinKeyEncryptedUserKey
+        encryptedPinByUserId[userId] = encryptedPin
 
         if requirePasswordAfterRestart {
             accountVolatileData[

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
@@ -111,7 +111,7 @@ class VaultUnlockProcessor: StateProcessor<
         do {
             if try await services.authRepository.isPinUnlockAvailable() {
                 state.unlockMethod = .pin
-            } else if try await services.stateService.pinKeyEncryptedUserKey() != nil {
+            } else if try await services.stateService.getEncryptedPin() != nil {
                 state.unlockMethod = .password
             }
         } catch {

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
@@ -279,7 +279,7 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
     func test_perform_unlockVault() async throws {
         stateService.activeAccount = Account.fixture()
         stateService.pinProtectedUserKeyValue["1"] = "123"
-        stateService.pinKeyEncryptedUserKeyValue["1"] = "123"
+        stateService.encryptedPinByUserId["1"] = "123"
         subject.state.masterPassword = "password"
 
         await subject.perform(.unlockVault)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2326](https://livefront.atlassian.net/browse/BIT-2326)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a pin unlock failure after upgrading from Xamarin/Maui.

The root cause was that we had the keys for reading the values from UserDefaults swapped between the encrypted pin and the pin protected user key from what Xamarin/Maui was using. We were using `pinProtectedUserKey` (which needed to be `protectedPin`) but we should have been using `pinKeyEncryptedUserKey`.

To clear up some confusion, I renamed usages of `pinKeyEncryptedUserKey` to `encryptedPin` which matches the [SDK's verbiage](https://github.com/bitwarden/sdk-swift/blob/e43a06f542d58f02587614edb9c8e6b6c839bca5/Sources/BitwardenSdk/BitwardenCore.swift#L2147-L2154).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
