### PR TITLE
BIT-2325: Handle migrating username generator options without a forwarded email service selected

### DIFF
--- a/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
@@ -38,4 +38,14 @@ enum ForwardedEmailServiceType: Int, CaseIterable, Codable, Equatable, Menuable 
             return Localizations.simpleLogin
         }
     }
+
+    // MARK: Initialization
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(RawValue.self)
+        // Handle unknown service types by defaulting to the first option (e.g. -1 for an unselected
+        // service when migrating from the legacy app).
+        self = Self(rawValue: rawValue) ?? .addyIO
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2325](https://livefront.atlassian.net/browse/BIT-2325)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The Xamarin/Maui app uses -1 for the forwarded email service if one hasn't yet been selected. Since we don't have an equivalent in the native app, this defaults the service to the first option.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
