### PR TITLE
[PM-10487] Handle cancellation on setting up the PIN on Fido2 flows

### DIFF
--- a/BitwardenShared/UI/Auth/Utilities/UserVerificationHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/UserVerificationHelper.swift
@@ -79,18 +79,24 @@ extension DefaultUserVerificationHelper: UserVerificationHelper {
                 return
             }
 
-            userVerificationDelegate.showAlert(.enterPINCode { pin in
-                do {
-                    guard !pin.isEmpty else {
-                        throw Fido2Error.failedToSetupPin
-                    }
+            userVerificationDelegate.showAlert(.enterPINCode(
+                onCancelled: { () in
+                    continuation.resume(throwing: UserVerificationError.cancelled)
+                },
+                settingUp: true,
+                completion: { pin in
+                    do {
+                        guard !pin.isEmpty else {
+                            throw Fido2Error.failedToSetupPin
+                        }
 
-                    try await self.authRepository.setPins(pin, requirePasswordAfterRestart: false)
-                    continuation.resume()
-                } catch {
-                    continuation.resume(throwing: error)
+                        try await self.authRepository.setPins(pin, requirePasswordAfterRestart: false)
+                        continuation.resume()
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
                 }
-            })
+            ))
         }
     }
 

--- a/BitwardenShared/UI/Auth/Utilities/UserVerificationHelperTests.swift
+++ b/BitwardenShared/UI/Auth/Utilities/UserVerificationHelperTests.swift
@@ -114,6 +114,24 @@ class UserVerificationHelperTests: BitwardenTestCase { // swiftlint:disable:this
         }
     }
 
+    /// `setupPin()` with cancelled setup.
+    func test_setupPin_cancelled() async throws {
+        let task = Task {
+            try await self.subject.setupPin()
+        }
+
+        try await waitForAsync {
+            !self.userVerificationDelegate.alertShown.isEmpty
+        }
+
+        let alert = try XCTUnwrap(userVerificationDelegate.alertShown.last)
+        try await alert.tapAction(title: Localizations.cancel)
+
+        await assertAsyncThrows(error: UserVerificationError.cancelled) {
+            _ = try await task.value
+        }
+    }
+
     /// `verifyDeviceLocalAuth()` with device status not authorized.
     func test_verifyDeviceLocalAuth_notAuthorized() async throws {
         localAuthService.deviceAuthenticationStatus = .notDetermined


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10487](https://bitwarden.atlassian.net/browse/PM-10487)

## 📔 Objective

Fix cancellation handling on setting up the PIN on Fido2 flows.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10487]: https://bitwarden.atlassian.net/browse/PM-10487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ