### PR TITLE
[PM-11133] Annotate things as Sendable

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Enum/AuthRequestType.swift
+++ b/BitwardenShared/Core/Auth/Models/Enum/AuthRequestType.swift
@@ -2,7 +2,7 @@
 
 /// The type of auth request.
 ///
-public enum AuthRequestType: Int, Codable {
+public enum AuthRequestType: Int, Codable, Sendable {
     /// Login with device request
     case authenticateAndUnlock = 0
 

--- a/BitwardenShared/Core/Auth/Models/Enum/RegionType.swift
+++ b/BitwardenShared/Core/Auth/Models/Enum/RegionType.swift
@@ -1,7 +1,7 @@
 // MARK: - RegionType
 
 /// A region that the user can select when creating or signing into their account.
-public enum RegionType: CaseIterable {
+public enum RegionType: CaseIterable, Sendable {
     /// The United States region.
     case unitedStates
 

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
@@ -37,7 +37,7 @@ struct IdentityTokenErrorModel: Codable {
 // MARK: - AuthMethodsData
 
 /// The structure of the data returned in the two-factor authentication error.
-public struct AuthMethodsData: Codable, Equatable {
+public struct AuthMethodsData: Codable, Equatable, Sendable {
     /// Key names used for encoding and decoding.
     enum CodingKeys: String, CodingKey {
         case email = "1"
@@ -98,7 +98,7 @@ public struct Duo: Codable, Equatable {
 // MARK: - Email
 
 /// Struct with information regarding Email two factor authentication
-public struct Email: Codable, Equatable {
+public struct Email: Codable, Equatable, Sendable {
     enum CodingKeys: String, CodingKey {
         case email = "Email"
     }

--- a/BitwardenShared/Core/Auth/Models/Response/LoginRequest.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/LoginRequest.swift
@@ -5,7 +5,7 @@ import Networking
 
 /// A data structure representing a login request.
 ///
-public struct LoginRequest: JSONResponse, Equatable {
+public struct LoginRequest: JSONResponse, Equatable, Sendable {
     public static let decoder = JSONDecoder.defaultDecoder
 
     // MARK: Properties

--- a/BitwardenShared/Core/Platform/Models/Domain/Account.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/Account.swift
@@ -1,6 +1,6 @@
 /// Domain model for a user account.
 ///
-public struct Account: Codable, Equatable, Hashable {
+public struct Account: Codable, Equatable, Hashable, Sendable {
     // MARK: Types
 
     /// Key names used for encoding and decoding.

--- a/BitwardenShared/Core/Platform/Models/Domain/DefaultableType.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/DefaultableType.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - DefaultableType
 
 /// A wrapper around any `CaseIterable` and `Menuable` type that can be set to a default value.
-enum DefaultableType<T: Menuable>: Menuable {
+enum DefaultableType<T: Menuable & Sendable>: Menuable, Sendable {
     // MARK: Cases
 
     /// placeholder default value of the type.

--- a/BitwardenShared/Core/Platform/Models/Domain/EventData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EventData.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Domain model for tracked events.
 ///
-public struct EventData: Codable, Equatable {
+public struct EventData: Codable, Equatable, Sendable {
     /// The type of event.
     let type: EventType
 

--- a/BitwardenShared/Core/Platform/Models/Domain/ServerConfig.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/ServerConfig.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// Model that represents the configuration provided by the server at a particular time.
 ///
-struct ServerConfig: Equatable, Codable {
+struct ServerConfig: Equatable, Codable, Sendable {
     // MARK: Properties
 
     /// The environment URLs of the server.

--- a/BitwardenShared/Core/Platform/Models/Enum/EventType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/EventType.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-public enum EventType: Int, Codable {
+public enum EventType: Int, Codable, Sendable {
     case userLoggedIn = 1000
     case userChangedPassword = 1001
     case userUpdated2fa = 1002

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// An enum to represent a feature flag sent by the server
 ///
-enum FeatureFlag: String, Codable {
+enum FeatureFlag: String, Codable, Sendable {
     /// Flag to enable/disable email verification during registration
     /// This flag introduces a new flow for account creation
     case emailVerification = "email-verification"

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// An enum to represent a feature flag sent by the server
 ///
-enum FeatureFlag: String, Codable, Sendable {
+enum FeatureFlag: String, Codable {
     /// Flag to enable/disable email verification during registration
     /// This flag introduces a new flow for account creation
     case emailVerification = "email-verification"

--- a/BitwardenShared/Core/Platform/Utilities/AnyCodable.swift
+++ b/BitwardenShared/Core/Platform/Utilities/AnyCodable.swift
@@ -2,7 +2,7 @@
 
 /// A custom codable type that can be used to encode/decode a variety of primitive types.
 ///
-public enum AnyCodable: Codable, Equatable {
+public enum AnyCodable: Codable, Equatable, Sendable {
     /// The wrapped value is a bool value.
     case bool(Bool)
 

--- a/BitwardenShared/Core/Vault/Models/Domain/Organization.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Organization.swift
@@ -1,6 +1,6 @@
 /// A domain model containing the details of an organization.
 ///
-public struct Organization: Equatable, Hashable {
+public struct Organization: Equatable, Hashable, Sendable {
     // MARK: Properties
 
     /// Whether the profile organization is enabled.

--- a/BitwardenShared/Core/Vault/Models/Enum/VaultFilterType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/VaultFilterType.swift
@@ -4,7 +4,7 @@ import BitwardenSdk
 
 /// An enum that describes the options for filtering the user's vault.
 ///
-public enum VaultFilterType: Equatable, Hashable {
+public enum VaultFilterType: Equatable, Hashable, Sendable {
     /// Show my and all organization vaults in the vault list.
     case allVaults
 

--- a/BitwardenShared/Core/Vault/Models/Response/PolicyResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/PolicyResponseModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// API response model for a policy.
 ///
-struct PolicyResponseModel: Codable, Equatable {
+struct PolicyResponseModel: Codable, Equatable, Sendable {
     // MARK: Properties
 
     /// Custom policy key value pairs.

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - PolicyService
 

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Combine
 import Foundation
 import OSLog

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationState.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationState.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 /// An object that defines the current state of a `CompleteRegistrationView`.
 ///
-struct CompleteRegistrationState: Equatable {
+struct CompleteRegistrationState: Equatable, Sendable {
     // MARK: Properties
 
     /// Whether passwords are visible in the view's text fields.

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Combine
 import Foundation
 import OSLog

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - LoginWithDeviceProcessor

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceState.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceState.swift
@@ -2,7 +2,7 @@
 
 /// An object that defines the current state of the `LoginWithDeviceView`.
 ///
-struct LoginWithDeviceState: Equatable {
+struct LoginWithDeviceState: Equatable, Sendable {
     /// The user's email.
     var email = ""
 

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - TwoFactorAuthState
 
 /// The state used to present the `TwoFactorAuthView`.
-struct TwoFactorAuthState: Equatable {
+struct TwoFactorAuthState: Equatable, Sendable {
     // MARK: Properties
 
     /// The selected authenticator method.

--- a/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - SetMasterPasswordProcessor

--- a/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordState.swift
+++ b/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordState.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - SetMasterPasswordState
 
 /// An object that defines the current state of a `SetMasterPasswordView`.
 ///
-struct SetMasterPasswordState: Equatable {
+struct SetMasterPasswordState: Equatable, Sendable {
     // MARK: Properties
 
     /// A flag indicating if the current master password should be revealed or not.

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - UpdateMasterPasswordProcessor

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordState.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordState.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - UpdateMasterPasswordState
 
 /// An object that defines the current state of a `UpdateMasterPasswordView`.
 ///
-struct UpdateMasterPasswordState: Equatable {
+struct UpdateMasterPasswordState: Equatable, Sendable {
     // MARK: Properties
 
     /// The current master password provided by the user.

--- a/BitwardenShared/UI/Platform/Application/LoadingState.swift
+++ b/BitwardenShared/UI/Platform/Application/LoadingState.swift
@@ -4,7 +4,7 @@ import SwiftUI
 // MARK: - LoadingState
 
 /// An enumeration of the possible loading states for any screen with a loading state.
-enum LoadingState<T: Equatable>: Equatable {
+enum LoadingState<T: Equatable & Sendable>: Equatable, Sendable {
     /// The data that should be displayed on screen.
     case data(T)
 

--- a/BitwardenShared/UI/Platform/Application/LoadingView.swift
+++ b/BitwardenShared/UI/Platform/Application/LoadingView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // MARK: - LoadingView
 
 /// A view that displays either a loading indicator or the content view for a set of loaded data.
-struct LoadingView<T: Equatable, Contents: View>: View {
+struct LoadingView<T: Equatable & Sendable, Contents: View>: View {
     /// The state of this view.
     var state: LoadingState<T>
 

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationState.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationState.swift
@@ -2,7 +2,7 @@
 
 /// An object that defines the current state of a `ExtensionActivationView`.
 ///
-struct ExtensionActivationState: Equatable {
+struct ExtensionActivationState: Equatable, Sendable {
     // MARK: Properties
 
     /// The type of extension to show the activation view for.

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationType.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationType.swift
@@ -2,7 +2,7 @@
 
 /// The different types of extensions to show the activation view for.
 ///
-public enum ExtensionActivationType: Equatable {
+public enum ExtensionActivationType: Equatable, Sendable {
     /// The app's action extension.
     case appExtension
 

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestState.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestState.swift
@@ -1,7 +1,7 @@
 // MARK: - LoginRequestState
 
 /// The state used to present the `LoginRequestView`.
-struct LoginRequestState: Equatable {
+struct LoginRequestState: Equatable, Sendable {
     /// The user's email.
     var email: String?
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsState.swift
@@ -1,7 +1,7 @@
 // MARK: - PendingRequestsState
 
 /// The state used to present the `PendingRequestsView`.
-struct PendingRequestsState: Equatable {
+struct PendingRequestsState: Equatable, Sendable {
     /// The loading state of the pending requests screen.
     var loadingState: LoadingState<[LoginRequest]> = .loading(nil)
 

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListAction.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListAction.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - PasswordHistoryListAction
 
 /// Actions that can be processed by a `PasswordHistoryListProcessor`.
 ///
-enum PasswordHistoryListAction: Equatable {
+enum PasswordHistoryListAction: Equatable, Sendable {
     /// The copy password button was tapped for a password.
     case copyPassword(PasswordHistoryView)
 

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListProcessor.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import OSLog
 
 // MARK: - PasswordHistoryListProcessor

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListState.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListState.swift
@@ -1,11 +1,11 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - PasswordHistoryList
 
 /// An object that defines the current state of a `PasswordHistoryListView`.
 ///
-struct PasswordHistoryListState: Equatable {
+struct PasswordHistoryListState: Equatable, Sendable {
     // MARK: Types
 
     /// The source of the password history.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListAction.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListAction.swift
@@ -2,7 +2,7 @@
 
 /// Actions that can be processed by a `SendListProcessor`.
 ///
-enum SendListAction: Equatable {
+enum SendListAction: Equatable, Sendable {
     /// The add item button was pressed.
     case addItemPressed
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItem.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItem.swift
@@ -1,12 +1,12 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 /// Data model for an item displayed in the vault list.
 ///
-public struct SendListItem: Equatable, Identifiable {
+public struct SendListItem: Equatable, Identifiable, Sendable {
     // MARK: Types
 
     /// An enumeration for the type of item being displayed by this item.
-    public enum ItemType: Equatable {
+    public enum ItemType: Equatable, Sendable {
         /// The wrapped item is a send.
         case send(BitwardenSdk.SendView)
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import SwiftUI
 
 // MARK: - SendListItemRowState
@@ -35,7 +35,7 @@ struct SendListItemRowState: Equatable {
 // MARK: - SendListItemRowAction
 
 /// Actions that can be sent from a `SendListItemRowView`.
-enum SendListItemRowAction: Equatable {
+enum SendListItemRowAction: Equatable, Sendable {
     /// The edit button was pressed.
     case editPressed(_ sendView: SendView)
 
@@ -45,7 +45,7 @@ enum SendListItemRowAction: Equatable {
 
 // MARK: - SendListItemRowEffect
 
-enum SendListItemRowEffect: Equatable {
+enum SendListItemRowEffect: Equatable, Sendable {
     /// The copy link button was pressed.
     case copyLinkPressed(_ sendView: SendView)
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - SendListProcessor

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// An object that defines the current state of a `SendListView`.
 ///
-struct SendListState {
+struct SendListState: Sendable {
     /// The info URL to open.
     var infoUrl: URL?
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // swiftlint:disable file_length

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -1,11 +1,11 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - AddEditSendItemState
 
 /// An object that defines the current state of a `AddEditSendItemView`.
 ///
-struct AddEditSendItemState: Equatable {
+struct AddEditSendItemState: Equatable, Sendable {
     // MARK: Types
 
     enum Mode: Equatable {

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 /// A helper class to handle when a cipher is selected for autofill.
 ///

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -1,5 +1,5 @@
 import AuthenticationServices
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - VaultAutofillListProcessor
 

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListState.swift
@@ -5,7 +5,7 @@ import Foundation
 
 /// An object that defines the current state of a `VaultAutofillListView`.
 ///
-struct VaultAutofillListState: Equatable {
+struct VaultAutofillListState: Equatable, Sendable {
     // MARK: Properties
 
     /// The list of cipher items matching matching the `searchText` grouped in sections, if needed.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
@@ -1,7 +1,7 @@
 // MARK: - VaultGroupAction
 
 /// Actions that can be processed by a `VaultGroupProcessor`.
-enum VaultGroupAction: Equatable {
+enum VaultGroupAction: Equatable, Sendable {
     /// The add item button was pressed.
     ///
     case addItemPressed

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - VaultGroupState
 
 /// The state of a `VaultGroupView`.
-struct VaultGroupState: Equatable {
+struct VaultGroupState: Equatable, Sendable {
     // MARK: Properties
 
     /// Whether the vault filter can be shown.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListGroup.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListGroup.swift
@@ -2,7 +2,7 @@ import BitwardenSdk
 
 /// An enumeration of groups of items displayed in the vault list.
 ///
-public enum VaultListGroup: Equatable, Hashable {
+public enum VaultListGroup: Equatable, Hashable, Sendable {
     // MARK: Cipher Types
 
     /// A group of card type ciphers.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItem.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItem.swift
@@ -1,13 +1,13 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 /// Data model for an item displayed in the vault list.
 ///
-public struct VaultListItem: Equatable, Identifiable, VaultItemWithDecorativeIcon {
+public struct VaultListItem: Equatable, Identifiable, Sendable, VaultItemWithDecorativeIcon {
     // MARK: Types
 
     /// An enumeration for the type of item being displayed by this item.
-    public enum ItemType: Equatable {
+    public enum ItemType: Equatable, Sendable {
         /// The wrapped item is a cipher.
         ///
         /// - Parameters
@@ -204,7 +204,7 @@ extension CipherView {
     }
 }
 
-public struct VaultListTOTP: Equatable {
+public struct VaultListTOTP: Equatable, Sendable {
     /// The id of the associated Cipher.
     ///
     let id: String

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
@@ -1,6 +1,6 @@
 /// Data model for a section of items in the vault list.
 ///
-public struct VaultListSection: Equatable, Identifiable {
+public struct VaultListSection: Equatable, Identifiable, Sendable {
     // MARK: Properties
 
     /// The identifier for the section.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemAction.swift
@@ -2,7 +2,7 @@
 
 /// An enum of actions for adding or editing a card Item in its add/edit state.
 ///
-enum AddEditCardItemAction: Equatable {
+enum AddEditCardItemAction: Equatable, Sendable {
     /// The brand of the card changed.
     case brandChanged(DefaultableType<CardComponent.Brand>)
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemAction.swift
@@ -3,7 +3,7 @@
 import BitwardenSdk
 
 /// Actions that can be handled by an `AddEditItemProcessor`.
-enum AddEditItemAction: Equatable {
+enum AddEditItemAction: Equatable, Sendable {
     /// The auth key visibility was toggled.
     case authKeyVisibilityTapped(Bool)
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - CipherItemOperationDelegate

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsAction.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - AttachmentsAction
 
 /// Actions that can be processed by an `AttachmentsProcessor`.
 ///
-enum AttachmentsAction: Equatable {
+enum AttachmentsAction: Equatable, Sendable {
     /// The choose file button was pressed.
     case chooseFilePressed
 

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - MoveToOrganizationProcessor

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsState.swift
@@ -1,11 +1,11 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - AttachmentsState
 
 /// An object that defines the current state of a `AttachmentsView`.
 ///
-struct AttachmentsState: Equatable {
+struct AttachmentsState: Equatable, Sendable {
     /// The cipher.
     var cipher: CipherView?
 

--- a/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsState.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - EditCollectionsState
 
 /// An object that defines the current state of a `EditCollectionsView`.
 ///
-struct EditCollectionsState: Equatable {
+struct EditCollectionsState: Equatable, Sendable {
     // MARK: Properties
 
     /// The cipher being edited.

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationState.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - MoveToOrganizationState
 
 /// An object that defines the current state of a `MoveToOrganizationView`.
 ///
-struct MoveToOrganizationState: Equatable {
+struct MoveToOrganizationState: Equatable, Sendable {
     // MARK: Properties
 
     /// The cipher to move to an organization.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemState.swift
@@ -2,7 +2,7 @@
 
 /// A protocol for an equatable type that models a Card Item in it's view state.
 ///
-protocol ViewCardItemState: Equatable {
+protocol ViewCardItemState: Equatable, Sendable {
     /// The brand of the card.
     var brand: DefaultableType<CardComponent.Brand> { get }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -1,9 +1,9 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 
 // MARK: - ViewItemAction
 
 /// Actions that can be processed by a `ViewItemProcessor`.
-enum ViewItemAction: Equatable {
+enum ViewItemAction: Equatable, Sendable {
     /// A card item action
     case cardItemAction(ViewCardItemAction)
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -1,4 +1,4 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - ViewItemProcessor

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -1,10 +1,10 @@
-import BitwardenSdk
+@preconcurrency import BitwardenSdk
 import Foundation
 
 // MARK: - ViewItemState
 
 /// The state of a `ViewItemProcessor`.
-struct ViewItemState: Equatable {
+struct ViewItemState: Equatable, Sendable {
     // MARK: Properties
 
     /// A flag indicating if the current cipher can be cloned.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11133

## 📔 Objective

This is part of the iOS 18 / Xcode 16 / Swift 6 effort

This adds `Sendable` annotations to various `struct` and `enum` declarations that were not already implicitly Sendable. This greatly reduces the number of warnings with strict concurrency turned on. As well, `@preconcurrency` annotations are being added to `BitwardenSDK` imports because those objects will be marked as Sendable at some point in the future, and this enables the newly-Sendable objects to be warning-free.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
