### PR TITLE
PM-9117: Fix missing generator slider on iOS 15/16

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/FormFields/SliderFieldView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/FormFields/SliderFieldView.swift
@@ -90,6 +90,8 @@ struct SliderFieldView<State>: View {
                         onValueChanged(min(field.value + field.step, field.range.upperBound))
                         return .handled
                     }
+                } else {
+                    view
                 }
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9117](https://bitwarden.atlassian.net/browse/PM-9117)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a bug where the generator's length slider was missing on iOS 15 & 16. The `apply` view modifier that is being used to add keypresses for iOS 17+ needs to return a view in all cases which was missing for lower iOS versions.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| -- | -- |
| <img width="839" alt="Screenshot 2024-07-17 at 11 16 29 AM" src="https://github.com/user-attachments/assets/053b57f1-ae06-421f-85ea-109002547130"> | <img width="839" alt="Screenshot 2024-07-17 at 11 18 02 AM" src="https://github.com/user-attachments/assets/67b09059-4c1e-4ca3-9108-7a98392066d0"> |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9117]: https://bitwarden.atlassian.net/browse/PM-9117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ