### PR TITLE
BIT-2349: Allow adding an OTP key to existing items

### DIFF
--- a/BitwardenShared/UI/Auth/Utilities/UserVerificationHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/UserVerificationHelper.swift
@@ -162,6 +162,12 @@ public enum UserVerificationError: Error {
 ///
 @MainActor
 protocol UserVerificationDelegate: AnyObject {
+    /// Shows the provided alert to the user.
+    ///
+    /// - Parameter alert: The alert to show.
+    ///
+    func showAlert(_ alert: Alert)
+
     /// Shows an alert to the user
     ///
     /// - Parameters:
@@ -169,14 +175,4 @@ protocol UserVerificationDelegate: AnyObject {
     ///   - onDismissed: An optional closure that is called when the alert is dismissed.
     ///
     func showAlert(_ alert: Alert, onDismissed: (() -> Void)?)
-}
-
-extension UserVerificationDelegate {
-    /// Shows the provided alert to the user.
-    ///
-    /// - Parameter alert: The alert to show.
-    ///
-    func showAlert(_ alert: Alert) {
-        showAlert(alert, onDismissed: nil)
-    }
 }

--- a/BitwardenShared/UI/Auth/Utilities/UserVerificationHelperTests.swift
+++ b/BitwardenShared/UI/Auth/Utilities/UserVerificationHelperTests.swift
@@ -228,6 +228,10 @@ class MockUserVerificationHelperDelegate: UserVerificationDelegate {
     var alertShown = [Alert]()
     var alertOnDismissed: (() -> Void)?
 
+    func showAlert(_ alert: Alert) {
+        alertShown.append(alert)
+    }
+
     func showAlert(_ alert: BitwardenShared.Alert, onDismissed: (() -> Void)?) {
         alertShown.append(alert)
         alertOnDismissed = onDismissed

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -61,6 +61,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
         & HasCameraService
         & HasEnvironmentService
         & HasErrorReporter
+        & HasLocalAuthService
         & HasNotificationService
         & HasStateService
         & HasTimeProvider
@@ -139,7 +140,8 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
                         group: group,
                         hasPremium: hasPremium ?? false,
                         newCipherOptions: newCipherOptions
-                    )
+                    ),
+                    delegate: context as? CipherItemOperationDelegate
                 )
             }
         case .autofillList:
@@ -242,7 +244,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
     ///
     /// - Parameter route: The route to navigate to in the coordinator.
     ///
-    private func showVaultItem(route: VaultItemRoute, delegate: CipherItemOperationDelegate? = nil) {
+    private func showVaultItem(route: VaultItemRoute, delegate: CipherItemOperationDelegate?) {
         let navigationController = UINavigationController()
         let coordinator = module.makeVaultItemCoordinator(stackNavigator: navigationController)
         coordinator.start()
@@ -262,6 +264,10 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
             state: VaultItemSelectionState(
                 iconBaseURL: services.environmentService.iconsURL,
                 otpAuthModel: otpAuthModel
+            ),
+            userVerificationHelper: DefaultUserVerificationHelper(
+                userVerificationDelegate: self,
+                services: services
             )
         )
         let view = VaultItemSelectionView(store: Store(processor: processor))
@@ -269,3 +275,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
         stackNavigator?.present(UINavigationController(rootViewController: viewController))
     }
 }
+
+// MARK: - UserVerificationDelegate
+
+extension VaultCoordinator: UserVerificationDelegate {}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
@@ -189,6 +189,7 @@ extension CipherView {
             collectionIds: collectionIds,
             deletedDate: deletedDate,
             folderId: folderId,
+            login: login,
             organizationId: organizationId
         )
     }
@@ -203,6 +204,7 @@ extension CipherView {
             collectionIds: collectionIds,
             deletedDate: deletedDate,
             folderId: folderId,
+            login: login,
             organizationId: organizationId
         )
     }
@@ -217,6 +219,22 @@ extension CipherView {
             collectionIds: collectionIds,
             deletedDate: deletedDate,
             folderId: folderId,
+            login: login,
+            organizationId: organizationId
+        )
+    }
+
+    /// Returns a copy of the existing cipher with updated login properties.
+    ///
+    /// - Parameter login: The login property to update.
+    /// - Returns: A copy of the existing cipher, with the login property updated.
+    ///
+    func update(login: BitwardenSdk.LoginView) -> CipherView {
+        update(
+            collectionIds: collectionIds,
+            deletedDate: deletedDate,
+            folderId: folderId,
+            login: login,
             organizationId: organizationId
         )
     }
@@ -227,7 +245,9 @@ extension CipherView {
     ///
     /// - Parameters:
     ///   - collectionIds: The identifiers of any collections containing the cipher.
+    ///   - deletedDate: The deleted date of the cipher.
     ///   - folderId: The identifier of the cipher's folder
+    ///   - login: Login data if the cipher is a login.
     ///   - organizationId: The identifier of the cipher's organization.
     /// - Returns: A copy of the existing cipher, with the specified properties updated.
     ///
@@ -235,6 +255,7 @@ extension CipherView {
         collectionIds: [String],
         deletedDate: Date?,
         folderId: String?,
+        login: BitwardenSdk.LoginView?,
         organizationId: String?
     ) -> CipherView {
         CipherView(
@@ -262,6 +283,25 @@ extension CipherView {
             creationDate: creationDate,
             deletedDate: deletedDate,
             revisionDate: revisionDate
+        )
+    }
+}
+
+extension BitwardenSdk.LoginView {
+    /// Returns a copy of the existing login with an updated TOTP key.
+    ///
+    /// - Parameter totp: The TOTP key to update.
+    /// - Returns: A copy of the existing login, with the specified properties updated.
+    ///
+    func update(totp: String?) -> BitwardenSdk.LoginView {
+        BitwardenSdk.LoginView(
+            username: username,
+            password: password,
+            passwordRevisionDate: passwordRevisionDate,
+            uris: uris,
+            totp: totp,
+            autofillOnPageLoad: autofillOnPageLoad,
+            fido2Credentials: fido2Credentials
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2349](https://livefront.atlassian.net/browse/BIT-2349)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Allows adding an OTP key from a QR code to an existing item in the vault. Selecting a vault item brings up the edit view with the key populated.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/a445a8b4-2333-415f-9768-605704725559


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
