### PR TITLE
BIT-2348: Add OTP key parsing for account name and issuer

### DIFF
--- a/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModel.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModel.swift
@@ -71,25 +71,21 @@ struct OTPAuthModel: Equatable {
             return nil
         }
 
+        let algorithm = TOTPCryptoHashAlgorithm(from: queryItems.first { $0.name == "algorithm" }?.value)
+        let digits = queryItems.first { $0.name == "digits" }?.value.flatMap(Int.init) ?? 6
+        var issuer = queryItems.first { $0.name == "issuer" }?.value
+        let period = queryItems.first { $0.name == "period" }?.value.flatMap(Int.init) ?? 30
+
         var accountName: String?
-        var issuer: String?
         if let label = urlComponents.url?.lastPathComponent {
             let parts = label.split(separator: ":")
             if parts.count > 1 {
-                issuer = String(parts[0])
+                issuer = issuer ?? String(parts[0])
                 accountName = String(parts[1])
             } else {
                 accountName = label
             }
         }
-
-        if issuer == nil {
-            issuer = queryItems.first { $0.name == "issuer" }?.value
-        }
-
-        let period = queryItems.first { $0.name == "period" }?.value.flatMap(Int.init) ?? 30
-        let digits = queryItems.first { $0.name == "digits" }?.value.flatMap(Int.init) ?? 6
-        let algorithm = TOTPCryptoHashAlgorithm(from: queryItems.first { $0.name == "algorithm" }?.value)
 
         self.init(
             accountName: accountName,

--- a/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
@@ -15,14 +15,14 @@ class OTPAuthModelTests: BitwardenTestCase {
 
     /// Tests that a malformed string does not create a model.
     func test_init_otpAuthKey_failure_incompletePrefix() {
-        let subject = OTPAuthModel(otpAuthKey: "totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP")
+        let subject = OTPAuthModel(otpAuthKey: "totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP")
         XCTAssertNil(subject)
     }
 
     /// Tests that a malformed string does not create a model.
     func test_init_otpAuthKey_failure_noSecret() {
         let subject = OTPAuthModel(
-            otpAuthKey: "otpauth://totp/Example:eliot@livefront.com?issuer=Example&algorithm=SHA256&digits=6&period=30"
+            otpAuthKey: "otpauth://totp/Example:user@bitwarden.com?issuer=Example&algorithm=SHA256&digits=6&period=30"
         )
         XCTAssertNil(subject)
     }
@@ -36,15 +36,88 @@ class OTPAuthModelTests: BitwardenTestCase {
     /// Tests that a fully formatted OTP Auth string creates the model.
     func test_init_otpAuthKey_success_full() {
         let subject = OTPAuthModel(otpAuthKey: .otpAuthUriKeyComplete)
-        XCTAssertNotNil(subject)
+        XCTAssertEqual(
+            subject,
+            OTPAuthModel(
+                accountName: "user@bitwarden.com",
+                algorithm: .sha256,
+                digits: 6,
+                issuer: "Example",
+                keyB32: "JBSWY3DPEHPK3PXP",
+                period: 30,
+                uri: .otpAuthUriKeyComplete
+            )
+        )
+    }
+
+    /// Test that a key with a issuer query parameter instead of in the label creates the model.
+    func test_init_otpAuthKey_success_issuerQueryParam() {
+        let key = "otpauth://totp/user@bitwarden.com?secret=JBSWY3DPEHPK3PXP&issuer=Bitwarden"
+        let subject = OTPAuthModel(otpAuthKey: key)
+        XCTAssertEqual(
+            subject,
+            OTPAuthModel(
+                accountName: "user@bitwarden.com",
+                algorithm: .sha1,
+                digits: 6,
+                issuer: "Bitwarden",
+                keyB32: "JBSWY3DPEHPK3PXP",
+                period: 30,
+                uri: key
+            )
+        )
     }
 
     /// Tests that a partially formatted OTP Auth string creates the model.
     func test_init_otpAuthKey_success_partial() {
         let subject = OTPAuthModel(otpAuthKey: .otpAuthUriKeyPartial)
-        XCTAssertNotNil(subject)
-        XCTAssertEqual(subject?.digits, 6)
-        XCTAssertEqual(subject?.period, 30)
-        XCTAssertEqual(subject?.algorithm, .sha1)
+        XCTAssertEqual(
+            subject,
+            OTPAuthModel(
+                accountName: "user@bitwarden.com",
+                algorithm: .sha1,
+                digits: 6,
+                issuer: "Example",
+                keyB32: "JBSWY3DPEHPK3PXP",
+                period: 30,
+                uri: .otpAuthUriKeyPartial
+            )
+        )
+    }
+
+    /// Test that a key with a percent encoded issuer creates the model.
+    func test_init_otpAuthKey_success_percentEncodedIssuer() {
+        let key = "otpauth://totp/ACME%20Co:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP&issuer=ACME%20Co"
+        let subject = OTPAuthModel(otpAuthKey: key)
+        XCTAssertEqual(
+            subject,
+            OTPAuthModel(
+                accountName: "user@bitwarden.com",
+                algorithm: .sha1,
+                digits: 6,
+                issuer: "ACME Co",
+                keyB32: "JBSWY3DPEHPK3PXP",
+                period: 30,
+                uri: key
+            )
+        )
+    }
+
+    /// Test that a key with a percent encoded label separator creates the model.
+    func test_init_otpAuthKey_success_percentEncodedLabelSeparator() {
+        let key = "otpauth://totp/Bitwarden%3Auser@bitwarden.com?secret=JBSWY3DPEHPK3PXP&issuer=Bitwarden"
+        let subject = OTPAuthModel(otpAuthKey: key)
+        XCTAssertEqual(
+            subject,
+            OTPAuthModel(
+                accountName: "user@bitwarden.com",
+                algorithm: .sha1,
+                digits: 6,
+                issuer: "Bitwarden",
+                keyB32: "JBSWY3DPEHPK3PXP",
+                period: 30,
+                uri: key
+            )
+        )
     }
 }

--- a/BitwardenShared/Core/Vault/Services/TOTP/TOTPCodeConfigTests.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TOTPCodeConfigTests.swift
@@ -10,7 +10,7 @@ final class TOTPCodeConfigTests: BitwardenTestCase {
     /// Tests that a malformed string does not create a model.
     func test_init_totpCodeConfig_failure_incompletePrefix() {
         let subject = TOTPKeyModel(
-            authenticatorKey: "totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP"
+            authenticatorKey: "totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP"
         )
         XCTAssertNil(subject)
     }
@@ -18,7 +18,7 @@ final class TOTPCodeConfigTests: BitwardenTestCase {
     /// Tests that a malformed string does not create a model.
     func test_init_totpCodeConfig_failure_noSecret() {
         let subject = TOTPKeyModel(
-            authenticatorKey: "otpauth://totp/Example:eliot@livefront.com?issuer=Example&algorithm=SHA256&digits=6&period=30" // swiftlint:disable:this line_length
+            authenticatorKey: "otpauth://totp/Example:user@bitwarden.com?issuer=Example&algorithm=SHA256&digits=6&period=30" // swiftlint:disable:this line_length
         )
         XCTAssertNil(subject)
     }
@@ -40,7 +40,7 @@ final class TOTPCodeConfigTests: BitwardenTestCase {
         XCTAssertNotNil(subject)
         XCTAssertEqual(
             subject?.base32Key,
-            .base32Key.lowercased()
+            .base32Key
         )
     }
 
@@ -52,7 +52,7 @@ final class TOTPCodeConfigTests: BitwardenTestCase {
         XCTAssertNotNil(subject)
         XCTAssertEqual(
             subject?.base32Key,
-            .base32Key.lowercased()
+            .base32Key
         )
     }
 
@@ -64,7 +64,7 @@ final class TOTPCodeConfigTests: BitwardenTestCase {
         XCTAssertNotNil(subject)
         XCTAssertEqual(
             subject?.base32Key,
-            .base32Key.lowercased()
+            .base32Key
         )
     }
 

--- a/BitwardenShared/Core/Vault/Services/TOTP/TestHelpers/String+TOTPFixtures.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TestHelpers/String+TOTPFixtures.swift
@@ -3,9 +3,9 @@
 extension String {
     static let base32Key = "JBSWY3DPEHPK3PXP"
     // swiftlint:disable:next line_length
-    static let otpAuthUriKeyComplete = "otpauth://totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&algorithm=SHA256&digits=6&period=30"
-    static let otpAuthUriKeyPartial = "otpauth://totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP"
+    static let otpAuthUriKeyComplete = "otpauth://totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&algorithm=SHA256&digits=6&period=30"
+    static let otpAuthUriKeyPartial = "otpauth://totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP"
     // swiftlint:disable:next line_length
-    static let otpAuthUriKeySHA512 = "otpauth://totp/Example:eliot@livefront.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA512"
+    static let otpAuthUriKeySHA512 = "otpauth://totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA512"
     static let steamUriKey = "steam://JBSWY3DPEHPK3PXP"
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2348](https://livefront.atlassian.net/browse/BIT-2350)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for parsing the account name and issuer from the OTP key.

This is needed as a precursor to searching for matching ciphers based on the account name or issuer from the key.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
