### PR TITLE
BIT-2349: Handle navigating to the vault item selection screen after vault unlock or switching accounts

### DIFF
--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
@@ -7,6 +7,7 @@ class MockVaultTimeoutService: VaultTimeoutService {
     var account: Account = .fixture()
     var lastActiveTime = [String: Date]()
     var shouldSessionTimeout = [String: Bool]()
+    var shouldSessionTimeoutError: Error?
     var timeProvider = MockTimeProvider(.currentTime)
     var sessionTimeoutValueError: Error?
     var vaultTimeout = [String: SessionTimeoutValue]()
@@ -36,7 +37,10 @@ class MockVaultTimeoutService: VaultTimeoutService {
     }
 
     func hasPassedSessionTimeout(userId: String) async throws -> Bool {
-        shouldSessionTimeout[userId] ?? false
+        if let shouldSessionTimeoutError {
+            throw shouldSessionTimeoutError
+        }
+        return shouldSessionTimeout[userId] ?? false
     }
 
     func unlockVault(userId: String?) async throws {

--- a/BitwardenShared/UI/Auth/AuthAction.swift
+++ b/BitwardenShared/UI/Auth/AuthAction.swift
@@ -22,6 +22,8 @@ public enum AuthAction: Equatable {
     /// - Parameters:
     ///   - isAutomatic: Did the system trigger the account switch?
     ///   - userId: The user Id of the selected account.
+    ///   - authCompletionRoute: An optional route that should be navigated to after switching
+    ///     accounts and vault unlock
     ///
-    case switchAccount(isAutomatic: Bool, userId: String)
+    case switchAccount(isAutomatic: Bool, userId: String, authCompletionRoute: AppRoute? = nil)
 }

--- a/BitwardenShared/UI/Auth/AuthRouter.swift
+++ b/BitwardenShared/UI/Auth/AuthRouter.swift
@@ -99,7 +99,7 @@ final class AuthRouter: NSObject, Router {
             return await lockVaultRedirect(userId: userId)
         case let .logout(userId, userInitiated):
             return await logoutRedirect(userId: userId, userInitiated: userInitiated)
-        case let .switchAccount(isAutomatic, userId):
+        case let .switchAccount(isAutomatic, userId, _):
             return await switchAccountRedirect(
                 isAutomatic: isAutomatic,
                 userId: userId

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
@@ -25,6 +25,9 @@ protocol ProfileSwitcherHandler: AnyObject {
     /// Should the handler replace the toolbar icon with two dots?
     var showPlaceholderToolbarIcon: Bool { get }
 
+    /// The route that should be navigated to after switching accounts and vault unlock.
+    var switchAccountAuthCompletionRoute: AppRoute? { get }
+
     /// The `State` for a toast view.
     var toast: Toast? { get set }
 
@@ -65,6 +68,11 @@ extension ProfileSwitcherHandler {
     /// Default to non-placeholder switcher icon.
     var showPlaceholderToolbarIcon: Bool {
         false
+    }
+
+    /// Default the auth completion route after switching accounts to `nil` to navigate to the vault list.
+    var switchAccountAuthCompletionRoute: AppRoute? {
+        nil
     }
 
     func handleProfileSwitcherAction(_ action: ProfileSwitcherAction) {
@@ -221,7 +229,8 @@ private extension ProfileSwitcherHandler {
             .action(
                 .switchAccount(
                     isAutomatic: false,
-                    userId: account.userId
+                    userId: account.userId,
+                    authCompletionRoute: switchAccountAuthCompletionRoute
                 )
             )
         )

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -26,6 +26,9 @@ class AppCoordinator: Coordinator, HasRootNavigator {
     /// A delegate used to communicate with the app extension.
     private weak var appExtensionDelegate: AppExtensionDelegate?
 
+    /// A route to navigate to after auth completes.
+    private(set) var authCompletionRoute: AppRoute?
+
     /// The coordinator currently being displayed.
     private var childCoordinator: AnyObject?
 
@@ -75,6 +78,8 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             await handleAuthEvent(.didStart)
         case let .didTimeout(userId):
             await handleAuthEvent(.didTimeout(userId: userId))
+        case let .setAuthCompletionRoute(route):
+            authCompletionRoute = route
         }
     }
 
@@ -260,6 +265,11 @@ extension AppCoordinator: AuthCoordinatorDelegate {
             navigate(to: route)
         case .mainApp:
             showTab(route: .vault(.list))
+
+            if let authCompletionRoute {
+                navigate(to: authCompletionRoute)
+                self.authCompletionRoute = nil
+            }
         }
     }
 }

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -354,13 +354,15 @@ extension AppCoordinator: SettingsCoordinatorDelegate {
 // MARK: - VaultCoordinatorDelegate
 
 extension AppCoordinator: VaultCoordinatorDelegate {
-    func switchAccount(userId: String, isAutomatic: Bool) {
+    func switchAccount(userId: String, isAutomatic: Bool, authCompletionRoute: AppRoute?) {
         Task {
+            self.authCompletionRoute = authCompletionRoute
             await handleAuthEvent(
                 .action(
                     .switchAccount(
                         isAutomatic: isAutomatic,
-                        userId: userId
+                        userId: userId,
+                        authCompletionRoute: authCompletionRoute
                     )
                 )
             )

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -78,6 +78,18 @@ class AppCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(appExtensionDelegate.didCompleteAuthCalled)
     }
 
+    /// `didCompleteAuth()` starts the tab coordinator and navigates to the vault list and the auth completion route.
+    func test_didCompleteAuth_authCompletionRoute() async {
+        await subject.handleEvent(.setAuthCompletionRoute(.tab(.vault(.addAccount))))
+        XCTAssertNotNil(subject.authCompletionRoute)
+
+        subject.didCompleteAuth()
+
+        XCTAssertTrue(module.tabCoordinator.isStarted)
+        XCTAssertEqual(module.tabCoordinator.routes, [.vault(.list), .vault(.addAccount)])
+        XCTAssertNil(subject.authCompletionRoute)
+    }
+
     /// `didDeleteAccount(otherAccounts:)` navigates to the `didDeleteAccount` route.
     func test_didDeleteAccount() throws {
         subject.didDeleteAccount()

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -321,4 +321,23 @@ class AppCoordinatorTests: BitwardenTestCase {
 
         XCTAssertFalse(module.authCoordinator.isStarted)
     }
+
+    /// `switchAccount(userId:isAutomatic:authCompletionRoute:)` sets the auth completion route and
+    /// navigates to the appropriate route.
+    func test_switchAccount() throws {
+        let authCompletionRoute = AppRoute.tab(.vault(.vaultItemSelection(.fixtureExample)))
+        subject.switchAccount(
+            userId: "1",
+            isAutomatic: true,
+            authCompletionRoute: authCompletionRoute
+        )
+
+        waitFor(!module.authCoordinator.routes.isEmpty)
+        XCTAssertEqual(subject.authCompletionRoute, authCompletionRoute)
+        XCTAssertEqual(
+            router.events,
+            [.action(.switchAccount(isAutomatic: true, userId: "1", authCompletionRoute: authCompletionRoute))]
+        )
+        XCTAssertEqual(module.authCoordinator.routes, [AuthRoute.landing])
+    }
 }

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -81,7 +81,8 @@ public class AppProcessor {
 
         let vaultItemSelectionRoute = AppRoute.tab(.vault(.vaultItemSelection(otpAuthModel)))
         guard let userId = try? await services.stateService.getActiveAccountId(),
-              !services.vaultTimeoutService.isLocked(userId: userId)
+              !services.vaultTimeoutService.isLocked(userId: userId),
+              await !((try? services.vaultTimeoutService.hasPassedSessionTimeout(userId: userId)) ?? true)
         else {
             await coordinator?.handleEvent(.setAuthCompletionRoute(vaultItemSelectionRoute))
             return

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -82,7 +82,7 @@ public class AppProcessor {
         let vaultItemSelectionRoute = AppRoute.tab(.vault(.vaultItemSelection(otpAuthModel)))
         guard let userId = try? await services.stateService.getActiveAccountId(),
               !services.vaultTimeoutService.isLocked(userId: userId),
-              await !((try? services.vaultTimeoutService.hasPassedSessionTimeout(userId: userId)) ?? true)
+              await (try? services.vaultTimeoutService.hasPassedSessionTimeout(userId: userId)) == false
         else {
             await coordinator?.handleEvent(.setAuthCompletionRoute(vaultItemSelectionRoute))
             return

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -78,7 +78,15 @@ public class AppProcessor {
             coordinator?.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             return
         }
-        coordinator?.navigate(to: .tab(.vault(.vaultItemSelection(otpAuthModel))))
+
+        let vaultItemSelectionRoute = AppRoute.tab(.vault(.vaultItemSelection(otpAuthModel)))
+        guard let userId = try? await services.stateService.getActiveAccountId(),
+              !services.vaultTimeoutService.isLocked(userId: userId)
+        else {
+            await coordinator?.handleEvent(.setAuthCompletionRoute(vaultItemSelectionRoute))
+            return
+        }
+        coordinator?.navigate(to: vaultItemSelectionRoute)
     }
 
     /// Starts the application flow by navigating the user to the first flow.

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -4,6 +4,8 @@ import XCTest
 
 @testable import BitwardenShared
 
+// swiftlint:disable file_length
+
 class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
@@ -158,6 +160,38 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
         XCTAssertEqual(coordinator.routes.last, .tab(.vault(.vaultItemSelection(model))))
+    }
+
+    /// `openUrl(_:)` handles receiving an OTP deep link and setting an auth completion route on the
+    /// coordinator if the the user's vault is unlocked but will be timing out as the app is
+    /// foregrounded.
+    func test_openUrl_otpKey_vaultUnlockedTimeout() async throws {
+        let account = Account.fixture()
+        let otpKey: String = .otpAuthUriKeyComplete
+        stateService.activeAccount = .fixture()
+        vaultTimeoutService.isClientLocked[account.profile.userId] = false
+        vaultTimeoutService.shouldSessionTimeout[account.profile.userId] = true
+
+        try await subject.openUrl(XCTUnwrap(URL(string: otpKey)))
+
+        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        XCTAssertEqual(coordinator.events, [.setAuthCompletionRoute(.tab(.vault(.vaultItemSelection(model))))])
+    }
+
+    /// `openUrl(_:)` handles receiving an OTP deep link and setting an auth completion route on the
+    /// coordinator if the the user's vault is unlocked but will be timing out as the app is
+    /// foregrounded.
+    func test_openUrl_otpKey_vaultUnlockedTimeoutError() async throws {
+        let account = Account.fixture()
+        let otpKey: String = .otpAuthUriKeyComplete
+        stateService.activeAccount = .fixture()
+        vaultTimeoutService.isClientLocked[account.profile.userId] = false
+        vaultTimeoutService.shouldSessionTimeoutError = BitwardenTestError.example
+
+        try await subject.openUrl(XCTUnwrap(URL(string: otpKey)))
+
+        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        XCTAssertEqual(coordinator.events, [.setAuthCompletionRoute(.tab(.vault(.vaultItemSelection(model))))])
     }
 
     /// `openUrl(_:)` handles receiving an OTP deep link if the URL isn't an OTP key.

--- a/BitwardenShared/UI/Platform/Application/AppRoute.swift
+++ b/BitwardenShared/UI/Platform/Application/AppRoute.swift
@@ -36,4 +36,7 @@ public enum AppEvent: Equatable {
 
     /// When an account has timed out.
     case didTimeout(userId: String)
+
+    /// Allows setting a route that should be navigated to after the user's vault is unlocked.
+    case setAuthCompletionRoute(AppRoute)
 }

--- a/BitwardenShared/UI/Platform/Application/Utilities/RootViewController.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/RootViewController.swift
@@ -18,6 +18,8 @@ public class RootViewController: UIViewController {
     ///
     public var childViewController: UIViewController? {
         didSet {
+            dismiss(animated: false)
+
             if let fromViewController = oldValue {
                 fromViewController.willMove(toParent: nil)
                 fromViewController.view.removeFromSuperview()

--- a/BitwardenShared/UI/Platform/Application/Utilities/RootViewControllerTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/RootViewControllerTests.swift
@@ -37,6 +37,24 @@ class RootViewControllerTests: BitwardenTestCase {
         XCTAssertFalse(subject.children.contains(viewController1))
     }
 
+    /// `childViewController` dismisses a presented view controller before swapping between
+    /// different view controllers.
+    func test_childViewController_withPresentedViewController() {
+        let viewController1 = UIViewController()
+        subject.childViewController = viewController1
+        viewController1.present(UIViewController(), animated: false)
+        XCTAssertTrue(subject.children.contains(viewController1))
+        XCTAssertNotNil(viewController1.presentedViewController)
+
+        let viewController2 = UIViewController()
+        subject.childViewController = viewController2
+        XCTAssertTrue(subject.children.contains(viewController2))
+        XCTAssertFalse(subject.children.contains(viewController1))
+
+        waitFor(subject.presentedViewController == nil)
+        XCTAssertNil(subject.presentedViewController)
+    }
+
     /// `childViewController` removes the current view controller when set to `nil`.
     func test_childViewController_nil() {
         let viewController1 = UIViewController()

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -110,7 +110,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
                 delegate?.lockVault(userId: userId)
             case let .logout(userId, userInitiated):
                 delegate?.logout(userId: userId, userInitiated: userInitiated)
-            case let .switchAccount(isAutomatic, userId):
+            case let .switchAccount(isAutomatic, userId, _):
                 delegate?.switchAccount(isAutomatic: isAutomatic, userId: userId)
             }
         case .didDeleteAccount:

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -42,8 +42,10 @@ public protocol VaultCoordinatorDelegate: AnyObject {
     /// - Parameters:
     ///   - userId: The user Id of the account.
     ///   - isAutomatic: Did the system trigger the account switch?
+    ///   - authCompletionRoute: An optional route that should be navigated to after switching
+    ///     accounts and vault unlock
     ///
-    func switchAccount(userId: String, isAutomatic: Bool)
+    func switchAccount(userId: String, isAutomatic: Bool, authCompletionRoute: AppRoute?)
 }
 
 // MARK: - VaultCoordinator
@@ -123,8 +125,12 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
             delegate?.logout(userId: userId, userInitiated: userInitiated)
         case let .lockVault(userId):
             delegate?.lockVault(userId: userId)
-        case let .switchAccount(isAutomatic, userId):
-            delegate?.switchAccount(userId: userId, isAutomatic: isAutomatic)
+        case let .switchAccount(isAutomatic, userId, authCompletionRoute):
+            delegate?.switchAccount(
+                userId: userId,
+                isAutomatic: isAutomatic,
+                authCompletionRoute: authCompletionRoute
+            )
         }
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -41,6 +41,22 @@ class VaultCoordinatorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `handleEvent(_:context:)` with `.switchAccount` notifies the delegate to switch to the
+    /// specified account.
+    func test_handleEvent_switchAccount() async {
+        let route = AppRoute.tab(.vault(.vaultItemSelection(.fixtureExample)))
+        await subject.handleEvent(.switchAccount(
+            isAutomatic: true,
+            userId: "1",
+            authCompletionRoute: route
+        ))
+
+        XCTAssertTrue(delegate.switchedAccounts)
+        XCTAssertEqual(delegate.switchAccountAuthCompletionRoute, route)
+        XCTAssertTrue(delegate.switchAccountIsAutomatic)
+        XCTAssertEqual(delegate.switchAccountUserId, "1")
+    }
+
     /// `navigate(to:)` with `.autofillList` replaces the stack navigator's stack with the autofill list.
     func test_navigateTo_autofillList() throws {
         subject.navigate(to: .autofillList)
@@ -210,6 +226,9 @@ class MockVaultCoordinatorDelegate: VaultCoordinatorDelegate {
     var logoutTapped = false
     var logoutUserId: String?
     var presentLoginRequestRequest: LoginRequest?
+    var switchAccountAuthCompletionRoute: AppRoute?
+    var switchAccountIsAutomatic = false
+    var switchAccountUserId: String?
     var switchedAccounts = false
     var userInitiated: Bool?
 
@@ -236,6 +255,9 @@ class MockVaultCoordinatorDelegate: VaultCoordinatorDelegate {
     }
 
     func switchAccount(userId: String, isAutomatic: Bool, authCompletionRoute: AppRoute?) {
+        switchAccountAuthCompletionRoute = authCompletionRoute
+        switchAccountIsAutomatic = isAutomatic
+        switchAccountUserId = userId
         switchedAccounts = true
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -235,7 +235,7 @@ class MockVaultCoordinatorDelegate: VaultCoordinatorDelegate {
         presentLoginRequestRequest = loginRequest
     }
 
-    func switchAccount(userId: String, isAutomatic: Bool) {
+    func switchAccount(userId: String, isAutomatic: Bool, authCompletionRoute: AppRoute?) {
         switchedAccounts = true
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -267,6 +267,10 @@ extension VaultItemSelectionProcessor: ProfileSwitcherHandler {
         true
     }
 
+    var switchAccountAuthCompletionRoute: AppRoute? {
+        .tab(.vault(.vaultItemSelection(state.otpAuthModel)))
+    }
+
     var toast: Toast? {
         get {
             state.toast

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -108,7 +108,14 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         ]
 
         XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
-        XCTAssertEqual(coordinator.events.last, .switchAccount(isAutomatic: false, userId: "1"))
+        XCTAssertEqual(
+            coordinator.events.last,
+            .switchAccount(
+                isAutomatic: false,
+                userId: "1",
+                authCompletionRoute: .tab(.vault(.vaultItemSelection(.fixtureExample)))
+            )
+        )
     }
 
     /// `perform(_:)` with `.profileSwitcher(.lock)` does nothing.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BIT-2349](https://livefront.atlassian.net/browse/BIT-2349)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If the vault is locked when a TOTP QR code is scanned, open the vault item selection screen after the user's vault has been unlocked. Additionally, this handles switching between accounts with the profile switcher.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/bitwarden/ios/assets/126492398/b144c77e-14e1-495c-8359-416852caf42f


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
