### PR TITLE
[PM-10539] Remove all identities when switching to a locked account

### DIFF
--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -82,7 +82,7 @@ class DefaultAutofillCredentialService {
     /// The service used to manage the credentials available for AutoFill suggestions.
     private let identityStore: CredentialIdentityStore
 
-    /// The last user ID that has been their identities synced.
+    /// The last user ID that had their identities synced.
     private var lastSyncedUserId: String?
 
     /// The service used to manage copy/pasting from the device's clipboard.

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -174,18 +174,6 @@ class DefaultAutofillCredentialService {
         }
     }
 
-    private func shouldRemoveAllIdentities(vaultLockStatus: VaultLockStatus?) -> Bool {
-        guard let vaultLockStatus else {
-            return true
-        }
-
-        guard let lastSyncedUserId else {
-            return false
-        }
-
-        return vaultLockStatus.isVaultLocked && lastSyncedUserId != vaultLockStatus.userId
-    }
-
     /// Removes all credential identities from the identity store.
     ///
     private func removeAllIdentities() async {
@@ -237,6 +225,21 @@ class DefaultAutofillCredentialService {
         } catch {
             errorReporter.log(error: error)
         }
+    }
+
+    /// Determines whether all identities in store should be removed.
+    /// - Parameter vaultLockStatus: The vault lock status from the publisher.
+    /// - Returns: `true` if all identities should be removed, `false` otherwise.
+    private func shouldRemoveAllIdentities(vaultLockStatus: VaultLockStatus?) -> Bool {
+        guard let vaultLockStatus else {
+            return true
+        }
+
+        guard let lastSyncedUserId else {
+            return false
+        }
+
+        return vaultLockStatus.isVaultLocked && lastSyncedUserId != vaultLockStatus.userId
     }
 
     /// Attempts to unlock the user's vault if it can be done without user interaction (e.g. if

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -629,6 +629,70 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
+    /// `syncIdentities(vaultLockStatus:)` removes identities from the store when the user switches from a previous
+    /// synced vault to another user.
+    func test_syncIdentities_removeOnSwitched() async throws {
+        try await waitAndResetRemoveAllCredentialIdentitiesCalled()
+
+        cipherService.fetchAllCiphersResult = .success([
+            .fixture(
+                id: "1",
+                login: .fixture(
+                    password: "password123",
+                    uris: [.fixture(uri: "bitwarden.com")],
+                    username: "user@bitwarden.com"
+                )
+            ),
+        ])
+
+        vaultTimeoutService.vaultLockStatusSubject.send(VaultLockStatus(isVaultLocked: false, userId: "1"))
+        try await waitForAsync {
+            self.identityStore.replaceCredentialIdentitiesIdentities != nil
+        }
+        XCTAssertEqual(identityStore.replaceCredentialIdentitiesIdentities?.count, 1)
+
+        vaultTimeoutService.vaultLockStatusSubject.send(VaultLockStatus(isVaultLocked: true, userId: "2"))
+        try await waitForAsync {
+            self.identityStore.removeAllCredentialIdentitiesCalled
+        }
+
+        XCTAssertTrue(identityStore.removeAllCredentialIdentitiesCalled)
+    }
+
+    /// `syncIdentities(vaultLockStatus:)` doesn't remove identities from the store when the user locks their vault.
+    func test_syncIdentities_dontRemoveOnSwitchedEqualUser() async throws {
+        try await waitAndResetRemoveAllCredentialIdentitiesCalled()
+
+        cipherService.fetchAllCiphersResult = .success([
+            .fixture(
+                id: "1",
+                login: .fixture(
+                    password: "password123",
+                    uris: [.fixture(uri: "bitwarden.com")],
+                    username: "user@bitwarden.com"
+                )
+            ),
+        ])
+
+        vaultTimeoutService.vaultLockStatusSubject.send(VaultLockStatus(isVaultLocked: false, userId: "1"))
+        try await waitForAsync {
+            self.identityStore.replaceCredentialIdentitiesIdentities != nil
+        }
+        XCTAssertEqual(identityStore.replaceCredentialIdentitiesIdentities?.count, 1)
+
+        vaultTimeoutService.vaultLockStatusSubject.send(VaultLockStatus(isVaultLocked: true, userId: "1"))
+        XCTAssertFalse(identityStore.removeAllCredentialIdentitiesCalled)
+    }
+
+    /// `syncIdentities(vaultLockStatus:)` doesn't remove identities from the store when it tries to sync
+    /// for the first time and it's locked (last user ID synced is `nil`).
+    func test_syncIdentities_dontRemoveOnFirstSyncLocked() async throws {
+        try await waitAndResetRemoveAllCredentialIdentitiesCalled()
+
+        vaultTimeoutService.vaultLockStatusSubject.send(VaultLockStatus(isVaultLocked: true, userId: "1"))
+        XCTAssertFalse(identityStore.removeAllCredentialIdentitiesCalled)
+    }
+
     /// `syncIdentities(vaultLockStatus:)` removes identities from the store when the user logs out.
     func test_syncIdentities_removeOnLogout() {
         cipherService.fetchAllCiphersResult = .success([
@@ -669,5 +733,18 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         waitFor(identityStore.replaceCredentialIdentitiesCalled)
 
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    // MARK: Private
+
+    /// Waits until `identityStore.removeAllCredentialIdentitiesCalled` is `true` and then resets it
+    /// to `false`. This happens because of the first value of `vaultTimeoutService.vaultLockStatusSubject`
+    /// which is `nil` and removes all credentials when the test is setup.
+    private func waitAndResetRemoveAllCredentialIdentitiesCalled() async throws {
+        try await waitForAsync {
+            self.identityStore.removeAllCredentialIdentitiesCalled
+        }
+
+        identityStore.removeAllCredentialIdentitiesCalled = false
     }
 } // swiftlint:disable:this file_length


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10539](https://bitwarden.atlassian.net/browse/PM-10539)

## 📔 Objective

Remove all OS Store identities when switching to a locked account. This fixes an issue where the user was changing to a locked account and then trying to autofill which was showing the previous user credentials, and when opening the autofill extension it was failing as the credential was not belonging to the current (locked) user.

## 📸 Screenshots


https://github.com/user-attachments/assets/f505431f-c792-4eeb-8914-16cd26eee30e



## ⏰ Reminders before review
- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10539]: https://bitwarden.atlassian.net/browse/PM-10539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ