### PR TITLE
PM-8690: Fix vault timeout logout action for inactive accounts

### DIFF
--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -123,6 +123,51 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
+    /// `init()` subscribes to will enter foreground events and handles an active user timeout.
+    func test_init_appForeground_activeUserTimeout() {
+        let account1 = Account.fixture(profile: .fixture(userId: "1"))
+        let account2 = Account.fixture(profile: .fixture(userId: "2"))
+        stateService.activeAccount = account1
+        stateService.accounts = [account1, account2]
+
+        vaultTimeoutService.shouldSessionTimeout["1"] = true
+        notificationCenterService.willEnterForegroundSubject.send()
+
+        waitFor(!coordinator.events.isEmpty)
+        XCTAssertEqual(coordinator.events, [.didTimeout(userId: "1")])
+    }
+
+    /// `init()` subscribes to will enter foreground events and handles an inactive user timeout.
+    func test_init_appForeground_inactiveUserTimeout() {
+        let account1 = Account.fixture(profile: .fixture(userId: "1"))
+        let account2 = Account.fixture(profile: .fixture(userId: "2"))
+        stateService.activeAccount = account1
+        stateService.accounts = [account1, account2]
+
+        vaultTimeoutService.shouldSessionTimeout["2"] = true
+        notificationCenterService.willEnterForegroundSubject.send()
+
+        waitFor(vaultTimeoutService.isClientLocked["2"] == true)
+        XCTAssertEqual(vaultTimeoutService.isClientLocked, ["2": true])
+    }
+
+    /// `init()` subscribes to will enter foreground events and handles an inactive user timeout
+    /// with an logout action.
+    func test_init_appForeground_inactiveUserTimeoutLogout() {
+        let account1 = Account.fixture(profile: .fixture(userId: "1"))
+        let account2 = Account.fixture(profile: .fixture(userId: "2"))
+        stateService.activeAccount = account1
+        stateService.accounts = [account1, account2]
+        authRepository.sessionTimeoutAction["2"] = .logout
+
+        vaultTimeoutService.shouldSessionTimeout["2"] = true
+        notificationCenterService.willEnterForegroundSubject.send()
+
+        waitFor(authRepository.logoutCalled)
+        XCTAssertTrue(authRepository.logoutCalled)
+        XCTAssertEqual(authRepository.logoutUserId, "2")
+    }
+
     /// `init()` sets the `AppProcessor` as the delegate of any necessary services.
     func test_init_setDelegates() {
         XCTAssertIdentical(notificationService.delegate, subject)
@@ -343,39 +388,6 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(authRepository.logoutUserId, "1")
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.events, [.didLogout(userId: "1", userInitiated: false)])
-    }
-
-    /// Upon a session timeout on app foreground, send the user to the `.didTimeout` route.
-    func test_shouldSessionTimeout_navigateTo_didTimeout() throws {
-        let rootNavigator = MockRootNavigator()
-        let user = Account.fixture()
-        let userId = user.profile.userId
-        let user2 = Account.fixture()
-        let user2Id = user2.profile.userId
-
-        stateService.activeAccount = user
-        stateService.accounts = [user, user2]
-
-        let task = Task {
-            await subject.start(appContext: .mainApp, navigator: rootNavigator, window: nil)
-        }
-        waitFor(coordinator.events == [.didStart])
-        task.cancel()
-
-        vaultTimeoutService.shouldSessionTimeout[userId] = true
-        notificationCenterService.willEnterForegroundSubject.send()
-
-        waitFor(vaultTimeoutService.shouldSessionTimeout[userId] == true)
-        waitFor(coordinator.events.count > 1)
-        waitFor(vaultTimeoutService.isLocked(userId: user2Id))
-
-        XCTAssertEqual(
-            coordinator.events,
-            [
-                .didStart,
-                .didTimeout(userId: userId),
-            ]
-        )
     }
 
     /// `showLoginRequest(_:)` navigates to show the login request view.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-8690](https://bitwarden.atlassian.net/browse/PM-8690)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes a bug where an inactive account with a logout timeout action was being locked on timeout instead of logged out. Previously, we were incorrectly locking the vault for any inactive accounts. This updates the logic to consider the timeout action.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
