### PR TITLE
PM-9155: Hide the vault filter when personal ownership and single organization policies apply

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -523,6 +523,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             errorReporter: errorReporter,
             folderService: folderService,
             organizationService: organizationService,
+            policyService: policyService,
             settingsService: settingsService,
             stateService: stateService,
             syncService: syncService,

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -10,6 +10,8 @@ class MockVaultRepository: VaultRepository {
     var addCipherCiphers = [CipherView]()
     var addCipherResult: Result<Void, Error> = .success(())
 
+    var canShowVaultFilter = true
+
     var ciphersAutofillPublisherUriCalled: String?
     var ciphersSubject = CurrentValueSubject<[CipherListView], Error>([])
     var ciphersAutofillSubject = CurrentValueSubject<[BitwardenShared.VaultListSection], Error>([])
@@ -111,6 +113,10 @@ class MockVaultRepository: VaultRepository {
     func addCipher(_ cipher: BitwardenSdk.CipherView) async throws {
         addCipherCiphers.append(cipher)
         try addCipherResult.get()
+    }
+
+    func canShowVaultFilter() async -> Bool {
+        canShowVaultFilter
     }
 
     func cipherPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[CipherListView], Error>> {

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -164,7 +164,8 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
             do {
                 for try await organizations in try await vaultRepository.organizationsPublisher() {
                     guard let navigator = tabNavigator?.navigator(for: TabRoute.vault(.list)) else { return }
-                    if organizations.isEmpty {
+                    let canShowVaultFilter = await vaultRepository.canShowVaultFilter()
+                    if organizations.isEmpty || !canShowVaultFilter {
                         navigator.rootViewController?.title = Localizations.myVault
                     } else {
                         navigator.rootViewController?.title = Localizations.vaults

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -167,6 +167,24 @@ class TabCoordinatorTests: BitwardenTestCase {
         XCTAssertEqual(viewController.title, Localizations.vaults)
     }
 
+    /// `start()` subscribes to the organization publisher and updates the vault navigation bar
+    /// title if the vault filter can't be shown.
+    func test_start_organizationsCanShowVaultFilterDisabled() {
+        let mockRoot = MockRootNavigator()
+        let viewController = UIViewController()
+        mockRoot.rootViewController = viewController
+        tabNavigator.navigatorForTabReturns = mockRoot
+        vaultRepository.canShowVaultFilter = false
+        vaultRepository.organizationsSubject = .init([
+            .fixture(),
+        ])
+
+        subject.start()
+
+        waitFor(viewController.title != nil)
+        XCTAssertEqual(viewController.title, Localizations.myVault)
+    }
+
     /// `start()` presents the tab navigator within the root navigator and starts the child-coordinators.
     func test_start_organizationsError() throws {
         let mockRoot = MockRootNavigator()

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -158,6 +158,7 @@ final class VaultGroupProcessor: StateProcessor<
     private func checkPersonalOwnershipPolicy() async {
         let isPersonalOwnershipDisabled = await services.policyService.policyAppliesToUser(.personalOwnership)
         state.isPersonalOwnershipDisabled = isPersonalOwnershipDisabled
+        state.canShowVaultFilter = await services.vaultRepository.canShowVaultFilter()
     }
 
     /// Refreshes the vault group's TOTP Codes.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -143,6 +143,43 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertTrue(subject.state.isPersonalOwnershipDisabled)
     }
 
+    /// `perform(_:)` with `appeared` determines whether the vault filter can be shown based on
+    /// policy settings.
+    func test_perform_appeared_policyCanShowVaultFilterDisabled() {
+        vaultRepository.canShowVaultFilter = false
+        subject.state.organizations = [.fixture()]
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+        waitFor(subject.state.loadingState == .data([]))
+        task.cancel()
+
+        XCTAssertFalse(subject.state.canShowVaultFilter)
+        XCTAssertFalse(subject.state.vaultFilterState.canShowVaultFilter)
+        XCTAssertEqual(subject.state.vaultFilterState.vaultFilterOptions, [])
+    }
+
+    /// `perform(_:)` with `appeared` determines whether the vault filter can be shown based on
+    /// policy settings.
+    func test_perform_appeared_policyCanShowVaultFilterEnabled() {
+        vaultRepository.canShowVaultFilter = true
+        subject.state.organizations = [.fixture()]
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+        waitFor(subject.state.loadingState == .data([]))
+        task.cancel()
+
+        XCTAssertTrue(subject.state.canShowVaultFilter)
+        XCTAssertTrue(subject.state.vaultFilterState.canShowVaultFilter)
+        XCTAssertEqual(
+            subject.state.vaultFilterState.vaultFilterOptions,
+            [.allVaults, .myVault, .organization(.fixture())]
+        )
+    }
+
     /// `perform(_:)` with `.morePressed` has the vault item more options helper display the alert.
     func test_perform_morePressed() async throws {
         await subject.perform(.morePressed(.fixture()))

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -6,6 +6,9 @@ import Foundation
 struct VaultGroupState: Equatable {
     // MARK: Properties
 
+    /// Whether the vault filter can be shown.
+    var canShowVaultFilter = true
+
     /// Whether there is data for the vault group.
     var emptyData: Bool {
         loadingState.data.isEmptyOrNil
@@ -82,6 +85,16 @@ struct VaultGroupState: Equatable {
 
     /// The url to open in the device's web browser.
     var url: URL?
+
+    /// The state for showing the vault filter.
+    var vaultFilterState: SearchVaultFilterRowState {
+        SearchVaultFilterRowState(
+            canShowVaultFilter: canShowVaultFilter,
+            isPersonalOwnershipDisabled: isPersonalOwnershipDisabled,
+            organizations: organizations,
+            searchVaultFilterType: searchVaultFilterType
+        )
+    }
 
     /// The vault filter used to display a single or all vaults for the user.
     let vaultFilterType: VaultFilterType

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -156,13 +156,7 @@ struct VaultGroupView: View {
     private var searchVaultFilterRow: some View {
         SearchVaultFilterRowView(
             hasDivider: true, store: store.child(
-                state: { state in
-                    SearchVaultFilterRowState(
-                        organizations: state.organizations,
-                        searchVaultFilterType: state.searchVaultFilterType,
-                        isPersonalOwnershipDisabled: state.isPersonalOwnershipDisabled
-                    )
-                },
+                state: \.vaultFilterState,
                 mapAction: { action in
                     switch action {
                     case let .searchVaultFilterChanged(type):

--- a/BitwardenShared/UI/Vault/Vault/VaultList/SearchVaultFilterRowView/SearchVaultFilterRowState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/SearchVaultFilterRowView/SearchVaultFilterRowState.swift
@@ -5,19 +5,22 @@
 struct SearchVaultFilterRowState: Equatable {
     // MARK: Properties
 
+    /// Whether the vault filter can be shown.
+    var canShowVaultFilter = true
+
+    /// Whether the policy is enforced to disable personal vault ownership.
+    var isPersonalOwnershipDisabled: Bool = false
+
     /// The list of organizations the user is a member of.
     var organizations: [Organization] = []
 
     /// The search vault filter used to display a single or all vaults for the user.
     var searchVaultFilterType: VaultFilterType = .allVaults
 
-    /// Whether the policy is enforced to disable personal vault ownership.
-    var isPersonalOwnershipDisabled: Bool = false
-
     /// The list of vault filter options that can be used to filter the vault, if the user is a
     /// member of any organizations.
     var vaultFilterOptions: [VaultFilterType] {
-        guard !organizations.isEmpty else { return [] }
+        guard !organizations.isEmpty, canShowVaultFilter else { return [] }
 
         let sortedOrganizations = organizations
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/SearchVaultFilterRowView/SearchVaultFilterRowStateTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/SearchVaultFilterRowView/SearchVaultFilterRowStateTests.swift
@@ -45,4 +45,34 @@ class SearchVaultFilterRowStateTests: BitwardenTestCase {
             ]
         )
     }
+
+    /// `vaultFilterOptions` returns no filter options if organizations exist but the filter should be hidden.
+    func test_vaultFilterOptions_organizationsShouldNotShowVaultFilter() {
+        subject.organizations = [
+            Organization.fixture(id: "1", name: "Org 1"),
+            Organization.fixture(id: "2", name: "Test Org"),
+            Organization.fixture(id: "3", name: "ABC Org"),
+        ]
+        subject.canShowVaultFilter = false
+        XCTAssertEqual(subject.vaultFilterOptions, [])
+    }
+
+    /// `vaultFilterOptions` returns the filter organization filter options if personal ownership is disabled.
+    func test_vaultFilterOptions_personalOwnershipDisabled() {
+        subject.organizations = [
+            Organization.fixture(id: "1", name: "Org 1"),
+            Organization.fixture(id: "2", name: "Test Org"),
+            Organization.fixture(id: "3", name: "ABC Org"),
+        ]
+        subject.isPersonalOwnershipDisabled = true
+        XCTAssertEqual(
+            subject.vaultFilterOptions,
+            [
+                .allVaults,
+                .organization(Organization.fixture(id: "3", name: "ABC Org")),
+                .organization(Organization.fixture(id: "1", name: "Org 1")),
+                .organization(Organization.fixture(id: "2", name: "Test Org")),
+            ]
+        )
+    }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -179,6 +179,7 @@ extension VaultListProcessor {
     private func checkPersonalOwnershipPolicy() async {
         let isPersonalOwnershipDisabled = await services.policyService.policyAppliesToUser(.personalOwnership)
         state.isPersonalOwnershipDisabled = isPersonalOwnershipDisabled
+        state.canShowVaultFilter = await services.vaultRepository.canShowVaultFilter()
     }
 
     /// Checks if we need to display the unassigned ciphers alert, and displays if necessary.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
@@ -7,6 +7,9 @@ import Foundation
 struct VaultListState: Equatable {
     // MARK: Properties
 
+    /// Whether the vault filter can be shown.
+    var canShowVaultFilter = true
+
     /// The base url used to fetch icons.
     var iconBaseURL: URL?
 
@@ -50,11 +53,21 @@ struct VaultListState: Equatable {
 
     /// The navigation title for the view.
     var navigationTitle: String {
-        if organizations.isEmpty {
+        if organizations.isEmpty || !canShowVaultFilter {
             Localizations.myVault
         } else {
             Localizations.vaults
         }
+    }
+
+    /// The state for showing the vault filter.
+    var vaultFilterState: SearchVaultFilterRowState {
+        SearchVaultFilterRowState(
+            canShowVaultFilter: canShowVaultFilter,
+            isPersonalOwnershipDisabled: isPersonalOwnershipDisabled,
+            organizations: organizations,
+            searchVaultFilterType: searchVaultFilterType
+        )
     }
 
     /// The user's initials.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -128,13 +128,7 @@ private struct SearchableVaultListView: View {
     private var searchVaultFilterRow: some View {
         SearchVaultFilterRowView(
             hasDivider: true, store: store.child(
-                state: { state in
-                    SearchVaultFilterRowState(
-                        organizations: state.organizations,
-                        searchVaultFilterType: state.searchVaultFilterType,
-                        isPersonalOwnershipDisabled: state.isPersonalOwnershipDisabled
-                    )
-                },
+                state: \.vaultFilterState,
                 mapAction: { action in
                     switch action {
                     case let .searchVaultFilterChanged(type):
@@ -163,13 +157,7 @@ private struct SearchableVaultListView: View {
             hasDivider: false,
             accessibilityID: "ActiveFilterRow",
             store: store.child(
-                state: { state in
-                    SearchVaultFilterRowState(
-                        organizations: state.organizations,
-                        searchVaultFilterType: state.vaultFilterType,
-                        isPersonalOwnershipDisabled: state.isPersonalOwnershipDisabled
-                    )
-                },
+                state: \.vaultFilterState,
                 mapAction: { action in
                     switch action {
                     case let .searchVaultFilterChanged(type):


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9155](https://bitwarden.atlassian.net/browse/PM-9155)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If the personal ownership and single organization policies are both enabled, the vault filter should be hidden.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9155]: https://bitwarden.atlassian.net/browse/PM-9155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ