### PR TITLE
[PM-9849] Fix cipher matching logic to sanitize the URL

### DIFF
--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
@@ -53,8 +53,8 @@ class CipherMatchingHelper {
         guard let uri else { return [] }
 
         let matchURL = URL(string: uri)
-        let matchDomain = matchURL?.domain
         let matchIsApp = matchURL?.isApp ?? false
+        let matchDomain = matchIsApp ? matchURL?.domain : matchURL?.sanitized.domain
         let matchAppWebURL = matchURL?.appWebURL
 
         let (matching: matchingDomains, fuzzyMatching: matchingFuzzyDomains) = await getMatchingDomains(
@@ -107,7 +107,7 @@ class CipherMatchingHelper {
         matchingDomains: Set<String>,
         matchingFuzzyDomains: Set<String>
     ) -> MatchResult {
-        let loginUriDomain = URL(string: loginUri)?.domain?.lowercased()
+        let loginUriDomain = URL(string: loginUri)?.sanitized.domain?.lowercased()
 
         if matchingDomains.contains(loginUri) {
             return .exact

--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelperTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelperTests.swift
@@ -140,6 +140,61 @@ class CipherMatchingHelperTests: BitwardenTestCase { // swiftlint:disable:this t
         }
     }
 
+    /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the base
+    /// domain match type using an equivalent domain when the uri to match doesn't have the protocol specified.
+    func test_ciphersMatching_baseDomain_equivalentDomainsNoHttpsInUri() async {
+        settingsService.fetchEquivalentDomainsResult = .success([["google.com", "youtube.com"]])
+        let ciphers = ciphersForUris(
+            [
+                ("Google", "https://google.com"),
+                ("Google Account", "https://accounts.google.com"),
+                ("Youtube", "https://youtube.com/login"),
+                ("Yahoo", "https://yahoo.com"),
+            ],
+            matchType: .domain
+        )
+
+        let matchingCiphers = await subject.ciphersMatching(uri: "google.com", ciphers: ciphers)
+        assertInlineSnapshot(
+            of: dumpMatchingCiphers(matchingCiphers),
+            as: .lines
+        ) {
+            """
+            Google
+            Google Account
+            Youtube
+            """
+        }
+    }
+
+    /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI for the base
+    /// domain match type using an equivalent domain when the uri to match doesn't have the protocol specified
+    /// and the uris of the ciphers don't have protocols
+    func test_ciphersMatching_baseDomain_equivalentDomainsNoProtocols() async {
+        settingsService.fetchEquivalentDomainsResult = .success([["google.com", "youtube.com"]])
+        let ciphers = ciphersForUris(
+            [
+                ("Google", "google.com"),
+                ("Google Account", "accounts.google.com"),
+                ("Youtube", "youtube.com/login"),
+                ("Yahoo", "yahoo.com"),
+            ],
+            matchType: .domain
+        )
+
+        let matchingCiphers = await subject.ciphersMatching(uri: "google.com", ciphers: ciphers)
+        assertInlineSnapshot(
+            of: dumpMatchingCiphers(matchingCiphers),
+            as: .lines
+        ) {
+            """
+            Google
+            Google Account
+            Youtube
+            """
+        }
+    }
+
     /// `ciphersMatching(uri:ciphers)` returns the list of ciphers that match the URI using the
     /// default match type if the cipher doesn't specify a match type.
     func test_ciphersMatching_defaultMatchType() async {
@@ -363,4 +418,4 @@ class CipherMatchingHelperTests: BitwardenTestCase { // swiftlint:disable:this t
     func dumpMatchingCiphers(_ ciphers: [CipherView]) -> String {
         ciphers.map(\.name).joined(separator: "\n")
     }
-}
+} // swiftlint:disable:this file_length


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9849](https://bitwarden.atlassian.net/browse/PM-9849)

## 📔 Objective

Fix ciphers matching filter on autofill extension by sanitizing the URL when it doesn't come from an App.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9849]: https://bitwarden.atlassian.net/browse/PM-9849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ