### PR TITLE
PM-8141: Subscribe to send search results to get updates

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -215,6 +215,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
                 state.searchResults = sends
             }
         } catch {
+            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -47,8 +47,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
         case .loadData:
             await loadData()
         case let .search(text):
-            let results = await searchSends(for: text)
-            state.searchResults = results
+            await searchSends(for: text)
         case .refresh:
             await refresh()
         case let .sendListItemRow(effect):
@@ -200,12 +199,11 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     /// Searches the sends using the provided string, and returns any matching results.
     ///
     /// - Parameter searchText: The string to use when searching the sends.
-    /// - Returns: An array of `SendListItem`s. If no results can be found, an empty array will be
-    ///   returned.
     ///
-    private func searchSends(for searchText: String) async -> [SendListItem] {
+    private func searchSends(for searchText: String) async {
         guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            return []
+            state.searchResults = []
+            return
         }
 
         do {
@@ -214,13 +212,11 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
                 type: state.type
             )
             for try await sends in result {
-                return sends
+                state.searchResults = sends
             }
         } catch {
             services.errorReporter.log(error: error)
         }
-
-        return []
     }
 }
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -77,6 +77,23 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertNil(sendRepository.searchSendType)
     }
 
+    /// `perform(_:)` with `search(_:)` displays an alert and logs an error if one occurs.
+    func test_perform_search_error() {
+        subject.state.searchResults = []
+
+        sendRepository.searchSendSubject.send(completion: .failure(BitwardenTestError.example))
+
+        let task = Task {
+            await subject.perform(.search("send"))
+        }
+
+        waitFor(!errorReporter.errors.isEmpty)
+        task.cancel()
+
+        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
     /// `perform(_:)` with `search(_:)` uses the send repository to perform a search and updates the
     /// state.
     func test_perform_search_nilType() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-8141](https://bitwarden.atlassian.net/browse/PM-8141)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a bug where deleting a send in the search results doesn't remove it from the list of search results. The view now subscribes to the search results rather than using a static list.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/54e8a195-edce-44db-868e-894b244f75b9



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8141]: https://bitwarden.atlassian.net/browse/PM-8141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ