### PR TITLE
[PM-7982] Use a different GoogleService-Info.plist file on beta builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
-          SOURCE_FILE: GoogleService-Info.plist
+          SOURCE_FILE: GoogleService-Info-ios-pm-beta.plist
           TARGET_FILE: GoogleService-Info.plist
         run: |
           mkdir -p $HOME/secrets

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,8 @@ jobs:
               --file $HOME/secrets/$FILE --output none
           done
 
-      - name: Retrieve Google Services secret
+      - name: Retrieve production Google Services secret
+        if: env.build-variant == 'Production'
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -119,6 +120,18 @@ jobs:
           mkdir -p $HOME/secrets
           az storage blob download --account-name $ACCOUNT_NAME --container-name $CONTAINER_NAME --name $FILE \
             --file Bitwarden/Application/Support/$FILE --output none
+
+      - name: Retrieve beta Google Services secret
+        if: env.build-variant == 'Beta'
+        env:
+          ACCOUNT_NAME: bitwardenci
+          CONTAINER_NAME: mobile
+          SOURCE_FILE: GoogleService-Info.plist
+          TARGET_FILE: GoogleService-Info.plist
+        run: |
+          mkdir -p $HOME/secrets
+          az storage blob download --account-name $ACCOUNT_NAME --container-name $CONTAINER_NAME --name $SOURCE_FILE \
+            --file Bitwarden/Application/Support/$TARGET_FILE --output none
 
       - name: Retrieve certificates
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-7982

## 📔 Objective

This splits the build step to retrieve the `GoogleServices-Info.plist` from Azure so that the production and beta builds use different plists. This should allow Crashlytics to work for the Beta build.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
