### PR TITLE
PM-10893: Add option to prevent feature flags from being configured remotely

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -5,12 +5,36 @@ import Foundation
 /// An enum to represent a feature flag sent by the server
 ///
 enum FeatureFlag: String, Codable {
+    /// Flag to enable/disable email verification during registration
+    /// This flag introduces a new flow for account creation
+    case emailVerification = "email-verification"
+
     /// A feature flag for the intro carousel flow.
     case nativeCarouselFlow = "native-carousel-flow"
 
     /// A feature flag for showing the unassigned items banner.
     case unassignedItemsBanner = "unassigned-items-banner"
-    /// Flag to enable/disable email verification during registration
-    /// This flag introduces a new flow for account creation
-    case emailVerification = "email-verification"
+
+    // MARK: Test Flags
+
+    /// A test feature flag that isn't remotely configured.
+    case testLocalFeatureFlag = "test-local-feature-flag"
+
+    /// A test feature flag that can be remotely configured.
+    case testRemoteFeatureFlag = "test-remote-feature-flag"
+
+    // MARK: Properties
+
+    /// Whether this feature can be enabled remotely.
+    var isRemotelyConfigured: Bool {
+        switch self {
+        case .emailVerification,
+             .nativeCarouselFlow,
+             .testLocalFeatureFlag:
+            false
+        case .testRemoteFeatureFlag,
+             .unassignedItemsBanner:
+            true
+        }
+    }
 }

--- a/BitwardenShared/Core/Platform/Services/API/Fixtures/ValidServerConfig.json
+++ b/BitwardenShared/Core/Platform/Services/API/Fixtures/ValidServerConfig.json
@@ -30,7 +30,9 @@
         "enable-consolidated-billing": false,
         "AC-1795_updated-subscription-status-section": true,
         "unassigned-items-banner": true,
-        "AC-1218-delete-provider": false
+        "AC-1218-delete-provider": false,
+        "test-local-feature-flag": true,
+        "test-remote-feature-flag": true
     },
     "object": "config"
 }

--- a/BitwardenShared/Core/Platform/Services/ConfigService.swift
+++ b/BitwardenShared/Core/Platform/Services/ConfigService.swift
@@ -139,16 +139,19 @@ class DefaultConfigService: ConfigService {
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Bool = false, forceRefresh: Bool = false) async -> Bool {
+        guard flag.isRemotelyConfigured else { return defaultValue }
         let configuration = await getConfig(forceRefresh: forceRefresh)
         return configuration?.featureStates[flag]?.boolValue ?? defaultValue
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Int = 0, forceRefresh: Bool = false) async -> Int {
+        guard flag.isRemotelyConfigured else { return defaultValue }
         let configuration = await getConfig(forceRefresh: forceRefresh)
         return configuration?.featureStates[flag]?.intValue ?? defaultValue
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: String? = nil, forceRefresh: Bool = false) async -> String? {
+        guard flag.isRemotelyConfigured else { return defaultValue }
         let configuration = await getConfig(forceRefresh: forceRefresh)
         return configuration?.featureStates[flag]?.stringValue ?? defaultValue
     }

--- a/BitwardenShared/Core/Platform/Services/ConfigServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ConfigServiceTests.swift
@@ -102,7 +102,7 @@ final class ConfigServiceTests: BitwardenTestCase {
         let response = await subject.getConfig(forceRefresh: false)
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertEqual(response?.gitHash, "75238191")
-        XCTAssertEqual(response?.featureStates[.unassignedItemsBanner], .bool(true))
+        XCTAssertEqual(response?.featureStates[.testRemoteFeatureFlag], .bool(true))
     }
 
     /// `getFeatureFlag(:)` can return a boolean if it's in the configuration
@@ -111,13 +111,13 @@ final class ConfigServiceTests: BitwardenTestCase {
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["unassigned-items-banner": .bool(true)],
+                featureStates: ["test-remote-feature-flag": .bool(true)],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.unassignedItemsBanner, defaultValue: false, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: false, forceRefresh: false)
         XCTAssertTrue(value)
     }
 
@@ -133,8 +133,24 @@ final class ConfigServiceTests: BitwardenTestCase {
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.unassignedItemsBanner, defaultValue: true, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: true, forceRefresh: false)
         XCTAssertTrue(value)
+    }
+
+    /// `getFeatureFlag(:)` returns the default value if the feature is not remotely configurable for booleans
+    func test_getFeatureFlag_bool_notRemotelyConfigured() async {
+        stateService.serverConfig["1"] = ServerConfig(
+            date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
+            responseModel: ConfigResponseModel(
+                environment: nil,
+                featureStates: ["test-remote-feature-flag": .bool(true)],
+                gitHash: "75238191",
+                server: nil,
+                version: "2024.4.0"
+            )
+        )
+        let value = await subject.getFeatureFlag(.testLocalFeatureFlag, defaultValue: false, forceRefresh: false)
+        XCTAssertFalse(value)
     }
 
     /// `getFeatureFlag(:)` can return an integer if it's in the configuration
@@ -143,13 +159,13 @@ final class ConfigServiceTests: BitwardenTestCase {
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["unassigned-items-banner": .int(42)],
+                featureStates: ["test-remote-feature-flag": .int(42)],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.unassignedItemsBanner, defaultValue: 30, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: 30, forceRefresh: false)
         XCTAssertEqual(value, 42)
     }
 
@@ -165,7 +181,23 @@ final class ConfigServiceTests: BitwardenTestCase {
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.unassignedItemsBanner, defaultValue: 30, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: 30, forceRefresh: false)
+        XCTAssertEqual(value, 30)
+    }
+
+    /// `getFeatureFlag(:)` returns the default value if the feature is not remotely configurable for integers
+    func test_getFeatureFlag_int_notRemotelyConfigured() async {
+        stateService.serverConfig["1"] = ServerConfig(
+            date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
+            responseModel: ConfigResponseModel(
+                environment: nil,
+                featureStates: ["test-remote-feature-flag": .int(42)],
+                gitHash: "75238191",
+                server: nil,
+                version: "2024.4.0"
+            )
+        )
+        let value = await subject.getFeatureFlag(.testLocalFeatureFlag, defaultValue: 30, forceRefresh: false)
         XCTAssertEqual(value, 30)
     }
 
@@ -175,17 +207,17 @@ final class ConfigServiceTests: BitwardenTestCase {
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["unassigned-items-banner": .string("exists")],
+                featureStates: ["test-remote-feature-flag": .string("exists")],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.unassignedItemsBanner, defaultValue: "fallback", forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: "fallback", forceRefresh: false)
         XCTAssertEqual(value, "exists")
     }
 
-    /// `getFeatureFlag(:)` returns the default value for booleans
+    /// `getFeatureFlag(:)` returns the default value for strings
     func test_getFeatureFlag_string_fallback() async {
         stateService.serverConfig["1"] = ServerConfig(
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
@@ -197,7 +229,23 @@ final class ConfigServiceTests: BitwardenTestCase {
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.unassignedItemsBanner, defaultValue: "fallback", forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: "fallback", forceRefresh: false)
+        XCTAssertEqual(value, "fallback")
+    }
+
+    /// `getFeatureFlag(:)` returns the default value if the feature is not remotely configurable for strings
+    func test_getFeatureFlag_string_notRemotelyConfigured() async {
+        stateService.serverConfig["1"] = ServerConfig(
+            date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
+            responseModel: ConfigResponseModel(
+                environment: nil,
+                featureStates: ["test-remote-feature-flag": .string("exists")],
+                gitHash: "75238191",
+                server: nil,
+                version: "2024.4.0"
+            )
+        )
+        let value = await subject.getFeatureFlag(.testLocalFeatureFlag, defaultValue: "fallback", forceRefresh: false)
         XCTAssertEqual(value, "fallback")
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10893](https://bitwarden.atlassian.net/browse/PM-10893)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a property to feature flags to prevent them from being configured remotely. Since some features are developed behind feature flags, when the flag is ready to be enabled, there may be previous app versions in use that have that flag but are not feature complete. This ensures that feature flags can only enabled on app versions after we allow remote configuration. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10893]: https://bitwarden.atlassian.net/browse/PM-10893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ