### PR TITLE
[PM-10080] Don't constrain OTP auth codes to base-32 secrets

### DIFF
--- a/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModel.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModel.swift
@@ -66,8 +66,7 @@ public struct OTPAuthModel: Equatable, Hashable, Sendable {
         guard let urlComponents = URLComponents(string: otpAuthKey),
               urlComponents.scheme == "otpauth",
               let queryItems = urlComponents.queryItems,
-              let secret = queryItems.first(where: { $0.name == "secret" })?.value,
-              secret.uppercased().isBase32 else {
+              let secret = queryItems.first(where: { $0.name == "secret" })?.value else {
             return nil
         }
 

--- a/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
@@ -85,6 +85,23 @@ class OTPAuthModelTests: BitwardenTestCase {
         )
     }
 
+    /// Tests that an OTP Auth string with a non-base32 key creates a model.
+    func test_init_otpAuthKey_success_nonbase32() {
+        let subject = OTPAuthModel(otpAuthKey: .otpAuthUriKeyNonBase32)
+        XCTAssertEqual(
+            subject,
+            OTPAuthModel(
+                accountName: nil,
+                algorithm: .sha1,
+                digits: 6,
+                issuer: nil,
+                key: "1234567890",
+                period: 30,
+                uri: .otpAuthUriKeyNonBase32
+            )
+        )
+    }
+
     /// Tests that a partially formatted OTP Auth string creates the model.
     func test_init_otpAuthKey_success_partial() {
         let subject = OTPAuthModel(otpAuthKey: .otpAuthUriKeyPartial)

--- a/BitwardenShared/UI/Vault/PreviewContent/String+TOTPFixtures.swift
+++ b/BitwardenShared/UI/Vault/PreviewContent/String+TOTPFixtures.swift
@@ -5,6 +5,7 @@ extension String {
     // swiftlint:disable:next line_length
     static let otpAuthUriKeyComplete = "otpauth://totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP&issuer=Example&algorithm=SHA256&digits=6&period=30"
     static let otpAuthUriKeyMinimum = "otpauth://totp/:?secret=JBSWY3DPEHPK3PXP"
+    static let otpAuthUriKeyNonBase32 = "otpauth://totp/:?secret=1234567890"
     static let otpAuthUriKeyPartial = "otpauth://totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP"
     // swiftlint:disable:next line_length
     static let otpAuthUriKeySHA512 = "otpauth://totp/Example:user@bitwarden.com?secret=JBSWY3DPEHPK3PXP&algorithm=SHA512"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10080

## 📔 Objective

OTP-auth URLs were still doing base-32 checking on their secrets. This changes that so any secret will be allowed, even if it's not base-32 encoded. In practice, we should never see things that aren't base-32, but since the SDK handles it, it seems reasonable for us to allow it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
