### PR TITLE
[PM-11133] Eliminate some static variable warnings

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/CaptchaRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/CaptchaRequestModel.swift
@@ -8,7 +8,7 @@ import Networking
 struct CaptchaRequestModel: JSONRequestBody {
     // MARK: Static Properties
 
-    static var encoder = JSONEncoder()
+    static let encoder = JSONEncoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Request/DeleteAccountRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/DeleteAccountRequestModel.swift
@@ -8,7 +8,7 @@ import Networking
 struct DeleteAccountRequestModel: JSONRequestBody {
     // MARK: Static Properties
 
-    static var encoder = JSONEncoder()
+    static let encoder = JSONEncoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Request/ResendEmailCodeRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/ResendEmailCodeRequestModel.swift
@@ -8,7 +8,7 @@ import Networking
 struct ResendEmailCodeRequestModel: JSONRequestBody {
     // MARK: Static Properties
 
-    static var encoder = JSONEncoder()
+    static let encoder = JSONEncoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Request/SingleSignOnDetailsRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/SingleSignOnDetailsRequestModel.swift
@@ -8,7 +8,7 @@ import Networking
 struct SingleSignOnDetailsRequestModel: JSONRequestBody {
     // MARK: Static Properties
 
-    static var encoder = JSONEncoder()
+    static let encoder = JSONEncoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Request/TrustedDeviceKeysRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/TrustedDeviceKeysRequestModel.swift
@@ -8,7 +8,7 @@ import Networking
 struct TrustedDeviceKeysRequestModel: JSONRequestBody, Equatable {
     // MARK: Properties
 
-    static var encoder = JSONEncoder()
+    static let encoder = JSONEncoder()
 
     /// The encrypted private key used in a `TrustedDeviceKeysRequest`.
     let encryptedPrivateKey: String

--- a/BitwardenShared/Core/Auth/Models/Response/CreateAccountResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/CreateAccountResponseModel.swift
@@ -6,7 +6,7 @@ import Networking
 /// The response returned from the API upon creating an account.
 ///
 struct CreateAccountResponseModel: JSONResponse {
-    static var decoder = JSONDecoder()
+    static let decoder = JSONDecoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/ErrorResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/ErrorResponseModel.swift
@@ -32,5 +32,5 @@ struct ErrorResponseModel: Codable, Equatable {
 // MARK: JSONResponse
 
 extension ErrorResponseModel: JSONResponse {
-    static var decoder = JSONDecoder.pascalOrSnakeCaseDecoder
+    static let decoder = JSONDecoder.pascalOrSnakeCaseDecoder
 }

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenRefreshResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenRefreshResponseModel.swift
@@ -4,7 +4,7 @@ import Networking
 /// API response model for the identity token refresh request.
 ///
 struct IdentityTokenRefreshResponseModel: JSONResponse, Equatable {
-    static var decoder = JSONDecoder.snakeCaseDecoder
+    static let decoder = JSONDecoder.snakeCaseDecoder
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
@@ -4,7 +4,7 @@ import Networking
 /// API response model for the identity token request.
 ///
 struct IdentityTokenResponseModel: Equatable, JSONResponse, KdfConfigProtocol {
-    static var decoder = JSONDecoder.pascalOrSnakeCaseDecoder
+    static let decoder = JSONDecoder.pascalOrSnakeCaseDecoder
 
     // MARK: Account Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/KnownDeviceResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/KnownDeviceResponseModel.swift
@@ -5,7 +5,7 @@ import Networking
 
 /// An object containing a value defining if this device has previously logged into this account or not.
 struct KnownDeviceResponseModel: JSONResponse {
-    static var decoder = JSONDecoder()
+    static let decoder = JSONDecoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/LoginRequest.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/LoginRequest.swift
@@ -6,7 +6,7 @@ import Networking
 /// A data structure representing a login request.
 ///
 public struct LoginRequest: JSONResponse, Equatable {
-    public static var decoder = JSONDecoder.defaultDecoder
+    public static let decoder = JSONDecoder.defaultDecoder
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/PendingLoginsResponse.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/PendingLoginsResponse.swift
@@ -6,7 +6,7 @@ import Networking
 /// The response returned from the API when requesting the pending login requests.
 ///
 struct PendingLoginsResponse: JSONResponse {
-    static var decoder = JSONDecoder.defaultDecoder
+    static let decoder = JSONDecoder.defaultDecoder
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/PreValidateSingleSignOnResponse.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/PreValidateSingleSignOnResponse.swift
@@ -6,7 +6,7 @@ import Networking
 /// The response returned from the API upon pre-validating the single-sign on.
 ///
 struct PreValidateSingleSignOnResponse: JSONResponse, Equatable {
-    static var decoder = JSONDecoder()
+    static let decoder = JSONDecoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/RegisterFinishResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/RegisterFinishResponseModel.swift
@@ -6,7 +6,7 @@ import Networking
 /// The response returned from the API upon creating an account.
 ///
 struct RegisterFinishResponseModel: JSONResponse {
-    static var decoder = JSONDecoder()
+    static let decoder = JSONDecoder()
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModel.swift
@@ -31,5 +31,5 @@ struct ErrorModel: Codable, Equatable {
 // MARK: JSONResponse
 
 extension ResponseValidationErrorModel: JSONResponse {
-    static var decoder = JSONDecoder.pascalOrSnakeCaseDecoder
+    static let decoder = JSONDecoder.pascalOrSnakeCaseDecoder
 }

--- a/BitwardenShared/Core/Auth/Models/Response/SingleSignOnDetailsResponse.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/SingleSignOnDetailsResponse.swift
@@ -6,7 +6,7 @@ import Networking
 /// The response returned from the API when requesting the single sign on details.
 ///
 struct SingleSignOnDetailsResponse: JSONResponse, Equatable {
-    static var decoder = JSONDecoder.pascalOrSnakeCaseDecoder
+    static let decoder = JSONDecoder.pascalOrSnakeCaseDecoder
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Platform/Extensions/Logger+Bitwarden.swift
+++ b/BitwardenShared/Core/Platform/Extensions/Logger+Bitwarden.swift
@@ -16,5 +16,5 @@ public extension Logger {
 
     /// The Logger subsystem passed along with logs to the logging system to identify logs from this
     /// application.
-    private static var subsystem = Bundle.main.bundleIdentifier!
+    private static let subsystem = Bundle.main.bundleIdentifier!
 }

--- a/BitwardenShared/Core/Platform/Models/Enum/AppTheme.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/AppTheme.swift
@@ -4,7 +4,7 @@ import UIKit
 
 /// An enum listing the display theme options.
 ///
-public enum AppTheme: String, Menuable {
+public enum AppTheme: String, Menuable, Sendable {
     /// Use the dark theme.
     case dark
 

--- a/BitwardenShared/Core/Platform/Models/Enum/LanguageOption.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/LanguageOption.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// An enum listing all the language options, either default (system settings) or any of the currently available
 /// localizable files.
-public enum LanguageOption: Equatable {
+public enum LanguageOption: Equatable, Sendable {
     /// Use the system settings.
     case `default`
 

--- a/BitwardenShared/Core/Tools/Models/Enum/SendType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/SendType.swift
@@ -4,7 +4,7 @@ import BitwardenSdk
 
 /// An enum describing the type of data in a send.
 ///
-public enum SendType: Int, CaseIterable, Codable, Equatable, Menuable {
+public enum SendType: Int, CaseIterable, Codable, Equatable, Menuable, Sendable {
     /// The send contains text data.
     case text = 0
 

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
@@ -40,7 +40,7 @@ extension CipherType {
 }
 
 extension CipherType: CaseIterable {
-    static var allCases: [CipherType] = [.login, .card, .identity, .secureNote]
+    static let allCases: [CipherType] = [.login, .card, .identity, .secureNote]
 }
 
 extension CipherType: Menuable {

--- a/BitwardenShared/Core/Vault/Models/Enum/TitleType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/TitleType.swift
@@ -59,5 +59,5 @@ enum TitleType: String, Codable, Equatable, Hashable, Menuable {
 }
 
 extension TitleType: CaseIterable {
-    static var allCases: [TitleType] = [.mr, .mrs, .ms, .mx, .dr]
+    static let allCases: [TitleType] = [.mr, .mrs, .ms, .mx, .dr]
 }

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRow.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRow.swift
@@ -250,7 +250,7 @@ struct ProfileSwitcherRow: View {
 
 #if DEBUG
 extension ProfileSwitcherItem {
-    static var unlockedAccountPreview = ProfileSwitcherItem(
+    static let unlockedAccountPreview = ProfileSwitcherItem(
         color: .purple,
         email: "anne.account@bitwarden.com",
         isUnlocked: true,
@@ -259,7 +259,7 @@ extension ProfileSwitcherItem {
         webVault: "bitwarden.com"
     )
 
-    static var lockedAccountPreview = ProfileSwitcherItem(
+    static let lockedAccountPreview = ProfileSwitcherItem(
         color: .purple,
         email: "anne.account@bitwarden.com",
         isUnlocked: false,

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -19,7 +19,7 @@ public enum UnlockMethod {
 
 /// An enumeration of session timeout values to choose from.
 ///
-public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menuable {
+public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menuable, Sendable {
     /// Timeout immediately.
     case immediately
 
@@ -141,7 +141,7 @@ public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menu
 
 /// The action to perform on session timeout.
 ///
-public enum SessionTimeoutAction: Int, CaseIterable, Codable, Equatable, Menuable {
+public enum SessionTimeoutAction: Int, CaseIterable, Codable, Equatable, Menuable, Sendable {
     /// Lock the vault.
     case lock = 0
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -4,7 +4,7 @@
 
 /// The type of value to generate.
 ///
-public enum GeneratorType: CaseIterable, Equatable, Menuable {
+public enum GeneratorType: CaseIterable, Equatable, Menuable, Sendable {
     /// Generate a password or passphrase.
     case password
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11133

## 📔 Objective

This is part of the iOS 18 / Xcode 16 / Swift 6 effort.

This eliminates errors with static variables, either by turning them from `var` into `let` or making the enum `Sendable`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
