### PR TITLE
BIT-2366: Alert user to switch to existing account with matching email on login

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -473,13 +473,14 @@ extension DefaultAuthRepository: AuthRepository {
     }
 
     func existingAccountUserId(email: String) async -> String? {
-        guard let userId = await stateService.getUserId(email: email),
-              let baseUrl = try? await stateService.getEnvironmentUrls(userId: userId)?.base,
-              baseUrl == environmentService.baseURL
-        else {
-            return nil
+        let matchingUserIds = await stateService.getUserIds(email: email)
+        for userId in matchingUserIds {
+            guard let baseUrl = try? await stateService.getEnvironmentUrls(userId: userId)?.base,
+                  baseUrl == environmentService.baseURL
+            else { continue }
+            return userId
         }
-        return userId
+        return nil
     }
 
     func getAccount(for userId: String?) async throws -> Account {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -42,6 +42,14 @@ protocol AuthRepository: AnyObject {
     ///
     func deleteAccount(otp: String?, passwordText: String?) async throws
 
+    /// Returns the user ID of an existing account that is already logged in on the device matching
+    /// the specified email.
+    ///
+    /// - Parameter email: The email for the account to check.
+    /// - Returns: The user ID of the account that is already logged in on the device, or `nil` otherwise.
+    ///
+    func existingAccountUserId(email: String) async -> String?
+
     /// Gets the account for a user id.
     ///
     /// - Parameter userId: The user Id to be mapped to an account.
@@ -462,6 +470,16 @@ extension DefaultAuthRepository: AuthRepository {
 
         try await stateService.deleteAccount()
         await vaultTimeoutService.remove(userId: nil)
+    }
+
+    func existingAccountUserId(email: String) async -> String? {
+        guard let userId = await stateService.getUserId(email: email),
+              let baseUrl = try? await stateService.getEnvironmentUrls(userId: userId)?.base,
+              baseUrl == environmentService.baseURL
+        else {
+            return nil
+        }
+        return userId
     }
 
     func getAccount(for userId: String?) async throws -> Account {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -475,10 +475,10 @@ extension DefaultAuthRepository: AuthRepository {
     func existingAccountUserId(email: String) async -> String? {
         let matchingUserIds = await stateService.getUserIds(email: email)
         for userId in matchingUserIds {
-            guard let baseUrl = try? await stateService.getEnvironmentUrls(userId: userId)?.base,
-                  baseUrl == environmentService.baseURL
-            else { continue }
-            return userId
+            if let baseUrl = try? await stateService.getEnvironmentUrls(userId: userId)?.base,
+               baseUrl == environmentService.baseURL {
+                return userId
+            }
         }
         return nil
     }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -253,11 +253,23 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultUS.base)
         stateService.activeAccount = .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1"))
         stateService.environmentUrls["1"] = .defaultUS
-        stateService.userId = "1"
+        stateService.userIds = ["1"]
 
         let userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
 
         XCTAssertEqual(userId, "1")
+    }
+
+    /// `existingAccountUserId(email:)` returns `nil` if getting the environment URLs throws an error.
+    func test_existingAccountUserId_getEnvironmentUrlsError() async throws {
+        environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultUS.base)
+        stateService.activeAccount = .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1"))
+        stateService.environmentUrlsError = StateServiceError.noAccounts
+        stateService.userIds = ["1"]
+
+        let userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
+
+        XCTAssertNil(userId)
     }
 
     /// `existingAccountUserId(email:)` returns `nil` if there's an existing account with the same
@@ -266,11 +278,28 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultEU.base)
         stateService.activeAccount = .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1"))
         stateService.environmentUrls["1"] = .defaultUS
-        stateService.userId = "1"
+        stateService.userIds = ["1"]
 
         let userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
 
         XCTAssertNil(userId)
+    }
+
+    /// `existingAccountUserId(email:)` returns the matching user ID with the same base URL, if
+    /// there are multiple matches for the user's email.
+    func test_existingAccountUserId_multipleMatching() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1"))
+        stateService.environmentUrls["1"] = .defaultUS
+        stateService.environmentUrls["2"] = .defaultEU
+        stateService.userIds = ["1", "2"]
+
+        environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultUS.base)
+        var userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
+        XCTAssertEqual(userId, "1")
+
+        environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultEU.base)
+        userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
+        XCTAssertEqual(userId, "2")
     }
 
     /// `existingAccountUserId(email:)` returns `nil` if there isn't an account that matches the email.

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -247,6 +247,39 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(client.requests[0].url, URL(string: "https://example.com/api/accounts"))
     }
 
+    /// `existingAccountUserId(email:)` returns the user ID of the existing account with the same
+    /// email and base URLs.
+    func test_existingAccountUserId() async throws {
+        environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultUS.base)
+        stateService.activeAccount = .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1"))
+        stateService.environmentUrls["1"] = .defaultUS
+        stateService.userId = "1"
+
+        let userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
+
+        XCTAssertEqual(userId, "1")
+    }
+
+    /// `existingAccountUserId(email:)` returns `nil` if there's an existing account with the same
+    /// email but the base URLs are different.
+    func test_existingAccountUserId_matchingAccountDifferentBaseUrl() async throws {
+        environmentService.baseURL = try XCTUnwrap(EnvironmentUrlData.defaultEU.base)
+        stateService.activeAccount = .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1"))
+        stateService.environmentUrls["1"] = .defaultUS
+        stateService.userId = "1"
+
+        let userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
+
+        XCTAssertNil(userId)
+    }
+
+    /// `existingAccountUserId(email:)` returns `nil` if there isn't an account that matches the email.
+    func test_existingAccountUserId_noMatchingAccount() async throws {
+        let userId = await subject.existingAccountUserId(email: "user@bitwarden.com")
+
+        XCTAssertNil(userId)
+    }
+
     /// `allowBioMetricUnlock(:)` throws an error if required.
     func test_allowBioMetricUnlock_biometricsRepositoryError() async throws {
         biometricsRepository.setBiometricUnlockKeyError = BiometricsServiceError.setAuthKeyFailed

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -14,6 +14,8 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var deviceId: String = ""
     var email: String = ""
     var encryptedPin: String = "123"
+    var existingAccountUserIdEmail: String?
+    var existingAccountUserIdResult: String?
     var fingerprintPhraseResult: Result<String, Error> = .success("fingerprint")
     var activeAccount: Account?
     var altAccounts = [Account]()
@@ -97,6 +99,11 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     func deleteAccount(otp: String?, passwordText _: String?) async throws {
         deleteAccountCalled = true
         try deleteAccountResult.get()
+    }
+
+    func existingAccountUserId(email: String) async -> String? {
+        existingAccountUserIdEmail = email
+        return existingAccountUserIdResult
     }
 
     func getAccount(for userId: String?) async throws -> Account {

--- a/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
@@ -9,6 +9,9 @@ protocol EnvironmentService {
     /// The URL for the API.
     var apiURL: URL { get }
 
+    /// The environment's base URL.
+    var baseURL: URL { get }
+
     /// The URL for the events API.
     var eventsURL: URL { get }
 
@@ -107,6 +110,10 @@ class DefaultEnvironmentService: EnvironmentService {
 extension DefaultEnvironmentService {
     var apiURL: URL {
         environmentUrls.apiURL
+    }
+
+    var baseURL: URL {
+        environmentUrls.baseURL
     }
 
     var eventsURL: URL {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -261,6 +261,13 @@ protocol StateService: AnyObject {
     ///
     func getUserHasMasterPassword(userId: String?) async throws -> Bool
 
+    /// Gets the user ID for an account with the specified email.
+    ///
+    /// - Parameter email: The email of the account.
+    /// - Returns: The user ID of the account with a matching email.
+    ///
+    func getUserId(email: String) async -> String?
+
     /// Gets the username generation options for a user ID.
     ///
     /// - Parameter userId: The user ID associated with the username generation options.
@@ -1184,6 +1191,12 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
 
     func getUserHasMasterPassword(userId: String?) async throws -> Bool {
         try getAccount(userId: userId).profile.userDecryptionOptions?.hasMasterPassword ?? true
+    }
+
+    func getUserId(email: String) async -> String? {
+        guard let state = appSettingsStore.state else { return nil }
+        let account = state.accounts.values.first { $0.profile.email == email }
+        return account?.profile.userId
     }
 
     func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -261,12 +261,12 @@ protocol StateService: AnyObject {
     ///
     func getUserHasMasterPassword(userId: String?) async throws -> Bool
 
-    /// Gets the user ID for an account with the specified email.
+    /// Gets the user ID of any accounts with the specified email.
     ///
     /// - Parameter email: The email of the account.
-    /// - Returns: The user ID of the account with a matching email.
+    /// - Returns: A list of user IDs for the accounts with a matching email.
     ///
-    func getUserId(email: String) async -> String?
+    func getUserIds(email: String) async -> [String]
 
     /// Gets the username generation options for a user ID.
     ///
@@ -1193,10 +1193,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         try getAccount(userId: userId).profile.userDecryptionOptions?.hasMasterPassword ?? true
     }
 
-    func getUserId(email: String) async -> String? {
-        guard let state = appSettingsStore.state else { return nil }
-        let account = state.accounts.values.first { $0.profile.email == email }
-        return account?.profile.userId
+    func getUserIds(email: String) async -> [String] {
+        guard let state = appSettingsStore.state else { return [] }
+        let userIds = state.accounts.values.filter { $0.profile.email == email }.map(\.profile.userId)
+        return userIds
     }
 
     func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -729,8 +729,8 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertTrue(userHasMasterPassword)
     }
 
-    /// `getUserId(email:)` returns the user ID of the user with a matching email.
-    func test_getUserId() async {
+    /// `getUserIds(email:)` returns the user ID of any users with a matching email.
+    func test_getUserIds() async {
         appSettingsStore.state = State(
             accounts: [
                 "1": .fixture(profile: .fixture(email: "user1@bitwarden.com", userId: "1")),
@@ -739,29 +739,43 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
             ]
         )
 
-        let user1Id = await subject.getUserId(email: "user1@bitwarden.com")
-        XCTAssertEqual(user1Id, "1")
+        let user1Ids = await subject.getUserIds(email: "user1@bitwarden.com")
+        XCTAssertEqual(user1Ids, ["1"])
 
-        let user3Id = await subject.getUserId(email: "user3@bitwarden.com")
-        XCTAssertEqual(user3Id, "3")
+        let user3Ids = await subject.getUserIds(email: "user3@bitwarden.com")
+        XCTAssertEqual(user3Ids, ["3"])
     }
 
-    /// `getUserId(email:)` returns `nil` if there isn't a user with a matching email.
-    func test_getUserId_noMatchingUser() async {
+    /// `getUserIds(email:)` returns multiple user IDs if they all have a matching email.
+    func test_getUserIds_multiple() async {
+        appSettingsStore.state = State(
+            accounts: [
+                "1": .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1")),
+                "2": .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "2")),
+                "3": .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "3")),
+            ]
+        )
+
+        let userIds = await subject.getUserIds(email: "user@bitwarden.com")
+        XCTAssertEqual(userIds.sorted(), ["1", "2", "3"])
+    }
+
+    /// `getUserIds(email:)` returns `nil` if there isn't a user with a matching email.
+    func test_getUserIds_noMatchingUser() async {
         appSettingsStore.state = State(
             accounts: [
                 "1": .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1")),
             ]
         )
 
-        let userId = await subject.getUserId(email: "user@example.com")
-        XCTAssertNil(userId)
+        let userIds = await subject.getUserIds(email: "user@example.com")
+        XCTAssertTrue(userIds.isEmpty)
     }
 
-    /// `getUserId(email:)` returns `nil` if there are no other users.
-    func test_getUserId_noUsers() async {
-        let userId = await subject.getUserId(email: "user@bitwarden.com")
-        XCTAssertNil(userId)
+    /// `getUserIds(email:)` returns `nil` if there are no other users.
+    func test_getUserIds_noUsers() async {
+        let userIds = await subject.getUserIds(email: "user@bitwarden.com")
+        XCTAssertTrue(userIds.isEmpty)
     }
 
     /// `getUsernameGenerationOptions()` gets the saved username generation options for the account.

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -729,6 +729,41 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertTrue(userHasMasterPassword)
     }
 
+    /// `getUserId(email:)` returns the user ID of the user with a matching email.
+    func test_getUserId() async {
+        appSettingsStore.state = State(
+            accounts: [
+                "1": .fixture(profile: .fixture(email: "user1@bitwarden.com", userId: "1")),
+                "2": .fixture(profile: .fixture(email: "user2@bitwarden.com", userId: "2")),
+                "3": .fixture(profile: .fixture(email: "user3@bitwarden.com", userId: "3")),
+            ]
+        )
+
+        let user1Id = await subject.getUserId(email: "user1@bitwarden.com")
+        XCTAssertEqual(user1Id, "1")
+
+        let user3Id = await subject.getUserId(email: "user3@bitwarden.com")
+        XCTAssertEqual(user3Id, "3")
+    }
+
+    /// `getUserId(email:)` returns `nil` if there isn't a user with a matching email.
+    func test_getUserId_noMatchingUser() async {
+        appSettingsStore.state = State(
+            accounts: [
+                "1": .fixture(profile: .fixture(email: "user@bitwarden.com", userId: "1")),
+            ]
+        )
+
+        let userId = await subject.getUserId(email: "user@example.com")
+        XCTAssertNil(userId)
+    }
+
+    /// `getUserId(email:)` returns `nil` if there are no other users.
+    func test_getUserId_noUsers() async {
+        let userId = await subject.getUserId(email: "user@bitwarden.com")
+        XCTAssertNil(userId)
+    }
+
     /// `getUsernameGenerationOptions()` gets the saved username generation options for the account.
     func test_getUsernameGenerationOptions() async throws {
         let options1 = UsernameGenerationOptions(plusAddressedEmail: "user@bitwarden.com")

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockEnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockEnvironmentService.swift
@@ -8,6 +8,7 @@ class MockEnvironmentService: EnvironmentService {
     var setPreAuthEnvironmentUrlsData: EnvironmentUrlData?
 
     var apiURL = URL(string: "https://example.com/api")!
+    var baseURL = URL(string: "https://example.com")!
     var eventsURL = URL(string: "https://example.com/events")!
     var iconsURL = URL(string: "https://example.com/icons")!
     var identityURL = URL(string: "https://example.com/identity")!

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -58,6 +58,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var updateProfileResponse: ProfileResponseModel?
     var updateProfileUserId: String?
     var userHasMasterPassword = [String: Bool]()
+    var userId: String?
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
     var vaultTimeout = [String: SessionTimeoutValue]()
 
@@ -249,6 +250,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func getUserHasMasterPassword(userId: String?) async throws -> Bool {
         let userId = try unwrapUserId(userId)
         return userHasMasterPassword[userId] ?? true
+    }
+
+    func getUserId(email: String) async -> String? {
+        userId
     }
 
     func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -30,6 +30,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var doesActiveAccountHavePremiumResult: Result<Bool, Error> = .success(true)
     var encryptedPinByUserId = [String: String]()
     var environmentUrls = [String: EnvironmentUrlData]()
+    var environmentUrlsError: Error?
     var forcePasswordResetReason = [String: ForcePasswordResetReason]()
     var lastActiveTime = [String: Date]()
     var loginRequest: LoginRequestNotification?
@@ -58,7 +59,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var updateProfileResponse: ProfileResponseModel?
     var updateProfileUserId: String?
     var userHasMasterPassword = [String: Bool]()
-    var userId: String?
+    var userIds = [String]()
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
     var vaultTimeout = [String: SessionTimeoutValue]()
 
@@ -178,6 +179,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     }
 
     func getEnvironmentUrls(userId: String?) async throws -> EnvironmentUrlData? {
+        if let environmentUrlsError {
+            throw environmentUrlsError
+        }
         let userId = try unwrapUserId(userId)
         return environmentUrls[userId]
     }
@@ -252,8 +256,8 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         return userHasMasterPassword[userId] ?? true
     }
 
-    func getUserId(email: String) async -> String? {
-        userId
+    func getUserIds(email: String) async -> [String] {
+        userIds
     }
 
     func getUsernameGenerationOptions(userId: String?) async throws -> UsernameGenerationOptions? {

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -217,6 +217,26 @@ extension Alert {
         )
     }
 
+    /// An alert asking the user if they want to switch to the already existing account when adding
+    /// a new account.
+    ///
+    /// - Parameter action: The action taken if the user wants to switch to the existing account.
+    /// - Returns: An alert asking the user if they want to switch to the already existing account
+    ///     when adding a new account.
+    ///
+    static func switchToExistingAccount(
+        action: @escaping () async -> Void
+    ) -> Alert {
+        Alert(
+            title: Localizations.accountAlreadyAdded,
+            message: Localizations.switchToAlreadyAddedAccountConfirmation,
+            alertActions: [
+                AlertAction(title: Localizations.cancel, style: .cancel),
+                AlertAction(title: Localizations.yes, style: .default) { _ in await action() },
+            ]
+        )
+    }
+
     /// An alert notifying the user that they have unassigned ciphers.
     ///
     /// - Parameters:

--- a/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
@@ -164,4 +164,25 @@ class AlertAuthTests: BitwardenTestCase {
 
         await fulfillment(of: [expectation], timeout: 3)
     }
+
+    /// `switchToExistingAccount(action:)` builds an `Alert` for switching to an existing account.
+    func test_switchToExistingAccount() async throws {
+        var actionCalled = false
+        let subject = Alert.switchToExistingAccount {
+            actionCalled = true
+        }
+
+        XCTAssertEqual(subject.title, Localizations.accountAlreadyAdded)
+        XCTAssertEqual(subject.message, Localizations.switchToAlreadyAddedAccountConfirmation)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.cancel)
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.yes)
+
+        try await subject.tapAction(title: Localizations.cancel)
+        XCTAssertFalse(actionCalled)
+
+        try await subject.tapAction(title: Localizations.yes)
+        XCTAssertTrue(actionCalled)
+    }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingAction.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingAction.swift
@@ -2,9 +2,6 @@
 
 /// Actions that can be processed by a `LandingProcessor`.
 enum LandingAction: Equatable {
-    /// The continue button was pressed.
-    case continuePressed
-
     /// The create account button was pressed.
     case createAccountPressed
 

--- a/BitwardenShared/UI/Auth/Landing/LandingEffect.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingEffect.swift
@@ -1,9 +1,12 @@
 // MARK: - LandingEffect
 
 /// Effects that can be processed by a `LandingProcessor`.
-enum LandingEffect {
+enum LandingEffect: Equatable {
     /// The vault list appeared on screen.
     case appeared
+
+    /// The continue button was pressed.
+    case continuePressed
 
     /// A Profile Switcher Effect.
     case profileSwitcher(ProfileSwitcherEffect)

--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -91,7 +91,7 @@ struct LandingView: View {
                 .textFieldConfiguration(.email)
                 .onSubmit {
                     guard store.state.isContinueButtonEnabled else { return }
-                    store.send(.continuePressed)
+                    Task { await store.perform(.continuePressed) }
                 }
 
                 Button {
@@ -121,8 +121,8 @@ struct LandingView: View {
                 .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
                 .toggleStyle(.bitwarden)
 
-                Button(Localizations.continue) {
-                    store.send(.continuePressed)
+                AsyncButton(Localizations.continue) {
+                    await store.perform(.continuePressed)
                 }
                 .accessibilityIdentifier("ContinueButton")
                 .disabled(!store.state.isContinueButtonEnabled)

--- a/BitwardenShared/UI/Auth/Landing/LandingViewTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingViewTests.swift
@@ -45,11 +45,11 @@ class LandingViewTests: BitwardenTestCase {
     }
 
     /// Tapping the continue button dispatches the `.continuePressed` action.
-    func test_continueButton_tap() throws {
+    func test_continueButton_tap() async throws {
         processor.state.email = "email@example.com"
-        let button = try subject.inspect().find(button: Localizations.continue)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .continuePressed)
+        let button = try subject.inspect().find(asyncButton: Localizations.continue)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .continuePressed)
     }
 
     /// Tapping the create account button dispatches the `.createAccountPressed` action.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2366](https://livefront.atlassian.net/browse/BIT-2366)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

On login, if the user's entered email matches an existing account and the base URLs match, present an alert to switch to that account.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/bitwarden/ios/assets/126492398/8f506a9d-99ad-4c40-9027-a7ae21e179aa


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
