### PR TITLE
[PM-11189] Allow app to build in Xcode 16

### DIFF
--- a/Bitwarden/Application/UIApplication+Application.swift
+++ b/Bitwarden/Application/UIApplication+Application.swift
@@ -1,4 +1,14 @@
 import BitwardenShared
 import UIKit
 
-extension UIApplication: Application {}
+extension UIApplication: Application {
+    public func startBackgroundTask(withName: String?, expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
+        // Because the annotations for `UIApplication.beginBackgroundTask(::)` changed
+        // between Xcode 15.4 and Xcode 16 and also between Swift 5 and Swift 6,
+        // we need this shim to make the same thing compile across the board.
+        // Once we migrate to Swift 6 + Xcode 16, we can return to a more transparent
+        // protocol method
+        // TODO: PM-11189
+        beginBackgroundTask(withName: withName, expirationHandler: expirationHandler)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/Application.swift
+++ b/BitwardenShared/Core/Platform/Services/Application.swift
@@ -4,9 +4,11 @@ import UIKit
 ///
 public protocol Application {
     /// Marks the start of a task with a custom name that should continue if the app enters the background.
+    /// See note in `UIApplication+Application.swift`
+    /// TODO: PM-11189
     ///
     nonisolated
-    func beginBackgroundTask(
+    func startBackgroundTask(
         withName: String?,
         expirationHandler: (() -> Void)?
     ) -> UIBackgroundTaskIdentifier

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockApplication.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockApplication.swift
@@ -9,7 +9,9 @@ class MockApplication: Application {
     var endBackgroundTaskIdentifier: UIBackgroundTaskIdentifier?
     var registerForRemoteNotificationsCalled = false
 
-    func beginBackgroundTask(withName: String?, expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
+    func startBackgroundTask(withName: String?, expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
+        // See note in `UIApplication+Application.swift`
+        // TODO: PM-11189
         beginBackgroundTaskName = withName
         beginBackgroundTaskHandler = expirationHandler
         return beginBackgroundTaskIdentifier

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -355,7 +355,7 @@ public class AppProcessor {
             services.application?.endBackgroundTask(taskId)
             backgroundTaskId = nil
         }
-        backgroundTaskId = services.application?.beginBackgroundTask(
+        backgroundTaskId = services.application?.startBackgroundTask(
             withName: "SendEventBackgroundTask",
             expirationHandler: { [weak self] in
                 if let backgroundTaskId = self?.backgroundTaskId {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11189

## 📔 Objective

Xcode 15 and 16 have different signatures for `UIApplication.beginBackgroundTask(::)` due to changes in Swift Concurrency, and that was preventing the app from building in Xocde 16.

This does not fix tests, however—that will have to wait until a new version of [ViewInspector](https://github.com/nalexn/ViewInspector) to be released. This work is captured in [PM-11213](https://bitwarden.atlassian.net/browse/PM-11213).

This is part of the broader effort to get the app ready for iOS 18, Xcode 16, and Swift 6

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11213]: https://bitwarden.atlassian.net/browse/PM-11213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ