### PR TITLE
Fix tests clearing app's keychain values

### DIFF
--- a/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
@@ -12,6 +12,9 @@ class MigrationServiceTests: BitwardenTestCase {
     var standardUserDefaults: UserDefaults!
     var subject: DefaultMigrationService!
 
+    /// A keychain service name to use during tests to avoid corrupting the app's keychain items.
+    private let testKeychainServiceName = "com.bitwarden.test"
+
     // MARK: Setup & Teardown
 
     override func setUp() {
@@ -24,14 +27,19 @@ class MigrationServiceTests: BitwardenTestCase {
         standardUserDefaults = UserDefaults(suiteName: "test")
 
         standardUserDefaults.removeObject(forKey: "MSAppCenterCrashesIsEnabled")
-        SecItemDelete([kSecClass: kSecClassGenericPassword] as CFDictionary)
+        SecItemDelete(
+            [
+                kSecClass: kSecClassGenericPassword,
+                kSecAttrService: testKeychainServiceName,
+            ] as CFDictionary
+        )
 
         subject = DefaultMigrationService(
             appSettingsStore: appSettingsStore,
             errorReporter: errorReporter,
             keychainRepository: keychainRepository,
             keychainService: keychainService,
-            keychainServiceName: "com.bitwarden.test",
+            keychainServiceName: testKeychainServiceName,
             standardUserDefaults: standardUserDefaults
         )
     }
@@ -176,7 +184,7 @@ class MigrationServiceTests: BitwardenTestCase {
                 [
                     kSecClass: kSecClassGenericPassword,
                     kSecAttrAccount: item.account,
-                    kSecAttrService: "com.bitwarden.test",
+                    kSecAttrService: testKeychainServiceName,
                     kSecAttrGeneric: Data(item.value.utf8),
                 ] as CFDictionary,
                 nil
@@ -189,7 +197,7 @@ class MigrationServiceTests: BitwardenTestCase {
         SecItemCopyMatching(
             [
                 kSecClass: kSecClassGenericPassword,
-                kSecAttrService: "com.bitwarden.test",
+                kSecAttrService: testKeychainServiceName,
                 kSecMatchLimit: kSecMatchLimitAll,
                 kSecReturnData: true,
                 kSecReturnAttributes: true,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

N/A

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In #639 I introduced a test that uses the keychain directly as opposed to a mock. I thought I had it set up to avoid conflicts with any entries that the app was using, but ended up clearing all keychain values 🤦‍♂️. This led to missing keychain items after running tests... This should fix that.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
