### PR TITLE
[PM-9695] Add step to fix Xcode version instead of relying on the default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,11 @@ jobs:
       MINT_LINK_PATH: .mint/bin
 
     steps:
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: 15.0.1
+
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,16 +39,16 @@ jobs:
       MINT_LINK_PATH: .mint/bin
 
     steps:
-      - name: Set Xcode version
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: ${{ env.xcode-version }}
-
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           filter: tree:0
+
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: ${{ env.xcode-version }}
 
       - name: Cache Mint packages
         id: mint-cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,14 @@ on:
         description: "Optional. Build number to use. Overrides default of GitHub run number."
         required: false
         type: number
+      xcode-version:
+        description: "Optional. Xcode version to use. Overrides default."
+        required: false
+        type: string
 
 env:
   build-variant: ${{ inputs.build-variant || 'Beta' }}
+  xcode-version: ${{ inputs.xcode-version || '15.0.1' }}
 
 jobs:
   build:
@@ -37,7 +42,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 15.0.1
+          xcode-version: ${{ env.xcode-version }}
 
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ on:
         type: string
 
 env:
-  build-variant: ${{ inputs.build-variant || 'Beta' }}
-  xcode-version: ${{ inputs.xcode-version || '15.0.1' }}
+  BUILD_VARIANT: ${{ inputs.build-variant || 'Beta' }}
+  XCODE_VERSION: ${{ inputs.xcode-version || '15.0.1' }}
 
 jobs:
   build:
@@ -48,7 +48,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: ${{ env.xcode-version }}
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Cache Mint packages
         id: mint-cache
@@ -77,7 +77,7 @@ jobs:
           secrets: "appcenter-ios-token"
 
       - name: Retrieve production provisioning profiles
-        if: env.build-variant == 'Production'
+        if: env.BUILD_VARIANT == 'Production'
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: profiles
@@ -99,7 +99,7 @@ jobs:
           done
 
       - name: Retrieve beta provisioning profiles
-        if: env.build-variant == 'Beta'
+        if: env.BUILD_VARIANT == 'Beta'
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: profiles
@@ -121,7 +121,7 @@ jobs:
           done
 
       - name: Retrieve production Google Services secret
-        if: env.build-variant == 'Production'
+        if: env.BUILD_VARIANT == 'Production'
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -132,7 +132,7 @@ jobs:
             --file Bitwarden/Application/Support/$FILE --output none
 
       - name: Retrieve beta Google Services secret
-        if: env.build-variant == 'Beta'
+        if: env.BUILD_VARIANT == 'Beta'
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -174,7 +174,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $KEYCHAIN_PASSWORD build.keychain
 
       - name: Configure production provisioning profiles
-        if: env.build-variant == 'Production'
+        if: env.BUILD_VARIANT == 'Production'
         run: |
           AUTOFILL_PROFILE_PATH=$HOME/secrets/dist_autofill.mobileprovision
           BITWARDEN_PROFILE_PATH=$HOME/secrets/dist_bitwarden.mobileprovision
@@ -205,7 +205,7 @@ jobs:
           cp $WATCH_APP_EXTENSION_PROFILE_PATH "$PROFILES_DIR_PATH/$WATCH_APP_EXTENSION_UUID.mobileprovision"
 
       - name: Configure beta provisioning profiles
-        if: env.build-variant == 'Beta'
+        if: env.BUILD_VARIANT == 'Beta'
         run: |
           AUTOFILL_PROFILE_PATH=$HOME/secrets/dist_beta_autofill.mobileprovision
           BITWARDEN_PROFILE_PATH=$HOME/secrets/dist_beta_bitwarden.mobileprovision
@@ -236,12 +236,12 @@ jobs:
           cp $WATCH_APP_EXTENSION_PROFILE_PATH "$PROFILES_DIR_PATH/$WATCH_APP_EXTENSION_UUID.mobileprovision"
 
       - name: Update beta export compliance key
-        if: env.build-variant == 'Beta'
+        if: env.BUILD_VARIANT == 'Beta'
         run: |
           plutil -replace ITSEncryptionExportComplianceCode -string 3dd3e32f-efa6-4d99-b410-28aa28b1cb77 Bitwarden/Application/Support/Info.plist
 
       - name: Update beta Fastlane Appfile
-        if: env.build-variant == 'Beta'
+        if: env.BUILD_VARIANT == 'Beta'
         run: |
           echo 'app_identifier "com.8bit.bitwarden.beta"' > fastlane/Appfile
 
@@ -265,7 +265,7 @@ jobs:
 
       - name: Select variant
         run: |
-          ./Scripts/select_variant.sh ${{ env.build-variant }}
+          ./Scripts/select_variant.sh ${{ env.BUILD_VARIANT }}
 
       - name: Calculate build version
         id: calculate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,9 +6,8 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-      - "katherine/set-xcode-version"
-  # pull_request_target:
-  #   types: [opened, synchronize]
+  pull_request_target:
+    types: [opened, synchronize]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ env:
   SIMULATOR_DESTINATION: platform=iOS Simulator,name=iPhone 15 Pro,OS=17.0.1
   RESULT_BUNDLE_PATH: build/BitwardenTests.xcresult
   COVERAGE_PATH: build/coverage.xml
-  XCODE_VERSION: 15.4
+  XCODE_VERSION: 15.0.1
 
 jobs:
   check-run:
@@ -42,7 +42,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: 15.4
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Configure Ruby
         uses: ruby/setup-ruby@2a9a743e19810b9f3c38060637daf594dbd7b37f # v1.186.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,9 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request_target:
-    types: [opened, synchronize]
+      - "katherine/set-xcode-version"
+  # pull_request_target:
+  #   types: [opened, synchronize]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ on:
     types: [opened, synchronize]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
   MINT_LINK_PATH: .mint/bin
   MINT_PATH: .mint/lib
   SIMULATOR_DESTINATION: platform=iOS Simulator,name=iPhone 15 Pro,OS=17.0.1
   RESULT_BUNDLE_PATH: build/BitwardenTests.xcresult
   COVERAGE_PATH: build/coverage.xml
-  XCODE_VERSION: 15.0.1
+  XCODE_VERSION: 15.4
 
 jobs:
   check-run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ env:
   SIMULATOR_DESTINATION: platform=iOS Simulator,name=iPhone 15 Pro,OS=17.0.1
   RESULT_BUNDLE_PATH: build/BitwardenTests.xcresult
   COVERAGE_PATH: build/coverage.xml
+  XCODE_VERSION: 15.0.1
 
 jobs:
   check-run:
@@ -32,6 +33,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
+
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,11 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-      - "katherine/set-xcode-version"
-  # pull_request_target:
-  #   types: [opened, synchronize]
+  pull_request_target:
+    types: [opened, synchronize]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_15.4.app/Contents/Developer
+  DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer
   MINT_LINK_PATH: .mint/bin
   MINT_PATH: .mint/lib
   SIMULATOR_DESTINATION: platform=iOS Simulator,name=iPhone 15 Pro,OS=17.0.1
@@ -79,7 +78,7 @@ jobs:
       - name: Build and test
         run: |
           set -o pipefail && \
-            xcodebuild test \
+            xcrun xcodebuild test \
             -project Bitwarden.xcodeproj \
             -scheme Bitwarden \
             -configuration Debug \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
-          xcode-version: ${{ env.XCODE_VERSION }}
+          xcode-version: 15.4
 
       - name: Configure Ruby
         uses: ruby/setup-ruby@2a9a743e19810b9f3c38060637daf594dbd7b37f # v1.186.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,9 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request_target:
-    types: [opened, synchronize]
+      - "katherine/set-xcode-version"
+  # pull_request_target:
+  #   types: [opened, synchronize]
 
 env:
   DEVELOPER_DIR: /Applications/Xcode_15.0.1.app/Contents/Developer

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,15 +33,15 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Set Xcode version
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: ${{ env.XCODE_VERSION }}
-
       - name: Check out repo
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{  github.event.pull_request.head.sha }}
+
+      - name: Set Xcode version
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Configure Ruby
         uses: ruby/setup-ruby@2a9a743e19810b9f3c38060637daf594dbd7b37f # v1.186.0


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9695

## 📔 Objective

This adds a step to the workflow that explicitly sets the Xcode version, instead of relying on the default in the [runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md). As the default is currently 15.0.1, that's the version I set to as the default (so there should be no change).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
