### PR TITLE
BIT-2393: Enable TOTP features for organizations that use TOTP without premium

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
@@ -146,9 +146,9 @@ class AlertTests: BitwardenTestCase {
             viewPassword: true
         )
         let alert = Alert.moreOptions(
+            canCopyTotp: false,
             cipherView: cipher,
             hasMasterPassword: false,
-            hasPremium: false,
             id: cipher.id!,
             showEdit: true,
             action: action
@@ -226,9 +226,9 @@ class AlertTests: BitwardenTestCase {
             viewPassword: false
         )
         let alert = Alert.moreOptions(
+            canCopyTotp: false,
             cipherView: cipher,
             hasMasterPassword: false,
-            hasPremium: false,
             id: cipher.id!,
             showEdit: true,
             action: action

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -94,9 +94,10 @@ extension Alert {
     /// An alert presenting the user with more options for a vault list item.
     ///
     /// - Parameters:
+    ///   - canCopyTotp: Whether the user can copy the TOTP code (because they have premium or the
+    ///     organization uses TOTP).
     ///   - cipherView: The cipher view to show.
     ///   - hasMasterPassword: Whether the user has a master password.
-    ///   - hasPremium: Whether the user has a premium account.
     ///   - id: The id of the item.
     ///   - showEdit: Whether to show the edit option (should be `false` for items in the trash).
     ///   - action: The action to perform after selecting an option.
@@ -104,9 +105,9 @@ extension Alert {
     /// - Returns: An alert presenting the user with options to select an attachment type.
     @MainActor
     static func moreOptions( // swiftlint:disable:this function_body_length function_parameter_count
+        canCopyTotp: Bool,
         cipherView: CipherView,
         hasMasterPassword: Bool,
-        hasPremium: Bool,
         id: String,
         showEdit: Bool,
         action: @escaping (_ action: MoreOptionsAction) async -> Void
@@ -167,7 +168,7 @@ extension Alert {
                     ))
                 })
             }
-            if hasPremium, let totp = cipherView.login?.totp, let totpKey = TOTPKeyModel(authenticatorKey: totp) {
+            if canCopyTotp, let totp = cipherView.login?.totp, let totpKey = TOTPKeyModel(authenticatorKey: totp) {
                 alertActions.append(AlertAction(title: Localizations.copyTotp, style: .default) { _, _ in
                     await action(.copyTotp(
                         totpKey: totpKey,

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -109,8 +109,10 @@ class AutofillHelper {
 
         do {
             let disableAutoTotpCopy = try await services.vaultRepository.getDisableAutoTotpCopy()
+            let accountHasPremium = try await services.vaultRepository.doesActiveAccountHavePremium()
             if !disableAutoTotpCopy,
                let totp = cipherView.login?.totp,
+               cipherView.organizationUseTotp || accountHasPremium,
                let key = TOTPKeyModel(authenticatorKey: totp),
                let codeModel = try await services.vaultRepository.refreshTOTPCode(for: key).codeModel {
                 services.pasteboardService.copy(codeModel.code)

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -243,9 +243,9 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
             let hasMasterPassword = try await services.stateService.getUserHasMasterPassword()
 
             coordinator.showAlert(.moreOptions(
+                canCopyTotp: hasPremium || cipherView.organizationUseTotp,
                 cipherView: cipherView,
                 hasMasterPassword: hasMasterPassword,
-                hasPremium: hasPremium,
                 id: item.id,
                 showEdit: state.group != .trash,
                 action: handleMoreOptionsAction

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -387,6 +387,41 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
     }
 
+    /// `perform(_:)` with `.morePressed` and press `copyTotp` copies the TOTP code if the user
+    /// doesn't have premium but the organization uses TOTP.
+    func test_perform_morePressed_copyTotp_organizationUseTotp() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.userHasMasterPassword = [account.profile.userId: true]
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .base32Key)!,
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
+            )
+        )
+
+        let item = try XCTUnwrap(
+            VaultListItem(
+                cipherView: .fixture(
+                    login: .fixture(totp: "totpKey"),
+                    organizationUseTotp: true
+                )
+            )
+        )
+
+        await subject.perform(.morePressed(item))
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.copyTotp)
+
+        XCTAssertEqual(pasteboardService.copiedString, "123321")
+        XCTAssertEqual(
+            subject.state.toast?.text,
+            Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp)
+        )
+    }
+
     /// `perform(_:)` with `.morePressed` shows the appropriate more options alert for a login cipher.
     func test_perform_morePressed_login_full() async throws {
         let account = Account.fixture()

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -326,9 +326,9 @@ extension VaultListProcessor {
             let hasMasterPassword = try await services.stateService.getUserHasMasterPassword()
 
             coordinator.showAlert(.moreOptions(
+                canCopyTotp: hasPremium || cipherView.organizationUseTotp,
                 cipherView: cipherView,
                 hasMasterPassword: hasMasterPassword,
-                hasPremium: hasPremium,
                 id: item.id,
                 showEdit: true,
                 action: handleMoreOptionsAction

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -271,7 +271,7 @@ struct CipherItemState: Equatable {
             isPersonalOwnershipDisabled: false,
             loginState: cipherView.loginItemState(
                 isTOTPCodeVisible: !(hasMasterPassword && cipherView.reprompt == .password),
-                showTOTP: hasPremium
+                showTOTP: hasPremium || cipherView.organizationUseTotp
             ),
             name: cipherView.name,
             notes: cipherView.notes ?? "",

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -28,4 +28,26 @@ class CipherItemStateTests: BitwardenTestCase {
         XCTAssertEqual(state.type, .init(type: cipher.type))
         XCTAssertEqual(state.updatedDate, cipher.revisionDate)
     }
+
+    /// `init(existing:hasPremium:)` sets `loginState.isTOTPAvailable` to false if the user doesn't
+    /// have premium and the organization doesn't use TOTP.
+    func test_init_existing_isTOTPAvailable_notAvailable() throws {
+        let cipher = CipherView.loginFixture(login: .fixture())
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: false))
+        XCTAssertFalse(state.loginState.isTOTPAvailable)
+    }
+
+    /// `init(existing:hasPremium:)` sets `loginState.isTOTPAvailable` to true if the user has premium.
+    func test_init_existing_isTOTPAvailable_premium() throws {
+        let cipher = CipherView.loginFixture(login: .fixture())
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertTrue(state.loginState.isTOTPAvailable)
+    }
+
+    /// `init(existing:hasPremium:)` sets `loginState.isTOTPAvailable` to true if the organization uses TOTP.
+    func test_init_existing_isTOTPAvailable_organizationUseTotp() throws {
+        let cipher = CipherView.loginFixture(login: .fixture(), organizationUseTotp: true)
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: false))
+        XCTAssertTrue(state.loginState.isTOTPAvailable)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2393](https://livefront.atlassian.net/browse/BIT-2393)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables TOTP features for ciphers in an organization that uses TOTP without giving users premium access.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
