### PR TITLE
BIT-2357: Fix generate username for login

### DIFF
--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -83,17 +83,6 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertFalse(subject.state.isPolicyInEffect)
     }
 
-    /// `init` loads the password generation options and logs an error if one occurs.
-    func test_init_loadsPasswordOptions_error() {
-        generatorRepository.getPasswordGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
-        setUpSubject()
-        waitFor { !errorReporter.errors.isEmpty }
-        XCTAssertEqual(
-            errorReporter.errors[0] as NSError,
-            BitwardenError.generatorOptionsError(error: StateServiceError.noActiveAccount)
-        )
-    }
-
     /// `init` loads the password generation options and updates the state
     /// based on the previously selected options.
     func test_init_loadsPasswordOptions_withValues() {
@@ -282,6 +271,22 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.anErrorHasOccurred))
     }
 
+    /// If an error occurs loading the generator options, an alert is shown and a new value isn't generated.
+    func test_generateValue_loadGeneratorOptionsError() async {
+        generatorRepository.getPasswordGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
+        setUpSubject()
+
+        await subject.perform(.appeared)
+
+        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
+        XCTAssertEqual(
+            errorReporter.errors as? [StateServiceError],
+            [StateServiceError.noActiveAccount]
+        )
+        XCTAssertNil(generatorRepository.passwordGeneratorRequest)
+        XCTAssertEqual(subject.state.generatedValue, "")
+    }
+
     /// `init` loads the username generation options and doesn't change the defaults if the options
     /// are empty.
     func test_init_loadsUsernameOptions_empty() {
@@ -308,17 +313,6 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
                 capitalize: false,
                 includeNumber: false
             )
-        )
-    }
-
-    /// `init` loads the username generation options and logs an error if one occurs.
-    func test_init_loadsUsernameOptions_error() {
-        generatorRepository.getUsernameGenerationOptionsResult = .failure(StateServiceError.noActiveAccount)
-        setUpSubject()
-        waitFor { !errorReporter.errors.isEmpty }
-        XCTAssertEqual(
-            errorReporter.errors[0] as NSError,
-            BitwardenError.generatorOptionsError(error: StateServiceError.noActiveAccount)
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2357](https://livefront.atlassian.net/browse/BIT-2357)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When generating a username for a login, there was a race condition where attempting to generate the value would occur before the generator options have loaded. This ensures that the options have finished loading, otherwise generating a vault happens immediately after the options have loaded.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <video src="https://github.com/bitwarden/ios/assets/126492398/113c06e9-0c44-454b-94aa-e119c7cffefd"> | <video src="https://github.com/bitwarden/ios/assets/126492398/e91a9538-5fde-4e1c-a314-394ffa66dba1"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
