### PR TITLE
BIT-2347: Add autofill master password reprompt bypass for TDE users

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -17,7 +17,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var activeAccount: Account?
     var altAccounts = [Account]()
     var getAccountError: Error?
-    var hasMasterPassword: Bool = true
+    var hasMasterPasswordResult = Result<Bool, Error>.success(true)
     var isLockedResult: Result<Bool, Error> = .success(true)
     var isPinUnlockAvailableResult: Result<Bool, Error> = .success(false)
     var lockVaultUserId: String?
@@ -137,7 +137,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     }
 
     func hasMasterPassword() async throws -> Bool {
-        hasMasterPassword
+        try hasMasterPasswordResult.get()
     }
 
     func isLocked(userId: String?) async throws -> Bool {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
@@ -127,7 +127,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
     /// Perform with `.deleteAccount` presents the OTP code verification alert for users without a
     /// master password. Pressing submit on the alert deletes the user's account.
     func test_perform_deleteAccount_submitPressed_noMasterPassword() async throws {
-        authRepository.hasMasterPassword = false
+        authRepository.hasMasterPasswordResult = .success(false)
         stateService.activeAccount = Account.fixtureWithTdeNoPassword()
 
         await subject.perform(.deleteAccount)
@@ -155,7 +155,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
     /// Perform with `.deleteAccount` presents the OTP code verification alert for users without a
     /// master password. If an error occurs it's logged and an alert is shown.
     func test_perform_deleteAccount_submitPressed_noMasterPassword_error() async throws {
-        authRepository.hasMasterPassword = false
+        authRepository.hasMasterPasswordResult = .success(false)
         authRepository.requestOtpResult = .failure(BitwardenTestError.example)
         stateService.activeAccount = Account.fixtureWithTdeNoPassword()
 
@@ -176,7 +176,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
                 )
             )
         )
-        authRepository.hasMasterPassword = false
+        authRepository.hasMasterPasswordResult = .success(false)
 
         await subject.perform(.deleteAccount)
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -551,14 +551,14 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 
     /// `perform(_:)` with `.appeared` checks if user has masterpassword.
     func test_perform_appeared_checkUserHasMasterPassword_true() async {
-        authRepository.hasMasterPassword = true
+        authRepository.hasMasterPasswordResult = .success(true)
         await subject.perform(.appeared)
         XCTAssertTrue(subject.state.showMasterPasswordReprompt)
     }
 
     /// `perform(_:)` with `.appeared` checks if user has masterpassword.
     func test_perform_appeared_checkUserHasMasterPassword_false() async {
-        authRepository.hasMasterPassword = false
+        authRepository.hasMasterPasswordResult = .success(false)
         await subject.perform(.appeared)
         XCTAssertFalse(subject.state.showMasterPasswordReprompt)
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2347](https://livefront.atlassian.net/browse/BIT-2347)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

For TDE users without a master password, bypass reprompting for master password when autofilling a credential.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
