### PR TITLE
[PM-10539] Remove all identities when switching to a locked account

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1112,6 +1112,41 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         }
     }
 
+    /// `setActiveAccount(userId: )` calls `onProfileSwitched` when the old vs active user IDs are different.
+    func test_setActiveAccount_onProfileSwitched() async throws {
+        stateService.accounts = [
+            anneAccount,
+            beeAccount,
+        ]
+        stateService.activeAccount = anneAccount
+        let delegate = MockAuthProfileSwitchDelegate()
+        subject.setAuthProfileSwitchDelegate(delegate: delegate)
+        _ = try await subject.setActiveAccount(userId: beeAccount.profile.userId)
+        XCTAssertTrue(delegate.onProfileSwitchedMocker.called)
+        XCTAssertEqual(
+            delegate.onProfileSwitchedMocker.invokedParam?.oldUserId,
+            anneAccount.profile.userId
+        )
+        XCTAssertEqual(
+            delegate.onProfileSwitchedMocker.invokedParam?.activeUserId,
+            beeAccount.profile.userId
+        )
+    }
+
+    /// `setActiveAccount(userId: )` doesn't call `onProfileSwitched`
+    /// when the old user ID is equal to the active user ID.
+    func test_setActiveAccount_onProfileSwitchedNotCalled() async throws {
+        stateService.accounts = [
+            anneAccount,
+            beeAccount,
+        ]
+        stateService.activeAccount = anneAccount
+        let delegate = MockAuthProfileSwitchDelegate()
+        subject.setAuthProfileSwitchDelegate(delegate: delegate)
+        _ = try await subject.setActiveAccount(userId: anneAccount.profile.userId)
+        XCTAssertFalse(delegate.onProfileSwitchedMocker.called)
+    }
+
     /// `setPins(_:requirePasswordAfterRestart:)` sets the user's pins.
     func test_setPins() async throws {
         let account = Account.fixture()

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthProfileSwitchDelegate.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthProfileSwitchDelegate.swift
@@ -1,0 +1,9 @@
+@testable import BitwardenShared
+
+class MockAuthProfileSwitchDelegate: AuthProfileSwitchDelegate {
+    var onProfileSwitchedMocker = InvocationMocker<(oldUserId: String?, activeUserId: String)>()
+
+    func onProfileSwitched(oldUserId: String?, activeUserId: String) async throws {
+        onProfileSwitchedMocker.invoke(param: (oldUserId, activeUserId))
+    }
+}

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -4,6 +4,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var allowBiometricUnlock: Bool?
     var allowBiometricUnlockResult: Result<Void, Error> = .success(())
     var accountForItemResult: Result<Account, Error> = .failure(StateServiceError.noAccounts)
+    var authProfileSwitchDelegate: AuthProfileSwitchDelegate?
     var canVerifyMasterPasswordResult: Result<Bool, Error> = .success(true)
     var clearPinsCalled = false
     var createNewSsoUserRememberDevice: Bool = false
@@ -199,6 +200,10 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
             .filter { $0.profile.userId == userId }
             + [priorActive].compactMap { $0 }
         return match
+    }
+
+    func setAuthProfileSwitchDelegate(delegate: AuthProfileSwitchDelegate) {
+        authProfileSwitchDelegate = delegate
     }
 
     func setPins(_ pin: String, requirePasswordAfterRestart _: Bool) async throws {

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -374,6 +374,16 @@ extension DefaultAutofillCredentialService: AutofillCredentialService {
     }
 }
 
+// MARK: - AuthProfileSwitchDelegate
+
+extension DefaultAutofillCredentialService: AuthProfileSwitchDelegate {
+    func onProfileSwitched(oldUserId: String?, activeUserId: String) async throws {
+        if let oldUserId, vaultTimeoutService.isLocked(userId: activeUserId) {
+            await removeAllIdentities()
+        }
+    }
+}
+
 // MARK: - CipherView
 
 private extension CipherView {

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -574,6 +574,8 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             vaultTimeoutService: vaultTimeoutService
         )
 
+        authRepository.setAuthProfileSwitchDelegate(delegate: autofillCredentialService)
+
         self.init(
             apiService: apiService,
             appIdService: appIdService,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10539](https://bitwarden.atlassian.net/browse/PM-10539)

## 📔 Objective

Remove all OS Store identities when switching to a locked account. This fixes an issue where the user was changing to a locked account and then trying to autofill which was showing the previous user credentials, and when opening the autofill extension it was failing as the credential was not belonging to the current (locked) user.

## 📸 Screenshots


https://github.com/user-attachments/assets/f505431f-c792-4eeb-8914-16cd26eee30e



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10539]: https://bitwarden.atlassian.net/browse/PM-10539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ