### PR TITLE
PM-8362: Add pin setup for passkey user verification

### DIFF
--- a/BitwardenShared/Core/Autofill/Utilities/Fido2Error.swift
+++ b/BitwardenShared/Core/Autofill/Utilities/Fido2Error.swift
@@ -1,7 +1,10 @@
 import Foundation
 
-/// Errrors related to Fido2 flows.
+/// Errors related to Fido2 flows.
 public enum Fido2Error: Error {
+    /// The user failed to set up a Bitwarden pin.
+    case failedToSetupPin
+
     /// Thrown when the operation to be performed is invalid under the
     /// current circumstances.
     case invalidOperationError

--- a/BitwardenShared/UI/Auth/Utilities/TestHelpers/MockUserVerificationHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/TestHelpers/MockUserVerificationHelper.swift
@@ -7,6 +7,7 @@ class MockUserVerificationHelper: UserVerificationHelper {
     var userVerificationDelegate: (any BitwardenShared.UserVerificationDelegate)?
 
     var canVerifyDeviceLocalAuthResult: Bool = false
+    var setupPinCalled = false
     var verifyDeviceLocalAuthBecauseValue: String?
     var verifyDeviceLocalAuthCalled: Bool = false
     var verifyDeviceLocalAuthResult: Result<BitwardenShared.UserVerificationResult, Error> = .success(.verified)
@@ -17,6 +18,10 @@ class MockUserVerificationHelper: UserVerificationHelper {
 
     func canVerifyDeviceLocalAuth() -> Bool {
         canVerifyDeviceLocalAuthResult
+    }
+
+    func setupPin() async throws {
+        setupPinCalled = true
     }
 
     func verifyDeviceLocalAuth(reason: String) async throws -> UserVerificationResult {

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediator.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediator.swift
@@ -9,9 +9,6 @@ import BitwardenSdk
 protocol Fido2UserVerificationMediatorDelegate: UserVerificationDelegate {
     /// Performs additional logic when user interaction is needed and throws if needed.
     func onNeedsUserInteraction() async throws
-
-    /// Set up the Bitwarden Pin for the current account
-    func setupPin() async throws
 }
 
 // MARK: - Fido2UserVerificationMediator
@@ -146,11 +143,7 @@ extension DefaultFido2UserVerificationMediator: Fido2UserVerificationMediator {
                 return CheckUserResult(userPresent: true, userVerified: result == .verified)
             }
 
-            guard let fido2UserVerificationMediatorDelegate else {
-                return CheckUserResult(userPresent: true, userVerified: false)
-            }
-
-            try await fido2UserVerificationMediatorDelegate.setupPin()
+            try await userVerificationHelper.setupPin()
 
             return CheckUserResult(userPresent: true, userVerified: true)
         }

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
@@ -192,7 +192,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase { // swiftlint:disab
         XCTAssertTrue(userVerificationRunner.verifyInQueueCalled)
         XCTAssertTrue(userVerificationRunner.verifyWithAttemptsTimesCalled == 2)
         XCTAssertEqual(result, CheckUserResult(userPresent: true, userVerified: true))
-        XCTAssertTrue(fido2UserVerificationMediatorDelegate.setupPinCalled)
+        XCTAssertTrue(userVerificationHelper.setupPinCalled)
         XCTAssertEqual(
             userVerificationHelper.verifyDeviceLocalAuthBecauseValue,
             Localizations.userVerificationForPasskey
@@ -418,16 +418,11 @@ class MockFido2UserVerificationMediatorDelegate: // swiftlint:disable:this type_
     Fido2UserVerificationMediatorDelegate {
     var onNeedsUserInteractionCalled = false
     var onNeedsUserInteractionError: Error?
-    var setupPinCalled = false
 
     func onNeedsUserInteraction() async throws {
         onNeedsUserInteractionCalled = true
         if let onNeedsUserInteractionError {
             throw onNeedsUserInteractionError
         }
-    }
-
-    func setupPin() async throws {
-        setupPinCalled = true
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Platform/Application/AppProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor+Fido2Tests.swift
@@ -164,13 +164,6 @@ class AppProcessorFido2Tests: BitwardenTestCase {
         }
     }
 
-    /// `setupPin()` navigates to the setup pin view.
-    func test_setupPin() async throws {
-        // TODO: PM-8362 navigate to pin setup
-        try await subject.setupPin()
-        throw XCTSkip("TODO: PM-8362 navigate to pin setup")
-    }
-
     /// `showAlert(_:onDismissed:)` shows the alert with the coordinator.
     func test_showAlert_withOnDismissed() async throws {
         subject.showAlert(Alert(title: "Test", message: "testing"), onDismissed: nil)

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -421,10 +421,6 @@ extension AppProcessor: Fido2UserVerificationMediatorDelegate {
         }
     }
 
-    func setupPin() async throws {
-        // TODO: PM-8362 navigate to pin setup
-    }
-
     func showAlert(_ alert: Alert) {
         coordinator?.showAlert(alert)
     }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -273,10 +273,6 @@ extension VaultAutofillListProcessor: Fido2UserVerificationMediatorDelegate {
         // No-Op for this processor.
     }
 
-    func setupPin() async throws {
-        // TODO: PM-8362 navigate to pin setup
-    }
-
     func showAlert(_ alert: Alert, onDismissed: (() -> Void)?) {
         coordinator.showAlert(alert, onDismissed: onDismissed)
     }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
@@ -323,13 +323,6 @@ class VaultAutofillListProcessorTests: BitwardenTestCase {
         XCTAssertNil(subject.state.toast)
     }
 
-    /// `setupPin()` navigates to the setup pin view.
-    func test_setupPin() async throws {
-        // TODO: PM-8362 navigate to pin setup
-        try await subject.setupPin()
-        throw XCTSkip("TODO: PM-8362 navigate to pin setup")
-    }
-
     /// `showAlert(_:onDismissed:)` shows the alert with the coordinator.
     func test_showAlert_withOnDismissed() async throws {
         subject.showAlert(Alert(title: "Test", message: "testing"), onDismissed: nil)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-8362](https://bitwarden.atlassian.net/browse/PM-8362)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Implements the set up pin flow for passkey user verification.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Pin set up:

https://github.com/user-attachments/assets/ca19200d-4281-42bb-a9d1-ada74560b861

Pin verification:

https://github.com/user-attachments/assets/ecc1cf73-962e-4a90-b665-99886cb74464





## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8362]: https://bitwarden.atlassian.net/browse/PM-8362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ