### PR TITLE
BIT-2407: Update cipher on server when SDK adds a cipher key

### DIFF
--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -272,9 +272,8 @@ extension DefaultSyncService {
         try await folderService.deleteFolderWithLocalStorage(id: data.id)
 
         let updatedCiphers = try await cipherService.fetchAllCiphers()
-            .asyncMap { try await clientService.vault().ciphers().decrypt(cipher: $0) }
+            .filter { $0.folderId == data.id }
             .map { $0.update(folderId: nil) }
-            .asyncMap { try await clientService.vault().ciphers().encrypt(cipherView: $0) }
 
         for cipher in updatedCiphers {
             try await cipherService.updateCipherWithLocalStorage(cipher)

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -606,7 +606,10 @@ class SyncServiceTests: BitwardenTestCase {
     func test_deleteFolder() async throws {
         stateService.activeAccount = .fixture()
         folderService.deleteFolderWithLocalStorageResult = .success(())
-        cipherService.fetchAllCiphersResult = .success([.fixture(folderId: "id")])
+        cipherService.fetchAllCiphersResult = .success([
+            .fixture(folderId: "id", id: "1"),
+            .fixture(folderId: "other", id: "2"),
+        ])
         cipherService.updateCipherWithLocalStorageResult = .success(())
 
         let notification = SyncFolderNotification(
@@ -616,7 +619,10 @@ class SyncServiceTests: BitwardenTestCase {
         )
         try await subject.deleteFolder(data: notification)
         XCTAssertEqual(folderService.deleteFolderWithLocalStorageId, "id")
-        XCTAssertEqual(cipherService.updateCipherWithLocalStorageCipher, .fixture(folderId: nil))
+        XCTAssertEqual(
+            cipherService.updateCipherWithLocalStorageCiphers,
+            [.fixture(folderId: nil, id: "1")]
+        )
     }
 
     func test_deleteSend() async throws {

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
@@ -51,7 +51,7 @@ class MockCipherService: CipherService {
     var syncCipherWithServerId: String?
     var syncCipherWithServerResult: Result<Void, Error> = .success(())
 
-    var updateCipherWithLocalStorageCipher: BitwardenSdk.Cipher?
+    var updateCipherWithLocalStorageCiphers = [BitwardenSdk.Cipher]()
     var updateCipherWithLocalStorageResult: Result<Void, Error> = .success(())
 
     var updateCipherWithServerCiphers = [Cipher]()
@@ -135,7 +135,7 @@ class MockCipherService: CipherService {
     }
 
     func updateCipherWithLocalStorage(_ cipher: Cipher) async throws {
-        updateCipherWithLocalStorageCipher = cipher
+        updateCipherWithLocalStorageCiphers.append(cipher)
         return try updateCipherWithLocalStorageResult.get()
     }
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockClientVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockClientVaultService.swift
@@ -86,6 +86,7 @@ class MockClientAttachments: ClientAttachmentsProtocol {
 // MARK: - MockClientCiphers
 
 class MockClientCiphers: ClientCiphersProtocol {
+    var encryptCipherResult: Result<Cipher, Error>?
     var encryptError: Error?
     var encryptedCiphers = [CipherView]()
     var moveToOrganizationCipher: CipherView?
@@ -106,7 +107,7 @@ class MockClientCiphers: ClientCiphersProtocol {
         if let encryptError {
             throw encryptError
         }
-        return Cipher(cipherView: cipherView)
+        return try encryptCipherResult?.get() ?? Cipher(cipherView: cipherView)
     }
 
     func moveToOrganization(

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/Cipher+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/Cipher+Update.swift
@@ -34,4 +34,38 @@ extension Cipher {
             revisionDate: revisionDate
         )
     }
+
+    /// Returns a copy of the existing cipher with an updated folder ID.
+    ///
+    /// - Parameter folderId: The folder ID to update in the cipher.
+    /// - Returns: A copy of the existing cipher, with the specified properties updated.
+    ///
+    func update(folderId: String?) -> Cipher {
+        Cipher(
+            id: id,
+            organizationId: organizationId,
+            folderId: folderId,
+            collectionIds: collectionIds,
+            key: key,
+            name: name,
+            notes: notes,
+            type: type,
+            login: login,
+            identity: identity,
+            card: card,
+            secureNote: secureNote,
+            favorite: favorite,
+            reprompt: reprompt,
+            organizationUseTotp: organizationUseTotp,
+            edit: edit,
+            viewPassword: viewPassword,
+            localData: localData,
+            attachments: attachments,
+            fields: fields,
+            passwordHistory: passwordHistory,
+            creationDate: creationDate,
+            deletedDate: deletedDate,
+            revisionDate: revisionDate
+        )
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2407](https://livefront.atlassian.net/browse/BIT-2407)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When a cipher encryption key is added to the cipher by the SDK as part of encryption, ensure the cipher is updated in the API. This handles the cipher operations which don't send the cipher to the API. This includes downloading or saving an attachment, soft deleting or restoring a cipher.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
