### PR TITLE
BIT-2406: Implement SDK move to organization

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -240,7 +240,7 @@ class MockVaultRepository: VaultRepository {
         return searchVaultListSubject.eraseToAnyPublisher().values
     }
 
-    func shareCipher(_ cipher: CipherView) async throws {
+    func shareCipher(_ cipher: CipherView, newOrganizationId: String, newCollectionIds: [String]) async throws {
         shareCipherCiphers.append(cipher)
         try shareCipherResult.get()
     }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -1031,12 +1031,16 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService.activeAccount = .fixtureAccountLogin()
 
         let cipher = CipherView.fixture()
-        try await subject.shareCipher(cipher)
+        try await subject.shareCipher(cipher, newOrganizationId: "5", newCollectionIds: ["6", "7"])
 
-        XCTAssertEqual(cipherService.shareCipherWithServerCiphers, [Cipher(cipherView: cipher)])
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        let updatedCipher = cipher.update(collectionIds: ["6", "7"])
 
-        XCTAssertEqual(cipherService.shareCipherWithServerCiphers.last, Cipher(cipherView: cipher))
+        XCTAssertEqual(cipherService.shareCipherWithServerCiphers, [Cipher(cipherView: updatedCipher)])
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [updatedCipher])
+        XCTAssertEqual(clientCiphers.moveToOrganizationCipher, cipher)
+        XCTAssertEqual(clientCiphers.moveToOrganizationOrganizationId, "5")
+
+        XCTAssertEqual(cipherService.shareCipherWithServerCiphers.last, Cipher(cipherView: updatedCipher))
     }
 
     /// `shouldShowUnassignedCiphersAlert` is true if the feature flag is on,

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessor.swift
@@ -95,7 +95,9 @@ class MoveToOrganizationProcessor: StateProcessor<
     /// Performs the API request to move the cipher to the organization.
     ///
     private func moveCipher() async {
-        guard !state.collectionIds.isEmpty, let owner = state.owner else {
+        guard !state.collectionIds.isEmpty,
+              let owner = state.owner,
+              let organizationId = state.organizationId else {
             coordinator.showAlert(
                 .defaultAlert(
                     title: Localizations.anErrorHasOccurred,
@@ -109,7 +111,11 @@ class MoveToOrganizationProcessor: StateProcessor<
             coordinator.showLoadingOverlay(LoadingOverlayState(title: Localizations.saving))
             defer { coordinator.hideLoadingOverlay() }
 
-            try await services.vaultRepository.shareCipher(state.updatedCipher)
+            try await services.vaultRepository.shareCipher(
+                state.cipher,
+                newOrganizationId: organizationId,
+                newCollectionIds: state.collectionIds
+            )
 
             coordinator.navigate(to: .dismiss(DismissAction {
                 self.delegate?.didMoveCipher(self.state.cipher, to: owner)

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessorTests.swift
@@ -80,10 +80,7 @@ class MoveToOrganizationProcessorTests: BitwardenTestCase {
 
         await subject.perform(.moveCipher)
 
-        XCTAssertEqual(vaultRepository.shareCipherCiphers, [subject.state.updatedCipher])
-        let sharedCipher = vaultRepository.shareCipherCiphers[0]
-        XCTAssertEqual(sharedCipher.collectionIds, ["1"])
-        XCTAssertEqual(sharedCipher.organizationId, "123")
+        XCTAssertEqual(vaultRepository.shareCipherCiphers, [subject.state.cipher])
 
         guard case let .dismiss(dismissAction) = coordinator.routes.last else {
             return XCTFail("Expected a `.dismiss` route.")

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationState.swift
@@ -63,13 +63,3 @@ struct MoveToOrganizationState: Equatable {
         }
     }
 }
-
-extension MoveToOrganizationState {
-    /// The updated cipher with the assigned organization and collections.
-    var updatedCipher: CipherView {
-        cipher.update(
-            collectionIds: collectionIds,
-            organizationId: organizationId
-        )
-    }
-}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
@@ -193,25 +193,6 @@ extension CipherView {
         )
     }
 
-    /// Returns a copy of the existing cipher with an updated organization and list of collection IDs.
-    ///
-    /// - Parameters:
-    ///   - collectionIds: The identifiers of any collections containing the cipher.
-    ///   - organizationId: The identifier of the cipher's organization.
-    /// - Returns: A copy of the existing cipher, with the specified properties updated.
-    ///
-    func update(
-        collectionIds: [String],
-        organizationId: String?
-    ) -> CipherView {
-        update(
-            collectionIds: collectionIds,
-            deletedDate: deletedDate,
-            folderId: folderId,
-            organizationId: organizationId
-        )
-    }
-
     /// Returns a copy of the existing cipher with an updated deleted date.
     ///
     /// - Parameter deletedDate: The deleted date of the cipher.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2406](https://livefront.atlassian.net/browse/BIT-2406)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an error when moving a cipher into an organization by implementing the SDK's move to organization call which handles ciphers with individual encryption keys.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
