### PR TITLE
PM-10127 - Can't Share File or Photo For Send via iOS Share Menu

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -286,6 +286,7 @@ targets:
     settings:
       base:
         INFOPLIST_FILE: BitwardenShareExtension/Application/Support/Info.plist
+        CODE_SIGN_ENTITLEMENTS: BitwardenShareExtension/Application/Support/BitwardenShareExtension.entitlements
     sources:
       - path: BitwardenShareExtension
         excludes:
@@ -298,7 +299,6 @@ targets:
     platform: iOS
     settings:
       base:
-        CODE_SIGN_ENTITLEMENTS: BitwardenShareExtension/Application/Support/BitwardenShareExtension.entitlements
         INFOPLIST_FILE: BitwardenShareExtension/Application/TestHelpers/Support/Info.plist
     sources:
       - path: BitwardenShareExtension


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10127](https://bitwarden.atlassian.net/browse/PM-10127)

## 📔 Objective

- Allow sharing of a file/photo from the iOS Share Menu.  When trying to share we saw a screen flicker but no action was taken place.  Noticed the entitlement was missing from the share extension so added that back in and removed it from the test target.  
- I was seeing a weird issue that causes the app to crash within `DefaultAutofillCredentialService` when trying to send.  The function `replaceAllIdentities(userId:)` was the culprit but this must have been something I had set up locally that was causing the issue because after starting with a fresh build I was not able to replicate this behavior.  If this comes back from QA then further investigation would be required to move the logic that kicks off the task in DefaultAutofillCredentialService.init to a method that we only call if the user is in the app or within either of the autofill extensions. 

## 📸 Screenshots

https://github.com/user-attachments/assets/b91b720b-7460-4288-a9cc-68249a895ac9

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10127]: https://bitwarden.atlassian.net/browse/PM-10127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ