### PR TITLE
PM-10945: Add Key Connector API requests

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/PostKeyConnectorUserKeyRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/PostKeyConnectorUserKeyRequestModel.swift
@@ -1,0 +1,12 @@
+import Networking
+
+// MARK: - PostKeyConnectorUserKeyRequestModel
+
+/// API request model for sending a user's key to the key connector API.
+///
+struct PostKeyConnectorUserKeyRequestModel: JSONRequestBody {
+    // MARK: Properties
+
+    /// The user's key.
+    let key: String
+}

--- a/BitwardenShared/Core/Auth/Models/Request/SetKeyConnectorKeyRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/SetKeyConnectorKeyRequestModel.swift
@@ -1,0 +1,50 @@
+import Networking
+
+// MARK: - SetKeyConnectorKeyRequestModel
+
+/// API request model for sending a user's key connector key to the API.
+///
+struct SetKeyConnectorKeyRequestModel: JSONRequestBody {
+    // MARK: Properties
+
+    /// The type of kdf for this request.
+    let kdf: KdfType
+
+    /// The number of kdf iterations performed in this request.
+    let kdfIterations: Int
+
+    /// The kdf memory allocated for the computed password hash.
+    let kdfMemory: Int?
+
+    /// The number of threads upon which the kdf iterations are performed.
+    let kdfParallelism: Int?
+
+    /// The user's key.
+    let key: String
+
+    /// The keys used for this request.
+    let keys: KeysRequestModel
+
+    /// The organization's identifier.
+    let orgIdentifier: String
+
+    // MARK: Initialization
+
+    /// Initializes a `SetKeyConnectorKeyRequestModel`.
+    ///
+    /// - Parameters:
+    ///   - kdfConfig: The user's KDF options.
+    ///   - key: The user's key.
+    ///   - keys: The user's keys.
+    ///   - orgIdentifier: The organization's identifier.
+    ///
+    init(kdfConfig: KdfConfig, key: String, keys: KeysRequestModel, orgIdentifier: String) {
+        kdf = kdfConfig.kdf
+        kdfIterations = kdfConfig.kdfIterations
+        kdfMemory = kdfConfig.kdfMemory
+        kdfParallelism = kdfConfig.kdfParallelism
+        self.key = key
+        self.keys = keys
+        self.orgIdentifier = orgIdentifier
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Response/KeyConnectorUserKeyResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/KeyConnectorUserKeyResponseModel.swift
@@ -1,0 +1,12 @@
+import Networking
+
+// MARK: - KeyConnectorUserKeyResponseModel
+
+/// The response returned from the API when fetching the user's key from the key connector API.
+///
+struct KeyConnectorUserKeyResponseModel: JSONResponse {
+    // MARK: Properties
+
+    /// The user's key.
+    let key: String
+}

--- a/BitwardenShared/Core/Auth/Models/Response/KeyConnectorUserKeyResponseModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/KeyConnectorUserKeyResponseModelTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class KeyConnectorUserKeyResponseModelTests: BitwardenTestCase {
+    // MARK: - Tests
+
+    /// Tests the successful decoding of a JSON response.
+    func test_decode_success() throws {
+        let json = APITestData.keyConnectorUserKey.data
+        let subject = try KeyConnectorUserKeyResponseModel.decoder.decode(
+            KeyConnectorUserKeyResponseModel.self,
+            from: json
+        )
+        XCTAssertEqual(subject.key, "EXsYYd2Wx4H/9dhzmINS0P30lpG8bZ44RRn/T15tVA8=")
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIService.swift
@@ -21,6 +21,10 @@ protocol AccountAPIService {
     ///
     func checkDataBreaches(password: String) async throws -> Int
 
+    /// Converts the user's account to use key connector.
+    ///
+    func convertToKeyConnector() async throws
+
     /// Creates an API call for when the user submits an account creation form.
     ///
     /// - Parameter body: The body to be included in the request.
@@ -73,6 +77,12 @@ protocol AccountAPIService {
     ///
     func setAccountKeys(requestModel: KeysRequestModel) async throws
 
+    /// Sets the user's key from key connector.
+    ///
+    /// - Parameter requestModel: The request model containing the user's key connector key.
+    ///
+    func setKeyConnectorKey(_ requestModel: SetKeyConnectorKeyRequestModel) async throws
+
     /// Performs the API request to set the user's password.
     ///
     /// - Parameter requestModel: The request model containing the details needed to set the user's
@@ -124,6 +134,10 @@ extension APIService: AccountAPIService {
         return response.leakedHashes[hashWithoutPrefix] ?? 0
     }
 
+    func convertToKeyConnector() async throws {
+        _ = try await apiService.send(ConvertToKeyConnectorRequest())
+    }
+
     func createNewAccount(body: CreateAccountRequestModel) async throws -> CreateAccountResponseModel {
         let request = CreateAccountRequest(body: body)
         return try await identityService.send(request)
@@ -156,6 +170,10 @@ extension APIService: AccountAPIService {
 
     func setAccountKeys(requestModel: KeysRequestModel) async throws {
         _ = try await apiService.send(SetAccountKeysRequest(body: requestModel))
+    }
+
+    func setKeyConnectorKey(_ requestModel: SetKeyConnectorKeyRequestModel) async throws {
+        _ = try await apiService.send(SetKeyConnectorKeyRequest(requestModel: requestModel))
     }
 
     func setPassword(_ requestModel: SetPasswordRequestModel) async throws {

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/ConvertToKeyConnectorRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/ConvertToKeyConnectorRequest.swift
@@ -1,0 +1,17 @@
+import Networking
+
+// MARK: - ConvertToKeyConnectorRequest
+
+/// The API request sent to convert a user's account to use key connector.
+///
+struct ConvertToKeyConnectorRequest: Request {
+    typealias Response = EmptyResponse
+
+    // MARK: Properties
+
+    /// The HTTP method for this request.
+    let method: HTTPMethod = .post
+
+    /// The URL path for this request.
+    let path: String = "/accounts/convert-to-key-connector"
+}

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/ConvertToKeyConnectorRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/ConvertToKeyConnectorRequestTests.swift
@@ -1,0 +1,27 @@
+import Networking
+import XCTest
+
+@testable import BitwardenShared
+
+class ConvertToKeyConnectorRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let subject = ConvertToKeyConnectorRequest()
+
+    // MARK: Tests
+
+    /// Validate that the request's body is `nil`.
+    func test_body() {
+        XCTAssertNil(subject.body)
+    }
+
+    /// Validate that the method is correct.
+    func test_method() {
+        XCTAssertEqual(subject.method, .post)
+    }
+
+    /// Validate that the path is correct.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/accounts/convert-to-key-connector")
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/SetKeyConnectorKeyRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/SetKeyConnectorKeyRequest.swift
@@ -1,0 +1,30 @@
+import Networking
+
+// MARK: - SetKeyConnectorKeyRequest
+
+/// The API request sent to set a user's key connector key.
+///
+struct SetKeyConnectorKeyRequest: Request {
+    typealias Response = EmptyResponse
+
+    // MARK: Properties
+
+    /// The body of this request.
+    var body: SetKeyConnectorKeyRequestModel?
+
+    /// The HTTP method for this request.
+    let method: HTTPMethod = .post
+
+    /// The URL path for this request.
+    let path: String = "/accounts/set-key-connector-key"
+
+    // MARK: Initialization
+
+    /// Creates a new `SetKeyConnectorKeyRequest` instance.
+    ///
+    /// - Parameter requestModel: The data model to send in the body of the request.
+    ///
+    init(requestModel: SetKeyConnectorKeyRequestModel) {
+        body = requestModel
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/SetKeyConnectorKeyRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/SetKeyConnectorKeyRequestTests.swift
@@ -1,0 +1,52 @@
+import Networking
+import XCTest
+
+@testable import BitwardenShared
+
+class SetKeyConnectorKeyRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let subject = SetKeyConnectorKeyRequest(
+        requestModel: SetKeyConnectorKeyRequestModel(
+            kdfConfig: KdfConfig(),
+            key: "key",
+            keys: KeysRequestModel(
+                encryptedPrivateKey: "encrypted-private-key",
+                publicKey: "public-key"
+            ),
+            orgIdentifier: "org-id"
+        )
+    )
+
+    // MARK: Tests
+
+    /// `body` is the JSON encoded request model.
+    func test_body() throws {
+        let bodyData = try XCTUnwrap(subject.body?.encode())
+        XCTAssertEqual(
+            bodyData.prettyPrintedJson,
+            """
+            {
+              "kdf" : 0,
+              "kdfIterations" : 600000,
+              "key" : "key",
+              "keys" : {
+                "encryptedPrivateKey" : "encrypted-private-key",
+                "publicKey" : "public-key"
+              },
+              "orgIdentifier" : "org-id"
+            }
+            """
+        )
+    }
+
+    /// Validate that the method is correct.
+    func test_method() {
+        XCTAssertEqual(subject.method, .post)
+    }
+
+    /// Validate that the path is correct.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/accounts/set-key-connector-key")
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/Fixtures/APITestData+KeyConnector.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/Fixtures/APITestData+KeyConnector.swift
@@ -1,0 +1,3 @@
+extension APITestData {
+    static let keyConnectorUserKey = loadFromJsonBundle(resource: "KeyConnectorUserKey")
+}

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/Fixtures/KeyConnectorUserKey.json
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/Fixtures/KeyConnectorUserKey.json
@@ -1,0 +1,3 @@
+{
+  "key": "EXsYYd2Wx4H/9dhzmINS0P30lpG8bZ44RRn/T15tVA8="
+}

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/KeyConnectorAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/KeyConnectorAPIService.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+// swiftlint:disable inclusive_language
+
+// MARK: - KeyConnectorAPIService
+
+/// A protocol for an API service used to make key connector requests.
+///
+protocol KeyConnectorAPIService {
+    /// Gets the user's master key from the key connector API.
+    ///
+    /// - Parameter keyConnectorUrl: The base URL of the key connector API.
+    /// - Returns: The user's master key.
+    ///
+    func getMasterKeyFromKeyConnector(keyConnectorUrl: URL) async throws -> String
+
+    /// Sends the user's master key to the key connector API.
+    ///
+    /// - Parameters:
+    ///   - key: The user's master key.
+    ///   - keyConnectorUrl: The base URL of the key connector API.
+    ///
+    func postMasterKeyToKeyConnector(key: String, keyConnectorUrl: URL) async throws
+}
+
+// MARK: - APIService
+
+extension APIService: KeyConnectorAPIService {
+    func getMasterKeyFromKeyConnector(keyConnectorUrl: URL) async throws -> String {
+        let service = buildKeyConnectorService(baseURL: keyConnectorUrl)
+        let response = try await service.send(KeyConnectorUserKeyRequest())
+        return response.key
+    }
+
+    func postMasterKeyToKeyConnector(key: String, keyConnectorUrl: URL) async throws {
+        let service = buildKeyConnectorService(baseURL: keyConnectorUrl)
+        let body = PostKeyConnectorUserKeyRequestModel(key: key)
+        _ = try await service.send(PostKeyConnectorUserKeyRequest(body: body))
+    }
+}
+
+// swiftlint:enable inclusive_language

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/KeyConnectorAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/KeyConnectorAPIServiceTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+
+@testable import BitwardenShared
+
+// swiftlint:disable inclusive_language
+
+class KeyConnectorAPIServiceTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var client: MockHTTPClient!
+    var subject: APIService!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        client = MockHTTPClient()
+        subject = APIService(client: client)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        client = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `getMasterKeyFromKeyConnector(keyConnectorUrl:)` returns the user's key.
+    func test_getMasterKeyFromKeyConnector() async throws {
+        client.result = .httpSuccess(testData: .keyConnectorUserKey)
+
+        let key = try await subject.getMasterKeyFromKeyConnector(
+            keyConnectorUrl: URL(string: "https://example.com")!
+        )
+        XCTAssertEqual(key, "EXsYYd2Wx4H/9dhzmINS0P30lpG8bZ44RRn/T15tVA8=")
+
+        let request = try XCTUnwrap(client.requests.first)
+        XCTAssertEqual(request.method, .get)
+        XCTAssertEqual(request.url.relativePath, "/user-keys")
+    }
+
+    /// `getMasterKeyFromKeyConnector(keyConnectorUrl:)` throws an error if the request fails.
+    func test_getMasterKeyFromKeyConnector_httpFailure() async throws {
+        client.result = .httpFailure(BitwardenTestError.example)
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await subject.getMasterKeyFromKeyConnector(
+                keyConnectorUrl: URL(string: "https://example.com")!
+            )
+        }
+    }
+
+    /// `postMasterKeyToKeyConnector(keyConnectorUrl:)` sends the user's key to the API.
+    func test_postMasterKeyToKeyConnector() async throws {
+        client.result = .httpSuccess(testData: .emptyResponse)
+
+        await assertAsyncDoesNotThrow {
+            try await subject.postMasterKeyToKeyConnector(
+                key: "🔑",
+                keyConnectorUrl: URL(string: "https://example.com")!
+            )
+        }
+
+        let request = try XCTUnwrap(client.requests.first)
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.url.relativePath, "/user-keys")
+        XCTAssertNotNil(request.body)
+    }
+
+    /// `postMasterKeyToKeyConnector(keyConnectorUrl:)` throws an error if the request fails.
+    func test_postMasterKeyToKeyConnector_httpFailure() async throws {
+        client.result = .httpFailure(BitwardenTestError.example)
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await subject.postMasterKeyToKeyConnector(
+                key: "🔑",
+                keyConnectorUrl: URL(string: "https://example.com")!
+            )
+        }
+    }
+}
+
+// swiftlint:enable inclusive_language

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/KeyConnectorUserKeyRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/KeyConnectorUserKeyRequest.swift
@@ -1,0 +1,17 @@
+import Networking
+
+// MARK: - KeyConnectorUserKeyRequest
+
+/// The API request sent when getting the user's key from the key connector API.
+///
+struct KeyConnectorUserKeyRequest: Request {
+    typealias Response = KeyConnectorUserKeyResponseModel
+
+    // MARK: Properties
+
+    /// The HTTP method for this request.
+    let method: HTTPMethod = .get
+
+    /// The URL path for this request.
+    let path: String = "/user-keys"
+}

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/KeyConnectorUserKeyRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/KeyConnectorUserKeyRequestTests.swift
@@ -1,0 +1,27 @@
+import Networking
+import XCTest
+
+@testable import BitwardenShared
+
+class KeyConnectorUserKeyRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let subject = KeyConnectorUserKeyRequest()
+
+    // MARK: Tests
+
+    /// Validate that the request's body is `nil`.
+    func test_body() {
+        XCTAssertNil(subject.body)
+    }
+
+    /// Validate that the method is correct.
+    func test_method() {
+        XCTAssertEqual(subject.method, .get)
+    }
+
+    /// Validate that the path is correct.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/user-keys")
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/PostKeyConnectorUserKeyRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/PostKeyConnectorUserKeyRequest.swift
@@ -1,0 +1,30 @@
+import Networking
+
+// MARK: - PostKeyConnectorUserKeyRequest
+
+/// The API request sent when sending the user's key to the key connector API.
+///
+struct PostKeyConnectorUserKeyRequest: Request {
+    typealias Response = EmptyResponse
+
+    // MARK: Properties
+
+    /// The body of this request.
+    var body: PostKeyConnectorUserKeyRequestModel?
+
+    /// The HTTP method for this request.
+    let method: HTTPMethod = .post
+
+    /// The URL path for this request.
+    let path: String = "/user-keys"
+
+    // MARK: Initialization
+
+    /// Creates a new `PostKeyConnectorUserKeyRequest` instance.
+    ///
+    /// - Parameter body: The body of the request.
+    ///
+    init(body: PostKeyConnectorUserKeyRequestModel) {
+        self.body = body
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/PostKeyConnectorUserKeyRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/KeyConnector/Requests/PostKeyConnectorUserKeyRequestTests.swift
@@ -1,0 +1,35 @@
+import Networking
+import XCTest
+
+@testable import BitwardenShared
+
+class PostKeyConnectorUserKeyRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let subject = PostKeyConnectorUserKeyRequest(body: PostKeyConnectorUserKeyRequestModel(key: "🔑"))
+
+    // MARK: Tests
+
+    /// `body` is the JSON encoded request model.
+    func test_body() throws {
+        let bodyData = try XCTUnwrap(subject.body?.encode())
+        XCTAssertEqual(
+            bodyData.prettyPrintedJson,
+            """
+            {
+              "key" : "🔑"
+            }
+            """
+        )
+    }
+
+    /// Validate that the method is correct.
+    func test_method() {
+        XCTAssertEqual(subject.method, .post)
+    }
+
+    /// Validate that the path is correct.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/user-keys")
+    }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Organization/OrganizationAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Organization/OrganizationAPIService.swift
@@ -22,6 +22,12 @@ protocol OrganizationAPIService {
     /// - Returns: A `SingleSignOnDetailsResponse`.
     ///
     func getSingleSignOnDetails(email: String) async throws -> SingleSignOnDetailsResponse
+
+    /// Removes the user from an organization.
+    ///
+    /// - Parameter organizationId: The organization's ID.
+    ///
+    func leaveOrganization(organizationId: String) async throws
 }
 
 extension APIService: OrganizationAPIService {
@@ -35,5 +41,9 @@ extension APIService: OrganizationAPIService {
 
     func getSingleSignOnDetails(email: String) async throws -> SingleSignOnDetailsResponse {
         try await apiUnauthenticatedService.send(SingleSignOnDetailsRequest(email: email))
+    }
+
+    func leaveOrganization(organizationId: String) async throws {
+        _ = try await apiService.send(LeaveOrganizationRequest(organizationId: organizationId))
     }
 }

--- a/BitwardenShared/Core/Auth/Services/API/Organization/OrganizationAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Organization/OrganizationAPIServiceTests.swift
@@ -68,4 +68,27 @@ class OrganizationAPIServiceTests: BitwardenTestCase {
             SingleSignOnDetailsResponse(organizationIdentifier: "TeamLivefront", ssoAvailable: true)
         )
     }
+
+    /// `leaveOrganization(organizationId:)` removes the user from the organization.
+    func test_leaveOrganization() async throws {
+        client.result = .httpSuccess(testData: .emptyResponse)
+
+        await assertAsyncDoesNotThrow {
+            _ = try await subject.leaveOrganization(organizationId: "1")
+        }
+
+        let request = try XCTUnwrap(client.requests.first)
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.url.relativePath, "/api/organizations/1/leave")
+        XCTAssertNil(request.body)
+    }
+
+    /// `leaveOrganization(organizationId:)` throws an error if the request fails.
+    func test_leaveOrganization_httpFailure() async throws {
+        client.result = .httpFailure()
+
+        await assertAsyncThrows {
+            _ = try await subject.leaveOrganization(organizationId: "1")
+        }
+    }
 }

--- a/BitwardenShared/Core/Auth/Services/API/Organization/Requests/LeaveOrganizationRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Organization/Requests/LeaveOrganizationRequest.swift
@@ -1,0 +1,20 @@
+import Networking
+
+// MARK: - LeaveOrganizationRequest
+
+/// The API request sent for a user to leave an organization.
+///
+struct LeaveOrganizationRequest: Request {
+    typealias Response = EmptyResponse
+
+    // MARK: Properties
+
+    /// The HTTP method for this request.
+    let method: HTTPMethod = .post
+
+    /// The organization's ID.
+    let organizationId: String
+
+    /// The URL path for this request.
+    var path: String { "/organizations/\(organizationId)/leave" }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Organization/Requests/LeaveOrganizationRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Organization/Requests/LeaveOrganizationRequestTests.swift
@@ -1,0 +1,27 @@
+import Networking
+import XCTest
+
+@testable import BitwardenShared
+
+class LeaveOrganizationRequestTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let subject = LeaveOrganizationRequest(organizationId: "org-id")
+
+    // MARK: Tests
+
+    /// Validate that the request's body is `nil`.
+    func test_body() {
+        XCTAssertNil(subject.body)
+    }
+
+    /// Validate that the method is correct.
+    func test_method() {
+        XCTAssertEqual(subject.method, .post)
+    }
+
+    /// Validate that the path is correct.
+    func test_path() {
+        XCTAssertEqual(subject.path, "/organizations/org-id/leave")
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/APIServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/APIServiceTests.swift
@@ -18,6 +18,20 @@ class APIServiceTests: BitwardenTestCase {
         subject = nil
     }
 
+    // MARK: Tests
+
+    /// `buildKeyConnectorService(baseURL:)` builds a `HTTPService` for communicating with the key
+    /// connector API.
+    func test_buildKeyConnectorService() {
+        let service = subject.buildKeyConnectorService(baseURL: URL(string: "https://example.com/api")!)
+
+        XCTAssertEqual(service.responseHandlers.count, 1)
+        XCTAssertTrue(service.responseHandlers.contains(where: { $0 is ResponseValidationHandler }))
+        XCTAssertEqual(service.requestHandlers.count, 1)
+        XCTAssertTrue(service.requestHandlers.contains(where: { $0 is DefaultHeadersRequestHandler }))
+        XCTAssertTrue(service.tokenProvider is AccountTokenProvider)
+    }
+
     /// `init(client:)` sets the default base URLs for the HTTP services.
     func test_init_defaultURLs() {
         let apiServiceBaseURL = subject.apiService.baseURL


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10945](https://bitwarden.atlassian.net/browse/PM-10945)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the following API requests needed to implement key connector:

- `GET {key-connector-url}/user-keys`
- `POST {key-connector-url}/user-keys`
- `POST /accounts/convert-to-key-connector`
- `POST /accounts/set-key-connector-key`
- `POST /organizations/{id}/leave`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10945]: https://bitwarden.atlassian.net/browse/PM-10945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ