### PR TITLE
[PM-6498] Fix favicons to be shown on autofill extension.

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -193,7 +193,9 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
             appExtensionDelegate: appExtensionDelegate,
             coordinator: asAnyCoordinator(),
             services: services,
-            state: VaultAutofillListState()
+            state: VaultAutofillListState(
+                iconBaseURL: services.environmentService.iconsURL
+            )
         )
         let view = VaultAutofillListView(store: Store(processor: processor))
         stackNavigator?.replace(view)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-6498](https://bitwarden.atlassian.net/browse/PM-6498)

## 📔 Objective

Fix favicons to be shown on autofill extension

## 📸 Screenshots

### Password Autofill with favicon
<img width="314" alt="Password Autofill with favicon" src="https://github.com/user-attachments/assets/de63e5c7-fab9-47e2-9125-4bc85d359671">

### Passkey Autofill with favicon
<img width="314" alt="Passkey Autofill with favicon" src="https://github.com/user-attachments/assets/73a27ce9-dcc7-44cd-bf51-852bcd391c53">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-6498]: https://bitwarden.atlassian.net/browse/PM-6498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ