### PR TITLE
PM-10639: Implement conditional logic for showing the intro carousel

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -163,6 +163,12 @@ protocol StateService: AnyObject {
     ///
     func getEvents(userId: String?) async throws -> [EventData]
 
+    /// Gets whether the intro carousel screen has been shown.
+    ///
+    /// - Returns: Whether the intro carousel screen has been shown.
+    ///
+    func getIntroCarouselShown() async -> Bool
+
     /// Gets the user's last active time within the app.
     /// This value is set when the app is backgrounded.
     ///
@@ -409,6 +415,12 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setForcePasswordResetReason(_ reason: ForcePasswordResetReason?, userId: String?) async throws
+
+    /// Sets whether the intro carousel screen has been shown.
+    ///
+    /// - Parameter shown: Whether the intro carousel screen has been shown.
+    ///
+    func setIntroCarouselShown(_ shown: Bool) async
 
     /// Sets the last active time within the app.
     ///
@@ -1163,6 +1175,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         return appSettingsStore.events(userId: userId)
     }
 
+    func getIntroCarouselShown() async -> Bool {
+        appSettingsStore.introCarouselShown
+    }
+
     func getLastActiveTime(userId: String?) async throws -> Date? {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.lastActiveTime(userId: userId)
@@ -1364,6 +1380,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         }
         defer { appSettingsStore.state = state }
         state.accounts[userId]?.profile.forcePasswordResetReason = reason
+    }
+
+    func setIntroCarouselShown(_ shown: Bool) async {
+        appSettingsStore.introCarouselShown = shown
     }
 
     func setLastActiveTime(_ date: Date?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -567,6 +567,16 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(actual, events)
     }
 
+    /// `getIntroCarouselShown()` returns whether the intro carousel screen has been shown.
+    func test_getIntroCarouselShown() async {
+        var hasShownCarousel = await subject.getIntroCarouselShown()
+        XCTAssertFalse(hasShownCarousel)
+
+        appSettingsStore.introCarouselShown = true
+        hasShownCarousel = await subject.getIntroCarouselShown()
+        XCTAssertTrue(hasShownCarousel)
+    }
+
     /// `getLastActiveTime(userId:)` gets the user's last active time.
     func test_getLastActiveTime() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
@@ -1315,6 +1325,15 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.setEvents(events, userId: "1")
         XCTAssertEqual(appSettingsStore.eventsByUserId["1"], events)
+    }
+
+    /// `setIntroCarouselShown(_:)` sets whether the intro carousel screen has been shown.
+    func test_setIntroCarouselShown() async {
+        await subject.setIntroCarouselShown(true)
+        XCTAssertTrue(appSettingsStore.introCarouselShown)
+
+        await subject.setIntroCarouselShown(false)
+        XCTAssertFalse(appSettingsStore.introCarouselShown)
     }
 
     /// `setLastSyncTime(_:userId:)` sets the last sync time for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -31,6 +31,9 @@ protocol AppSettingsStore: AnyObject {
     /// Whether to disable the website icons.
     var disableWebIcons: Bool { get set }
 
+    /// Whether the intro carousel screen has been shown.
+    var introCarouselShown: Bool { get set }
+
     /// The last value of the connect to watch setting, ignoring the user id. Used for
     /// sending the status to the watch if the user is logged out.
     var lastUserShouldConnectToWatch: Bool { get set }
@@ -575,6 +578,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case encryptedPrivateKey(userId: String)
         case encryptedUserKey(userId: String)
         case events(userId: String)
+        case introCarouselShown
         case lastActiveTime(userId: String)
         case lastSync(userId: String)
         case lastUserShouldConnectToWatch
@@ -635,6 +639,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "encPrivateKey_\(userId)"
             case let .events(userId):
                 key = "events_\(userId)"
+            case .introCarouselShown:
+                key = "introCarouselShown"
             case let .lastActiveTime(userId):
                 key = "lastActiveTime_\(userId)"
             case let .lastSync(userId):
@@ -710,6 +716,11 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     var disableWebIcons: Bool {
         get { fetch(for: .disableWebIcons) }
         set { store(newValue, for: .disableWebIcons) }
+    }
+
+    var introCarouselShown: Bool {
+        get { fetch(for: .introCarouselShown) }
+        set { store(newValue, for: .introCarouselShown) }
     }
 
     var lastUserShouldConnectToWatch: Bool {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -338,6 +338,22 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertFalse(subject.isBiometricAuthenticationEnabled(userId: "-1"))
     }
 
+    /// `introCarouselShown` returns `false` if there isn't a previously stored value.
+    func test_introCarouselShown_isInitiallyFalse() {
+        XCTAssertFalse(subject.introCarouselShown)
+    }
+
+    /// `introCarouselShown` can be used to get and set the persisted value in user defaults.
+    func test_introCarouselShown_withValue() {
+        subject.introCarouselShown = true
+        XCTAssertTrue(subject.introCarouselShown)
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:introCarouselShown"))
+
+        subject.introCarouselShown = false
+        XCTAssertFalse(subject.introCarouselShown)
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:introCarouselShown"))
+    }
+
     /// `isBiometricAuthenticationEnabled` can be used to get the biometric unlock preference for a user.
     func test_isBiometricAuthenticationEnabled_withValue() {
         subject.setBiometricAuthenticationEnabled(false, for: "0")

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -11,6 +11,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var appTheme: String?
     var biometricIntegrityStateLegacy: String?
     var disableWebIcons = false
+    var introCarouselShown = false
     var lastUserShouldConnectToWatch = false
     var loginRequest: LoginRequestNotification?
     var migrationVersion = 0

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -34,6 +34,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var eventsResult: Result<Void, Error> = .success(())
     var events = [String: [EventData]]()
     var forcePasswordResetReason = [String: ForcePasswordResetReason]()
+    var introCarouselShown = false
     var lastActiveTime = [String: Date]()
     var loginRequest: LoginRequestNotification?
     var getAccountEncryptionKeysError: Error?
@@ -202,6 +203,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         try eventsResult.get()
         let userId = try unwrapUserId(userId)
         return events[userId] ?? []
+    }
+
+    func getIntroCarouselShown() async -> Bool {
+        introCarouselShown
     }
 
     func getLastActiveTime(userId: String?) async throws -> Date? {
@@ -374,6 +379,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func setForcePasswordResetReason(_ reason: ForcePasswordResetReason?, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         forcePasswordResetReason[userId] = reason
+    }
+
+    func setIntroCarouselShown(_ shown: Bool) async {
+        introCarouselShown = shown
     }
 
     func setIsAuthenticated() {

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -117,6 +117,30 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(route, .complete)
     }
 
+    /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.landing` and doesn't set the
+    /// carousel shown flag if the carousel feature flag is off.
+    func test_handleAndRoute_didCompleteAuth_carouselNotShown() async {
+        authRepository.activeAccount = .fixture()
+        configService.featureFlagsBool[.nativeCarouselFlow] = false
+
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+
+        XCTAssertEqual(route, .complete)
+        XCTAssertFalse(stateService.introCarouselShown)
+    }
+
+    /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.landing` and sets the carousel shown
+    /// flag if the carousel feature flag is on and the carousel hasn't been shown yet.
+    func test_handleAndRoute_didCompleteAuth_carouselShown() async {
+        authRepository.activeAccount = .fixture()
+        configService.featureFlagsBool[.nativeCarouselFlow] = true
+
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+
+        XCTAssertEqual(route, .complete)
+        XCTAssertTrue(stateService.introCarouselShown)
+    }
+
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to complete the auth flow if the account
     /// doesn't require an updated password.
     func test_handleAndRoute_didCompleteAuth_complete() async {
@@ -716,6 +740,27 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
+    /// `handleAndRoute(_ :)` redirects `.didStart` to `.introCarousel` if there's no accounts and
+    /// the carousel flow is enabled.
+    func test_handleAndRoute_didStart_carouselFlow() async {
+        configService.featureFlagsBool[.nativeCarouselFlow] = true
+
+        let route = await subject.handleAndRoute(.didStart)
+
+        XCTAssertEqual(route, .introCarousel)
+    }
+
+    /// `handleAndRoute(_ :)` redirects `.didStart` to `.landing` if there's no accounts, the
+    /// carousel flow is enabled, but the carousel has already been shown.
+    func test_handleAndRoute_didStart_carouselFlow_carouselShown() async {
+        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        stateService.introCarouselShown = true
+
+        let route = await subject.handleAndRoute(.didStart)
+
+        XCTAssertEqual(route, .landing)
+    }
+
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.completeWithNeverUnlockKey` and unlocks the vault if the
     /// account never times out with a logout timeout action.
     func test_handleAndRoute_didStart_neverLockLogout() async {
@@ -770,16 +815,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
         XCTAssertEqual(route, .landing)
         XCTAssertTrue(authRepository.logoutCalled)
-    }
-
-    /// `handleAndRoute(_ :)` redirects `.didStart` to `.introCarousel` if there's no accounts and
-    /// the carousel flow is enabled.
-    func test_handleAndRoute_didStart_createAccountFlow() async {
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
-
-        let route = await subject.handleAndRoute(.didStart)
-
-        XCTAssertEqual(route, .introCarousel)
     }
 
     /// `handleAndRoute(_ :)` redirects `.didTimeout` to `.complete`

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -761,6 +761,20 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(route, .landing)
     }
 
+    /// `handleAndRoute(_ :)` redirects `.didStart` to `.completeWithNeverUnlockKey` if there's an
+    /// existing account with never lock enabled and sets the intro carousel as shown.
+    func test_handleAndRoute_didStart_carouselFlow_existingAccountNeverLock() async {
+        let account = Account.fixture()
+        authRepository.activeAccount = .fixture()
+        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        vaultTimeoutService.vaultTimeout[account.profile.userId] = .never
+
+        let route = await subject.handleAndRoute(.didStart)
+
+        XCTAssertEqual(route, .completeWithNeverUnlockKey)
+        XCTAssertTrue(stateService.introCarouselShown)
+    }
+
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.completeWithNeverUnlockKey` and unlocks the vault if the
     /// account never times out with a logout timeout action.
     func test_handleAndRoute_didStart_neverLockLogout() async {

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -31,6 +31,12 @@ extension AuthRouter {
         if account.profile.forcePasswordResetReason != nil {
             return .updateMasterPassword
         } else {
+            let isCarouselEnabled: Bool = await services.configService.getFeatureFlag(.nativeCarouselFlow)
+            let introCarouselShown = await services.stateService.getIntroCarouselShown()
+            if isCarouselEnabled, !introCarouselShown {
+                await services.stateService.setIntroCarouselShown(true)
+            }
+
             return .complete
         }
     }
@@ -206,7 +212,8 @@ extension AuthRouter {
         guard let activeAccount = try? await configureActiveAccount(shouldSwitchAutomatically: true) else {
             // If no account can be set to active, go to the landing or carousel screen.
             let isCarouselEnabled: Bool = await services.configService.getFeatureFlag(.nativeCarouselFlow)
-            return isCarouselEnabled ? .introCarousel : .landing
+            let introCarouselShown = await services.stateService.getIntroCarouselShown()
+            return isCarouselEnabled && !introCarouselShown ? .introCarousel : .landing
         }
 
         // Check for a `logout` timeout action.

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -31,12 +31,7 @@ extension AuthRouter {
         if account.profile.forcePasswordResetReason != nil {
             return .updateMasterPassword
         } else {
-            let isCarouselEnabled: Bool = await services.configService.getFeatureFlag(.nativeCarouselFlow)
-            let introCarouselShown = await services.stateService.getIntroCarouselShown()
-            if isCarouselEnabled, !introCarouselShown {
-                await services.stateService.setIntroCarouselShown(true)
-            }
-
+            await setCarouselShownIfEnabled()
             return .complete
         }
     }
@@ -216,6 +211,9 @@ extension AuthRouter {
             return isCarouselEnabled && !introCarouselShown ? .introCarousel : .landing
         }
 
+        // If there's existing accounts, mark the carousel as shown.
+        await setCarouselShownIfEnabled()
+
         // Check for a `logout` timeout action.
         let userId = activeAccount.profile.userId
         if await (try? services.authRepository.sessionTimeoutAction(userId: userId)) == .logout,
@@ -365,6 +363,18 @@ extension AuthRouter {
                 attemptAutomaticBiometricUnlock: attemptAutomaticBiometricUnlock,
                 didSwitchAccountAutomatically: didSwitchAccountAutomatically
             )
+        }
+    }
+
+    /// Sets the flag indicating that the carousel was shown (or in the case of existing accounts,
+    /// that it doesn't need to be shown again). This should be called on app launch if there's
+    /// existing account or once logging in or creating an account is successful.
+    ///
+    private func setCarouselShownIfEnabled() async {
+        let isCarouselEnabled: Bool = await services.configService.getFeatureFlag(.nativeCarouselFlow)
+        let introCarouselShown = await services.stateService.getIntroCarouselShown()
+        if isCarouselEnabled, !introCarouselShown {
+            await services.stateService.setIntroCarouselShown(true)
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10639](https://bitwarden.atlassian.net/browse/PM-10639)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the logic to determine when to show the intro carousel. If the feature is enabled, and there's no accounts on the device, the intro carousel should be shown on app launch. Once the user successfully creates an account or logs in, the carousel won't be shown on future app launches.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10639]: https://bitwarden.atlassian.net/browse/PM-10639?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ