### PR TITLE
PM-9002: Fix vault early timeout

### DIFF
--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -117,9 +117,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     // MARK: Methods
 
     func hasPassedSessionTimeout(userId: String) async throws -> Bool {
-        guard let lastActiveTime = try await stateService.getLastActiveTime(userId: userId) else { return true }
         let vaultTimeout = try await sessionTimeoutValue(userId: userId)
-
         switch vaultTimeout {
         case .never,
              .onAppRestart:
@@ -128,8 +126,11 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
             return false
         default:
             // Otherwise, calculate a timeout.
+            guard let lastActiveTime = try await stateService.getLastActiveTime(userId: userId)
+            else { return true }
+
             return timeProvider.presentTime.timeIntervalSince(lastActiveTime)
-                >= TimeInterval(vaultTimeout.rawValue)
+                >= TimeInterval(vaultTimeout.seconds)
         }
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -90,6 +90,12 @@ public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menu
         }
     }
 
+    /// The session timeout value in seconds.
+    var seconds: Int {
+        rawValue * 60
+    }
+
+    /// The session timeout value in minutes.
     public var rawValue: Int {
         switch self {
         case .immediately: 0


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9002](https://bitwarden.atlassian.net/browse/PM-9002)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes the vault from timing out earlier than it should. We were originally storing the timeout value in seconds, but changed to minutes to support migrating from the MAUI app. This case was missed, and the vault was timing out using the timeout value in seconds rather than minutes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9002]: https://bitwarden.atlassian.net/browse/PM-9002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ