### PR TITLE
[PM-9192] Update Crowdin destination path

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -36,7 +36,6 @@ jobs:
           CROWDIN_API_TOKEN: ${{ steps.retrieve-secrets.outputs.crowdin-api-token }}
         with:
           config: crowdin.yml
-          crowdin_branch_name: main
           upload_sources: false
           upload_translations: false
           download_translations: true

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,6 @@
 project_id_env: _CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_API_TOKEN
+preserve_hierarchy: true
 files:
   - source: "/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings"
     dest: "/ios/%original_file_name%"

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,28 +1,11 @@
 project_id_env: _CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_API_TOKEN
-preserve_hierarchy: true
 files:
   - source: "/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings"
-    dest: "/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/%original_file_name%"
-    translation: "/BitwardenShared/UI/Platform/Application/Support/Localizations/%two_letters_code%.lproj/%original_file_name%"
+    dest: "/ios/%original_file_name%"
+    translation: "/BitwardenShared/UI/Platform/Application/Support/Localizations/%osx_locale%.lproj/%original_file_name%"
     update_option: update_as_unapproved
-    languages_mapping:
-      two_letters_code:
-        zh-CN: zh-Hans
-        zh-TW: zh-Hant
-        pt-BR: pt-BR
-        pt-PT: pt-PT
-        en-GB: en-GB
-        en-IN: en-IN
   - source: "/BitwardenWatchApp/Localization/en.lproj/Localizable.strings"
-    dest: "/BitwardenWatchApp/Localization/en.lproj/%original_file_name%"
-    translation: "/BitwardenWatchApp/Localization/%two_letters_code%.lproj/%original_file_name%"
+    dest: "/ios-watch/%original_file_name%"
+    translation: "/BitwardenWatchApp/Localization/%osx_locale%.lproj/%original_file_name%"
     update_option: update_as_unapproved
-    languages_mapping:
-      two_letters_code:
-        zh-CN: zh-Hans
-        zh-TW: zh-Hant
-        pt-BR: pt-BR
-        pt-PT: pt-PT
-        en-GB: en-GB
-        en-IN: en-IN

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -4,9 +4,9 @@ preserve_hierarchy: true
 files:
   - source: "/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings"
     dest: "/ios/%original_file_name%"
-    translation: "/BitwardenShared/UI/Platform/Application/Support/Localizations/%osx_locale%.lproj/%original_file_name%"
+    translation: "/BitwardenShared/UI/Platform/Application/Support/Localizations/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved
   - source: "/BitwardenWatchApp/Localization/en.lproj/Localizable.strings"
     dest: "/ios-watch/%original_file_name%"
-    translation: "/BitwardenWatchApp/Localization/%osx_locale%.lproj/%original_file_name%"
+    translation: "/BitwardenWatchApp/Localization/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9192

## 📔 Objective

This updates the Crowdin paths to `ios` and `ios-watch` directories instead of long trees.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
