### PR TITLE
[PM-10838] Use CI-main for regular builds to production and beta

### DIFF
--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -88,9 +88,6 @@ jobs:
       matrix:
         variant: [Beta, Production]
         xcode: [15.4]
-        include:
-          - variant: Production
-            xcode: 16.0-beta
     with:
       build-variant: ${{ matrix.variant }}
       build-version: ${{ needs.resolve-values.outputs.build_version }}

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -15,6 +15,9 @@ on:
         required: false
         type: number
 
+env:
+  XCODE_VERSION: '15.4'
+
 jobs:
   resolve-values:
     name: "Resolve values"
@@ -77,7 +80,6 @@ jobs:
           echo "**Build Number**: $next_number" | tee -a $GITHUB_STEP_SUMMARY
           echo "version=$next_version" >> $GITHUB_OUTPUT
           echo "build_number=$next_number" >> $GITHUB_OUTPUT
-          echo "variant=$BUILD_VARIANT" >> $GITHUB_OUTPUT
           echo "xcode_version=$XCODE_VERSION" >> $GITHUB_OUTPUT
 
   build:
@@ -87,10 +89,9 @@ jobs:
     strategy:
       matrix:
         variant: [Beta, Production]
-        xcode: [15.4]
     with:
       build-variant: ${{ matrix.variant }}
       build-version: ${{ needs.resolve-values.outputs.build_version }}
       build-number: ${{ needs.resolve-values.outputs.build_number }}
-      xcode-version: ${{ matrix.xcode }}
+      xcode-version: ${{ needs.resolve-values.outputs.xcode_version }}
     secrets: inherit

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -18,15 +18,10 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-14
-    env:
-      MINT_PATH: .mint/lib
-      MINT_LINK_PATH: .mint/bin
-
-    steps:
-      - name: Check out repo
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        with:
-          fetch-depth: 0
-          filter: tree:0
-
+    uses: ./.github/workflows/build.yml
+    with:
+      build-variant: Beta
+      build-version: 1.2.3
+      build-number: 45
+      xcode-version: 15.4
+    secrets: inherit

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -88,6 +88,9 @@ jobs:
       matrix:
         variant: [Beta, Production]
         xcode: [15.4]
+        include:
+          - variant: Production
+            xcode: 16.0-beta
     with:
       build-variant: ${{ matrix.variant }}
       build-version: ${{ needs.resolve-values.outputs.build_version }}

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -16,7 +16,81 @@ on:
         type: number
 
 jobs:
+  resolve-values:
+    name: "Resolve values"
+    runs-on: macos-14
+    outputs:
+      build_variant: ${{ steps.calculate.outputs.variant }}
+      build_version: ${{ steps.calculate.outputs.version }}
+      build_number: ${{ steps.calculate.outputs.build_number }}
+      xcode_version: ${{ steps.calculate.outputs.xcode_version }}
+
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Calculate build version and number
+        id: calculate
+        run: |
+          if [[ ! -z "${{ inputs.build-version }}" ]]; then
+            echo -e "\nApplying build version override"
+            next_version=${{ inputs.build-version }}
+          else
+            echo -e "\nCalculating next version..."
+            current_year=$(date +%Y)
+            current_month=$(date +%-m)
+
+            latest_tag_version=$(git tag --sort=committerdate --list | tail -1)
+            latest_version=${latest_tag_version:1}  # remove 'v' from tag version
+
+            latest_major_version=$(echo $latest_version | cut -d "." -f 1)
+            latest_minor_version=$(echo $latest_version | cut -d "." -f 2)
+            latest_patch_version=$(echo $latest_version | cut -d "." -f 3)
+
+            echo "  Current Year:         $current_year"
+            echo "  Current Month:        $current_month"
+            echo "  Latest Version:       $latest_version"
+            echo "  Latest Major Version: $latest_major_version"
+            echo "  Latest Minor Version: $latest_minor_version"
+            echo "  Latest Patch Version: $latest_patch_version"
+
+            if [[ "$current_year" == "$latest_major_version" && "$current_month" == "$latest_minor_version" ]]; then
+              next_version="${latest_major_version}.${latest_minor_version}.$(($latest_patch_version + 1))"
+            else
+              next_version="${current_year}.${current_month}.0"
+            fi
+          fi
+
+          if [[ ! -z "${{ inputs.build-number }}" ]]; then
+            echo -e "\nApplying build number override"
+            next_number=${{ inputs.build-number }}
+          else
+            echo -e "\nCalculating build number..."
+            next_number=$(($GITHUB_RUN_NUMBER + 1000))
+          fi
+
+          echo -e "\n"
+          echo "**Version**: $next_version" | tee -a $GITHUB_STEP_SUMMARY
+          echo "**Build Number**: $next_number" | tee -a $GITHUB_STEP_SUMMARY
+          echo "version=$next_version" >> $GITHUB_OUTPUT
+          echo "build_number=$next_number" >> $GITHUB_OUTPUT
+          echo "variant=$BUILD_VARIANT" >> $GITHUB_OUTPUT
+          echo "xcode_version=$XCODE_VERSION" >> $GITHUB_OUTPUT
+
   build:
     name: Build
+    needs: resolve-values
     uses: ./.github/workflows/build.yml
+    strategy:
+      matrix:
+        variant: [Beta, Production]
+        xcode: [15.4]
+    with:
+      build-variant: ${{ matrix.variant }}
+      build-version: ${{ needs.resolve-values.outputs.build_version }}
+      build-number: ${{ needs.resolve-values.outputs.build_number }}
+      xcode-version: ${{ matrix.xcode }}
     secrets: inherit

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -19,9 +19,4 @@ jobs:
   build:
     name: Build
     uses: ./.github/workflows/build.yml
-    with:
-      build-variant: Beta
-      build-version: 1.2.3
-      build-number: 45
-      xcode-version: 15.4
     secrets: inherit

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -3,7 +3,7 @@ name: CI - main
 on:
   push:
     branches:
-      - pm-10838/ci-main 
+      - main
   workflow_dispatch:
     inputs:
       build-version:

--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -3,7 +3,7 @@ name: CI - main
 on:
   push:
     branches:
-      - none
+      - pm-10838/ci-main 
   workflow_dispatch:
     inputs:
       build-version:
@@ -29,3 +29,4 @@ jobs:
         with:
           fetch-depth: 0
           filter: tree:0
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,57 @@ jobs:
           fetch-depth: 0
           filter: tree:0
 
+      - name: Calculate build version and number
+        id: calculate
+        run: |
+          if [[ ! -z "${{ inputs.build-version }}" ]]; then
+            echo -e "\nApplying build version override"
+            next_version=${{ inputs.build-version }}
+          else
+            echo -e "\nCalculating next version..."
+            current_year=$(date +%Y)
+            current_month=$(date +%-m)
+
+            latest_tag_version=$(git tag --sort=committerdate --list | tail -1)
+            latest_version=${latest_tag_version:1}  # remove 'v' from tag version
+
+            latest_major_version=$(echo $latest_version | cut -d "." -f 1)
+            latest_minor_version=$(echo $latest_version | cut -d "." -f 2)
+            latest_patch_version=$(echo $latest_version | cut -d "." -f 3)
+
+            echo "  Current Year:         $current_year"
+            echo "  Current Month:        $current_month"
+            echo "  Latest Version:       $latest_version"
+            echo "  Latest Major Version: $latest_major_version"
+            echo "  Latest Minor Version: $latest_minor_version"
+            echo "  Latest Patch Version: $latest_patch_version"
+
+            if [[ "$current_year" == "$latest_major_version" && "$current_month" == "$latest_minor_version" ]]; then
+              next_version="${latest_major_version}.${latest_minor_version}.$(($latest_patch_version + 1))"
+            else
+              next_version="${current_year}.${current_month}.0"
+            fi
+          fi
+
+          if [[ ! -z "${{ inputs.build-number }}" ]]; then
+            echo -e "\nApplying build number override"
+            next_number=${{ inputs.build-number }}
+          else
+            echo -e "\nCalculating build number..."
+            next_number=$(($GITHUB_RUN_NUMBER))
+          fi
+
+          echo -e "\n"
+          echo "version=$next_version" >> $GITHUB_OUTPUT
+          echo "build_number=$next_number" >> $GITHUB_OUTPUT
+
+      - name: Print values
+        run: |
+          echo "**Variant**: ${{ env.BUILD_VARIANT }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "**Version**: ${{ steps.calculate.outputs.version }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "**Number**: ${{ steps.calculate.outputs.build_number }}" | tee -a $GITHUB_STEP_SUMMARY
+          echo "**Xcode**: ${{ env.XCODE_VERSION }}" | tee -a $GITHUB_STEP_SUMMARY
+
       - name: Set Xcode version
         uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
         with:
@@ -310,53 +361,6 @@ jobs:
       - name: Select variant
         run: |
           ./Scripts/select_variant.sh ${{ env.BUILD_VARIANT }}
-          echo "**Variant**: ${{ env.BUILD_VARIANT }}" | tee -a $GITHUB_STEP_SUMMARY
-
-      - name: Calculate build version and number
-        id: calculate
-        run: |
-          if [[ ! -z "${{ inputs.build-version }}" ]]; then
-            echo -e "\nApplying build version override"
-            next_version=${{ inputs.build-version }}
-          else
-            echo -e "\nCalculating next version..."
-            current_year=$(date +%Y)
-            current_month=$(date +%-m)
-
-            latest_tag_version=$(git tag --sort=committerdate --list | tail -1)
-            latest_version=${latest_tag_version:1}  # remove 'v' from tag version
-
-            latest_major_version=$(echo $latest_version | cut -d "." -f 1)
-            latest_minor_version=$(echo $latest_version | cut -d "." -f 2)
-            latest_patch_version=$(echo $latest_version | cut -d "." -f 3)
-
-            echo "  Current Year:         $current_year"
-            echo "  Current Month:        $current_month"
-            echo "  Latest Version:       $latest_version"
-            echo "  Latest Major Version: $latest_major_version"
-            echo "  Latest Minor Version: $latest_minor_version"
-            echo "  Latest Patch Version: $latest_patch_version"
-
-            if [[ "$current_year" == "$latest_major_version" && "$current_month" == "$latest_minor_version" ]]; then
-              next_version="${latest_major_version}.${latest_minor_version}.$(($latest_patch_version + 1))"
-            else
-              next_version="${current_year}.${current_month}.0"
-            fi
-          fi
-
-          if [[ ! -z "${{ inputs.build-number }}" ]]; then
-            echo -e "\nApplying build number override"
-            next_number=${{ inputs.build-number }}
-          else
-            echo -e "\nCalculating build number..."
-            next_number=$(($GITHUB_RUN_NUMBER))
-          fi
-
-          echo -e "\n"
-          echo "**Version**: $next_version" | tee -a $GITHUB_STEP_SUMMARY
-          echo "**Build Number**: $next_number" | tee -a $GITHUB_STEP_SUMMARY
-          echo "version=$next_version" >> $GITHUB_OUTPUT
-          echo "build_number=$next_number" >> $GITHUB_OUTPUT
 
       - name: Update build version and number
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,10 +403,10 @@ jobs:
             --apiKey "J46C83CB96" \
             --apiIssuer "${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}"
 
-      - name: Upload app to TestFlight with Fastlane
-        run: |
-          NEWLINE=$'\n'
-          fastlane upload_build \
-            api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
-            changelog:"$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINE$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-            ipa_path:"export/Bitwarden.ipa"
+      # - name: Upload app to TestFlight with Fastlane
+      #   run: |
+      #     NEWLINE=$'\n'
+      #     fastlane upload_build \
+      #       api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
+      #       changelog:"$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINE$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+      #       ipa_path:"export/Bitwarden.ipa"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -370,27 +370,26 @@ jobs:
           yq -i '.settings.MARKETING_VERSION = "${{ env.build_version }}"' 'project.yml'
           yq -i '.settings.CURRENT_PROJECT_VERSION = "${{ env.build_number }}"' 'project.yml'
 
-      - name: Update app CI Build info
+      - name: Update CI build info
         run: |
           ./Scripts/update_app_ci_build_info.sh ${{ github.run_id }} ${{ github.run_number }} ${{ github.run_attempt }}
 
-      # - name: Build iOS app
-      #   run: |
-      #     BUILD_NUMBER=$(($GITHUB_RUN_NUMBER))
-      #     ./Scripts/build.sh
+      - name: Build iOS app
+        run: |
+          ./Scripts/build.sh
 
-      # - name: Prepare IPA & dSYM files for upload to GitHub
-      #   run: |
-      #     mkdir -p export/dSYMs
-      #     cp build/Bitwarden/Bitwarden.ipa export
-      #     cp -rv build/Bitwarden.xcarchive/dSYMs/*.dSYM export/dSYMs
+      - name: Prepare IPA & dSYM files for upload to GitHub
+        run: |
+          mkdir -p export/dSYMs
+          cp build/Bitwarden/Bitwarden.ipa export
+          cp -rv build/Bitwarden.xcarchive/dSYMs/*.dSYM export/dSYMs
 
-      # - name: Upload IPA & dSYM files
-      #   uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      #   with:
-      #     name: Bitwarden iOS
-      #     path: export
-      #     if-no-files-found: error
+      - name: Upload IPA & dSYM files
+        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        with:
+          name: Bitwarden iOS ${{ env.BUILD_VARIANT }}
+          path: export
+          if-no-files-found: error
       
       # - name: Set up private auth key
       #   run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,24 @@ on:
         description: "Optional. Xcode version to use. Overrides default."
         required: false
         type: string
+  workflow_call:
+    inputs:
+      build-variant:
+        description: "Which variant of the app to build"
+        required: false
+        type: string
+      build-version:
+        description: "Version string to use, in X.Y.Z format"
+        required: false
+        type: string
+      build-number:
+        description: "Build number to use"
+        required: false
+        type: string
+      xcode-version:
+        description: "Xcode version to use"
+        required: false
+        type: string
 
 env:
   BUILD_VARIANT: ${{ inputs.build-variant || 'Beta' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -388,20 +388,20 @@ jobs:
           path: export
           if-no-files-found: error
       
-      # - name: Set up private auth key
-      #   run: |
-      #     mkdir ~/private_keys
-      #     cat << EOF > ~/private_keys/AuthKey_J46C83CB96.p8
-      #     ${{ secrets.APP_STORE_CONNECT_AUTH_KEY }}
-      #     EOF
+      - name: Set up private auth key
+        run: |
+          mkdir ~/private_keys
+          cat << EOF > ~/private_keys/AuthKey_J46C83CB96.p8
+          ${{ secrets.APP_STORE_CONNECT_AUTH_KEY }}
+          EOF
 
-      # - name: Validate app with App Store Connect
-      #   run: |
-      #     xcrun altool --validate-app \
-      #       --type ios \
-      #       --file "export/Bitwarden.ipa" \
-      #       --apiKey "J46C83CB96" \
-      #       --apiIssuer "${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}"
+      - name: Validate app with App Store Connect
+        run: |
+          xcrun altool --validate-app \
+            --type ios \
+            --file "export/Bitwarden.ipa" \
+            --apiKey "J46C83CB96" \
+            --apiIssuer "${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}"
 
       # - name: Upload app to TestFlight with Fastlane
       #   run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,10 +403,10 @@ jobs:
             --apiKey "J46C83CB96" \
             --apiIssuer "${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}"
 
-      # - name: Upload app to TestFlight with Fastlane
-      #   run: |
-      #     NEWLINE=$'\n'
-      #     fastlane upload_build \
-      #       api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
-      #       changelog:"$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINE$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-      #       ipa_path:"export/Bitwarden.ipa"
+      - name: Upload app to TestFlight with Fastlane
+        run: |
+          NEWLINE=$'\n'
+          fastlane upload_build \
+            api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
+            changelog:"$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINE$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            ipa_path:"export/Bitwarden.ipa"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -349,9 +349,9 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Install Fastlane, Mint, xcbeautify, and yq
+      - name: Install Fastlane, Mint
         run: |
-          brew install fastlane mint xcbeautify yq
+          brew install fastlane mint
 
       - name: Install Mint packages
         if: steps.mint-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       build-variant:
@@ -387,7 +384,7 @@ jobs:
       - name: Upload IPA & dSYM files
         uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
         with:
-          name: Bitwarden iOS ${{ env.BUILD_VARIANT }}
+          name: Bitwarden iOS ${{ steps.calculate.outputs.version }} (${{ steps.calculate.outputs.build_number }}) ${{ env.BUILD_VARIANT }} ${{ env.XCODE_VERSION }}
           path: export
           if-no-files-found: error
       

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,40 +368,40 @@ jobs:
 
       - name: Update app CI Build info
         run: |
-          ./Scripts/update_app_ci_build_info.sh ${{ github.run_id }} ${{ github.run_number }} ${{ github.run_attempt }}
+          ./Scripts/update_app_ci_build_info.sh ${{ github.run_id }} ${{ github.run_number }} ${{ github.run_attempt }}
 
-      - name: Build iOS app
-        run: |
-          BUILD_NUMBER=$(($GITHUB_RUN_NUMBER))
-          ./Scripts/build.sh
+      # - name: Build iOS app
+      #   run: |
+      #     BUILD_NUMBER=$(($GITHUB_RUN_NUMBER))
+      #     ./Scripts/build.sh
 
-      - name: Prepare IPA & dSYM files for upload to GitHub
-        run: |
-          mkdir -p export/dSYMs
-          cp build/Bitwarden/Bitwarden.ipa export
-          cp -rv build/Bitwarden.xcarchive/dSYMs/*.dSYM export/dSYMs
+      # - name: Prepare IPA & dSYM files for upload to GitHub
+      #   run: |
+      #     mkdir -p export/dSYMs
+      #     cp build/Bitwarden/Bitwarden.ipa export
+      #     cp -rv build/Bitwarden.xcarchive/dSYMs/*.dSYM export/dSYMs
 
-      - name: Upload IPA & dSYM files
-        uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-        with:
-          name: Bitwarden iOS
-          path: export
-          if-no-files-found: error
+      # - name: Upload IPA & dSYM files
+      #   uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+      #   with:
+      #     name: Bitwarden iOS
+      #     path: export
+      #     if-no-files-found: error
       
-      - name: Set up private auth key
-        run: |
-          mkdir ~/private_keys
-          cat << EOF > ~/private_keys/AuthKey_J46C83CB96.p8
-          ${{ secrets.APP_STORE_CONNECT_AUTH_KEY }}
-          EOF
+      # - name: Set up private auth key
+      #   run: |
+      #     mkdir ~/private_keys
+      #     cat << EOF > ~/private_keys/AuthKey_J46C83CB96.p8
+      #     ${{ secrets.APP_STORE_CONNECT_AUTH_KEY }}
+      #     EOF
 
-      - name: Validate app with App Store Connect
-        run: |
-          xcrun altool --validate-app \
-            --type ios \
-            --file "export/Bitwarden.ipa" \
-            --apiKey "J46C83CB96" \
-            --apiIssuer "${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}"
+      # - name: Validate app with App Store Connect
+      #   run: |
+      #     xcrun altool --validate-app \
+      #       --type ios \
+      #       --file "export/Bitwarden.ipa" \
+      #       --apiKey "J46C83CB96" \
+      #       --apiIssuer "${{ secrets.APP_STORE_CONNECT_TEAM_ISSUER }}"
 
       # - name: Upload app to TestFlight with Fastlane
       #   run: |


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10838

## 📔 Objective

This expands the `build.yml` workflow to be callable, and migrates building-on-pushes-to-main from it to `ci-main.yml`, which will call `build.yml` for those builds using a matrix strategy.

Unfortunately, we'll need to push the build numbers up to avoid conflicts for the time being.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
