### PR TITLE
[PM-10542] Handle TOTP codes with empty or whitespace-only keys

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -193,7 +193,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
         case .totpFieldLeftFocus:
             parseAndValidateEditedAuthenticatorKey(state.loginState.totpState.rawAuthenticatorKeyString)
         case let .totpKeyChanged(newValue):
-            state.loginState.totpState = .init(newValue)
+            state.loginState.totpState = LoginTOTPState(newValue)
         case let .typeChanged(newValue):
             state.type = newValue
             state.customFieldsState = AddEditCustomFieldsState(cipherType: newValue, customFields: [])

--- a/BitwardenShared/UI/Vault/VaultItem/LoginTOTPState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/LoginTOTPState.swift
@@ -85,7 +85,7 @@ public enum LoginTOTPState: Equatable, Sendable {
     ///   - authKeyString: The optional TOTP key string.
     ///
     init(_ authKeyString: String?) {
-        switch authKeyString?.nilIfEmpty {
+        switch authKeyString?.trimmingCharacters(in: .whitespaces).nilIfEmpty {
         case let .some(string):
             self = .key(TOTPKeyModel(authenticatorKey: string))
         case .none:

--- a/BitwardenShared/UI/Vault/VaultItem/LoginTOTPState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/LoginTOTPState.swift
@@ -85,7 +85,7 @@ public enum LoginTOTPState: Equatable, Sendable {
     ///   - authKeyString: The optional TOTP key string.
     ///
     init(_ authKeyString: String?) {
-        switch authKeyString {
+        switch authKeyString?.nilIfEmpty {
         case let .some(string):
             self = .key(TOTPKeyModel(authenticatorKey: string))
         case .none:

--- a/BitwardenShared/UI/Vault/VaultItem/LoginTOTPStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/LoginTOTPStateTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import BitwardenShared
+
+// MARK: - LoginTOTPStateTests
+
+class LoginTOTPStateTests: BitwardenTestCase {
+    func test_init_authKeyString_valid() {
+        let subject = LoginTOTPState("valid")
+        XCTAssertEqual(subject, .key(TOTPKeyModel(authenticatorKey: "valid")))
+    }
+
+    func test_init_authKeyString_nil() {
+        let subject = LoginTOTPState(nil)
+        XCTAssertEqual(subject, .none)
+    }
+
+    func test_init_authKeyString_empty() {
+        let subject = LoginTOTPState("")
+        XCTAssertEqual(subject, .none)
+    }
+
+    func test_init_authKeyString_internalWhitespace() {
+        let subject = LoginTOTPState("space key")
+        XCTAssertEqual(subject, .key(TOTPKeyModel(authenticatorKey: "space key")))
+    }
+
+    func test_init_authKeyString_justWhitespaces() {
+        let subject = LoginTOTPState("     ")
+        XCTAssertEqual(subject, .none)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10542

## 📔 Objective

When a TOTP was removed from a login entry that had one, the app was saving the TOTP as an empty string rather than nil; as well, if asked to generate a code for an empty string, it would assume it a valid key and generate it. This change adjusts this so that empty and whitespace-only strings coalesce into nil values. Some tests around this are also added.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
