### PR TITLE
PM-9003: Fix never lock with logout action error

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -57,6 +57,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var unlockVaultResult: Result<Void, Error> = .success(())
     var unlockVaultWithBiometricsResult: Result<Void, Error> = .success(())
     var unlockVaultWithDeviceKeyResult: Result<Void, Error> = .success(())
+    var unlockVaultWithNeverlockKeyCalled = false
     var unlockVaultWithNeverlockResult: Result<Void, Error> = .success(())
     var verifyOtpOpt: String?
     var verifyOtpResult: Result<Void, Error> = .success(())
@@ -266,7 +267,8 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     }
 
     func unlockVaultWithNeverlockKey() async throws {
-        try unlockVaultWithNeverlockResult.get()
+        unlockVaultWithNeverlockKeyCalled = true
+        return try unlockVaultWithNeverlockResult.get()
     }
 
     /// Attempts to convert a possible user id into a known account id.

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -711,6 +711,20 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
+    /// `handleAndRoute(_ :)` redirects `.didStart` to `.complete` and unlocks the vault if the
+    /// account never times out with a logout timeout action.
+    func test_handleAndRoute_didStart_neverLockLogout() async {
+        let account = Account.fixtureAccountLogin()
+        authRepository.activeAccount = account
+        authRepository.sessionTimeoutAction[account.profile.userId] = .logout
+        vaultTimeoutService.vaultTimeout[account.profile.userId] = .never
+
+        let route = await subject.handleAndRoute(.didStart)
+
+        XCTAssertEqual(route, .complete)
+        XCTAssertTrue(authRepository.unlockVaultWithNeverlockKeyCalled)
+    }
+
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.landing`
     ///     when there are no accounts.
     func test_handleAndRoute_didStart_noAccounts() async {

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -209,9 +209,9 @@ extension AuthRouter {
         }
 
         // Check for a `logout` timeout action.
-        let timeoutAction = try? await services.authRepository
-            .sessionTimeoutAction(userId: activeAccount.profile.userId)
-        if timeoutAction == .logout {
+        let userId = activeAccount.profile.userId
+        if await (try? services.authRepository.sessionTimeoutAction(userId: userId)) == .logout,
+           await (try? services.vaultTimeoutService.sessionTimeoutValue(userId: userId)) != .never {
             return await handleAndRoute(.didTimeout(userId: activeAccount.profile.userId))
         }
 

--- a/BitwardenShared/UI/Platform/Application/Extensions/UITabBarControllerExtensionsTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/UITabBarControllerExtensionsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - UITabBarControllerTests
 
-class UITabBarControllerTests: BitwardenTestCase {
+class UITabBarControllerExtensionsTests: BitwardenTestCase {
     var module: MockAppModule!
     var coordinator: TabCoordinator!
     var rootNavigator: MockRootNavigator!

--- a/BitwardenShared/UI/Platform/Application/Extensions/UITabBarControllerExtensionsTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/UITabBarControllerExtensionsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-// MARK: - UITabBarControllerTests
+// MARK: - UITabBarControllerExtensionsTests
 
 class UITabBarControllerExtensionsTests: BitwardenTestCase {
     var module: MockAppModule!


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9003](https://bitwarden.atlassian.net/browse/PM-9003)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes an error received on app launch if the account timeout settings are set to never / logout. Previously, this was being considered a timeout but then the never lock setting was bypassing vault unlock, so the vault was never unlocked. This adds an additional check for the never lock setting.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9003]: https://bitwarden.atlassian.net/browse/PM-9003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ