### PR TITLE
[PM-10512] Update build number calculation to just be GitHub run number

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -336,7 +336,7 @@ jobs:
 
       - name: Update build number
         run: |
-          BUILD_NUMBER=$(($GITHUB_RUN_NUMBER + 1000))
+          BUILD_NUMBER=$(($GITHUB_RUN_NUMBER))
           yq -i ".settings.CURRENT_PROJECT_VERSION = ${{ inputs.build-number || '$BUILD_NUMBER' }}" 'project.yml'
 
       - name: Build iOS app


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10512

## 📔 Objective

This updates the way the build number is calculated on an automatic build, so that instead of GitHub run number plus 1000, it's just the GitHub run number.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
