### PR TITLE
BIT-2364: Display alert on account deletion

### DIFF
--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -302,6 +302,8 @@ extension AppCoordinator: SettingsCoordinatorDelegate {
     func didDeleteAccount() {
         Task {
             await handleAuthEvent(.didDeleteAccount)
+
+            showAlert(.accountDeletedAlert())
         }
     }
 

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -79,7 +79,7 @@ class AppCoordinatorTests: BitwardenTestCase {
     }
 
     /// `didDeleteAccount(otherAccounts:)` navigates to the `didDeleteAccount` route.
-    func test_didDeleteAccount() {
+    func test_didDeleteAccount() throws {
         subject.didDeleteAccount()
         waitFor(!router.events.isEmpty)
         XCTAssertEqual(
@@ -88,6 +88,9 @@ class AppCoordinatorTests: BitwardenTestCase {
                 .didDeleteAccount,
             ]
         )
+
+        let alert = try XCTUnwrap(rootNavigator.alerts.last)
+        XCTAssertEqual(alert, .accountDeletedAlert())
     }
 
     /// `lockVault(_:)` passes the lock event to the router.

--- a/GlobalTestHelpers/MockRootNavigator.swift
+++ b/GlobalTestHelpers/MockRootNavigator.swift
@@ -2,9 +2,18 @@ import BitwardenShared
 import UIKit
 
 final class MockRootNavigator: RootNavigator {
+    var alerts: [Alert] = []
     var appTheme: AppTheme = .default
     var navigatorShown: Navigator?
     var rootViewController: UIViewController?
+
+    func present(_ alert: Alert) {
+        alerts.append(alert)
+    }
+
+    func present(_ alert: Alert, onDismissed: (() -> Void)?) {
+        alerts.append(alert)
+    }
 
     func show(child: Navigator) {
         navigatorShown = child


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2364](https://livefront.atlassian.net/browse/BIT-2364)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Display the deleted account alert once the account has been deleted.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/d09453b9-0ebc-4ce3-8d3d-3ec98d6b5f76



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
