### PR TITLE
PM-10519: Fix Face ID toggled off if device is locked while performing Face ID

### DIFF
--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
@@ -152,7 +152,8 @@ class DefaultBiometricsRepository: BiometricsRepository {
                 switch status {
                 case kLAErrorBiometryLockout:
                     throw BiometricsServiceError.biometryLocked
-                case errSecUserCanceled,
+                case errSecAuthFailed,
+                     errSecUserCanceled,
                      kLAErrorAppCancel,
                      kLAErrorSystemCancel,
                      kLAErrorUserCancel:

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepositoryTests.swift
@@ -111,6 +111,18 @@ final class BiometricsRepositoryTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(key, expectedKey)
     }
 
+    /// `setBiometricUnlockKey` throws a cancelled error for `errSecAuthFailed` if the device is
+    /// locked while performing biometrics.
+    func test_getBiometricUnlockKey_authFailed() async throws {
+        stateService.activeAccount = .fixture()
+        keychainService.getResult = .failure(
+            KeychainServiceError.osStatusError(errSecAuthFailed)
+        )
+        await assertAsyncThrows(error: BiometricsServiceError.biometryCancelled) {
+            _ = try await subject.getUserAuthKey()
+        }
+    }
+
     /// `getBiometricUnlockStatus` throws an error if the user has locked biometrics.
     func test_getBiometricUnlockStatus_lockout() async throws {
         let active = Account.fixture()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10519](https://bitwarden.atlassian.net/browse/PM-10519)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If the device is locked while performing Face ID, Face ID unlock was being disabled for the account. When Face ID is cancelled because the device locks, the `errSecAuthFailed` error is thrown. This was being converted to a `BiometricsServiceError.getAuthKeyFailed` error, which ends up toggling off Face ID. This changes that to instead throw a `BiometricsServiceError.biometryCancelled` error, similar to the other errors around cancellation. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10519]: https://bitwarden.atlassian.net/browse/PM-10519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ