### PR TITLE
PM-11253: Don't trigger set master password for non-TDE users on sync

### DIFF
--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -418,6 +418,7 @@ extension DefaultSyncService {
         if organizations.count == 1,
            organizations.contains(where: \.passwordRequired),
            let userOrgId = organizations.first?.identifier,
+           account.profile.userDecryptionOptions?.trustedDeviceOption != nil,
            account.profile.userDecryptionOptions?.hasMasterPassword == false {
             await delegate?.setMasterPassword(orgIdentifier: userOrgId)
         }

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -113,6 +113,23 @@ class SyncServiceTests: BitwardenTestCase {
         XCTAssertNil(syncServiceDelegate.setMasterPasswordOrgId)
     }
 
+    /// `checkTdeUserNeedsToSetPassword()` returns false if the user doesn't use TDE.
+    func test_checkTdeUserNeedsToSetPassword_false_nonTDE() async throws {
+        client.result = .httpSuccess(testData: .syncWithProfileSingleOrg)
+        stateService.activeAccount = .fixture(
+            profile: .fixture(
+                userDecryptionOptions: UserDecryptionOptions(
+                    hasMasterPassword: false,
+                    keyConnectorOption: KeyConnectorUserDecryptionOption(keyConnectorUrl: ""),
+                    trustedDeviceOption: nil
+                )
+            )
+        )
+
+        try await subject.fetchSync(forceSync: false)
+        XCTAssertFalse(syncServiceDelegate.setMasterPasswordCalled)
+    }
+
     /// `fetchSync()` only updates the user's timeout action to match the policy's
     /// if the user's timeout value is less than the policy's.
     func test_checkVaultTimeoutPolicy_actionOnly() async throws {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11253](https://bitwarden.atlassian.net/browse/PM-11253)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes a bug where the set master password screen is shown for a key connector user upon sync. This screen should only be shown as part of sync for TDE users who need a password but don't yet have one.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11253]: https://bitwarden.atlassian.net/browse/PM-11253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ