### PR TITLE
BIT-2434: Set a source view and rect when presenting popovers for iPadOS

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
@@ -301,6 +301,18 @@ extension UINavigationController: StackNavigator {
         if overFullscreen {
             viewController.modalPresentationStyle = .overFullScreen
         }
+        if let popoverPresentationController = viewController.popoverPresentationController,
+           popoverPresentationController.sourceView == nil,
+           popoverPresentationController.barButtonItem == nil,
+           let parentView = availablePresenter?.view {
+            // Provide a default source view and rect when presenting a popover if one isn't
+            // already specified. This prevents a crash when presenting popovers on iPadOS.
+            viewController.popoverPresentationController?.sourceView = view
+            viewController.popoverPresentationController?.sourceRect = CGRect(
+                x: parentView.bounds.midX, y: parentView.bounds.midY, width: 0, height: 0
+            )
+            viewController.popoverPresentationController?.permittedArrowDirections = []
+        }
         availablePresenter?.present(
             viewController,
             animated: animated,

--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
@@ -307,11 +307,11 @@ extension UINavigationController: StackNavigator {
            let parentView = availablePresenter?.view {
             // Provide a default source view and rect when presenting a popover if one isn't
             // already specified. This prevents a crash when presenting popovers on iPadOS.
-            viewController.popoverPresentationController?.sourceView = view
-            viewController.popoverPresentationController?.sourceRect = CGRect(
+            popoverPresentationController.sourceView = parentView
+            popoverPresentationController.sourceRect = CGRect(
                 x: parentView.bounds.midX, y: parentView.bounds.midY, width: 0, height: 0
             )
-            viewController.popoverPresentationController?.permittedArrowDirections = []
+            popoverPresentationController.permittedArrowDirections = []
         }
         availablePresenter?.present(
             viewController,

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -294,7 +294,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         stackNavigator?.present(navController)
     }
 
-    /// presents an activity contorller for an exported vault file URL.
+    /// Presents an activity controller for an exported vault file URL.
     ///
     private func showExportedVaultURL(_ fileURL: URL) {
         let activityVC = UIActivityViewController(activityItems: [fileURL], applicationActivities: nil)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2434](https://livefront.atlassian.net/browse/BIT-2434)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes a crash when presenting a `UIActivityViewController`. These are presented as popovers on iPadOS, and need a `sourceView` to be specified. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
