### PR TITLE
[PM-11133] Update Networking module for strict concurrency

### DIFF
--- a/Networking/Package.swift
+++ b/Networking/Package.swift
@@ -14,7 +14,12 @@ let package = Package(
         ),
     ],
     targets: [
-        .target(name: "Networking"),
+        .target(name: "Networking",
+                // TODO: PM-11195
+                // This package can be updated to Swift 6, and this feature enablement removed
+                swiftSettings: [
+                    .enableExperimentalFeature("StrictConcurrency"),
+                ]),
         .testTarget(
             name: "NetworkingTests",
             dependencies: ["Networking"]

--- a/Networking/Sources/Networking/Extensions/Logger+Networking.swift
+++ b/Networking/Sources/Networking/Extensions/Logger+Networking.swift
@@ -6,5 +6,5 @@ extension Logger {
 
     /// The OSLog subsystem passed along with logs to the logging system to identify logs from this
     /// library.
-    private static var subsystem = Bundle(for: HTTPService.self).bundleIdentifier!
+    private static let subsystem = Bundle(for: HTTPService.self).bundleIdentifier!
 }

--- a/Networking/Sources/Networking/HTTPMethod.swift
+++ b/Networking/Sources/Networking/HTTPMethod.swift
@@ -1,6 +1,6 @@
 /// A type representing the HTTP method.
 ///
-public struct HTTPMethod: Equatable {
+public struct HTTPMethod: Equatable, Sendable {
     /// The string value of the method.
     let rawValue: String
 }

--- a/Networking/Sources/Networking/HTTPResponse.swift
+++ b/Networking/Sources/Networking/HTTPResponse.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// A data model containing the details of an HTTP response that's been received.
 ///
-public struct HTTPResponse: Equatable {
+public struct HTTPResponse: Equatable, Sendable {
     // MARK: Properties
 
     /// Data received in the body of the response.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11133

## 📔 Objective

This is part of the iOS 18 / Xcode 16 / Swift 6 effort

This updates our Networking module to have no warnings with strict concurrency checking turned on, and also annotates `Sendable` to eliminate warnings in the main project.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
