### PR TITLE
[PM-11347] Include Xcode version in tester notes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,7 +416,7 @@ jobs:
       - name: Upload app to TestFlight with Fastlane
         run: |
           NEWLINE=$'\n'
-          CHANGELOG="$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINEXcode ${{ env.XCODE_VERSION }}$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          CHANGELOG="$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA${NEWLINE}Xcode ${{ env.XCODE_VERSION }}$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           fastlane upload_build \
             api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
             changelog:"$CHANGELOG" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,7 +416,7 @@ jobs:
       - name: Upload app to TestFlight with Fastlane
         run: |
           NEWLINE=$'\n'
-          CHANGELOG=$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINEXcode ${{ env.XCODE_VERSION }}$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
+          CHANGELOG="$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINEXcode ${{ env.XCODE_VERSION }}$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           fastlane upload_build \
             api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
             changelog:"$CHANGELOG" \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -416,7 +416,8 @@ jobs:
       - name: Upload app to TestFlight with Fastlane
         run: |
           NEWLINE=$'\n'
+          CHANGELOG=$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINEXcode ${{ env.XCODE_VERSION }}$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID
           fastlane upload_build \
             api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json" \
-            changelog:"$(git show -s --format=%s)$NEWLINE$GITHUB_REPOSITORY/$GITHUB_REF_NAME @ $GITHUB_SHA$NEWLINE$NEWLINE$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            changelog:"$CHANGELOG" \
             ipa_path:"export/Bitwarden.ipa"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11347

## 📔 Objective

This adds the version of Xcode a build was made with in the tester notes in TestFlight. When we start building the app with multiple versions of Xcode (primarily Beta Xcode versions), this will help people looking at TestFlight identify which version exactly they want to use.

## 📸 Screenshots

<img width="643" alt="Screenshot 2024-08-26 at 12 34 39 PM" src="https://github.com/user-attachments/assets/4cdb0261-a243-45fd-9012-f715d0980ba3">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
