### PR TITLE
PM-9660: Improve autofill extension flow with never lock

### DIFF
--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -217,8 +217,10 @@ class DefaultAutofillCredentialService {
     /// - Parameter delegate: The delegate used for autofill credential operations.
     ///
     private func tryUnlockVaultWithoutUserInteraction(delegate: AutofillCredentialServiceDelegate) async throws {
-        let vaultTimeout = try await vaultTimeoutService.sessionTimeoutValue(userId: stateService.getActiveAccountId())
-        guard vaultTimeout == .never else { return }
+        let userId = try await stateService.getActiveAccountId()
+        let isLocked = vaultTimeoutService.isLocked(userId: userId)
+        let vaultTimeout = try? await vaultTimeoutService.sessionTimeoutValue(userId: nil)
+        guard vaultTimeout == .never, isLocked else { return }
         try await delegate.unlockVaultWithNeverlockKey()
     }
 }

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -82,7 +82,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.activeAccount = .fixture()
         vaultTimeoutService.isClientLocked["1"] = false
 
-        let credential = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+        let credential = try await subject.provideCredential(
+            for: "1",
+            autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+            repromptPasswordValidated: false
+        )
 
         XCTAssertEqual(credential.password, "password123")
         XCTAssertEqual(credential.user, "user@bitwarden.com")
@@ -97,17 +101,29 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
 
         cipherService.fetchCipherResult = .success(.fixture(type: .identity))
         await assertAsyncThrows(error: ASExtensionError(.credentialIdentityNotFound)) {
-            _ = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
         }
 
         cipherService.fetchCipherResult = .success(.fixture(login: .fixture(password: nil, username: "user@bitwarden")))
         await assertAsyncThrows(error: ASExtensionError(.credentialIdentityNotFound)) {
-            _ = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
         }
 
         cipherService.fetchCipherResult = .success(.fixture(login: .fixture(password: "test", username: nil)))
         await assertAsyncThrows(error: ASExtensionError(.credentialIdentityNotFound)) {
-            _ = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
         }
     }
 
@@ -117,8 +133,33 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         vaultTimeoutService.isClientLocked["1"] = false
 
         await assertAsyncThrows(error: ASExtensionError(.credentialIdentityNotFound)) {
-            _ = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
         }
+    }
+
+    /// `provideCredential(for:)` unlocks the user's vault if they use never lock.
+    func test_provideCredential_neverLock() async throws {
+        cipherService.fetchCipherResult = .success(
+            .fixture(login: .fixture(password: "password123", username: "user@bitwarden.com"))
+        )
+        stateService.activeAccount = .fixture()
+        vaultTimeoutService.isClientLocked["1"] = false
+        vaultTimeoutService.vaultTimeout["1"] = .never
+
+        let credential = try await subject.provideCredential(
+            for: "1",
+            autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+            repromptPasswordValidated: false
+        )
+
+        XCTAssertTrue(autofillCredentialServiceDelegate.unlockVaultWithNeverlockKeyCalled)
+        XCTAssertEqual(credential.password, "password123")
+        XCTAssertEqual(credential.user, "user@bitwarden.com")
+        XCTAssertNil(pasteboardService.copiedString)
     }
 
     /// `provideCredential(for:)` throws an error if reprompt is required.
@@ -136,7 +177,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
             )
         )
         await assertAsyncThrows(error: ASExtensionError(.userInteractionRequired)) {
-            _ = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
         }
     }
 
@@ -152,7 +197,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.activeAccount = .fixture()
         vaultTimeoutService.isClientLocked["1"] = false
 
-        let credential = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+        let credential = try await subject.provideCredential(
+            for: "1",
+            autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+            repromptPasswordValidated: false
+        )
 
         XCTAssertEqual(credential.password, "password123")
         XCTAssertEqual(credential.user, "user@bitwarden.com")
@@ -173,7 +222,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.disableAutoTotpCopyByUserId["1"] = true
         vaultTimeoutService.isClientLocked["1"] = false
 
-        let credential = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+        let credential = try await subject.provideCredential(
+            for: "1",
+            autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+            repromptPasswordValidated: false
+        )
 
         XCTAssertEqual(credential.password, "password123")
         XCTAssertEqual(credential.user, "user@bitwarden.com")
@@ -193,7 +246,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.doesActiveAccountHavePremiumResult = .success(false)
         vaultTimeoutService.isClientLocked["1"] = false
 
-        let credential = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+        let credential = try await subject.provideCredential(
+            for: "1",
+            autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+            repromptPasswordValidated: false
+        )
 
         XCTAssertEqual(credential.password, "password123")
         XCTAssertEqual(credential.user, "user@bitwarden.com")
@@ -217,7 +274,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.doesActiveAccountHavePremiumResult = .success(false)
         vaultTimeoutService.isClientLocked["1"] = false
 
-        let credential = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+        let credential = try await subject.provideCredential(
+            for: "1",
+            autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+            repromptPasswordValidated: false
+        )
 
         XCTAssertEqual(credential.password, "password123")
         XCTAssertEqual(credential.user, "user@bitwarden.com")
@@ -230,7 +291,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         vaultTimeoutService.isClientLocked["1"] = true
 
         await assertAsyncThrows(error: ASExtensionError(.userInteractionRequired)) {
-            _ = try await subject.provideCredential(for: "1", repromptPasswordValidated: false)
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
         }
     }
 
@@ -280,7 +345,7 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
     @available(iOS 17.0, *)
     func test_provideFido2Credential_succeedsWithUnlockingNeverKey() async throws {
         stateService.activeAccount = .fixture()
-        vaultTimeoutService.isClientLocked["1"] = true
+        vaultTimeoutService.isClientLocked["1"] = false
         vaultTimeoutService.vaultTimeout["1"] = .never
 
         let passkeyIdentity = ASPasskeyCredentialIdentity.fixture()

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -143,11 +143,14 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
 
     /// `provideCredential(for:)` unlocks the user's vault if they use never lock.
     func test_provideCredential_neverLock() async throws {
+        autofillCredentialServiceDelegate.unlockVaultWithNaverlockHandler = { [weak self] in
+            self?.vaultTimeoutService.isClientLocked["1"] = false
+        }
         cipherService.fetchCipherResult = .success(
             .fixture(login: .fixture(password: "password123", username: "user@bitwarden.com"))
         )
         stateService.activeAccount = .fixture()
-        vaultTimeoutService.isClientLocked["1"] = false
+        vaultTimeoutService.isClientLocked["1"] = true
         vaultTimeoutService.vaultTimeout["1"] = .never
 
         let credential = try await subject.provideCredential(
@@ -344,8 +347,11 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
     /// succeeds when unlocking with never key.
     @available(iOS 17.0, *)
     func test_provideFido2Credential_succeedsWithUnlockingNeverKey() async throws {
+        autofillCredentialServiceDelegate.unlockVaultWithNaverlockHandler = { [weak self] in
+            self?.vaultTimeoutService.isClientLocked["1"] = false
+        }
         stateService.activeAccount = .fixture()
-        vaultTimeoutService.isClientLocked["1"] = false
+        vaultTimeoutService.isClientLocked["1"] = true
         vaultTimeoutService.vaultTimeout["1"] = .never
 
         let passkeyIdentity = ASPasskeyCredentialIdentity.fixture()

--- a/BitwardenShared/Core/Autofill/Services/TestHelpers/MockAutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/TestHelpers/MockAutofillCredentialService.swift
@@ -10,7 +10,11 @@ class MockAutofillCredentialService: AutofillCredentialService {
     var provideCredentialError: Error?
     var provideFido2CredentialResult: Result<PasskeyAssertionCredential, Error> = .failure(BitwardenTestError.example)
 
-    func provideCredential(for id: String, repromptPasswordValidated: Bool) async throws -> ASPasswordCredential {
+    func provideCredential(
+        for id: String,
+        autofillCredentialServiceDelegate: AutofillCredentialServiceDelegate,
+        repromptPasswordValidated: Bool
+    ) async throws -> ASPasswordCredential {
         guard let provideCredentialPasswordCredential else {
             throw provideCredentialError ?? ASExtensionError(.failed)
         }

--- a/BitwardenShared/Core/Autofill/Services/TestHelpers/MockAutofillCredentialServiceDelegate.swift
+++ b/BitwardenShared/Core/Autofill/Services/TestHelpers/MockAutofillCredentialServiceDelegate.swift
@@ -3,9 +3,11 @@
 class MockAutofillCredentialServiceDelegate: AutofillCredentialServiceDelegate {
     var unlockVaultWithNeverlockKeyCalled = false
     var unlockVaultWithNeverlockKeyError: Error?
+    var unlockVaultWithNaverlockHandler: (() -> Void)?
 
     func unlockVaultWithNeverlockKey() async throws {
         unlockVaultWithNeverlockKeyCalled = true
+        unlockVaultWithNaverlockHandler?()
         if let unlockVaultWithNeverlockKeyError {
             throw unlockVaultWithNeverlockKeyError
         }

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -155,6 +155,7 @@ public class AppProcessor {
     ) async throws -> ASPasswordCredential {
         try await services.autofillCredentialService.provideCredential(
             for: id,
+            autofillCredentialServiceDelegate: self,
             repromptPasswordValidated: repromptPasswordValidated
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9660](https://bitwarden.atlassian.net/browse/PM-9660)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If an account has never lock enabled, this unlocks the vault without user interaction prior to autofilling. This fixes a UI issue where a navigation controller would pop up briefly before the vault was unlocked.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ef50a363-ff29-4a10-8e39-3fa370b32ba4" /> | <video src="https://github.com/user-attachments/assets/62f8b038-05a6-4c32-b998-4061f0814e54" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9660]: https://bitwarden.atlassian.net/browse/PM-9660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ