### PR TITLE
[PM-8863] Fix CI/CD failure on non-debug build.

### DIFF
--- a/BitwardenShared/Core/Autofill/Utilities/Fido2Error.swift
+++ b/BitwardenShared/Core/Autofill/Utilities/Fido2Error.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Errrors related to Fido2 flows.
+enum Fido2Error: Error {
+    /// Thrown when the operation to be performed is invalid under the
+    /// current circumstances.
+    case invalidOperationError
+}

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
@@ -43,7 +43,7 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
         availableCredentials: [BitwardenSdk.CipherView]
     ) async throws -> BitwardenSdk.CipherViewWrapper {
         // TODO: PM-8829 implement pick credential for auth
-        CipherViewWrapper(cipher: .fixture())
+        throw Fido2Error.invalidOperationError
     }
 
     func checkUserAndPickCredentialForCreation(

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelperTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelperTests.swift
@@ -102,7 +102,9 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase {
     /// `pickCredentialForAuthentication(availableCredentials:)`
     func test_pickCredentialForAuthentication() async throws {
         //  TODO: PM-8829
-        _ = try await subject.pickCredentialForAuthentication(availableCredentials: [])
+        await assertAsyncThrows(error: Fido2Error.invalidOperationError) {
+            _ = try await subject.pickCredentialForAuthentication(availableCredentials: [])
+        }
         throw XCTSkip("TODO: PM-8829")
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[[PM-8863]](https://bitwarden.atlassian.net/browse/PM-8863)

## 📔 Objective

Fix CI/CD failure in `main` because of using `.fixture()` which is defined under `if #DEBUG` context. Now the function throws an error until it's implemented.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8863]: https://bitwarden.atlassian.net/browse/PM-8863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ