### PR TITLE
[PM-11133] Expand MainActor annotations

### DIFF
--- a/Bitwarden/Application/AppDelegate.swift
+++ b/Bitwarden/Application/AppDelegate.swift
@@ -4,6 +4,7 @@ import UIKit
 /// A protocol for an `AppDelegate` that can be used by the `SceneDelegate` to look up the
 /// `AppDelegate` when the app is running (`AppDelegate`) or testing (`TestingAppDelegate`).
 ///
+@MainActor
 protocol AppDelegateType: AnyObject {
     /// The processor that manages application level logic.
     var appProcessor: AppProcessor? { get }

--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -6,6 +6,7 @@ import Foundation
 
 /// An object that is signaled when specific circumstances in the captcha flow have been encountered.
 ///
+@MainActor
 protocol CaptchaFlowDelegate: AnyObject {
     /// Called when the captcha flow has been completed successfully.
     ///

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -5,6 +5,7 @@ import Foundation
 
 /// An object that is signaled when specific circumstances in the single sign on flow have been encountered.
 ///
+@MainActor
 protocol SingleSignOnFlowDelegate: AnyObject {
     /// Called when the single sign on flow has been completed successfully.
     ///

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -328,6 +328,7 @@ extension TwoFactorAuthProcessor: CaptchaFlowDelegate {
 
 /// An object that is signaled when specific circumstances in the web authentication on flow have been encountered.
 ///
+@MainActor
 protocol DuoAuthenticationFlowDelegate: AnyObject {
     /// Called when the web auth flow has been completed successfully.
     ///
@@ -416,6 +417,7 @@ enum DuoCallbackURLComponent: String {
 
 /// An object that is signaled when specific circumstances in the WebAuthn flow have been encountered.
 ///
+@MainActor
 protocol WebAuthnFlowDelegate: AnyObject {
     /// Called when the WebAuthn flow has been completed successfully.
     ///

--- a/BitwardenShared/UI/Autofill/Application/Fido2AppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Autofill/Application/Fido2AppExtensionDelegate.swift
@@ -3,6 +3,7 @@ import Combine
 
 /// A delegate that is used to handle actions and retrieve information from within an Autofill extension
 /// on Fido2 flows.
+@MainActor
 public protocol Fido2AppExtensionDelegate: AppExtensionDelegate {
     /// The mode in which the autofill extension is running.
     var extensionMode: AutofillExtensionMode { get }

--- a/BitwardenShared/UI/Autofill/Application/Fido2AppExtensionDelegateTests.swift
+++ b/BitwardenShared/UI/Autofill/Application/Fido2AppExtensionDelegateTests.swift
@@ -26,6 +26,7 @@ class Fido2AppExtensionDelegateTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `getter:autofillListMode`  returns the proper autofill list mode
+    @MainActor
     func test_autofillListMode() async throws {
         subject.extensionMode = .autofillFido2VaultList([], MockPasskeyCredentialRequestParameters())
         XCTAssertEqual(subject.autofillListMode, .combinedMultipleSections)
@@ -39,6 +40,7 @@ class Fido2AppExtensionDelegateTests: BitwardenTestCase {
 
     /// `getter:isCreatingFido2Credential`  returns `true`
     /// when there is a request for creation
+    @MainActor
     func test_isCreatingFido2Credential_true() async throws {
         subject.extensionMode = .registerFido2Credential(ASPasskeyCredentialRequest.fixture())
         XCTAssertTrue(subject.isCreatingFido2Credential)
@@ -46,11 +48,13 @@ class Fido2AppExtensionDelegateTests: BitwardenTestCase {
 
     /// `getter:isCreatingFido2Credential`  returns `false`
     /// when there is no request for creation
+    @MainActor
     func test_isCreatingFido2Credential_false() async throws {
         XCTAssertFalse(subject.isCreatingFido2Credential)
     }
 
     /// `getter:rpID`  returns the proper rpID
+    @MainActor
     func test_rpID() async throws {
         let expectedRpID = "myApp.com"
         subject.extensionMode = .autofillFido2VaultList([], MockPasskeyCredentialRequestParameters(

--- a/BitwardenShared/UI/Platform/Application/AppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Platform/Application/AppExtensionDelegate.swift
@@ -3,6 +3,7 @@ import BitwardenSdk
 /// A delegate that is used to handle actions and configure the display for when the app runs within
 /// an app extension.
 ///
+@MainActor
 public protocol AppExtensionDelegate: AnyObject {
     /// The app's route that the app should navigate to after auth has been completed.
     var authCompletionRoute: AppRoute? { get }

--- a/BitwardenShared/UI/Platform/Application/AppProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor+Fido2Tests.swift
@@ -116,6 +116,7 @@ class AppProcessorFido2Tests: BitwardenTestCase {
 
     /// `onNeedsUserInteraction()` throws when flows is not with user interaction but user interaction is required.
     @available(iOS 17.0, *)
+    @MainActor
     func test_onNeedsUserInteraction_throws() async {
         appExtensionDelegate.flowWithUserInteraction = false
 
@@ -128,6 +129,7 @@ class AppProcessorFido2Tests: BitwardenTestCase {
     /// `onNeedsUserInteraction()` doesn't throw when flows is not with user interaction
     /// but user interaction is required.
     @available(iOS 17.0, *)
+    @MainActor
     func test_onNeedsUserInteraction_flowWithUserInteraction() async {
         appExtensionDelegate.flowWithUserInteraction = true
 

--- a/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
@@ -99,6 +99,7 @@ protocol HasRootNavigator: HasNavigator {
 
 /// A protocol for an object that has a `Router`.
 ///
+@MainActor
 protocol HasRouter<Event, Route> {
     associatedtype Event
     associatedtype Route

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessor.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessor.swift
@@ -4,6 +4,7 @@ import Foundation
 
 /// An object that is notified when specific circumstances in the login request view have occurred.
 ///
+@MainActor
 protocol LoginRequestDelegate: AnyObject {
     /// The login request has been answered.
     ///

--- a/BitwardenShared/UI/Platform/Settings/Settings/Appearance/SelectLanguage/SelectLanguageProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Appearance/SelectLanguage/SelectLanguageProcessor.swift
@@ -1,6 +1,7 @@
 // MARK: - SelectLanguageDelegate
 
 /// The delegate for updating the parent view after a language has been selected.
+@MainActor
 protocol SelectLanguageDelegate: AnyObject {
     /// A language has been selected.
     func languageSelected(_ languageOption: LanguageOption)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AppExtension/AppExtensionProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AppExtension/AppExtensionProcessor.swift
@@ -2,6 +2,7 @@
 
 /// A delegate of the app extension setup flow that is notified when the user enables the extension.
 ///
+@MainActor
 protocol AppExtensionSetupDelegate: AnyObject {
     /// Called when the user dismisses the app extension or the activity view controller during the
     /// extension setup process.

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderProcessor.swift
@@ -2,6 +2,7 @@
 
 /// An object that is notified when specific circumstances in the add/edit folder view have occurred.
 ///
+@MainActor
 protocol AddEditFolderDelegate: AnyObject {
     /// Called when the folder has been successfully created.
     func folderAdded()

--- a/BitwardenShared/UI/Platform/Tabs/TabModule.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabModule.swift
@@ -4,6 +4,7 @@ import UIKit
 
 /// An object that builds coordinators for the tab interface.
 ///
+@MainActor
 public protocol TabModule: AnyObject {
     /// Initializes a coordinator for navigating to `TabRoute`s.
     ///

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -54,6 +54,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `handleCipherForAutofill(cipherListView:)` notifies the delegate of the username and
     /// password to autofill.
+    @MainActor
     func test_handleCipherForAutofill() async {
         vaultRepository.fetchCipherResult = .success(.fixture(
             login: .fixture(password: "PASSWORD", username: "user@bitwarden.com")
@@ -295,6 +296,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `handleCipherForAutofill(cipherListView:)` bypasses the master password reprompt if the
     /// user doesn't have a master password.
+    @MainActor
     func test_handleCipherForAutofill_passwordReprompt_noMasterPassword() async throws {
         authRepository.hasMasterPasswordResult = .success(false)
         vaultRepository.fetchCipherResult = .success(.fixture(
@@ -311,6 +313,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `handleCipherForAutofill(cipherListView:)` logs an error if generating the TOTP fails.
+    @MainActor
     func test_handleCipherForAutofill_generateTOTPError() async {
         vaultRepository.fetchCipherResult = .success(.fixture(
             login: .fixture(password: "PASSWORD", username: "user@bitwarden.com", totp: "totp")

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -268,6 +268,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
     /// `vaultItemTapped(_:)` with Fido2 credential signals the `Fido2UserInterfaceHelper`
     /// that a cipher has been picked for authentication when in `autofillFido2VaultList` mode.
     @available(iOSApplicationExtension 17.0, *)
+    @MainActor
     func test_perform_vaultItemTapped_fido2PickedForAuthentication() async {
         appExtensionDelegate.extensionMode = .autofillFido2VaultList([], MockPasskeyCredentialRequestParameters())
         let vaultListItem = VaultListItem(
@@ -388,6 +389,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
     /// `vaultItemTapped(_:)` with cipher signals the `Fido2UserInterfaceHelper`
     /// that a cipher has been picked when in creating Fido2 credential context and user check was verified.
     @available(iOSApplicationExtension 17.0, *)
+    @MainActor
     func test_perform_vaultItemTapped_cipherPickedForFido2Creation() async throws {
         let expectedResult = CipherView.fixture(
             login: .fixture()
@@ -420,6 +422,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
     /// `vaultItemTapped(_:)` with cipher signals the `Fido2UserInterfaceHelper`
     /// that a cipher has been picked when in creating Fido2 credential context and user check was not verified.
     @available(iOSApplicationExtension 17.0, *)
+    @MainActor
     func test_perform_vaultItemTapped_cipherPickedForFido2CreationUserCheckNotVerified() async throws {
         let expectedResult = CipherView.fixture(
             login: .fixture()
@@ -479,6 +482,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
     /// `vaultItemTapped(_:)` with cipher does nothing when
     /// a cipher has been picked in creating Fido2 credential context and user check is cancelled.
     @available(iOSApplicationExtension 17.0, *)
+    @MainActor
     func test_perform_vaultItemTapped_cipherPickedForFido2CreationUserCheckCancelled() async throws {
         let expectedResult = CipherView.fixture(
             login: .fixture()
@@ -650,6 +654,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
     /// `perform(_:)` with `.initFido2` calls `makeCredential` from the Fido2 authenticator when
     /// there is a create FIdo2 request and a credential identity in there as well and completes the registration
     /// when `makeCredential` ends successfully.
+    @MainActor
     func test_perform_initFido2_registerFido2CredentialThrows() async throws {
         appExtensionDelegate.extensionMode = .registerFido2Credential(ASPasskeyCredentialRequest.fixture())
 
@@ -678,6 +683,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
     /// `perform(_:)` with `.initFido2` doesn't call `makeCredential` from the Fido2 authenticator when
     /// there is NO create FIdo2 request.
+    @MainActor
     func test_perform_initFido2_noRequestForFido2Creation() async throws {
         await subject.perform(.initFido2)
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -5,6 +5,7 @@ import Foundation
 
 /// An object that is notified when specific circumstances in the add/edit/delete item view have occurred.
 ///
+@MainActor
 protocol CipherItemOperationDelegate: AnyObject {
     /// Called when a new cipher item has been successfully added.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/Extensions/ForEachIndexed.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/Extensions/ForEachIndexed.swift
@@ -73,7 +73,7 @@ public extension ForEachIndexed where ID == Data.Element.ID, Content: View, Data
     }
 }
 
-extension ForEachIndexed: DynamicViewContent where Content: View {}
+extension ForEachIndexed: @preconcurrency DynamicViewContent where Content: View {}
 
 /// A helper to provide an item id to `ForEachIndexed` to build a `ForEach`.
 ///

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/Extensions/ForEachIndexed.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/Extensions/ForEachIndexed.swift
@@ -73,7 +73,7 @@ public extension ForEachIndexed where ID == Data.Element.ID, Content: View, Data
     }
 }
 
-extension ForEachIndexed: @preconcurrency DynamicViewContent where Content: View {}
+extension ForEachIndexed: DynamicViewContent where Content: View {}
 
 /// A helper to provide an item id to `ForEachIndexed` to build a `ForEach`.
 ///

--- a/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessor.swift
@@ -3,6 +3,7 @@
 /// A delegate of `EditCollectionsProcessor` that is notified when the user successfully moves
 /// the cipher between collections.
 ///
+@MainActor
 protocol EditCollectionsProcessorDelegate: AnyObject {
     /// Called when the user successfully moves the cipher between collections.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessor.swift
@@ -5,6 +5,7 @@ import BitwardenSdk
 /// A delegate of `MoveToOrganizationProcessor` that is notified when the user successfully moves
 /// the cipher to an organization.
 ///
+@MainActor
 protocol MoveToOrganizationProcessorDelegate: AnyObject {
     /// Called when the user successfully moves the cipher to an organization.
     ///


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11133

## 📔 Objective

This is part of the iOS 18 / Xcode 16 / Swift 6 effort

This adds `@MainActor` annotations to a number of protocols to eliminate Swift 6 errors. On the whole, these are delegate protocols between a `Processor` (which is `@MainActor`) and a `Coordinator` (which is `@MainActor`).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
