### PR TITLE
PM-8797: Use localized strings for search bar and cancel button

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Appearance/UI.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/UI.swift
@@ -63,6 +63,7 @@ public enum UI {
         UITabBar.appearance().standardAppearance = tabBarAppearance
         UITabBar.appearance().tintColor = Asset.Colors.primaryBitwarden.color
 
+        UIBarButtonItem.appearance(whenContainedInInstancesOf: [UISearchBar.self]).title = Localizations.cancel
         UISearchBar.appearance().tintColor = Asset.Colors.primaryBitwarden.color
         // Explicitly tint the image so that it does not assume the tint color assigned to the entire search bar.
         let image = Asset.Images.cancelRound.image

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -113,6 +113,7 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
 
         let viewController = UIHostingController(rootView: view)
         let searchController = UISearchController()
+        searchController.searchBar.placeholder = Localizations.search
         searchController.searchResultsUpdater = searchHandler
 
         stackNavigator?.push(

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -227,6 +227,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
         )
         let viewController = UIHostingController(rootView: view)
         let searchController = UISearchController()
+        searchController.searchBar.placeholder = Localizations.search
         searchController.searchResultsUpdater = searchHandler
 
         stackNavigator?.push(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-8797](https://bitwarden.atlassian.net/browse/PM-8797)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the search bar to use Bitwarden localizations rather than the system localization. This ensures the correct localizations are used if the language used in the app is different from the system language.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| ![localizations-before 1](https://github.com/user-attachments/assets/1671c850-4c0a-494a-b48e-e5287fc407d5) | ![localizations-after 1](https://github.com/user-attachments/assets/7d53c676-25cb-4cd0-9a37-b3f3d6f5ba06) |
| ![localizations-before 2](https://github.com/user-attachments/assets/ee1e060c-8ff0-4e18-a395-40bdfd47c0ae) | ![localizations-after 2](https://github.com/user-attachments/assets/b338aa63-8927-4bdc-bb05-08e72eeb0303) |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8797]: https://bitwarden.atlassian.net/browse/PM-8797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ