### PR TITLE
[PM-585] Improved text when setting unlock with PIN on app restart

### DIFF
--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
@@ -30,12 +30,11 @@ protocol BiometricsRepository: AnyObject {
     ///     Should be called following a successful launch when biometric unlock is enabled.
     func configureBiometricIntegrity() async throws
 
-    /// Sets the biometric unlock preference for the active user.
-    ///   If permissions have not been requested, this request should trigger the system permisisons dialog.
+    /// Returns the status for device BiometricAuthenticationType.
     ///
-    /// - Parameter authKey: An optional `String` representing the user auth key. If nil, Biometric Unlock is disabled.
+    /// - Returns: The `BiometricAuthenticationType`.
     ///
-    func setBiometricUnlockKey(authKey: String?) async throws
+    func getBiometricAuthenticationType() -> BiometricAuthenticationType?
 
     /// Returns the status for user BiometricAuthentication.
     ///
@@ -46,6 +45,13 @@ protocol BiometricsRepository: AnyObject {
     /// Attempts to retrieve a user's auth key with biometrics.
     ///
     func getUserAuthKey() async throws -> String
+
+    /// Sets the biometric unlock preference for the active user.
+    ///   If permissions have not been requested, this request should trigger the system permisisons dialog.
+    ///
+    /// - Parameter authKey: An optional `String` representing the user auth key. If nil, Biometric Unlock is disabled.
+    ///
+    func setBiometricUnlockKey(authKey: String?) async throws
 }
 
 // MARK: - DefaultBiometricsRepository
@@ -90,6 +96,10 @@ class DefaultBiometricsRepository: BiometricsRepository {
             let base64State = state.base64EncodedString()
             try await stateService.setBiometricIntegrityState(base64State)
         }
+    }
+
+    func getBiometricAuthenticationType() -> BiometricAuthenticationType? {
+        biometricsService.getBiometricAuthenticationType()
     }
 
     func setBiometricUnlockKey(authKey: String?) async throws {

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
@@ -30,7 +30,7 @@ protocol BiometricsRepository: AnyObject {
     ///     Should be called following a successful launch when biometric unlock is enabled.
     func configureBiometricIntegrity() async throws
 
-    /// Returns the status for device BiometricAuthenticationType.
+    /// Returns the device BiometricAuthenticationType.
     ///
     /// - Returns: The `BiometricAuthenticationType`.
     ///

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepositoryTests.swift
@@ -73,6 +73,15 @@ final class BiometricsRepositoryTests: BitwardenTestCase { // swiftlint:disable:
         )
     }
 
+    /// `getBiometricAuthenticationType()` gets the current authentication type.
+    func test_getBiometricAuthenticationType() async throws {
+        biometricsService.biometricAuthenticationType = .faceID
+        XCTAssertEqual(subject.getBiometricAuthenticationType(), .faceID)
+
+        biometricsService.biometricAuthenticationType = nil
+        XCTAssertNil(subject.getBiometricAuthenticationType())
+    }
+
     /// `setBiometricUnlockKey` throws for a no user situation.
     func test_getBiometricUnlockKey_noActiveAccount() async throws {
         stateService.activeAccount = nil

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsService.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsService.swift
@@ -46,7 +46,7 @@ extension BiometricsService {
         return await evaluateBiometricPolicy(nil, for: initialStatus)
     }
 
-    /// Returns the status for device BiometricAuthenticationType.
+    /// Returns the device BiometricAuthenticationType.
     ///
     /// - Returns: The `BiometricAuthenticationType`.
     ///

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsService.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsService.swift
@@ -45,6 +45,14 @@ extension BiometricsService {
         let initialStatus = getBiometricAuthStatus()
         return await evaluateBiometricPolicy(nil, for: initialStatus)
     }
+
+    /// Returns the status for device BiometricAuthenticationType.
+    ///
+    /// - Returns: The `BiometricAuthenticationType`.
+    ///
+    func getBiometricAuthenticationType() -> BiometricAuthenticationType? {
+        getBiometricAuthenticationType(nil)
+    }
 }
 
 class DefaultBiometricsService: BiometricsService {

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockBiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockBiometricsRepository.swift
@@ -5,11 +5,16 @@ class MockBiometricsRepository: BiometricsRepository {
     var capturedUserAuthKey: String?
     var didConfigureBiometricIntegrity = false
     var didDeleteKey: Bool = false
+    var getBiometricAuthenticationTypeResult: BitwardenShared.BiometricAuthenticationType?
     var getUserAuthKeyResult: Result<String, Error> = .success("UserAuthKey")
     var setBiometricUnlockKeyError: Error?
 
     func configureBiometricIntegrity() async {
         didConfigureBiometricIntegrity = true
+    }
+
+    func getBiometricAuthenticationType() -> BitwardenShared.BiometricAuthenticationType? {
+        getBiometricAuthenticationTypeResult
     }
 
     func getBiometricUnlockStatus() async throws -> BitwardenShared.BiometricsUnlockStatus {

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -448,6 +448,7 @@
 "Exit" = "Exit";
 "ExitConfirmation" = "Are you sure you want to exit Bitwarden?";
 "PINRequireMasterPasswordRestart" = "Do you want to require unlocking with your master password when the application is restarted?";
+"PINRequireBioOrMasterPasswordRestart" = "Do you want to require unlocking with %1$@ or your master password when the application is restarted?";
 "Black" = "Black";
 "Nord" = "Nord";
 "SolarizedDark" = "Solarized Dark";

--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -237,13 +237,27 @@ extension Alert {
 
     /// An alert asking if the user wants to login with their PIN upon app restart.
     ///
-    /// - Parameter action: The action to occur if `Yes` is tapped.
-    /// - Returns: An alert asking if the user wants to login with their PIN upon app restart.
+    /// - Parameters:
+    ///   - biometricType: The biometirc type the app supports.
+    ///   - action: The action to occur if `Yes` is tapped
     ///
-    static func unlockWithPINCodeAlert(action: @escaping (Bool) async -> Void) -> Alert {
-        Alert(
+    /// - Returns: An alert asking if the user wants to login with their PIN upon app restart.
+    static func unlockWithPINCodeAlert(
+        biometricType: BiometricAuthenticationType?,
+        action: @escaping (Bool) async -> Void
+    ) -> Alert {
+        var message = Localizations.pinRequireMasterPasswordRestart
+        if let biometricType {
+            switch biometricType {
+            case .faceID:
+                message = Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.faceID)
+            case .touchID:
+                message = Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.touchID)
+            }
+        }
+        return Alert(
             title: Localizations.unlockWithPIN,
-            message: Localizations.pinRequireMasterPasswordRestart,
+            message: message,
             alertActions: [
                 AlertAction(title: Localizations.no, style: .cancel) { _ in
                     await action(false)

--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -246,14 +246,13 @@ extension Alert {
         biometricType: BiometricAuthenticationType?,
         action: @escaping (Bool) async -> Void
     ) -> Alert {
-        var message = Localizations.pinRequireMasterPasswordRestart
-        if let biometricType {
-            switch biometricType {
-            case .faceID:
-                message = Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.faceID)
-            case .touchID:
-                message = Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.touchID)
-            }
+        let message = switch biometricType {
+        case .faceID:
+            Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.faceID)
+        case .touchID:
+            Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.touchID)
+        case nil:
+            Localizations.pinRequireMasterPasswordRestart
         }
         return Alert(
             title: Localizations.unlockWithPIN,

--- a/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -189,14 +189,37 @@ class AlertSettingsTests: BitwardenTestCase {
         XCTAssertEqual(subject.alertActions.last?.style, .default)
     }
 
-    /// `unlockWithPINCodeAlert(action)` constructs an `Alert` with the correct title, message, Yes and No buttons.
+    /// `unlockWithPINCodeAlert(action)` constructs an `Alert` with the correct title, message, Yes and No buttons
+    /// when `biometricType` is `nil`.
     func test_unlockWithPINAlert() {
-        let subject = Alert.unlockWithPINCodeAlert { _ in }
+        let subject = Alert.unlockWithPINCodeAlert(biometricType: nil) { _ in }
 
         XCTAssertEqual(subject.alertActions.count, 2)
         XCTAssertEqual(subject.preferredStyle, .alert)
         XCTAssertEqual(subject.title, Localizations.unlockWithPIN)
         XCTAssertEqual(subject.message, Localizations.pinRequireMasterPasswordRestart)
+    }
+
+    /// `unlockWithPINCodeAlert(action)` constructs an `Alert` with the correct title, message, Yes and No buttons
+    /// when `biometricType` is `faceID`.
+    func test_unlockWithPINAlert_faceID() {
+        let subject = Alert.unlockWithPINCodeAlert(biometricType: .faceID) { _ in }
+
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.title, Localizations.unlockWithPIN)
+        XCTAssertEqual(subject.message, Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.faceID))
+    }
+
+    /// `unlockWithPINCodeAlert(action)` constructs an `Alert` with the correct title, message, Yes and No buttons
+    /// when `biometricType` is `touchID`.
+    func test_unlockWithPINAlert_touchID() {
+        let subject = Alert.unlockWithPINCodeAlert(biometricType: .touchID) { _ in }
+
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.title, Localizations.unlockWithPIN)
+        XCTAssertEqual(subject.message, Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.touchID))
     }
 
     /// `verificationCodePrompt(completion:)` constructs an `Alert` used to ask the user to entered

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -304,10 +304,13 @@ final class AccountSecurityProcessor: StateProcessor<
 
                 do {
                     let userHasMasterPassword = try await self.services.stateService.getUserHasMasterPassword()
+                    let biometricType = self.services.biometricsRepository.getBiometricAuthenticationType()
                     if userHasMasterPassword {
-                        self.coordinator.showAlert(.unlockWithPINCodeAlert { requirePassword in
-                            await self.setPin(pin, requirePasswordAfterRestart: requirePassword)
-                        })
+                        self.coordinator.showAlert(
+                            .unlockWithPINCodeAlert(biometricType: biometricType) { requirePassword in
+                                await self.setPin(pin, requirePasswordAfterRestart: requirePassword)
+                            }
+                        )
                     } else {
                         await self.setPin(pin, requirePasswordAfterRestart: false)
                     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -495,6 +495,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     @MainActor
     func test_receive_toggleUnlockWithPINCode_toggleOn_withPIN() async throws {
         stateService.activeAccount = .fixture()
+        biometricsRepository.getBiometricAuthenticationTypeResult = .faceID
         subject.state.isUnlockWithPINCodeOn = false
         subject.receive(.toggleUnlockWithPINCode(true))
 
@@ -503,6 +504,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         try await alert.tapAction(title: Localizations.submit)
 
         alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.message, Localizations.pinRequireBioOrMasterPasswordRestart(Localizations.faceID))
         try await alert.tapAction(title: Localizations.yes)
         XCTAssertTrue(subject.state.isUnlockWithPINCodeOn)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-585](https://bitwarden.atlassian.net/browse/PM-585)

## 📔 Objective

Improve text when setting unlock with PIN on app restart to say that it can be with biometrics or master password.

## 📸 Screenshots

### Unlock with PIN on app restart
<img width="314" alt="Unlock with PIN on app restart" src="https://github.com/user-attachments/assets/851a24bf-8f75-4255-9290-241974b85e9a">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-585]: https://bitwarden.atlassian.net/browse/PM-585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ