### PR TITLE
[PM-8965] Register for push notifications more aggressively

### DIFF
--- a/BitwardenShared/Core/Platform/Services/Services.swift
+++ b/BitwardenShared/Core/Platform/Services/Services.swift
@@ -5,6 +5,7 @@ typealias Services = HasAPIService
     & HasAccountAPIService
     & HasAppIdService
     & HasAppSettingsStore
+    & HasApplication
     & HasAuthAPIService
     & HasAuthRepository
     & HasAuthService
@@ -64,6 +65,13 @@ protocol HasAppIdService {
 protocol HasAppSettingsStore {
     /// The service used by the application to persist app setting values.
     var appSettingsStore: AppSettingsStore { get }
+}
+
+/// Protocol for an object that provides an `Application`.
+///
+protocol HasApplication {
+    /// The application instance, if the app isn't running in an extension.
+    var application: Application? { get }
 }
 
 /// Protocol for an object that provides an `AuthAPIService`.

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockApplication.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockApplication.swift
@@ -1,0 +1,9 @@
+@testable import BitwardenShared
+
+class MockApplication: Application {
+    var registerForRemoteNotificationsCalled = false
+
+    func registerForRemoteNotifications() {
+        registerForRemoteNotificationsCalled = true
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -41,6 +41,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastUserShouldConnectToWatch = false
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
+    var notificationsLastRegistrationError: Error?
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKeyValue = [String: String]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
@@ -201,6 +202,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     }
 
     func getNotificationsLastRegistrationDate(userId: String?) async throws -> Date? {
+        if let notificationsLastRegistrationError {
+            throw notificationsLastRegistrationError
+        }
         let userId = try unwrapUserId(userId)
         return notificationsLastRegistrationDates[userId]
     }

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -111,8 +111,6 @@ public class AppProcessor {
         await services.environmentService.loadURLsForActiveAccount()
         _ = await services.configService.getConfig()
 
-        services.application?.registerForRemoteNotifications()
-
         if let initialRoute {
             coordinator.navigate(to: initialRoute)
         } else {

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -56,9 +56,9 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
     typealias Module = GeneratorModule
         & VaultItemModule
 
-    typealias Services = HasAuthRepository
+    typealias Services = HasApplication
+        & HasAuthRepository
         & HasAuthService
-        & HasApplication
         & HasCameraService
         & HasEnvironmentService
         & HasErrorReporter

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -58,6 +58,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
 
     typealias Services = HasAuthRepository
         & HasAuthService
+        & HasApplication
         & HasCameraService
         & HasEnvironmentService
         & HasErrorReporter

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -256,9 +256,11 @@ extension VaultListProcessor {
         coordinator.showAlert(
             .pushNotificationsInformation { [services] in
                 do {
-                    _ = try await services.notificationService
+                    let authorized = try await services.notificationService
                         .requestAuthorization(options: [.alert, .sound, .badge])
-                    await self.registerForNotifications()
+                    if authorized {
+                        await self.registerForNotifications()
+                    }
                 } catch {
                     self.services.errorReporter.log(error: error)
                 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -14,13 +14,15 @@ final class VaultListProcessor: StateProcessor<
 > {
     // MARK: Types
 
-    typealias Services = HasAuthRepository
+    typealias Services = HasApplication
+        & HasAuthRepository
         & HasAuthService
         & HasErrorReporter
         & HasNotificationService
         & HasPasteboardService
         & HasPolicyService
         & HasStateService
+        & HasTimeProvider
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -61,7 +63,7 @@ final class VaultListProcessor: StateProcessor<
         switch effect {
         case .appeared:
             await refreshVault(isManualRefresh: false)
-            await requestNotificationPermissions()
+            await handleNotifications()
             await checkPendingLoginRequests()
             await checkPersonalOwnershipPolicy()
             if !isShowingNotificationPermissions {
@@ -201,6 +203,18 @@ extension VaultListProcessor {
         }
     }
 
+    /// Entry point to handling things around push notifications.
+    private func handleNotifications() async {
+        switch await services.notificationService.notificationAuthorization() {
+        case .authorized:
+            await registerForNotifications()
+        case .notDetermined:
+            await requestNotificationPermissions()
+        default:
+            break
+        }
+    }
+
     /// Refreshes the vault's contents.
     ///
     /// - Parameter isManualRefresh: Whether the sync is being performed as a manual refresh.
@@ -220,12 +234,22 @@ extension VaultListProcessor {
         }
     }
 
-    /// Request permission to send push notifications if the user hasn't granted or denied permissions before.
-    private func requestNotificationPermissions() async {
-        // Don't do anything if the user has already responded to the permission request.
-        let notificationAuthorization = await services.notificationService.notificationAuthorization()
-        guard notificationAuthorization == .notDetermined else { return }
+    /// Attempts to register the device for push notifications.
+    /// We only need to register once a day.
+    private func registerForNotifications() async {
+        do {
+            let lastReg = try await services.stateService.getNotificationsLastRegistrationDate() ?? Date.distantPast
+            if services.timeProvider.timeSince(lastReg) >= 86400 { // One day
+                services.application?.registerForRemoteNotifications()
+                try await services.stateService.setNotificationsLastRegistrationDate(services.timeProvider.presentTime)
+            }
+        } catch {
+            services.errorReporter.log(error: error)
+        }
+    }
 
+    /// Request permission to send push notifications.
+    private func requestNotificationPermissions() async {
         isShowingNotificationPermissions = true
 
         // Show the explanation alert before asking for permissions.
@@ -234,6 +258,7 @@ extension VaultListProcessor {
                 do {
                     _ = try await services.notificationService
                         .requestAuthorization(options: [.alert, .sound, .badge])
+                    await self.registerForNotifications()
                 } catch {
                     self.services.errorReporter.log(error: error)
                 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -159,6 +159,19 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
+    /// `perform(_:)` with `appeared` registers the device for notifications
+    /// if the device attempted registration exactly one day (that is, 86400 seconds) ago.
+    func test_perform_appeared_notificationRegistration_exactlyADay() async throws {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .authorized
+        stateService.notificationsLastRegistrationDates["1"] = timeProvider.presentTime.addingTimeInterval(-86400)
+
+        await subject.perform(.appeared)
+
+        XCTAssertTrue(application.registerForRemoteNotificationsCalled)
+        XCTAssertEqual(stateService.notificationsLastRegistrationDates["1"], timeProvider.presentTime)
+    }
+
     /// `perform(_:)` with `appeared` does not register the device for notifications
     /// if the device attempted registration less than one day (that is, 86400 seconds) ago.
     func test_perform_appeared_notificationRegistration_lessThanADay() async throws {
@@ -180,7 +193,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     func test_perform_appeared_notificationRegistration_moreThanADay() async throws {
         stateService.activeAccount = .fixture()
         notificationService.authorizationStatus = .authorized
-        stateService.notificationsLastRegistrationDates["1"] = timeProvider.presentTime.addingTimeInterval(-86400)
+        stateService.notificationsLastRegistrationDates["1"] = timeProvider.presentTime.addingTimeInterval(-86401)
 
         await subject.perform(.appeared)
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -10,6 +10,7 @@ import XCTest
 class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
+    var application: MockApplication!
     var authRepository: MockAuthRepository!
     var authService: MockAuthService!
     var coordinator: MockCoordinator<VaultRoute, AuthAction>!
@@ -18,6 +19,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     var pasteboardService: MockPasteboardService!
     var stateService: MockStateService!
     var subject: VaultListProcessor!
+    var timeProvider: MockTimeProvider!
     var vaultRepository: MockVaultRepository!
 
     let profile1 = ProfileSwitcherItem.fixture()
@@ -28,6 +30,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     override func setUp() {
         super.setUp()
 
+        application = MockApplication()
         authRepository = MockAuthRepository()
         authService = MockAuthService()
         errorReporter = MockErrorReporter()
@@ -36,14 +39,17 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         notificationService = MockNotificationService()
         pasteboardService = MockPasteboardService()
         stateService = MockStateService()
+        timeProvider = MockTimeProvider(.mockTime(Date(year: 2024, month: 6, day: 28)))
         vaultRepository = MockVaultRepository()
         let services = ServiceContainer.withMocks(
+            application: application,
             authRepository: authRepository,
             authService: authService,
             errorReporter: errorReporter,
             notificationService: notificationService,
             pasteboardService: pasteboardService,
             stateService: stateService,
+            timeProvider: timeProvider,
             vaultRepository: vaultRepository
         )
 
@@ -129,6 +135,71 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertNil(stateService.loginRequest)
     }
 
+    /// `perform(_:)` with `appeared` does not register the device for notifications
+    /// if the user has denied notifications
+    func test_perform_appeared_notificationRegistration_denied() async throws {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .denied
+
+        await subject.perform(.appeared)
+
+        XCTAssertFalse(application.registerForRemoteNotificationsCalled)
+    }
+
+    /// `perform(_:)` with `appeared` does not register the device for notifications
+    /// if there is an error
+    func test_perform_appeared_notificationRegistration_errored() async throws {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .authorized
+        stateService.notificationsLastRegistrationError = BitwardenTestError.example
+
+        await subject.perform(.appeared)
+
+        XCTAssertFalse(application.registerForRemoteNotificationsCalled)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `perform(_:)` with `appeared` does not register the device for notifications
+    /// if the device attempted registration less than one day (that is, 86400 seconds) ago.
+    func test_perform_appeared_notificationRegistration_lessThanADay() async throws {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .authorized
+        stateService.notificationsLastRegistrationDates["1"] = timeProvider.presentTime.addingTimeInterval(-86399)
+
+        await subject.perform(.appeared)
+
+        XCTAssertFalse(application.registerForRemoteNotificationsCalled)
+        XCTAssertEqual(
+            stateService.notificationsLastRegistrationDates["1"],
+            timeProvider.presentTime.addingTimeInterval(-86399)
+        )
+    }
+
+    /// `perform(_:)` with `appeared` registers the device for notifications
+    /// if the device attempted registration more than one day (that is, 86400 seconds) ago.
+    func test_perform_appeared_notificationRegistration_moreThanADay() async throws {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .authorized
+        stateService.notificationsLastRegistrationDates["1"] = timeProvider.presentTime.addingTimeInterval(-86400)
+
+        await subject.perform(.appeared)
+
+        XCTAssertTrue(application.registerForRemoteNotificationsCalled)
+        XCTAssertEqual(stateService.notificationsLastRegistrationDates["1"], timeProvider.presentTime)
+    }
+
+    /// `perform(_:)` with `appeared` registers the device for notifications
+    /// if the user has approved notifications and we have never registered before
+    func test_perform_appeared_notificationRegistration_never() async throws {
+        stateService.activeAccount = .fixture()
+        notificationService.authorizationStatus = .authorized
+
+        await subject.perform(.appeared)
+
+        XCTAssertTrue(application.registerForRemoteNotificationsCalled)
+        XCTAssertEqual(stateService.notificationsLastRegistrationDates["1"], timeProvider.presentTime)
+    }
+
     /// `perform(_:)` with `.appeared` requests notification permissions.
     func test_perform_appeared_requestNotifications_error() async throws {
         stateService.activeAccount = .fixture()
@@ -175,6 +246,8 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
             [.alert, .sound, .badge],
             notificationService.requestedOptions
         )
+        XCTAssertTrue(application.registerForRemoteNotificationsCalled)
+        XCTAssertEqual(stateService.notificationsLastRegistrationDates["1"], timeProvider.presentTime)
     }
 
     /// `perform(_:)` with `.appeared` checks for unassigned ciphers


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8965

## 📔 Objective

Previously, the app was only registering for push notifications on launch, which meant that it would only register for an active user at that time. This now registers more aggressively, by checking any time the user goes to the vault list. It will also register after a user has granted permission for push notifications. However, it will also only attempt to register once per day (defined as 86400 seconds), to match the MAUI app.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
