### PR TITLE
PM-10271: Set up unlock: allow configuring biometrics

### DIFF
--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
@@ -102,6 +102,7 @@ class DefaultBiometricsRepository: BiometricsRepository {
         }
 
         try await setUserBiometricAuthKey(value: authKey)
+        try await configureBiometricIntegrity()
         try await stateService.setBiometricAuthenticationEnabled(true)
     }
 

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -16,7 +16,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var appLanguage: LanguageOption = .default
     var appTheme: AppTheme?
     var biometricsEnabled = [String: Bool]()
-    var biometricIntegrityStates = [String: String?]()
+    var biometricIntegrityStates = [String: String]()
     var capturedUserId: String?
     var clearClipboardValues = [String: ClearClipboardValue]()
     var clearClipboardResult: Result<Void, Error> = .success(())

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessorTests.swift
@@ -5,6 +5,7 @@ import XCTest
 class VaultUnlockSetupProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
+    var authRepository: MockAuthRepository!
     var biometricsRepository: MockBiometricsRepository!
     var coordinator: MockCoordinator<AuthRoute, AuthEvent>!
     var errorReporter: MockErrorReporter!
@@ -15,6 +16,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        authRepository = MockAuthRepository()
         biometricsRepository = MockBiometricsRepository()
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
@@ -22,6 +24,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
         subject = VaultUnlockSetupProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
+                authRepository: authRepository,
                 biometricsRepository: biometricsRepository,
                 errorReporter: errorReporter
             ),
@@ -32,6 +35,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        authRepository = nil
         biometricsRepository = nil
         coordinator = nil
         errorReporter = nil
@@ -49,7 +53,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
         await subject.perform(.loadData)
 
         XCTAssertEqual(subject.state.biometricsStatus, status)
-        XCTAssertEqual(subject.state.unlockMethods, [.faceID, .pin])
+        XCTAssertEqual(subject.state.unlockMethods, [.biometrics(.faceID), .pin])
     }
 
     /// `perform(_:)` with `.loadData` logs the error and shows an alert if one occurs.
@@ -85,7 +89,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
         await subject.perform(.loadData)
 
         XCTAssertEqual(subject.state.biometricsStatus, status)
-        XCTAssertEqual(subject.state.unlockMethods, [.touchID, .pin])
+        XCTAssertEqual(subject.state.unlockMethods, [.biometrics(.touchID), .pin])
     }
 
     /// `receive(_:)` with `.continueFlow` navigates to autofill setup.
@@ -102,13 +106,70 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
         // TODO: PM-10270 Skip unlock setup
     }
 
-    /// `receive(_:)` with `.toggleUnlockMethod` updates the Face ID unlock method in the state.
+    /// `receive(_:)` with `.toggleUnlockMethod` disables biometrics and updates the state.
     @MainActor
-    func test_receive_toggleUnlockMethod_faceID() {
-        subject.receive(.toggleUnlockMethod(.faceID, newValue: true))
-        XCTAssertTrue(subject.state.isBiometricUnlockOn)
+    func test_receive_toggleUnlockMethod_biometrics_disable() {
+        let biometricUnlockStatus = BiometricsUnlockStatus.available(.faceID, enabled: false, hasValidIntegrity: false)
+        authRepository.allowBiometricUnlockResult = .success(())
+        biometricsRepository.biometricUnlockStatus = .success(biometricUnlockStatus)
+        subject.state.biometricsStatus = .available(.faceID, enabled: true, hasValidIntegrity: true)
 
-        subject.receive(.toggleUnlockMethod(.faceID, newValue: false))
+        subject.receive(.toggleUnlockMethod(.biometrics(.faceID), newValue: false))
+        waitFor { !subject.state.isBiometricUnlockOn }
+
+        XCTAssertEqual(authRepository.allowBiometricUnlock, false)
+        XCTAssertEqual(subject.state.biometricsStatus, biometricUnlockStatus)
+        XCTAssertFalse(subject.state.isBiometricUnlockOn)
+    }
+
+    /// `receive(_:)` with `.toggleUnlockMethod` logs an error and shows an alert if disabling biometrics fails.
+    @MainActor
+    func test_receive_toggleUnlockMethod_biometrics_disable_error() {
+        let biometricUnlockStatus = BiometricsUnlockStatus.available(.faceID, enabled: true, hasValidIntegrity: true)
+        authRepository.allowBiometricUnlockResult = .failure(BitwardenTestError.example)
+        biometricsRepository.biometricUnlockStatus = .success(biometricUnlockStatus)
+        subject.state.biometricsStatus = biometricUnlockStatus
+
+        subject.receive(.toggleUnlockMethod(.biometrics(.faceID), newValue: false))
+        waitFor { !coordinator.alertShown.isEmpty }
+
+        XCTAssertEqual(authRepository.allowBiometricUnlock, false)
+        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertEqual(subject.state.biometricsStatus, biometricUnlockStatus)
+        XCTAssertTrue(subject.state.isBiometricUnlockOn)
+    }
+
+    /// `receive(_:)` with `.toggleUnlockMethod` enables biometrics and updates the state.
+    @MainActor
+    func test_receive_toggleUnlockMethod_biometrics_enable() {
+        let biometricUnlockStatus = BiometricsUnlockStatus.available(.faceID, enabled: true, hasValidIntegrity: true)
+        authRepository.allowBiometricUnlockResult = .success(())
+        biometricsRepository.biometricUnlockStatus = .success(biometricUnlockStatus)
+
+        subject.receive(.toggleUnlockMethod(.biometrics(.faceID), newValue: true))
+        waitFor { subject.state.isBiometricUnlockOn }
+
+        XCTAssertEqual(authRepository.allowBiometricUnlock, true)
+        XCTAssertEqual(subject.state.biometricsStatus, biometricUnlockStatus)
+        XCTAssertTrue(subject.state.isBiometricUnlockOn)
+    }
+
+    /// `receive(_:)` with `.toggleUnlockMethod` logs an error and shows an alert if enabling biometrics fails.
+    @MainActor
+    func test_receive_toggleUnlockMethod_biometrics_enable_error() {
+        let biometricUnlockStatus = BiometricsUnlockStatus.available(.faceID, enabled: false, hasValidIntegrity: false)
+        authRepository.allowBiometricUnlockResult = .failure(BitwardenTestError.example)
+        biometricsRepository.biometricUnlockStatus = .success(biometricUnlockStatus)
+        subject.state.biometricsStatus = biometricUnlockStatus
+
+        subject.receive(.toggleUnlockMethod(.biometrics(.faceID), newValue: true))
+        waitFor { !coordinator.alertShown.isEmpty }
+
+        XCTAssertEqual(authRepository.allowBiometricUnlock, true)
+        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertEqual(subject.state.biometricsStatus, biometricUnlockStatus)
         XCTAssertFalse(subject.state.isBiometricUnlockOn)
     }
 
@@ -125,10 +186,20 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
     /// `receive(_:)` with `.toggleUnlockMethod` updates the touch ID unlock method in the state.
     @MainActor
     func test_receive_toggleUnlockMethod_touchID() {
-        subject.receive(.toggleUnlockMethod(.touchID, newValue: true))
+        subject.state.biometricsStatus = .available(.touchID, enabled: false, hasValidIntegrity: false)
+        biometricsRepository.biometricUnlockStatus = .success(
+            .available(.touchID, enabled: true, hasValidIntegrity: true)
+        )
+
+        subject.receive(.toggleUnlockMethod(.biometrics(.touchID), newValue: true))
+        waitFor { subject.state.isBiometricUnlockOn }
         XCTAssertTrue(subject.state.isBiometricUnlockOn)
 
-        subject.receive(.toggleUnlockMethod(.touchID, newValue: false))
+        biometricsRepository.biometricUnlockStatus = .success(
+            .available(.touchID, enabled: false, hasValidIntegrity: false)
+        )
+        subject.receive(.toggleUnlockMethod(.biometrics(.touchID), newValue: false))
+        waitFor { !subject.state.isBiometricUnlockOn }
         XCTAssertFalse(subject.state.isBiometricUnlockOn)
     }
 }

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupViewTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupViewTests.swift
@@ -32,7 +32,7 @@ class VaultUnlockSetupViewTests: BitwardenTestCase {
     /// Tapping the continue button dispatches the continue flow action.
     @MainActor
     func test_continue_tap() throws {
-        processor.state.isBiometricUnlockOn = true
+        processor.state.biometricsStatus = .available(.faceID, enabled: true, hasValidIntegrity: true)
         let button = try subject.inspect().find(button: Localizations.continue)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .continueFlow)
@@ -44,11 +44,11 @@ class VaultUnlockSetupViewTests: BitwardenTestCase {
         var button = try subject.inspect().find(button: Localizations.continue)
         XCTAssertTrue(button.isDisabled())
 
-        processor.state.isBiometricUnlockOn = true
+        processor.state.biometricsStatus = .available(.faceID, enabled: true, hasValidIntegrity: true)
         button = try subject.inspect().find(button: Localizations.continue)
         XCTAssertFalse(button.isDisabled())
 
-        processor.state.isBiometricUnlockOn = false
+        processor.state.biometricsStatus = .available(.faceID, enabled: false, hasValidIntegrity: false)
         processor.state.isPinUnlockOn = true
         button = try subject.inspect().find(button: Localizations.continue)
         XCTAssertFalse(button.isDisabled())
@@ -96,8 +96,7 @@ class VaultUnlockSetupViewTests: BitwardenTestCase {
     /// The vault unlock setup view renders correctly with an unlock method enabled.
     @MainActor
     func test_snapshot_vaultUnlockSetup_unlockMethodEnabled() {
-        processor.state.biometricsStatus = .available(.faceID, enabled: false, hasValidIntegrity: false)
-        processor.state.isBiometricUnlockOn = true
+        processor.state.biometricsStatus = .available(.faceID, enabled: true, hasValidIntegrity: true)
         assertSnapshots(
             of: subject.navStackWrapped,
             as: [.defaultPortrait]

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -262,11 +262,6 @@ final class AccountSecurityProcessor: StateProcessor<
         do {
             try await services.authRepository.allowBioMetricUnlock(enabled)
             state.biometricUnlockStatus = try await services.biometricsRepository.getBiometricUnlockStatus()
-            // Set biometric integrity if needed.
-            if case .available(_, true, false) = state.biometricUnlockStatus {
-                try await services.biometricsRepository.configureBiometricIntegrity()
-                state.biometricUnlockStatus = try await services.biometricsRepository.getBiometricUnlockStatus()
-            }
 
             // Refresh vault timeout action in case the user doesn't have a password and biometric
             // unlock was disabled.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -663,20 +663,6 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(subject.state.biometricUnlockStatus, biometricUnlockStatus)
     }
 
-    /// `perform(_:)` with `.toggleUnlockWithBiometrics` configures biometric integrity state if needed.
-    @MainActor
-    func test_perform_toggleUnlockWithBiometrics_invalidBiometryState() async {
-        let biometricUnlockStatus = BiometricsUnlockStatus.available(.faceID, enabled: true, hasValidIntegrity: false)
-        biometricsRepository.biometricUnlockStatus = .success(
-            biometricUnlockStatus
-        )
-        authRepository.allowBiometricUnlockResult = .success(())
-        subject.state.biometricUnlockStatus = .available(.faceID, enabled: false, hasValidIntegrity: false)
-        await subject.perform(.toggleUnlockWithBiometrics(false))
-
-        XCTAssertTrue(biometricsRepository.didConfigureBiometricIntegrity)
-    }
-
     /// `perform(_:)` with `.toggleUnlockWithBiometrics` updates the state.
     @MainActor
     func test_perform_toggleUnlockWithBiometrics_success() async {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10271](https://bitwarden.atlassian.net/browse/PM-10271)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

On the set up unlock view, this enables toggling the Face/Touch ID toggle for turning biometrics unlock on or off.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/0f274056-342b-4403-b565-68776a98912e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10271]: https://bitwarden.atlassian.net/browse/PM-10271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ