### PR TITLE
PM-9000 - User can save empty PIN (whitespaces)

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -305,7 +305,7 @@ final class AccountSecurityProcessor: StateProcessor<
     private func toggleUnlockWithPIN(_ isOn: Bool) {
         if isOn {
             coordinator.showAlert(.enterPINCode { pin in
-                guard !pin.isEmpty else { return }
+                guard !pin.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
 
                 do {
                     let userHasMasterPassword = try await self.services.stateService.getUserHasMasterPassword()

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -492,7 +492,19 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.submit)
+        XCTAssertFalse(subject.state.isUnlockWithPINCodeOn)
+    }
 
+    /// `receive(_:)` with `.toggleUnlockWithPINCode` displays an alert and updates the state when submit has been
+    /// pressed but an empty pin was passed.
+    func test_receive_toggleUnlockWithPINCode_toggleOn_withWhitespacePIN() async throws {
+        stateService.activeAccount = .fixture()
+        subject.state.isUnlockWithPINCodeOn = false
+        subject.receive(.toggleUnlockWithPINCode(true))
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try alert.setText(" ", forTextFieldWithId: "pin")
+        try await alert.tapAction(title: Localizations.submit)
         XCTAssertFalse(subject.state.isUnlockWithPINCodeOn)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9000](https://bitwarden.atlassian.net/browse/PM-9000)

## 📔 Objective

- This was returned from QA because we were still allowing whitespaces as an acceptable pin when validating.  This PR trims whitespaces before checking if the pin is empty or not.  

## 📸 Screenshots

https://github.com/user-attachments/assets/0161bc40-4739-4d19-ac9e-004ea5db6fcb

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9000]: https://bitwarden.atlassian.net/browse/PM-9000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ