### PR TITLE
[PM-10450] Fix FIdo2 never lock user verification not appearing

### DIFF
--- a/BitwardenAutoFillExtension/CredentialProviderViewController.swift
+++ b/BitwardenAutoFillExtension/CredentialProviderViewController.swift
@@ -1,6 +1,7 @@
 import AuthenticationServices
 import BitwardenSdk
 import BitwardenShared
+import Combine
 import OSLog
 
 /// An `ASCredentialProviderViewController` that implements credential autofill.
@@ -11,11 +12,20 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
     /// The app's theme.
     var appTheme: AppTheme = .default
 
+    /// A subject containing whether the controller did appear.
+    private var didAppearSubject = CurrentValueSubject<Bool, Never>(false)
+
     /// The processor that manages application level logic.
     private var appProcessor: AppProcessor?
 
     /// The context of the credential provider to see how the extension is being used.
     private var context: CredentialProviderContext?
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        didAppearSubject.send(true)
+    }
 
     // MARK: ASCredentialProviderViewController
 
@@ -305,6 +315,12 @@ extension CredentialProviderViewController: Fido2AppExtensionDelegate {
     @available(iOSApplicationExtension 17.0, *)
     func completeRegistrationRequest(asPasskeyRegistrationCredential: ASPasskeyRegistrationCredential) {
         extensionContext.completeRegistrationRequest(using: asPasskeyRegistrationCredential)
+    }
+
+    func getDidAppearPublisher() -> AsyncPublisher<AnyPublisher<Bool, Never>> {
+        didAppearSubject
+            .eraseToAnyPublisher()
+            .values
     }
 
     func setUserInteractionRequired() {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1579,8 +1579,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `validatePin(_:)` returns `false` if the there is no active account.
     func test_validatePin_noActiveAccount() async throws {
-        let account = Account.fixture()
-
         let isPinValid = try await subject.validatePin(pin: "123")
 
         XCTAssertFalse(isPinValid)

--- a/BitwardenShared/UI/Autofill/Application/Fido2AppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Autofill/Application/Fido2AppExtensionDelegate.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import Combine
 
 /// A delegate that is used to handle actions and retrieve information from within an Autofill extension
 /// on Fido2 flows.
@@ -18,6 +19,9 @@ public protocol Fido2AppExtensionDelegate: AppExtensionDelegate {
     /// - Parameter asPasskeyRegistrationCredential: The passkey credential to be used to complete the registration.
     @available(iOSApplicationExtension 17.0, *)
     func completeRegistrationRequest(asPasskeyRegistrationCredential: ASPasskeyRegistrationCredential)
+
+    /// Gets a publisher for when `didAppear` happens.
+    func getDidAppearPublisher() -> AsyncPublisher<AnyPublisher<Bool, Never>>
 
     /// Marks that user interaction is required.
     func setUserInteractionRequired()

--- a/BitwardenShared/UI/Autofill/Application/TestHelpers/MockFido2AppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Autofill/Application/TestHelpers/MockFido2AppExtensionDelegate.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import Combine
 import Foundation
 
 @testable import BitwardenShared
@@ -8,6 +9,7 @@ class MockFido2AppExtensionDelegate: MockAppExtensionDelegate, Fido2AppExtension
     var completeAssertionRequestMocker = InvocationMocker<ASPasskeyAssertionCredential>()
     var completeRegistrationRequestMocker = InvocationMocker<ASPasskeyRegistrationCredential>()
     var extensionMode: AutofillExtensionMode = .configureAutofill
+    var didAppearPublisher = CurrentValueSubject<Bool, Never>(false)
     var setUserInteractionRequiredCalled = false
 
     var flowWithUserInteraction: Bool = true
@@ -18,6 +20,12 @@ class MockFido2AppExtensionDelegate: MockAppExtensionDelegate, Fido2AppExtension
 
     func completeRegistrationRequest(asPasskeyRegistrationCredential: ASPasskeyRegistrationCredential) {
         completeRegistrationRequestMocker.invoke(param: asPasskeyRegistrationCredential)
+    }
+
+    func getDidAppearPublisher() -> AsyncPublisher<AnyPublisher<Bool, Never>> {
+        didAppearPublisher
+            .eraseToAnyPublisher()
+            .values
     }
 
     func setUserInteractionRequired() {

--- a/BitwardenShared/UI/Platform/Application/AppProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor+Fido2Tests.swift
@@ -129,8 +129,14 @@ class AppProcessorFido2Tests: BitwardenTestCase {
     func test_onNeedsUserInteraction_flowWithUserInteraction() async {
         appExtensionDelegate.flowWithUserInteraction = true
 
-        await assertAsyncDoesNotThrow {
+        let taskResult = Task {
             try await subject.onNeedsUserInteraction()
+        }
+
+        appExtensionDelegate.didAppearPublisher.send(true)
+
+        await assertAsyncDoesNotThrow {
+            try await taskResult.value
         }
         XCTAssertFalse(appExtensionDelegate.setUserInteractionRequiredCalled)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10450](https://bitwarden.atlassian.net/browse/PM-10450)

## 📔 Objective

Fix Fido2 flow user verification not appearing when in an account with never lock timeout.
The problem arises because of trying to perform user interaction, e.g. prompting for FaceID, before `viewDidAppear` happens. So as a solution we just for it to happen before continuing with user interaction flows.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10450]: https://bitwarden.atlassian.net/browse/PM-10450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ