### PR TITLE
PM-9836: Update password protected vault export confirmation alert

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -479,8 +479,6 @@
 "CodeSent" = "Code sent!";
 "ConfirmYourIdentity" = "Confirm your identity to continue.";
 "ExportVaultWarning" = "This export contains your vault data in an unencrypted format. You should not store or send the exported file over unsecure channels (such as email). Delete it immediately after you are done using it.";
-"EncExportKeyWarning" = "This export encrypts your data using your account's encryption key. If you ever rotate your account's encryption key you should export again since you will not be able to decrypt this export file.";
-"EncExportAccountWarning" = "Account encryption keys are unique to each Bitwarden user account, so you can't import an encrypted export into a different account.";
 "ExportVaultConfirmationTitle" = "Confirm vault export";
 "Warning" = "Warning";
 "ExportVaultFailure" = "There was a problem exporting your vault.  If the problem persists, you'll need to export from the web vault.";
@@ -920,3 +918,4 @@
 "UnknownAccount" = "Unknown account";
 "UserVerificationForPasskey" = "User verification for passkey";
 "NewItem" = "New item";
+"ExportVaultFilePwProtectInfo" = "This file export will be password protected and require the file password to decrypt.";

--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -66,9 +66,7 @@ extension Alert {
     static func confirmExportVault(encrypted: Bool, action: @escaping () async -> Void) -> Alert {
         Alert(
             title: Localizations.exportVaultConfirmationTitle,
-            message: encrypted ?
-                (Localizations.encExportKeyWarning + .newLine + Localizations.encExportAccountWarning) :
-                Localizations.exportVaultWarning,
+            message: encrypted ? Localizations.exportVaultFilePwProtectInfo : Localizations.exportVaultWarning,
             alertActions: [
                 AlertAction(title: Localizations.exportVault, style: .default) { _ in await action() },
                 AlertAction(title: Localizations.cancel, style: .cancel),

--- a/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -54,7 +54,7 @@ class AlertSettingsTests: BitwardenTestCase {
         XCTAssertEqual(subject.title, Localizations.exportVaultConfirmationTitle)
         XCTAssertEqual(
             subject.message,
-            Localizations.encExportKeyWarning + .newLine + Localizations.encExportAccountWarning
+            Localizations.exportVaultFilePwProtectInfo
         )
 
         subject = Alert.confirmExportVault(encrypted: false) {}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9836](https://bitwarden.atlassian.net/browse/PM-9836)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the confirmation alert when exporting the vault using the JSON password protected format.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="559" alt="Screenshot 2024-07-22 at 3 03 07 PM" src="https://github.com/user-attachments/assets/dbe786d8-de21-4aaf-a1d4-dac2f19bc5d5">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9836]: https://bitwarden.atlassian.net/browse/PM-9836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ