### PR TITLE
[PM-10487] Fix Fido2 creation when no OS Unlock configured

### DIFF
--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -360,6 +360,9 @@ extension DefaultAutofillCredentialService: AutofillCredentialService {
         fido2UserInterfaceHelper.setupDelegate(
             fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate
         )
+        fido2UserInterfaceHelper.setupCurrentUserVerificationPreference(
+            userVerificationPreference: request.options.uv
+        )
 
         #if DEBUG
         Fido2DebuggingReportBuilder.builder.withGetAssertionRequest(request)

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -334,6 +334,7 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         )
 
         XCTAssertFalse(autofillCredentialServiceDelegate.unlockVaultWithNeverlockKeyCalled)
+        XCTAssertEqual(fido2UserInterfaceHelper.userVerificationPreferenceSetup, .discouraged)
 
         XCTAssertEqual(result.userHandle, expectedAssertionResult.userHandle)
         XCTAssertEqual(result.relyingParty, passkeyIdentity.relyingPartyIdentifier)
@@ -382,6 +383,7 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         XCTAssertTrue(autofillCredentialServiceDelegate.unlockVaultWithNeverlockKeyCalled)
 
         XCTAssertNotNil(fido2UserInterfaceHelper.fido2UserInterfaceHelperDelegate)
+        XCTAssertEqual(fido2UserInterfaceHelper.userVerificationPreferenceSetup, .discouraged)
 
         XCTAssertEqual(result.userHandle, expectedAssertionResult.userHandle)
         XCTAssertEqual(result.relyingParty, passkeyIdentity.relyingPartyIdentifier)
@@ -426,6 +428,7 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         XCTAssertFalse(autofillCredentialServiceDelegate.unlockVaultWithNeverlockKeyCalled)
 
         XCTAssertNotNil(fido2UserInterfaceHelper.fido2UserInterfaceHelperDelegate)
+        XCTAssertEqual(fido2UserInterfaceHelper.userVerificationPreferenceSetup, .discouraged)
 
         XCTAssertEqual(result.userHandle, expectedAssertionResult.userHandle)
         XCTAssertEqual(result.relyingParty, passkeyIdentity.relyingPartyIdentifier)
@@ -542,6 +545,7 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
             for: passkeyParameters,
             fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate
         )
+        XCTAssertEqual(fido2UserInterfaceHelper.userVerificationPreferenceSetup, .preferred)
 
         XCTAssertEqual(result.userHandle, expectedAssertionResult.userHandle)
         XCTAssertEqual(result.relyingParty, passkeyParameters.relyingPartyIdentifier)

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
@@ -57,6 +57,10 @@ protocol Fido2UserInterfaceHelper: Fido2UserInterface {
     /// Sets up the delegate to use on Fido2 user verification flows and to get information of the FIdo2 flow.
     /// - Parameter fido2UserInterfaceHelperDelegate: The delegate to use
     func setupDelegate(fido2UserInterfaceHelperDelegate: Fido2UserInterfaceHelperDelegate)
+
+    /// Sets up the user verification preference of the current Fido2 flow.
+    /// - Parameter userVerificationPreference: User verification preference to set up.
+    func setupCurrentUserVerificationPreference(userVerificationPreference: Uv)
 }
 
 /// Default implemenation of `Fido2UserInterfaceHelper`.
@@ -77,6 +81,11 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
     )
     private(set) var fido2CreationOptions: BitwardenSdk.CheckUserOptions?
     private(set) var fido2CredentialNewView: BitwardenSdk.Fido2CredentialNewView?
+
+    /// The user verification preference of the current Fido2 flow.
+    /// This is needed as a workaround to be used in `isVerificationEnabled`
+    /// as currently we don't have the UV value provided by the SDK.
+    private var userVerificationPreference: Uv?
 
     /// Initializes a `DefaultFido2UserInterfaceHelper`.
     /// - Parameter fido2UserVerificationMediator: Mediator which manages user verification on Fido2 flows
@@ -161,7 +170,18 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
     }
 
     func isVerificationEnabled() async -> Bool {
-        await fido2UserVerificationMediator.isPreferredVerificationEnabled()
+        guard let userVerificationPreference else {
+            return false
+        }
+
+        switch userVerificationPreference {
+        case .discouraged:
+            return false
+        case .preferred:
+            return await fido2UserVerificationMediator.isPreferredVerificationEnabled()
+        case .required:
+            return true
+        }
     }
 
     func pickedCredentialForAuthentication(result: Result<CipherView, Error>) {
@@ -177,6 +197,10 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
         fido2UserVerificationMediator.setupDelegate(
             fido2UserVerificationMediatorDelegate: fido2UserInterfaceHelperDelegate
         )
+    }
+
+    func setupCurrentUserVerificationPreference(userVerificationPreference: Uv) {
+        self.userVerificationPreference = userVerificationPreference
     }
 
     // MARK: Private

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelperTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelperTests.swift
@@ -163,6 +163,7 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
         fido2UserVerificationMediator.checkUserResult = .success(
             CheckUserResult(userPresent: true, userVerified: false)
         )
+        subject.setupCurrentUserVerificationPreference(userVerificationPreference: .preferred)
         fido2UserVerificationMediator.isPreferredVerificationEnabledResult = true
         await assertAsyncThrows(error: Fido2UserVerificationError.requiredEnforcementFailed) {
             _ = try await subject.checkUser(
@@ -352,13 +353,22 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
 
     /// `isVerificationEnabled()`  returns what the mediator returns.
     func test_isVerificationEnabled() async throws {
+        subject.setupCurrentUserVerificationPreference(userVerificationPreference: .discouraged)
+        let resultDiscouraged = await subject.isVerificationEnabled()
+        XCTAssertFalse(resultDiscouraged)
+
+        subject.setupCurrentUserVerificationPreference(userVerificationPreference: .required)
+        let resultRequired = await subject.isVerificationEnabled()
+        XCTAssertTrue(resultRequired)
+
+        subject.setupCurrentUserVerificationPreference(userVerificationPreference: .preferred)
         fido2UserVerificationMediator.isPreferredVerificationEnabledResult = true
-        let resultTrue = await subject.isVerificationEnabled()
-        XCTAssertTrue(resultTrue)
+        let resultPreferredTrue = await subject.isVerificationEnabled()
+        XCTAssertTrue(resultPreferredTrue)
 
         fido2UserVerificationMediator.isPreferredVerificationEnabledResult = false
-        let resultFalse = await subject.isVerificationEnabled()
-        XCTAssertFalse(resultFalse)
+        let resultPreferredFalse = await subject.isVerificationEnabled()
+        XCTAssertFalse(resultPreferredFalse)
     }
 
     /// `setupDelegate(fido2UserVerificationMediatorDelegate:)`  sets up deleagte in inner mediator.

--- a/BitwardenShared/UI/Autofill/Utilities/TestHelpers/MockFido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/TestHelpers/MockFido2UserInterfaceHelper.swift
@@ -34,6 +34,7 @@ class MockFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
     )
     var isVerificationEnabledResult = false
     var fido2UserInterfaceHelperDelegate: Fido2UserInterfaceHelperDelegate?
+    var userVerificationPreferenceSetup: Uv?
 
     func availableCredentialsForAuthenticationPublisher() -> AnyPublisher<[BitwardenSdk.CipherView]?, Error> {
         credentialsForAuthenticationSubject.eraseToAnyPublisher()
@@ -85,5 +86,9 @@ class MockFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
 
     func setupDelegate(fido2UserInterfaceHelperDelegate: any BitwardenShared.Fido2UserInterfaceHelperDelegate) {
         self.fido2UserInterfaceHelperDelegate = fido2UserInterfaceHelperDelegate
+    }
+
+    func setupCurrentUserVerificationPreference(userVerificationPreference: BitwardenSdk.Uv) {
+        userVerificationPreferenceSetup = userVerificationPreference
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -622,6 +622,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         XCTAssertEqual(subject.state.emptyViewButtonText, Localizations.savePasskeyAsNewLogin)
 
         XCTAssertTrue(fido2UserInterfaceHelper.fido2UserInterfaceHelperDelegate != nil)
+        XCTAssertEqual(fido2UserInterfaceHelper.userVerificationPreferenceSetup, .discouraged)
         appExtensionDelegate.completeRegistrationRequestMocker.assertUnwrapping { credential in
             credential.relyingParty == expectedCredentialIdentity.relyingPartyIdentifier
                 && credential.clientDataHash == expectedRequest.clientDataHash

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -404,6 +404,7 @@ extension VaultAutofillListProcessor {
         credentialIdentity: ASPasskeyCredentialIdentity
     ) async {
         do {
+            let userVerificationPreference = Uv(preference: request.userVerificationPreference)
             let request = MakeCredentialRequest(
                 clientDataHash: request.clientDataHash,
                 rp: PublicKeyCredentialRpEntity(
@@ -419,9 +420,12 @@ extension VaultAutofillListProcessor {
                 excludeList: nil,
                 options: Options(
                     rk: true,
-                    uv: Uv(preference: request.userVerificationPreference)
+                    uv: userVerificationPreference
                 ),
                 extensions: nil
+            )
+            services.fido2UserInterfaceHelper.setupCurrentUserVerificationPreference(
+                userVerificationPreference: userVerificationPreference
             )
             let createdCredential = try await services.clientService.platform().fido2()
                 .authenticator(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10487](https://bitwarden.atlassian.net/browse/PM-10487)

## 📔 Objective

Fix Fido2 creation when no OS Biometrics nor Passcode is configured and the user has Never lock timeout.

### Note
As the SDK doesn't send the user verification preference for `isVerificationEnabled` I've workaround it by setting it up in the `Fido2UserVerificationHelper` directly to have it there when the method is triggered and be able to compare and trigger the appropriate logic for each value.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10487]: https://bitwarden.atlassian.net/browse/PM-10487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ