### PR TITLE
BIT-2360: Update error message for delete account invalid password/OTP

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -1,6 +1,6 @@
 @testable import BitwardenShared
 
-class MockAuthRepository: AuthRepository {
+class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_length
     var allowBiometricUnlock: Bool?
     var allowBiometricUnlockResult: Result<Void, Error> = .success(())
     var accountForItemResult: Result<Account, Error> = .failure(StateServiceError.noAccounts)
@@ -9,6 +9,7 @@ class MockAuthRepository: AuthRepository {
     var createNewSsoUserOrgIdentifier: String = ""
     var createNewSsoUserResult: Result<Void, Error> = .success(())
     var deleteAccountCalled = false
+    var deleteAccountResult: Result<Void, Error> = .success(())
     var deviceId: String = ""
     var email: String = ""
     var encryptedPin: String = "123"
@@ -90,6 +91,7 @@ class MockAuthRepository: AuthRepository {
 
     func deleteAccount(otp: String?, passwordText _: String?) async throws {
         deleteAccountCalled = true
+        try deleteAccountResult.get()
     }
 
     func getAccount(for userId: String?) async throws -> Account {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessor.swift
@@ -72,6 +72,14 @@ final class DeleteAccountProcessor: StateProcessor<DeleteAccountState, DeleteAcc
         do {
             try await services.authRepository.deleteAccount(otp: otp, passwordText: passwordText)
             navigatePostDeletion()
+        } catch ServerError.error {
+            coordinator.showAlert(
+                .defaultAlert(
+                    title: otp != nil
+                        ? Localizations.invalidVerificationCode
+                        : Localizations.invalidMasterPassword
+                )
+            )
         } catch {
             coordinator.showAlert(.networkResponseError(error) {
                 await self.deleteAccount(otp: otp, passwordText: passwordText)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2360](https://livefront.atlassian.net/browse/BIT-2360)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the error message that is displayed if the user enters an invalid password or OTP code when deleting their account.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| -- | -- |
| <img width="559" alt="Screenshot 2024-06-05 at 2 02 08 PM" src="https://github.com/bitwarden/ios/assets/126492398/2a556e92-4338-4b01-be26-866b0d85bb4a"> | <img width="559" alt="Screenshot 2024-06-05 at 2 04 28 PM" src="https://github.com/bitwarden/ios/assets/126492398/a1c94338-8cf0-46b7-b83f-e3c09a922c86"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
