### PR TITLE
PM-9001 - Item with MP Reprompt does not prompt for MP when downloading attachment

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -46,6 +46,7 @@ enum ViewItemAction: Equatable {
         switch self {
         case .cardItemAction,
              .customFieldVisibilityPressed,
+             .downloadAttachment,
              .editPressed,
              .morePressed,
              .passwordVisibilityPressed:
@@ -53,7 +54,6 @@ enum ViewItemAction: Equatable {
         case let .copyPressed(_, field):
             field.requiresMasterPasswordReprompt
         case .dismissPressed,
-             .downloadAttachment,
              .passwordHistoryPressed,
              .toastShown:
             false

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
@@ -38,7 +38,7 @@ class ViewItemActionTests: BitwardenTestCase {
 
         XCTAssertFalse(ViewItemAction.dismissPressed.requiresMasterPasswordReprompt)
 
-        XCTAssertFalse(ViewItemAction.downloadAttachment(.fixture()).requiresMasterPasswordReprompt)
+        XCTAssertTrue(ViewItemAction.downloadAttachment(.fixture()).requiresMasterPasswordReprompt)
 
         XCTAssertTrue(ViewItemAction.editPressed.requiresMasterPasswordReprompt)
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9001](https://bitwarden.atlassian.net/browse/PM-9001)

## 📔 Objective
- Prompt user for a master password when downloading an attachment. Right now we freely allow downloading an attachment without asking for the password. 

## 📸 Screenshots

https://github.com/user-attachments/assets/dd990020-d5f1-4f7a-aceb-46b736720e10

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9001]: https://bitwarden.atlassian.net/browse/PM-9001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ