### PR TITLE
[PM-8361] Added whether the vault has been unlocked interactively

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -922,6 +922,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         await assertAsyncDoesNotThrow {
             try await subject.unlockVaultWithNeverlockKey()
         }
+        XCTAssertFalse(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `test_unlockVaultWithDeviceKey` attempts to unlock the vault using the device key from the keychain.
@@ -947,6 +948,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         await assertAsyncDoesNotThrow {
             try await subject.unlockVaultWithDeviceKey()
         }
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `test_unlockVaultWithDeviceKey` attempts to unlock the vault using the device key from the keychain.
@@ -1182,6 +1184,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(authService.hashPasswordPassword, "password")
         XCTAssertEqual(stateService.masterPasswordHashes["1"], "hashed")
         XCTAssertFalse(biometricsRepository.didConfigureBiometricIntegrity)
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `unlockVaultWithPassword(password:)` configures biometric integrity refreshes.
@@ -1309,6 +1312,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         await assertAsyncDoesNotThrow {
             try await subject.unlockVaultWithBiometrics()
         }
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `logout` throws an error with no accounts.
@@ -1381,6 +1385,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 )
             )
         )
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `unlockVaultFromLoginWithDevice()` unlocks the vault using the key returned by an approved
@@ -1409,6 +1414,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 )
             )
         )
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN.
@@ -1437,6 +1443,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             )
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 
     /// `unlockVaultWithPIN(_:)` throws an error if there's no pin.

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -542,6 +542,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         let fido2UserInterfaceHelper = DefaultFido2UserInterfaceHelper(
             fido2UserVerificationMediator: DefaultFido2UserVerificationMediator(
                 authRepository: authRepository,
+                stateService: stateService,
                 userVerificationHelper: DefaultUserVerificationHelper(
                     authRepository: authRepository,
                     errorReporter: errorReporter,

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -49,9 +49,9 @@ protocol StateService: AnyObject {
     ///
     func getAccountEncryptionKeys(userId: String?) async throws -> AccountEncryptionKeys
 
-    /// Gets whether the user has unlocked their account in the current session.
+    /// Gets whether the user has unlocked their account in the current session interactively.
     /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
-    func getAccountHasBeenUnlockedInCurrentSession(userId: String?) async throws -> Bool
+    func getAccountHasBeenUnlockedInteractively(userId: String?) async throws -> Bool
 
     /// Gets all accounts.
     ///
@@ -316,11 +316,11 @@ protocol StateService: AnyObject {
     ///
     func setAccountEncryptionKeys(_ encryptionKeys: AccountEncryptionKeys, userId: String?) async throws
 
-    /// Sets whether the user has unlocked their account in the current session.
+    /// Sets whether the user has unlocked their account in the current session  interactively.
     /// - Parameters:
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///   - value: Whether the user has unlocked their account in the current session.
-    func setAccountHasBeenUnlockedInCurrentSession(userId: String?, value: Bool) async throws
+    func setAccountHasBeenUnlockedInteractively(userId: String?, value: Bool) async throws
 
     /// Sets the active account.
     ///
@@ -603,9 +603,9 @@ extension StateService {
         try await getAccountEncryptionKeys(userId: nil)
     }
 
-    /// Gets whether the user has unlocked their account in the current session.
-    func getAccountHasBeenUnlockedInCurrentSession() async throws -> Bool {
-        try await getAccountHasBeenUnlockedInCurrentSession(userId: nil)
+    /// Gets whether the user has unlocked their account in the current session  interactively.
+    func getAccountHasBeenUnlockedInteractively() async throws -> Bool {
+        try await getAccountHasBeenUnlockedInteractively(userId: nil)
     }
 
     /// Gets either a valid account id or the active account id.
@@ -819,10 +819,10 @@ extension StateService {
         try await setAccountEncryptionKeys(encryptionKeys, userId: nil)
     }
 
-    /// Sets whether the user has unlocked their account in the current session.
+    /// Sets whether the user has unlocked their account in the current session  interactively.
     /// - Parameter value: Whether the user has unlocked their account in the current session
-    func setAccountHasBeenUnlockedInCurrentSession(value: Bool) async throws {
-        try await setAccountHasBeenUnlockedInCurrentSession(userId: nil, value: value)
+    func setAccountHasBeenUnlockedInteractively(value: Bool) async throws {
+        try await setAccountHasBeenUnlockedInteractively(userId: nil, value: value)
     }
 
     /// Sets the allow sync on refresh value for the active account.
@@ -1096,9 +1096,9 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         )
     }
 
-    func getAccountHasBeenUnlockedInCurrentSession(userId: String?) async throws -> Bool {
+    func getAccountHasBeenUnlockedInteractively(userId: String?) async throws -> Bool {
         let userId = try userId ?? getActiveAccountUserId()
-        return accountVolatileData[userId]?.hasBeenUnlockedInCurrentSession == true
+        return accountVolatileData[userId]?.hasBeenUnlockedInteractively == true
     }
 
     func getAccounts() throws -> [Account] {
@@ -1295,12 +1295,12 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appSettingsStore.setEncryptedUserKey(key: encryptionKeys.encryptedUserKey, userId: userId)
     }
 
-    func setAccountHasBeenUnlockedInCurrentSession(userId: String?, value: Bool) async throws {
+    func setAccountHasBeenUnlockedInteractively(userId: String?, value: Bool) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         accountVolatileData[
             userId,
             default: AccountVolatileData()
-        ].hasBeenUnlockedInCurrentSession = value
+        ].hasBeenUnlockedInteractively = value
     }
 
     func setActiveAccount(userId: String) async throws {
@@ -1549,8 +1549,8 @@ struct AccountVolatileData {
     /// The pin protected user key.
     var pinProtectedUserKey: String?
 
-    /// Whether the account has been unlocked in the current session.
-    var hasBeenUnlockedInCurrentSession = false
+    /// Whether the account has been unlocked with user interaction.
+    var hasBeenUnlockedInteractively = false
 }
 
 // MARK: Biometrics

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -49,6 +49,10 @@ protocol StateService: AnyObject {
     ///
     func getAccountEncryptionKeys(userId: String?) async throws -> AccountEncryptionKeys
 
+    /// Gets whether the user has unlocked their account in the current session.
+    /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
+    func getAccountHasBeenUnlockedInCurrentSession(userId: String?) async throws -> Bool
+
     /// Gets all accounts.
     ///
     /// - Returns: The known user accounts.
@@ -311,6 +315,12 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setAccountEncryptionKeys(_ encryptionKeys: AccountEncryptionKeys, userId: String?) async throws
+
+    /// Sets whether the user has unlocked their account in the current session.
+    /// - Parameters:
+    ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
+    ///   - value: Whether the user has unlocked their account in the current session.
+    func setAccountHasBeenUnlockedInCurrentSession(userId: String?, value: Bool) async throws
 
     /// Sets the active account.
     ///
@@ -593,6 +603,11 @@ extension StateService {
         try await getAccountEncryptionKeys(userId: nil)
     }
 
+    /// Gets whether the user has unlocked their account in the current session.
+    func getAccountHasBeenUnlockedInCurrentSession() async throws -> Bool {
+        try await getAccountHasBeenUnlockedInCurrentSession(userId: nil)
+    }
+
     /// Gets either a valid account id or the active account id.
     ///
     /// - Parameter userId: The possible user id.
@@ -802,6 +817,12 @@ extension StateService {
     ///
     func setAccountEncryptionKeys(_ encryptionKeys: AccountEncryptionKeys) async throws {
         try await setAccountEncryptionKeys(encryptionKeys, userId: nil)
+    }
+
+    /// Sets whether the user has unlocked their account in the current session.
+    /// - Parameter value: Whether the user has unlocked their account in the current session
+    func setAccountHasBeenUnlockedInCurrentSession(value: Bool) async throws {
+        try await setAccountHasBeenUnlockedInCurrentSession(userId: nil, value: value)
     }
 
     /// Sets the allow sync on refresh value for the active account.
@@ -1030,7 +1051,7 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
 
     func clearPins() async throws {
         let userId = try getActiveAccountUserId()
-        accountVolatileData.removeValue(forKey: userId)
+        accountVolatileData[userId]?.pinProtectedUserKey = nil
         appSettingsStore.setEncryptedPin(nil, userId: userId)
         appSettingsStore.setPinProtectedUserKey(key: nil, userId: userId)
     }
@@ -1073,6 +1094,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
             encryptedPrivateKey: encryptedPrivateKey,
             encryptedUserKey: appSettingsStore.encryptedUserKey(userId: userId)
         )
+    }
+
+    func getAccountHasBeenUnlockedInCurrentSession(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccountUserId()
+        return accountVolatileData[userId]?.hasBeenUnlockedInCurrentSession == true
     }
 
     func getAccounts() throws -> [Account] {
@@ -1267,6 +1293,14 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setEncryptedPrivateKey(key: encryptionKeys.encryptedPrivateKey, userId: userId)
         appSettingsStore.setEncryptedUserKey(key: encryptionKeys.encryptedUserKey, userId: userId)
+    }
+
+    func setAccountHasBeenUnlockedInCurrentSession(userId: String?, value: Bool) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        accountVolatileData[
+            userId,
+            default: AccountVolatileData()
+        ].hasBeenUnlockedInCurrentSession = value
     }
 
     func setActiveAccount(userId: String) async throws {
@@ -1513,7 +1547,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
 ///
 struct AccountVolatileData {
     /// The pin protected user key.
-    var pinProtectedUserKey: String = ""
+    var pinProtectedUserKey: String?
+
+    /// Whether the account has been unlocked in the current session.
+    var hasBeenUnlockedInCurrentSession = false
 }
 
 // MARK: Biometrics

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -252,32 +252,44 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
             _ = try await subject.getAccountEncryptionKeys()
         }
     }
-    
-    /// `getAccountHasBeenUnlockedInCurrentSession()` gets the value from the active user.
-    func test_getAccountHasBeenUnlockedInCurrentSession() async throws {
+
+    /// `getAccountHasBeenUnlockedInteractively()` gets the default value from the active user.
+    func test_getAccountHasBeenUnlockedInteractively_default() async throws {
         appSettingsStore.state = State.fixture(
             accounts: [
                 "1": Account.fixture(),
             ],
             activeUserId: "1"
         )
-        try await subject.setAccountHasBeenUnlockedInCurrentSession(value: true)
-        let result = try await subject.getAccountHasBeenUnlockedInCurrentSession()
+        let result = try await subject.getAccountHasBeenUnlockedInteractively()
+        XCTAssertFalse(result)
+    }
+
+    /// `getAccountHasBeenUnlockedInteractively()` gets the value from the active user.
+    func test_getAccountHasBeenUnlockedInteractively() async throws {
+        appSettingsStore.state = State.fixture(
+            accounts: [
+                "1": Account.fixture(),
+            ],
+            activeUserId: "1"
+        )
+        try await subject.setAccountHasBeenUnlockedInteractively(value: true)
+        let result = try await subject.getAccountHasBeenUnlockedInteractively()
         XCTAssertTrue(result)
     }
 
-    /// `getAccountHasBeenUnlockedInCurrentSession(userId:)` gets the value from the given user.
-    func test_getAccountHasBeenUnlockedInCurrentSession_givenUser() async throws {
-        try await subject.setAccountHasBeenUnlockedInCurrentSession(userId: "2", value: true)
-        let result = try await subject.getAccountHasBeenUnlockedInCurrentSession(userId: "2")
+    /// `getAccountHasBeenUnlockedInteractively(userId:)` gets the value from the given user.
+    func test_getAccountHasBeenUnlockedInteractively_givenUser() async throws {
+        try await subject.setAccountHasBeenUnlockedInteractively(userId: "2", value: true)
+        let result = try await subject.getAccountHasBeenUnlockedInteractively(userId: "2")
         XCTAssertTrue(result)
     }
 
-    /// `getAccountHasBeenUnlockedInCurrentSession()` gets the value from the given user.
-    func test_getAccountHasBeenUnlockedInCurrentSession_throwsGettingTheUser() async throws {
+    /// `getAccountHasBeenUnlockedInteractively()` gets the value from the given user.
+    func test_getAccountHasBeenUnlockedInteractively_throwsGettingTheUser() async throws {
         appSettingsStore.state?.activeUserId = nil
         await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
-            _ = try await subject.getAccountHasBeenUnlockedInCurrentSession()
+            _ = try await subject.getAccountHasBeenUnlockedInteractively()
         }
     }
 
@@ -1340,39 +1352,39 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.disableAutoTotpCopyByUserId["1"], false)
     }
 
-    /// `setAccountHasBeenUnlockedInCurrentSession(userId:value:)` updates volatile data
-    func test_setAccountHasBeenUnlockedInCurrentSession() async throws {
-        try await subject.setAccountHasBeenUnlockedInCurrentSession(userId: "1", value: true)
-        let result = await subject.accountVolatileData["1"]?.hasBeenUnlockedInCurrentSession ?? false
+    /// `setAccountHasBeenUnlockedInteractively(userId:value:)` updates volatile data
+    func test_setAccountHasBeenUnlockedInteractively() async throws {
+        try await subject.setAccountHasBeenUnlockedInteractively(userId: "1", value: true)
+        let result = await subject.accountVolatileData["1"]?.hasBeenUnlockedInteractively ?? false
         XCTAssertTrue(result)
     }
 
-    /// `setAccountHasBeenUnlockedInCurrentSession(userId:value:)` updates volatile data for existing user.
-    func test_setAccountHasBeenUnlockedInCurrentSession_updateExisting() async throws {
-        try await subject.setAccountHasBeenUnlockedInCurrentSession(userId: "1", value: true)
-        try await subject.setAccountHasBeenUnlockedInCurrentSession(userId: "1", value: false)
-        let result = await subject.accountVolatileData["1"]?.hasBeenUnlockedInCurrentSession ?? false
+    /// `setAccountHasBeenUnlockedInteractively(userId:value:)` updates volatile data for existing user.
+    func test_setAccountHasBeenUnlockedInteractively_updateExisting() async throws {
+        try await subject.setAccountHasBeenUnlockedInteractively(userId: "1", value: true)
+        try await subject.setAccountHasBeenUnlockedInteractively(userId: "1", value: false)
+        let result = await subject.accountVolatileData["1"]?.hasBeenUnlockedInteractively ?? false
         XCTAssertFalse(result)
     }
 
-    /// `setAccountHasBeenUnlockedInCurrentSession(value:)` updates volatile data for current user.
-    func test_setAccountHasBeenUnlockedInCurrentSession_updateByCurrentUser() async throws {
+    /// `setAccountHasBeenUnlockedInteractively(value:)` updates volatile data for current user.
+    func test_setAccountHasBeenUnlockedInteractively_updateByCurrentUser() async throws {
         appSettingsStore.state = State.fixture(
             accounts: [
                 "1": Account.fixture(),
             ],
             activeUserId: "1"
         )
-        try await subject.setAccountHasBeenUnlockedInCurrentSession(value: true)
-        let result = await subject.accountVolatileData["1"]?.hasBeenUnlockedInCurrentSession ?? false
+        try await subject.setAccountHasBeenUnlockedInteractively(value: true)
+        let result = await subject.accountVolatileData["1"]?.hasBeenUnlockedInteractively ?? false
         XCTAssertTrue(result)
     }
 
-    /// `setAccountHasBeenUnlockedInCurrentSession(value:)` throws if it throws when getting the user id.
-    func test_setAccountHasBeenUnlockedInCurrentSession_throwsWhenGettingUserId() async throws {
+    /// `setAccountHasBeenUnlockedInteractively(value:)` throws if it throws when getting the user id.
+    func test_setAccountHasBeenUnlockedInteractively_throwsWhenGettingUserId() async throws {
         appSettingsStore.state?.activeUserId = nil
         await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
-            _ = try await subject.setAccountHasBeenUnlockedInCurrentSession(value: true)
+            _ = try await subject.setAccountHasBeenUnlockedInteractively(value: true)
         }
     }
 

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -37,6 +37,8 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastActiveTime = [String: Date]()
     var loginRequest: LoginRequestNotification?
     var getAccountEncryptionKeysError: Error?
+    // swiftlint:disable:next identifier_name
+    var getAccountHasBeenUnlockedInCurrentSessionResult: Result<Bool, Error> = .success(false)
     var getBiometricAuthenticationEnabledResult: Result<Void, Error> = .success(())
     var getBiometricIntegrityStateError: Error?
     var lastSyncTimeByUserId = [String: Date]()
@@ -53,6 +55,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var showWebIconsSubject = CurrentValueSubject<Bool, Never>(true)
     var timeoutAction = [String: SessionTimeoutAction]()
     var serverConfig = [String: ServerConfig]()
+    var setAccountHasBeenUnlockedInCurrentSessionHasBeenCalled = false // swiftlint:disable:this identifier_name
+    // swiftlint:disable:next identifier_name
+    var setAccountHasBeenUnlockedInCurrentSessionResult: Result<Void, Error> = .success(())
     var setBiometricAuthenticationEnabledResult: Result<Void, Error> = .success(())
     var setBiometricIntegrityStateError: Error?
     var shouldCheckOrganizationUnassignedItems = [String: Bool?]()
@@ -107,6 +112,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
             throw StateServiceError.noActiveAccount
         }
         return encryptionKeys
+    }
+
+    func getAccountHasBeenUnlockedInCurrentSession(userId: String?) async throws -> Bool {
+        try getAccountHasBeenUnlockedInCurrentSessionResult.get()
     }
 
     func getAccount(userId: String?) async throws -> BitwardenShared.Account {
@@ -295,6 +304,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func setAccountEncryptionKeys(_ encryptionKeys: AccountEncryptionKeys, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         accountEncryptionKeys[userId] = encryptionKeys
+    }
+
+    func setAccountHasBeenUnlockedInCurrentSession(userId: String?, value: Bool) async throws {
+        setAccountHasBeenUnlockedInCurrentSessionHasBeenCalled = true
+        try setAccountHasBeenUnlockedInCurrentSessionResult.get()
     }
 
     func setActiveAccount(userId: String) async throws {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -38,7 +38,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var loginRequest: LoginRequestNotification?
     var getAccountEncryptionKeysError: Error?
     // swiftlint:disable:next identifier_name
-    var getAccountHasBeenUnlockedInCurrentSessionResult: Result<Bool, Error> = .success(false)
+    var getAccountHasBeenUnlockedInteractivelyResult: Result<Bool, Error> = .success(false)
     var getBiometricAuthenticationEnabledResult: Result<Void, Error> = .success(())
     var getBiometricIntegrityStateError: Error?
     var lastSyncTimeByUserId = [String: Date]()
@@ -55,9 +55,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var showWebIconsSubject = CurrentValueSubject<Bool, Never>(true)
     var timeoutAction = [String: SessionTimeoutAction]()
     var serverConfig = [String: ServerConfig]()
-    var setAccountHasBeenUnlockedInCurrentSessionHasBeenCalled = false // swiftlint:disable:this identifier_name
+    var setAccountHasBeenUnlockedInteractivelyHasBeenCalled = false // swiftlint:disable:this identifier_name
     // swiftlint:disable:next identifier_name
-    var setAccountHasBeenUnlockedInCurrentSessionResult: Result<Void, Error> = .success(())
+    var setAccountHasBeenUnlockedInteractivelyResult: Result<Void, Error> = .success(())
     var setBiometricAuthenticationEnabledResult: Result<Void, Error> = .success(())
     var setBiometricIntegrityStateError: Error?
     var shouldCheckOrganizationUnassignedItems = [String: Bool?]()
@@ -114,8 +114,8 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         return encryptionKeys
     }
 
-    func getAccountHasBeenUnlockedInCurrentSession(userId: String?) async throws -> Bool {
-        try getAccountHasBeenUnlockedInCurrentSessionResult.get()
+    func getAccountHasBeenUnlockedInteractively(userId: String?) async throws -> Bool {
+        try getAccountHasBeenUnlockedInteractivelyResult.get()
     }
 
     func getAccount(userId: String?) async throws -> BitwardenShared.Account {
@@ -306,9 +306,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         accountEncryptionKeys[userId] = encryptionKeys
     }
 
-    func setAccountHasBeenUnlockedInCurrentSession(userId: String?, value: Bool) async throws {
-        setAccountHasBeenUnlockedInCurrentSessionHasBeenCalled = true
-        try setAccountHasBeenUnlockedInCurrentSessionResult.get()
+    func setAccountHasBeenUnlockedInteractively(userId: String?, value: Bool) async throws {
+        setAccountHasBeenUnlockedInteractivelyHasBeenCalled = true
+        try setAccountHasBeenUnlockedInteractivelyResult.get()
     }
 
     func setActiveAccount(userId: String) async throws {

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
@@ -11,6 +11,7 @@ class MockVaultTimeoutService: VaultTimeoutService {
     var shouldSessionTimeoutError: Error?
     var timeProvider = MockTimeProvider(.currentTime)
     var sessionTimeoutValueError: Error?
+    var unlockVaultHadUserInteraction = false
     var vaultTimeout = [String: SessionTimeoutValue]()
     var vaultLockStatusSubject = CurrentValueSubject<VaultLockStatus?, Never>(nil)
 
@@ -47,9 +48,10 @@ class MockVaultTimeoutService: VaultTimeoutService {
         return shouldSessionTimeout[userId] ?? false
     }
 
-    func unlockVault(userId: String?) async throws {
+    func unlockVault(userId: String?, hadUserInteraction: Bool) async throws {
         guard let userId else { return }
         isClientLocked[userId] = false
+        unlockVaultHadUserInteraction = hadUserInteraction
     }
 
     func remove(userId: String?) async {

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -59,10 +59,12 @@ protocol VaultTimeoutService: AnyObject {
 
     /// Unlocks the user's vault
     ///
-    /// - Parameter userId: The userId of the account to unlock.
+    /// - Parameters:
+    ///   - userId: The userId of the account to unlock.
     ///     Defaults to the active account if nil
-    ///
-    func unlockVault(userId: String?) async throws
+    ///   - hadUserInteraction: Whether the user had any interaction with the app to unlock the vault
+    ///   or the never lock key was used.
+    func unlockVault(userId: String?, hadUserInteraction: Bool) async throws
 
     /// Gets the `SessionTimeoutValue` for a user.
     ///
@@ -143,12 +145,14 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         guard let id = try? await stateService.getAccountIdOrActiveId(userId: userId) else { return }
         try? await clientService.removeClient(for: id)
         vaultLockStatusSubject.value[id] = true
+        try? await stateService.setAccountHasBeenUnlockedInCurrentSession(userId: id, value: false)
     }
 
     func remove(userId: String?) async {
         guard let id = try? await stateService.getAccountIdOrActiveId(userId: userId) else { return }
         try? await clientService.removeClient(for: id)
         vaultLockStatusSubject.value.removeValue(forKey: id)
+        try? await stateService.setAccountHasBeenUnlockedInCurrentSession(userId: id, value: false)
     }
 
     func setLastActiveTime(userId: String) async throws {
@@ -159,9 +163,10 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         try await stateService.setVaultTimeout(value: value, userId: userId)
     }
 
-    func unlockVault(userId: String?) async throws {
+    func unlockVault(userId: String?, hadUserInteraction: Bool) async throws {
         guard let id = try? await stateService.getAccountIdOrActiveId(userId: userId) else { return }
         vaultLockStatusSubject.value[id] = false
+        try await stateService.setAccountHasBeenUnlockedInCurrentSession(userId: id, value: hadUserInteraction)
     }
 
     func sessionTimeoutValue(userId: String?) async throws -> SessionTimeoutValue {

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -145,14 +145,14 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         guard let id = try? await stateService.getAccountIdOrActiveId(userId: userId) else { return }
         try? await clientService.removeClient(for: id)
         vaultLockStatusSubject.value[id] = true
-        try? await stateService.setAccountHasBeenUnlockedInCurrentSession(userId: id, value: false)
+        try? await stateService.setAccountHasBeenUnlockedInteractively(userId: id, value: false)
     }
 
     func remove(userId: String?) async {
         guard let id = try? await stateService.getAccountIdOrActiveId(userId: userId) else { return }
         try? await clientService.removeClient(for: id)
         vaultLockStatusSubject.value.removeValue(forKey: id)
-        try? await stateService.setAccountHasBeenUnlockedInCurrentSession(userId: id, value: false)
+        try? await stateService.setAccountHasBeenUnlockedInteractively(userId: id, value: false)
     }
 
     func setLastActiveTime(userId: String) async throws {
@@ -166,7 +166,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     func unlockVault(userId: String?, hadUserInteraction: Bool) async throws {
         guard let id = try? await stateService.getAccountIdOrActiveId(userId: userId) else { return }
         vaultLockStatusSubject.value[id] = false
-        try await stateService.setAccountHasBeenUnlockedInCurrentSession(userId: id, value: hadUserInteraction)
+        try await stateService.setAccountHasBeenUnlockedInteractively(userId: id, value: hadUserInteraction)
     }
 
     func sessionTimeoutValue(userId: String?) async throws -> SessionTimeoutValue {

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -296,15 +296,14 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         try await subject.unlockVault(userId: user2Id, hadUserInteraction: true)
         XCTAssertTrue(subject.isLocked(userId: userId))
         XCTAssertFalse(subject.isLocked(userId: user2Id))
-        XCTAssertTrue(stateService.setAccountHasBeenUnlockedInCurrentSessionHasBeenCalled)
+        XCTAssertTrue(stateService.setAccountHasBeenUnlockedInteractivelyHasBeenCalled)
     }
 
     /// `unlockVault(userId:hadUserInteraction:)` throws when setting account has been unlocked in current session.
     func test_unlock_locked_throws() async throws {
-        let userId = "1"
         let user2Id = "2"
 
-        stateService.setAccountHasBeenUnlockedInCurrentSessionResult = .failure(BitwardenTestError.example)
+        stateService.setAccountHasBeenUnlockedInteractivelyResult = .failure(BitwardenTestError.example)
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
             try await subject.unlockVault(userId: user2Id, hadUserInteraction: true)

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -148,7 +148,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         let account = Account.fixtureAccountLogin()
         let userId = account.profile.userId
 
-        try await subject.unlockVault(userId: userId)
+        try await subject.unlockVault(userId: userId, hadUserInteraction: false)
         XCTAssertFalse(subject.isLocked(userId: userId))
 
         await subject.lockVault(userId: userId)
@@ -160,7 +160,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         let userId = "1"
         let user2Id = "2"
 
-        try await subject.unlockVault(userId: user2Id)
+        try await subject.unlockVault(userId: user2Id, hadUserInteraction: false)
 
         XCTAssertTrue(subject.isLocked(userId: userId))
         XCTAssertFalse(subject.isLocked(userId: user2Id))
@@ -176,8 +176,8 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         let userId = "1"
         let user2Id = "2"
 
-        try await subject.unlockVault(userId: userId)
-        try await subject.unlockVault(userId: user2Id)
+        try await subject.unlockVault(userId: userId, hadUserInteraction: false)
+        try await subject.unlockVault(userId: user2Id, hadUserInteraction: false)
 
         await subject.lockVault(userId: user2Id)
 
@@ -189,7 +189,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
     func test_remove_unlocked() async throws {
         let userId = "1"
         clientService.userClientArray.updateValue(MockClient(), forKey: userId)
-        try await subject.unlockVault(userId: userId)
+        try await subject.unlockVault(userId: userId, hadUserInteraction: false)
 
         XCTAssertFalse(subject.isLocked(userId: userId))
         XCTAssertNotNil(clientService.userClientArray[userId])
@@ -213,7 +213,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         let userId = "1"
         clientService.userClientArray.updateValue(MockClient(), forKey: userId)
 
-        try await subject.unlockVault(userId: userId)
+        try await subject.unlockVault(userId: userId, hadUserInteraction: false)
         XCTAssertFalse(subject.isLocked(userId: userId))
         XCTAssertNotNil(clientService.userClientArray[userId])
 
@@ -269,7 +269,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         await subject.lockVault(userId: userId)
         XCTAssertTrue(subject.isLocked(userId: userId))
 
-        try await subject.unlockVault(userId: nil)
+        try await subject.unlockVault(userId: nil, hadUserInteraction: false)
         XCTAssertFalse(subject.isLocked(userId: userId))
     }
 
@@ -281,21 +281,34 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         stateService.activeAccount = nil
         stateService.accounts = []
 
-        try await subject.unlockVault(userId: nil)
+        try await subject.unlockVault(userId: nil, hadUserInteraction: false)
 
         XCTAssertTrue(subject.isLocked(userId: userId))
     }
 
-    /// `unlockVault(userId:)` preserves the locked status of a locked account.
+    /// `unlockVault(userId:hadUserInteraction:)` preserves the locked status of a locked account.
     func test_unlock_locked() async throws {
         let userId = "1"
         let user2Id = "2"
 
         XCTAssertTrue(subject.isLocked(userId: userId))
 
-        try await subject.unlockVault(userId: user2Id)
+        try await subject.unlockVault(userId: user2Id, hadUserInteraction: true)
         XCTAssertTrue(subject.isLocked(userId: userId))
         XCTAssertFalse(subject.isLocked(userId: user2Id))
+        XCTAssertTrue(stateService.setAccountHasBeenUnlockedInCurrentSessionHasBeenCalled)
+    }
+
+    /// `unlockVault(userId:hadUserInteraction:)` throws when setting account has been unlocked in current session.
+    func test_unlock_locked_throws() async throws {
+        let userId = "1"
+        let user2Id = "2"
+
+        stateService.setAccountHasBeenUnlockedInCurrentSessionResult = .failure(BitwardenTestError.example)
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            try await subject.unlockVault(userId: user2Id, hadUserInteraction: true)
+        }
     }
 
     /// `vaultLockStatusPublisher()` publishes the active user ID and whether their vault is locked.
@@ -308,9 +321,9 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         defer { publisher.cancel() }
 
         stateService.activeIdSubject.send("1")
-        try await subject.unlockVault(userId: "1")
+        try await subject.unlockVault(userId: "1", hadUserInteraction: false)
         stateService.activeIdSubject.send("2")
-        try await subject.unlockVault(userId: "2")
+        try await subject.unlockVault(userId: "2", hadUserInteraction: false)
         await subject.lockVault(userId: "2")
         stateService.activeIdSubject.send(nil)
 

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
@@ -115,7 +115,7 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
     }
 
     func isVerificationEnabled() async -> Bool {
-        fido2UserVerificationMediator.isPreferredVerificationEnabled()
+        await fido2UserVerificationMediator.isPreferredVerificationEnabled()
     }
 
     func pickedCredentialForCreation(result: Result<CheckUserAndPickCredentialForCreationResult, Error>) {

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediator.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediator.swift
@@ -107,7 +107,7 @@ extension DefaultFido2UserVerificationMediator: Fido2UserVerificationMediator {
             return CheckUserResult(userPresent: true, userVerified: true)
         }
 
-        if let hasBeenUnlocked = try? await stateService.getAccountHasBeenUnlockedInCurrentSession(),
+        if let hasBeenUnlocked = try? await stateService.getAccountHasBeenUnlockedInteractively(),
            hasBeenUnlocked {
             return CheckUserResult(userPresent: true, userVerified: true)
         }
@@ -155,7 +155,7 @@ extension DefaultFido2UserVerificationMediator: Fido2UserVerificationMediator {
     }
 
     func isPreferredVerificationEnabled() async -> Bool {
-        if let hasBeenUnlocked = try? await stateService.getAccountHasBeenUnlockedInCurrentSession(),
+        if let hasBeenUnlocked = try? await stateService.getAccountHasBeenUnlockedInteractively(),
            hasBeenUnlocked {
             return true
         }

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
@@ -46,6 +46,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
         authRepository = nil
         errorReporter = nil
         fido2UserVerificationMediatorDelegate = nil
+        stateService = nil
         userVerificationHelper = nil
         userVerificationRunner = nil
         subject = nil
@@ -184,7 +185,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
 
     /// `isPreferredVerificationEnabled)`  succeeds because user has been unlocked in the current transaction.
     func test_isPreferredVerificationEnabled_successUnlockedCurrentSession() async throws {
-        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(true)
+        stateService.getAccountHasBeenUnlockedInteractivelyResult = .success(true)
         let result = await subject.isPreferredVerificationEnabled()
         XCTAssertTrue(result)
     }
@@ -192,7 +193,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
     /// `isPreferredVerificationEnabled)`  succeeds because user not has been unlocked in the current transaction
     /// but can verify device local authentication
     func test_isPreferredVerificationEnabled_successCanVerifyDeviceLocalAuth() async throws {
-        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(false)
+        stateService.getAccountHasBeenUnlockedInteractivelyResult = .success(false)
         userVerificationHelper.canVerifyDeviceLocalAuthResult = true
         let result = await subject.isPreferredVerificationEnabled()
         XCTAssertTrue(result)
@@ -201,7 +202,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
     /// `isPreferredVerificationEnabled)`  succeeds because throws error when checking if user has been unlocked
     /// in the current transaction but can verify device local authentication
     func test_isPreferredVerificationEnabled_successCanVerifyDeviceErrorUnlockedCurrentSession() async throws {
-        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .failure(BitwardenTestError.example)
+        stateService.getAccountHasBeenUnlockedInteractivelyResult = .failure(BitwardenTestError.example)
         userVerificationHelper.canVerifyDeviceLocalAuthResult = true
         let result = await subject.isPreferredVerificationEnabled()
         XCTAssertTrue(result)
@@ -211,7 +212,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
     /// nor can verify device local authentication.
     func test_isPreferredVerificationEnabled_unlockedCurrentTransaction() async throws {
         userVerificationHelper.canVerifyDeviceLocalAuthResult = false
-        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(false)
+        stateService.getAccountHasBeenUnlockedInteractivelyResult = .success(false)
 
         let result = await subject.isPreferredVerificationEnabled()
         XCTAssertFalse(result)
@@ -272,7 +273,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
     private func checkUser_verified_when_unlockedCurrentTransation(
         _ userVerificationPreference: BitwardenSdk.Verification
     ) async throws {
-        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(true)
+        stateService.getAccountHasBeenUnlockedInteractivelyResult = .success(true)
         let cipher = CipherView.fixture()
         let result = try await subject.checkUser(
             userVerificationPreference: userVerificationPreference,

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
@@ -15,6 +15,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
     var authRepository: MockAuthRepository!
     var errorReporter: MockErrorReporter!
     var fido2UserVerificationMediatorDelegate: MockFido2UserVerificationMediatorDelegate!
+    var stateService: MockStateService!
     var subject: Fido2UserVerificationMediator!
     var userVerificationHelper: MockUserVerificationHelper!
     var userVerificationRunner: MockUserVerificationRunner!
@@ -27,10 +28,12 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
         fido2UserVerificationMediatorDelegate = MockFido2UserVerificationMediatorDelegate()
         authRepository = MockAuthRepository()
         errorReporter = MockErrorReporter()
+        stateService = MockStateService()
         userVerificationHelper = MockUserVerificationHelper()
         userVerificationRunner = MockUserVerificationRunner()
         subject = DefaultFido2UserVerificationMediator(
             authRepository: authRepository,
+            stateService: stateService,
             userVerificationHelper: userVerificationHelper,
             userVerificationRunner: userVerificationRunner
         )
@@ -72,6 +75,14 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
         try await checkUser_throws_when_reprompt_and_reprompt_throws(.discouraged)
         try await checkUser_throws_when_reprompt_and_reprompt_throws(.preferred)
         try await checkUser_throws_when_reprompt_and_reprompt_throws(.required)
+    }
+
+    /// `checkUser(userVerificationPreference:credential:)`  with each preference,
+    /// account has been unlocked in current transaction.
+    func test_checkUser_anyPreferenceUnlockedCurrentTransaction() async throws {
+        try await checkUser_verified_when_unlockedCurrentTransation(.discouraged)
+        try await checkUser_verified_when_unlockedCurrentTransation(.preferred)
+        try await checkUser_verified_when_unlockedCurrentTransation(.required)
     }
 
     /// `checkUser(userVerificationPreference:credential:)`  with preference discouraged,
@@ -171,13 +182,39 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
         )
     }
 
-    /// `isPreferredVerificationEnabled)`  verification
-    func test_isPreferredVerificationEnabled() async throws {
-        userVerificationHelper.canVerifyDeviceLocalAuthResult = true
-        XCTAssertTrue(subject.isPreferredVerificationEnabled())
+    /// `isPreferredVerificationEnabled)`  succeeds because user has been unlocked in the current transaction.
+    func test_isPreferredVerificationEnabled_successUnlockedCurrentSession() async throws {
+        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(true)
+        let result = await subject.isPreferredVerificationEnabled()
+        XCTAssertTrue(result)
+    }
 
+    /// `isPreferredVerificationEnabled)`  succeeds because user not has been unlocked in the current transaction
+    /// but can verify device local authentication
+    func test_isPreferredVerificationEnabled_successCanVerifyDeviceLocalAuth() async throws {
+        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(false)
+        userVerificationHelper.canVerifyDeviceLocalAuthResult = true
+        let result = await subject.isPreferredVerificationEnabled()
+        XCTAssertTrue(result)
+    }
+
+    /// `isPreferredVerificationEnabled)`  succeeds because throws error when checking if user has been unlocked
+    /// in the current transaction but can verify device local authentication
+    func test_isPreferredVerificationEnabled_successCanVerifyDeviceErrorUnlockedCurrentSession() async throws {
+        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .failure(BitwardenTestError.example)
+        userVerificationHelper.canVerifyDeviceLocalAuthResult = true
+        let result = await subject.isPreferredVerificationEnabled()
+        XCTAssertTrue(result)
+    }
+
+    /// `isPreferredVerificationEnabled)`  isn't enabled because user has not been unlocked in the current transaction
+    /// nor can verify device local authentication.
+    func test_isPreferredVerificationEnabled_unlockedCurrentTransaction() async throws {
         userVerificationHelper.canVerifyDeviceLocalAuthResult = false
-        XCTAssertFalse(subject.isPreferredVerificationEnabled())
+        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(false)
+
+        let result = await subject.isPreferredVerificationEnabled()
+        XCTAssertFalse(result)
     }
 
     // MARK: Private
@@ -230,6 +267,23 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase {
                 credential: cipher
             )
         }
+    }
+
+    private func checkUser_verified_when_unlockedCurrentTransation(
+        _ userVerificationPreference: BitwardenSdk.Verification
+    ) async throws {
+        stateService.getAccountHasBeenUnlockedInCurrentSessionResult = .success(true)
+        let cipher = CipherView.fixture()
+        let result = try await subject.checkUser(
+            userVerificationPreference: userVerificationPreference,
+            credential: cipher
+        )
+
+        XCTAssertEqual(
+            result,
+            CheckUserResult(userPresent: true, userVerified: true),
+            "Failed for preference \(userVerificationPreference)"
+        )
     }
 
     private func setup_checkUser_onVerifyFunctions() {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-8361](https://bitwarden.atlassian.net/browse/PM-8361)

## 📔 Objective

Added logic to know whether the vault has been unlocked in the current session and applied it to the Fido2 user verification flow.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8361]: https://bitwarden.atlassian.net/browse/PM-8361?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ