### PR TITLE
[PM-5885] Allow passkey deletion edit view

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -919,3 +919,5 @@
 "OrganizationUnassignedItemsMessageUSEUDescriptionLong" = "Unassigned organization items are no longer visible in the All Vaults view and only accessible via the Admin Console. Assign these items to a collection from the Admin Console to make them visible.";
 "UnknownAccount" = "Unknown account";
 "UserVerificationForPasskey" = "User verification for passkey";
+"RemovePasskey" = "Remove passkey";
+"PasskeyRemoved" = "Passkey removed";

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemAction.swift
@@ -86,6 +86,9 @@ enum AddEditItemAction: Equatable {
     /// The remove uri button was pressed.
     case removeUriPressed(index: Int)
 
+    /// The remove passkey button was pressed.
+    case removePasskeyPressed
+
     /// The username field was changed.
     case usernameChanged(String)
 }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -1,5 +1,6 @@
 import BitwardenSdk
 import Foundation
+import UIKit
 
 // MARK: - CipherItemOperationDelegate
 
@@ -175,6 +176,9 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             state.loginState.password = newValue
         case .removePasskeyPressed:
             state.loginState.fido2Credentials = []
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            UIAccessibility.post(notification: .announcement, argument: Localizations.passkeyRemoved)
+        }
         case let .removeUriPressed(index):
             guard index < state.loginState.uris.count else { return }
             state.loginState.uris.remove(at: index)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -173,6 +173,8 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             state.owner = newValue
         case let .passwordChanged(newValue):
             state.loginState.password = newValue
+        case .removePasskeyPressed:
+            state.loginState.fido2Credentials = []
         case let .removeUriPressed(index):
             guard index < state.loginState.uris.count else { return }
             state.loginState.uris.remove(at: index)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
@@ -47,7 +47,14 @@ struct AddEditLoginItemView: View {
                     fido2Credential.creationDate.formatted(date: .numeric, time: .omitted),
                     fido2Credential.creationDate.formatted(date: .omitted, time: .shortened)
                 )
-            )
+            ) {
+                Button {
+                    store.send(.removePasskeyPressed)
+                } label: {
+                    Asset.Images.minusRound.swiftUIImage
+                        .imageStyle(.accessoryIcon)
+                }
+            }
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemView.swift
@@ -48,12 +48,10 @@ struct AddEditLoginItemView: View {
                     fido2Credential.creationDate.formatted(date: .omitted, time: .shortened)
                 )
             ) {
-                Button {
+                AccessoryButton(asset: Asset.Images.minusRound, accessibilityLabel: Localizations.removePasskey) {
                     store.send(.removePasskeyPressed)
-                } label: {
-                    Asset.Images.minusRound.swiftUIImage
-                        .imageStyle(.accessoryIcon)
                 }
+                .accessibilityIdentifier("LoginRemovePasskeyButton")
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-5885

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Allow deletion of passkey from edit view. Voice over will announce when the passkey is removed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
