### PR TITLE
[PM-10977] Don't show welcome carousel when in an extension

### DIFF
--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -44,7 +44,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
             stateService: stateService,
             vaultTimeoutService: vaultTimeoutService
         )
-        authRouter = AuthRouter(services: services)
+        authRouter = AuthRouter(
+            isInAppExtension: false,
+            services: services
+        )
         subject = AuthCoordinator(
             appExtensionDelegate: MockAppExtensionDelegate(),
             delegate: authDelegate,

--- a/BitwardenShared/UI/Auth/AuthModule.swift
+++ b/BitwardenShared/UI/Auth/AuthModule.swift
@@ -45,6 +45,9 @@ extension DefaultAppModule: AuthModule {
     }
 
     func makeAuthRouter() -> AnyRouter<AuthEvent, AuthRoute> {
-        AuthRouter(services: services).asAnyRouter()
+        AuthRouter(
+            isInAppExtension: appExtensionDelegate != nil,
+            services: services
+        ).asAnyRouter()
     }
 }

--- a/BitwardenShared/UI/Auth/AuthRouter.swift
+++ b/BitwardenShared/UI/Auth/AuthRouter.swift
@@ -22,9 +22,10 @@ final class AuthRouter: NSObject, Router {
 
     /// Creates a new `AuthRouter`.
     ///
-    /// - Parameter services: The services used by this router.
-    ///
     /// - Parameters:
+    ///   - isInAppExtension: Whether the app is running as an extension.
+    ///   - services: The services used by this router.
+    ///
     init(
         isInAppExtension: Bool,
         services: Services

--- a/BitwardenShared/UI/Auth/AuthRouter.swift
+++ b/BitwardenShared/UI/Auth/AuthRouter.swift
@@ -12,6 +12,9 @@ final class AuthRouter: NSObject, Router {
         & HasStateService
         & HasVaultTimeoutService
 
+    /// Whether the app is running as an extension.
+    let isInAppExtension: Bool
+
     /// The services used by this router.
     let services: Services
 
@@ -22,7 +25,11 @@ final class AuthRouter: NSObject, Router {
     /// - Parameter services: The services used by this router.
     ///
     /// - Parameters:
-    init(services: Services) {
+    init(
+        isInAppExtension: Bool,
+        services: Services
+    ) {
+        self.isInAppExtension = isInAppExtension
         self.services = services
     }
 

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -26,6 +26,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         vaultTimeoutService = MockVaultTimeoutService()
 
         subject = AuthRouter(
+            isInAppExtension: false,
             services: ServiceContainer.withMocks(
                 authRepository: authRepository,
                 configService: configService,
@@ -757,6 +758,26 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     func test_handleAndRoute_didStart_carouselFlow_carouselShown() async {
         configService.featureFlagsBool[.nativeCarouselFlow] = true
         stateService.introCarouselShown = true
+
+        let route = await subject.handleAndRoute(.didStart)
+
+        XCTAssertEqual(route, .landing)
+    }
+
+    /// `handleAndRoute(_ :)` redirects `.didStart` to `.landing` if it's running in an extension.
+    func test_handleAndRoute_didStart_carouselFlow_extension() async {
+        configService.featureFlagsBool[.nativeCarouselFlow] = true
+
+        subject = await AuthRouter(
+            isInAppExtension: true,
+            services: ServiceContainer.withMocks(
+                authRepository: authRepository,
+                configService: configService,
+                errorReporter: errorReporter,
+                stateService: stateService,
+                vaultTimeoutService: vaultTimeoutService
+            )
+        )
 
         let route = await subject.handleAndRoute(.didStart)
 

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -208,8 +208,8 @@ extension AuthRouter {
             // If no account can be set to active, go to the landing or carousel screen.
             let isCarouselEnabled: Bool = await services.configService.getFeatureFlag(.nativeCarouselFlow)
             let introCarouselShown = await services.stateService.getIntroCarouselShown()
-            let shouldShowCarousel = isCarouselEnabled && !introCarouselShown
-            return shouldShowCarousel && !isInAppExtension ? .introCarousel : .landing
+            let shouldShowCarousel = isCarouselEnabled && !introCarouselShown && !isInAppExtension
+            return shouldShowCarousel ? .introCarousel : .landing
         }
 
         // If there's existing accounts, mark the carousel as shown.

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -208,7 +208,8 @@ extension AuthRouter {
             // If no account can be set to active, go to the landing or carousel screen.
             let isCarouselEnabled: Bool = await services.configService.getFeatureFlag(.nativeCarouselFlow)
             let introCarouselShown = await services.stateService.getIntroCarouselShown()
-            return isCarouselEnabled && !introCarouselShown ? .introCarousel : .landing
+            let shouldShowCarousel = isCarouselEnabled && !introCarouselShown
+            return shouldShowCarousel && !isInAppExtension ? .introCarousel : .landing
         }
 
         // If there's existing accounts, mark the carousel as shown.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-10977

## 📔 Objective

This prevents the welcome carousel from being displayed when using the app as an extension (e.g. for autofill).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
