### PR TITLE
BIT-2359: Disable session timeout action picker when policy is enabled

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -103,11 +103,7 @@ final class AccountSecurityProcessor: StateProcessor<
     private func appeared() async {
         do {
             if let policy = try await services.policyService.fetchTimeoutPolicyValues() {
-                // If the policy returns no timeout action, we present the user all timeout actions.
-                // If the policy returns a timeout action, it's the only one we show the user.
-                if policy.action != nil {
-                    state.policyTimeoutAction = policy.action
-                }
+                state.isTimeoutActionPolicyEnabled = policy.action != nil
 
                 state.policyTimeoutValue = policy.value
                 state.isTimeoutPolicyEnabled = true

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -83,10 +83,10 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         await subject.perform(.appeared)
 
-        XCTAssertEqual(subject.state.isTimeoutPolicyEnabled, true)
-        XCTAssertEqual(subject.state.policyTimeoutAction, .logout)
+        XCTAssertTrue(subject.state.isTimeoutPolicyEnabled)
+        XCTAssertTrue(subject.state.isTimeoutActionPolicyEnabled)
+        XCTAssertTrue(subject.state.isSessionTimeoutActionDisabled)
         XCTAssertEqual(subject.state.policyTimeoutValue, 60)
-        XCTAssertEqual(subject.state.availableTimeoutActions, [.logout])
         XCTAssertEqual(subject.state.policyTimeoutHours, 1)
         XCTAssertEqual(subject.state.policyTimeoutMinutes, 0)
         XCTAssertEqual(
@@ -110,9 +110,10 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         await subject.perform(.appeared)
 
-        XCTAssertEqual(subject.state.isTimeoutPolicyEnabled, true)
+        XCTAssertFalse(subject.state.isTimeoutActionPolicyEnabled)
+        XCTAssertTrue(subject.state.isTimeoutPolicyEnabled)
+        XCTAssertFalse(subject.state.isSessionTimeoutActionDisabled)
         XCTAssertEqual(subject.state.policyTimeoutValue, 61)
-        XCTAssertEqual(subject.state.availableTimeoutActions, [.lock, .logout])
         XCTAssertEqual(subject.state.policyTimeoutHours, 1)
         XCTAssertEqual(subject.state.policyTimeoutMinutes, 1)
         XCTAssertEqual(

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -177,21 +177,14 @@ struct AccountSecurityState: Equatable {
     /// Whether the user has a master password.
     var hasMasterPassword = true
 
-    /// Whether the maximum timeout value policy is in effect.
-    var isTimeoutPolicyEnabled: Bool = false
+    /// Whether the timeout policy specifies a timeout action.
+    var isTimeoutActionPolicyEnabled = false
+
+    /// Whether the timeout policy is in effect.
+    var isTimeoutPolicyEnabled = false
 
     /// Whether the unlock with pin code toggle is on.
     var isUnlockWithPINCodeOn: Bool = false
-
-    /// The maximum vault timeout policy action.
-    ///
-    /// When set, this is the only action option available to users.
-    var policyTimeoutAction: SessionTimeoutAction? = .lock {
-        didSet {
-            availableTimeoutActions = SessionTimeoutAction.allCases
-                .filter { $0 == policyTimeoutAction }
-        }
-    }
 
     /// The policy's maximum vault timeout value.
     ///
@@ -245,9 +238,9 @@ struct AccountSecurityState: Equatable {
         hasUnlockMethod
     }
 
-    /// Whether the session timeout row/picker should be disabled.
-    var isSessionTimeoutDisabled: Bool {
-        !hasUnlockMethod
+    /// Whether the session timeout action row/picker should be disabled.
+    var isSessionTimeoutActionDisabled: Bool {
+        !hasUnlockMethod || isTimeoutActionPolicyEnabled
     }
 
     /// Whether or not the custom session timeout field is shown.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
@@ -168,7 +168,7 @@ struct AccountSecurityView: View {
                         send: AccountSecurityAction.sessionTimeoutActionChanged
                     )
                 )
-                .disabled(store.state.isSessionTimeoutDisabled)
+                .disabled(store.state.isSessionTimeoutActionDisabled)
             }
             .clipShape(RoundedRectangle(cornerRadius: 10))
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2359](https://livefront.atlassian.net/browse/BIT-2359)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When a timeout action is set via a policy, disable the picker that allows you to select a timeout action. Previously we were removing all other options from the picker.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <img width="559" alt="Screenshot 2024-06-13 at 3 10 38 PM" src="https://github.com/bitwarden/ios/assets/126492398/30888118-3ac1-4730-8fbc-c8fd38912933"> | <img width="559" alt="Screenshot 2024-06-13 at 3 08 37 PM" src="https://github.com/bitwarden/ios/assets/126492398/97388d32-a0aa-4263-a17c-fe23e44cdf4e"> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
