### PR TITLE
[PM-11133] Fix preview macro warnings

### DIFF
--- a/BitwardenShared/UI/Auth/Login/LoginView.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginView.swift
@@ -137,7 +137,7 @@ struct LoginView: View {
 // MARK: - Previews
 
 #if DEBUG
-#Preview {
+#Preview("Empty") {
     NavigationView {
         LoginView(
             store: Store(
@@ -147,10 +147,9 @@ struct LoginView: View {
             )
         )
     }
-    .previewDisplayName("Empty")
 }
 
-#Preview {
+#Preview("With Device") {
     NavigationView {
         LoginView(
             store: Store(
@@ -162,6 +161,5 @@ struct LoginView: View {
             )
         )
     }
-    .previewDisplayName("With Device")
 }
 #endif

--- a/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/ScaledFrame.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/ScaledFrame.swift
@@ -97,7 +97,8 @@ extension Image {
 }
 
 #if DEBUG
-#Preview {
+@available(iOS 17.0, *)
+#Preview(traits: .sizeThatFitsLayout) {
     VStack {
         Image(systemName: "ruler.fill")
             .aspectRatio(contentMode: .fit)
@@ -119,6 +120,5 @@ extension Image {
             .scaledFrame(width: 24, height: 24)
             .environment(\.sizeCategory, .accessibilityExtraLarge)
     }
-    .previewLayout(.sizeThatFits)
 }
 #endif

--- a/BitwardenShared/UI/Platform/Application/Appearance/Styles/AccessoryButtonStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Styles/AccessoryButtonStyle.swift
@@ -29,20 +29,18 @@ extension ButtonStyle where Self == AccessoryButtonStyle {
 // MARK: Previews
 
 #if DEBUG
-#Preview {
+#Preview("Enabled") {
     Button {} label: {
         Asset.Images.bwiProvider.swiftUIImage
     }
     .buttonStyle(.accessory)
-    .previewDisplayName("Enabled")
 }
 
-#Preview {
+#Preview("Disabled") {
     Button {} label: {
         Asset.Images.bwiProvider.swiftUIImage
     }
     .buttonStyle(.accessory)
     .disabled(true)
-    .previewDisplayName("Disabled")
 }
 #endif

--- a/BitwardenShared/UI/Platform/Application/Appearance/Styles/PrimaryButtonStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Styles/PrimaryButtonStyle.swift
@@ -61,22 +61,19 @@ extension ButtonStyle where Self == PrimaryButtonStyle {
 // MARK: Previews
 
 #if DEBUG
-#Preview {
+#Preview("Enabled") {
     Button("Hello World!") {}
         .buttonStyle(.primary())
-        .previewDisplayName("Enabled")
 }
 
-#Preview {
+#Preview("Disabled") {
     Button("Hello World!") {}
         .buttonStyle(.primary())
         .disabled(true)
-        .previewDisplayName("Disabled")
 }
 
-#Preview {
+#Preview("Destructive") {
     Button("Hello World!") {}
         .buttonStyle(.primary(isDestructive: true))
-        .previewDisplayName("Destructive")
 }
 #endif

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenMenuField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenMenuField.swift
@@ -155,7 +155,7 @@ private enum MenuPreviewOptions: CaseIterable, Menuable {
     }
 }
 
-#Preview {
+#Preview("CipherType") {
     VStack {
         BitwardenMenuField(
             title: "Animals",
@@ -165,10 +165,9 @@ private enum MenuPreviewOptions: CaseIterable, Menuable {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("CipherType")
 }
 
-#Preview {
+#Preview("Trailing Button") {
     Group {
         BitwardenMenuField(
             title: "Animals",
@@ -183,10 +182,9 @@ private enum MenuPreviewOptions: CaseIterable, Menuable {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("Trailing Button")
 }
 
-#Preview {
+#Preview("Footer") {
     Group {
         BitwardenMenuField(
             title: "Animals",
@@ -197,6 +195,5 @@ private enum MenuPreviewOptions: CaseIterable, Menuable {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("Footer")
 }
 #endif

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -206,7 +206,7 @@ extension BitwardenTextField where TrailingContent == EmptyView {
 // MARK: Previews
 
 #if DEBUG
-#Preview {
+#Preview("No buttons") {
     VStack {
         BitwardenTextField(
             title: "Title",
@@ -216,10 +216,9 @@ extension BitwardenTextField where TrailingContent == EmptyView {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("No buttons")
 }
 
-#Preview {
+#Preview("Password button") {
     VStack {
         BitwardenTextField(
             title: "Title",
@@ -230,10 +229,9 @@ extension BitwardenTextField where TrailingContent == EmptyView {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("Password button")
 }
 
-#Preview {
+#Preview("Password revealed") {
     VStack {
         BitwardenTextField(
             title: "Title",
@@ -244,10 +242,9 @@ extension BitwardenTextField where TrailingContent == EmptyView {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("Password revealed")
 }
 
-#Preview {
+#Preview("Additional buttons") {
     VStack {
         BitwardenTextField(
             title: "Title",
@@ -258,10 +255,9 @@ extension BitwardenTextField where TrailingContent == EmptyView {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("Additional buttons")
 }
 
-#Preview {
+#Preview("Footer text") {
     VStack {
         BitwardenTextField(
             title: "Title",
@@ -274,6 +270,5 @@ extension BitwardenTextField where TrailingContent == EmptyView {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("Footer text")
 }
 #endif

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
@@ -93,7 +93,7 @@ extension BitwardenTextValueField where AccessoryContent == EmptyView {
 // MARK: Previews
 
 #if DEBUG
-#Preview {
+#Preview("No buttons") {
     VStack {
         BitwardenTextValueField(
             title: "Title",
@@ -102,6 +102,5 @@ extension BitwardenTextValueField where AccessoryContent == EmptyView {
         .padding()
     }
     .background(Color(.systemGroupedBackground))
-    .previewDisplayName("No buttons")
 }
 #endif

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditIdentityItem/AddEditIdentityItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditIdentityItem/AddEditIdentityItemView.swift
@@ -246,7 +246,7 @@ struct AddEditIdentityItemView: View {
 // MARK: Previews
 
 #if DEBUG
-#Preview {
+#Preview("Empty Add Edit Identity State") {
     NavigationView {
         ScrollView {
             LazyVStack(spacing: 20) {
@@ -263,6 +263,5 @@ struct AddEditIdentityItemView: View {
         .background(Asset.Colors.backgroundSecondary.swiftUIColor)
         .ignoresSafeArea()
     }
-    .previewDisplayName("Empty Add Edit Identity State")
 }
 #endif

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewIdentityItem/ViewIdentityItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewIdentityItem/ViewIdentityItemView.swift
@@ -94,7 +94,7 @@ struct ViewIdentityItemView: View {
     }
 }
 
-#Preview {
+#Preview("Empty Add Edit State") {
     NavigationView {
         ScrollView {
             LazyVStack(spacing: 20) {
@@ -125,5 +125,4 @@ struct ViewIdentityItemView: View {
         .background(Asset.Colors.backgroundSecondary.swiftUIColor)
         .ignoresSafeArea()
     }
-    .previewDisplayName("Empty Add Edit State")
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11133

## 📔 Objective

As of Xcode 16 and Swift 6, using `.previewDisplayName` and `.previewLayout` in a `#Preview` macro produces a warning. This updates all those instances in the code to the macro-ized form.

This does not fully complete PM-11133, but is a step along the way.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
