### PR TITLE
PM-9000 - User can save empty PIN

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/TestHelpers/Alert+TestHelpers.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/TestHelpers/Alert+TestHelpers.swift
@@ -1,14 +1,17 @@
-import Foundation
+import UIKit
 
 @testable import BitwardenShared
 
 enum AlertError: LocalizedError {
     case alertActionNotFound(title: String)
+    case alertTextFieldNotFound(id: String)
 
     var errorDescription: String? {
         switch self {
         case let .alertActionNotFound(title):
             "Unable to locate an alert action for the title: \(title)"
+        case let .alertTextFieldNotFound(id):
+            "Unable to locate a TextField with id: \(id)"
         }
     }
 }
@@ -20,10 +23,32 @@ extension Alert {
     ///   - title: The title of the alert action to trigger.
     ///   - alertTextFields: `AlertTextField` list to execute the action.
     /// - Throws: Throws an `AlertError` if the alert action cannot be found.
-    func tapAction(title: String, alertTextFields: [AlertTextField]? = nil) async throws {
+    func tapAction(
+        title: String,
+        alertTextFields: [AlertTextField]? = nil
+    ) async throws {
         guard let alertAction = alertActions.first(where: { $0.title == title }) else {
             throw AlertError.alertActionNotFound(title: title)
         }
         await alertAction.handler?(alertAction, alertTextFields ?? self.alertTextFields)
+    }
+
+    /// Sets the text for the alert text field with the specified identifier.
+    ///
+    /// - Parameters:
+    ///   - text: The text to set in the alert text field.
+    ///   - id: The identifier of the alert text field to set the text for.
+    /// - Throws: Throws an `AlertError` if the alert text field cannot be found.
+    func setText(
+        _ text: String,
+        forTextFieldWithId id: String
+    ) throws {
+        guard let textField = alertTextFields.first(where: { $0.id == id }) else {
+            throw AlertError.alertTextFieldNotFound(id: id)
+        }
+
+        let simulatedTextField = UITextField()
+        simulatedTextField.text = "1234"
+        textField.textChanged(in: simulatedTextField)
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -305,6 +305,8 @@ final class AccountSecurityProcessor: StateProcessor<
     private func toggleUnlockWithPIN(_ isOn: Bool) {
         if isOn {
             coordinator.showAlert(.enterPINCode { pin in
+                guard !pin.isEmpty else { return }
+
                 do {
                     let userHasMasterPassword = try await self.services.stateService.getUserHasMasterPassword()
                     if userHasMasterPassword {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -490,7 +490,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.state.isUnlockWithPINCodeOn = false
         subject.receive(.toggleUnlockWithPINCode(true))
 
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.submit)
 
         XCTAssertFalse(subject.state.isUnlockWithPINCodeOn)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -468,8 +468,24 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     }
 
     /// `receive(_:)` with `.toggleUnlockWithPINCode` displays an alert and updates the state when submit has been
-    /// pressed.
-    func test_receive_toggleUnlockWithPINCode_toggleOn() async throws {
+    /// pressed and the user has entered in a pin.
+    func test_receive_toggleUnlockWithPINCode_toggleOn_withPIN() async throws {
+        stateService.activeAccount = .fixture()
+        subject.state.isUnlockWithPINCodeOn = false
+        subject.receive(.toggleUnlockWithPINCode(true))
+
+        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        try alert.setText("1234", forTextFieldWithId: "pin")
+        try await alert.tapAction(title: Localizations.submit)
+
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.yes)
+        XCTAssertTrue(subject.state.isUnlockWithPINCodeOn)
+    }
+
+    /// `receive(_:)` with `.toggleUnlockWithPINCode` displays an alert and updates the state when submit has been
+    /// pressed but an empty pin was passed.
+    func test_receive_toggleUnlockWithPINCode_toggleOn_withEmptyPIN() async throws {
         stateService.activeAccount = .fixture()
         subject.state.isUnlockWithPINCodeOn = false
         subject.receive(.toggleUnlockWithPINCode(true))
@@ -477,9 +493,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         var alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.submit)
 
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.tapAction(title: Localizations.yes)
-        XCTAssertTrue(subject.state.isUnlockWithPINCodeOn)
+        XCTAssertFalse(subject.state.isUnlockWithPINCodeOn)
     }
 
     /// `receive(_:)` with `.toggleUnlockWithPINCode` displays an error if one occurs while setting
@@ -492,6 +506,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.receive(.toggleUnlockWithPINCode(true))
 
         let enterPinAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try enterPinAlert.setText("1234", forTextFieldWithId: "pin")
         try await enterPinAlert.tapAction(title: Localizations.submit)
 
         let requireMasterPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
@@ -511,6 +526,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.receive(.toggleUnlockWithPINCode(true))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try alert.setText("1234", forTextFieldWithId: "pin")
         try await alert.tapAction(title: Localizations.submit)
 
         XCTAssertTrue(subject.state.isUnlockWithPINCodeOn)
@@ -539,6 +555,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.receive(.toggleUnlockWithPINCode(true))
 
         let enterPinAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try enterPinAlert.setText("1234", forTextFieldWithId: "pin")
         try await enterPinAlert.tapAction(title: Localizations.submit)
 
         let errorAlert = try XCTUnwrap(coordinator.alertShown.last)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9000](https://bitwarden.atlassian.net/browse/PM-9000)

## 📔 Objective
- We needed a way to make sure empty pins would not be sent to the backend.  Verified with the android and the existing xamarin app that we allow the user to press "Submit" on the alert with an empty pin but no actual action is performed with setting the empty pin via the backend.  
- Updated tests to include adding in a pin so the logic would execute as expected and added one to make sure we don't perform logic when passing in an empty pin.

## 🎥  Video

https://github.com/user-attachments/assets/d5687bc1-d279-4c52-8be4-995149a5be84

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9000]: https://bitwarden.atlassian.net/browse/PM-9000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ