### PR TITLE
[PM-11133] Add preconcurrency annotations to imports

### DIFF
--- a/BitwardenShared/Core/Platform/Services/CameraService.swift
+++ b/BitwardenShared/Core/Platform/Services/CameraService.swift
@@ -1,4 +1,4 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import Combine
 import Foundation
 

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1,5 +1,5 @@
 import BitwardenSdk
-import Combine
+@preconcurrency import Combine
 import Foundation
 
 // swiftlint:disable file_length

--- a/BitwardenShared/Core/Tools/Utilities/ShareExtensionHelper.swift
+++ b/BitwardenShared/Core/Tools/Utilities/ShareExtensionHelper.swift
@@ -1,4 +1,4 @@
-import Foundation
+@preconcurrency import Foundation
 import OSLog
 import UIKit
 import UniformTypeIdentifiers

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - PolicyService
 

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Combine
 import Foundation
 import OSLog

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Combine
 import Foundation
 import OSLog

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - LoginWithDeviceProcessor

--- a/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - SetMasterPasswordProcessor

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - UpdateMasterPasswordProcessor

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -1,6 +1,6 @@
-import AuthenticationServices
+@preconcurrency import AuthenticationServices
 import BitwardenSdk
-import Combine
+@preconcurrency import Combine
 import Foundation
 import UIKit
 

--- a/BitwardenShared/UI/Platform/FileSelection/FileSelectionCoordinator.swift
+++ b/BitwardenShared/UI/Platform/FileSelection/FileSelectionCoordinator.swift
@@ -1,4 +1,4 @@
-import PhotosUI
+@preconcurrency import PhotosUI
 import UIKit
 
 // MARK: - FileSelectionCoordinator

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListProcessor.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import OSLog
 
 // MARK: - PasswordHistoryListProcessor

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - SendListProcessor

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // swiftlint:disable file_length

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 /// A helper class to handle when a cipher is selected for autofill.
 ///

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -1,5 +1,5 @@
-import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import AuthenticationServices
+@preconcurrency import BitwardenSdk
 
 // MARK: - VaultAutofillListProcessor
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - CipherItemOperationDelegate

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - MoveToOrganizationProcessor

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinator.swift
@@ -1,4 +1,4 @@
-import AVFoundation
+@preconcurrency import AVFoundation
 import SwiftUI
 
 // MARK: - AuthenticatorKeyCaptureDelegate

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - ViewItemProcessor


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11133

## 📔 Objective

This is part of the iOS 18 / Xcode 16 / Swift 6 effort

This adds `@preconcurrency` annotations to import statements to reduce warnings for now. In the future, we will want to remove these once the imported libraries have been updated; that work is captured also in [PM-11195](https://bitwarden.atlassian.net/browse/PM-11195), though as `@preconcurrency` annotations become unnecessary they will turn into warnings.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11195]: https://bitwarden.atlassian.net/browse/PM-11195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ