### PR TITLE
PM-10270: Set up unlock later

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -204,6 +204,13 @@ protocol StateService: AnyObject {
     ///
     func getMasterPasswordHash(userId: String?) async throws -> String?
 
+    /// Gets whether the user needs to set up vault unlock methods.
+    ///
+    /// - Parameter userId: The user ID associated with the value.
+    /// - Returns: Whether the user needs to set up vault unlock methods.
+    ///
+    func getNeedsVaultUnlockSetup(userId: String?) async throws -> Bool
+
     /// Gets the last notifications registration date for a user ID.
     ///
     /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
@@ -463,6 +470,14 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID associated with the master password hash.
     ///
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws
+
+    /// Sets whether the user needs to set up vault unlock methods.
+    ///
+    /// - Parameters:
+    ///   - needsVaultUnlockSetup: Whether the user needs to set up vault unlock methods.
+    ///   - userId: The user ID associated with the value.
+    ///
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String?) async throws
 
     /// Sets the last notifications registration date for a user ID.
     ///
@@ -750,6 +765,14 @@ extension StateService {
         try await getMasterPasswordHash(userId: nil)
     }
 
+    /// Gets whether the active account needs to set up vault unlock methods.
+    ///
+    /// - Returns: Whether the user needs to set up vault unlock methods.
+    ///
+    func getNeedsVaultUnlockSetup() async throws -> Bool {
+        try await getNeedsVaultUnlockSetup(userId: nil)
+    }
+
     /// Gets the last notifications registration date for the active account.
     ///
     /// - Returns: The last notifications registration date for the active account.
@@ -934,6 +957,14 @@ extension StateService {
     ///
     func setMasterPasswordHash(_ hash: String?) async throws {
         try await setMasterPasswordHash(hash, userId: nil)
+    }
+
+    /// Sets whether the active account needs to set up vault unlock methods.
+    ///
+    /// - Parameter needsVaultUnlockSetup: Whether the user needs to set up vault unlock methods.
+    ///
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool) async throws {
+        try await setNeedsVaultUnlockSetup(needsVaultUnlockSetup, userId: nil)
     }
 
     /// Sets the last notifications registration date for the active account.
@@ -1240,6 +1271,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         return appSettingsStore.masterPasswordHash(userId: userId)
     }
 
+    func getNeedsVaultUnlockSetup(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.needsVaultUnlockSetup(userId: userId)
+    }
+
     func getNotificationsLastRegistrationDate(userId: String?) async throws -> Date? {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.notificationsLastRegistrationDate(userId: userId)
@@ -1459,6 +1495,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setMasterPasswordHash(hash, userId: userId)
+    }
+
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setNeedsVaultUnlockSetup(needsVaultUnlockSetup, userId: userId)
     }
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -637,6 +637,25 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         }
     }
 
+    /// `getNeedsVaultUnlockSetup()` returns whether the user needs to set up vault unlock methods.
+    func test_getNeedsVaultUnlockSetup() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        let initialValue = try await subject.getNeedsVaultUnlockSetup()
+        XCTAssertFalse(initialValue)
+
+        appSettingsStore.needsVaultUnlockSetup["1"] = true
+        let needsVaultUnlockSetup = try await subject.getNeedsVaultUnlockSetup()
+        XCTAssertTrue(needsVaultUnlockSetup)
+    }
+
+    /// `getNeedsVaultUnlockSetup()` throws an error if there isn't an active account.
+    func test_getNeedsVaultUnlockSetup_noAccount() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.getNeedsVaultUnlockSetup()
+        }
+    }
+
     /// `getNotificationsLastRegistrationDate()` returns the user's last notifications registration date.
     func test_getNotificationsLastRegistrationDate() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
@@ -1533,6 +1552,17 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.setMasterPasswordHash("1234", userId: "1")
         XCTAssertEqual(appSettingsStore.masterPasswordHashes, ["1": "1234"])
+    }
+
+    /// `setNeedsVaultUnlockSetup(_:)` sets whether the user needs to set up vault unlock methods.
+    func test_setNeedsVaultUnlockSetup() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        try await subject.setNeedsVaultUnlockSetup(true)
+        XCTAssertEqual(appSettingsStore.needsVaultUnlockSetup, ["1": true])
+
+        try await subject.setNeedsVaultUnlockSetup(false, userId: "1")
+        XCTAssertEqual(appSettingsStore.needsVaultUnlockSetup, ["1": false])
     }
 
     /// `setNotificationsLastRegistrationDate(_:)` sets the last notifications registration date for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -162,6 +162,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func masterPasswordHash(userId: String) -> String?
 
+    /// Gets whether the user needs to set up vault unlock methods.
+    ///
+    /// - Parameter userId: The user ID associated with the value.
+    /// - Returns: Whether the user needs to set up vault unlock methods.
+    ///
+    func needsVaultUnlockSetup(userId: String) -> Bool
+
     /// Gets the last date the user successfully registered for push notifications.
     ///
     /// - Parameter userId: The user ID associated with the last notifications registration date.
@@ -304,6 +311,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the master password hash.
     ///
     func setMasterPasswordHash(_ hash: String?, userId: String)
+
+    /// Sets whether the user needs to set up vault unlock methods.
+    ///
+    /// - Parameters:
+    ///   - needsVaultUnlockSetup: Whether the user needs to set up vault unlock methods.
+    ///   - userId: The user ID associated with the value.
+    ///
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String)
 
     /// Sets the last notifications registration date for a user ID.
     ///
@@ -587,6 +602,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case loginRequest
         case masterPasswordHash(userId: String)
         case migrationVersion
+        case needsVaultUnlockSetup(userId: String)
         case notificationsLastRegistrationDate(userId: String)
         case passwordGenerationOptions(userId: String)
         case pinProtectedUserKey(userId: String)
@@ -656,6 +672,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "keyHash_\(userId)"
             case .migrationVersion:
                 key = "migrationVersion"
+            case let .needsVaultUnlockSetup(userId):
+                key = "needsVaultUnlockSetup_\(userId)"
             case let .notificationsLastRegistrationDate(userId):
                 key = "pushLastRegistrationDate_\(userId)"
             case let .passwordGenerationOptions(userId):
@@ -836,6 +854,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .masterPasswordHash(userId: userId))
     }
 
+    func needsVaultUnlockSetup(userId: String) -> Bool {
+        fetch(for: .needsVaultUnlockSetup(userId: userId))
+    }
+
     func notificationsLastRegistrationDate(userId: String) -> Date? {
         fetch(for: .notificationsLastRegistrationDate(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
@@ -912,6 +934,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setMasterPasswordHash(_ hash: String?, userId: String) {
         store(hash, for: .masterPasswordHash(userId: userId))
+    }
+
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String) {
+        store(needsVaultUnlockSetup, for: .needsVaultUnlockSetup(userId: userId))
     }
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -515,6 +515,23 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(userDefaults.double(forKey: "bwPreferencesStorage:pushLastRegistrationDate_2"), 1_696_204_800.0)
     }
 
+    /// `needsVaultUnlockSetup(userId:)` returns `false` if there isn't a previously stored value.
+    func test_needsVaultUnlockSetup_isInitiallyFalse() {
+        XCTAssertFalse(subject.needsVaultUnlockSetup(userId: "-1"))
+    }
+
+    /// `needsVaultUnlockSetup(userId:)` can be used to get whether the user needs to set up vault
+    /// unlock methods.
+    func test_needsVaultUnlockSetup__withValue() {
+        subject.setNeedsVaultUnlockSetup(true, userId: "1")
+        subject.setNeedsVaultUnlockSetup(false, userId: "2")
+
+        XCTAssertTrue(subject.needsVaultUnlockSetup(userId: "1"))
+        XCTAssertFalse(subject.needsVaultUnlockSetup(userId: "2"))
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:needsVaultUnlockSetup_1"))
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:needsVaultUnlockSetup_2"))
+    }
+
     /// `passwordGenerationOptions(userId:)` returns `nil` if there isn't a previously stored value.
     func test_passwordGenerationOptions_isInitiallyNil() {
         XCTAssertNil(subject.passwordGenerationOptions(userId: "-1"))

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -33,6 +33,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var lastActiveTime = [String: Date]()
     var lastSyncTimeByUserId = [String: Date]()
     var masterPasswordHashes = [String: String]()
+    var needsVaultUnlockSetup = [String: Bool]()
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKey = [String: String]()
@@ -99,6 +100,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func masterPasswordHash(userId: String) -> String? {
         masterPasswordHashes[userId]
+    }
+
+    func needsVaultUnlockSetup(userId: String) -> Bool {
+        needsVaultUnlockSetup[userId] ?? false
     }
 
     func notificationsLastRegistrationDate(userId: String) -> Date? {
@@ -179,6 +184,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String) {
         notificationsLastRegistrationDates[userId] = date
+    }
+
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String) {
+        self.needsVaultUnlockSetup[userId] = needsVaultUnlockSetup
     }
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -49,6 +49,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lastUserShouldConnectToWatch = false
     var masterPasswordHashes = [String: String]()
+    var needsVaultUnlockSetup = [String: Bool]()
     var notificationsLastRegistrationDates = [String: Date]()
     var notificationsLastRegistrationError: Error?
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
@@ -230,6 +231,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func getMasterPasswordHash(userId: String?) async throws -> String? {
         let userId = try unwrapUserId(userId)
         return masterPasswordHashes[userId]
+    }
+
+    func getNeedsVaultUnlockSetup(userId: String?) async throws -> Bool {
+        let userId = try unwrapUserId(userId)
+        return needsVaultUnlockSetup[userId] ?? false
     }
 
     func getNotificationsLastRegistrationDate(userId: String?) async throws -> Date? {
@@ -427,6 +433,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         masterPasswordHashes[userId] = hash
+    }
+
+    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        self.needsVaultUnlockSetup[userId] = needsVaultUnlockSetup
     }
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String?) async throws {

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -116,6 +116,9 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
 
     func navigate(to route: AuthRoute, context: AnyObject?) { // swiftlint:disable:this function_body_length
         switch route {
+        case .autofillSetup:
+            // TODO: PM-10278 Add autofill setup screen
+            break
         case let .captcha(url, callbackUrlScheme):
             showCaptcha(
                 url: url,

--- a/BitwardenShared/UI/Auth/AuthRoute.swift
+++ b/BitwardenShared/UI/Auth/AuthRoute.swift
@@ -4,6 +4,9 @@ import Foundation
 
 /// A route to a specific screen in the authentication flow.
 public enum AuthRoute: Equatable {
+    /// A route to the autofill setup screen.
+    case autofillSetup
+
     /// A route to the captcha screen.
     case captcha(url: URL, callbackUrlScheme: String)
 

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -228,7 +228,7 @@ extension Alert {
     static func setUpUnlockMethodLater(action: @escaping () async -> Void) -> Alert {
         Alert(
             title: Localizations.setUpLaterQuestion,
-            message: Localizations.youCanFinishSetupUnlockAnytime,
+            message: Localizations.youCanFinishSetupUnlockAnytimeDescriptionLong,
             alertActions: [
                 AlertAction(title: Localizations.cancel, style: .cancel),
                 AlertAction(title: Localizations.confirm, style: .default) { _ in

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -217,6 +217,27 @@ extension Alert {
         )
     }
 
+    /// An alert confirming that the user wants to finish setting up their vault unlock methods
+    /// later in settings.
+    ///
+    /// - Parameter action: The action taken when the user taps on Confirm to finish setting up
+    ///     their vault unlock methods later in settings.
+    /// - Returns: An alert confirming that the user wants to finish setting up their vault unlock
+    ///     methods later in settings.
+    ///
+    static func setUpUnlockMethodLater(action: @escaping () async -> Void) -> Alert {
+        Alert(
+            title: Localizations.setUpLaterQuestion,
+            message: Localizations.youCanFinishSetupUnlockAnytime,
+            alertActions: [
+                AlertAction(title: Localizations.cancel, style: .cancel),
+                AlertAction(title: Localizations.confirm, style: .default) { _ in
+                    await action()
+                },
+            ]
+        )
+    }
+
     /// An alert asking the user if they want to switch to the already existing account when adding
     /// a new account.
     ///

--- a/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
@@ -165,6 +165,28 @@ class AlertAuthTests: BitwardenTestCase {
         await fulfillment(of: [expectation], timeout: 3)
     }
 
+    /// `setUpUnlockMethodLater(action:)` builds an `Alert` confirming the user wants to set up
+    /// their unlock methods later.
+    func test_setUpUnlockMethodLater() async throws {
+        var actionCalled = false
+        let subject = Alert.setUpUnlockMethodLater {
+            actionCalled = true
+        }
+
+        XCTAssertEqual(subject.title, Localizations.setUpLaterQuestion)
+        XCTAssertEqual(subject.message, Localizations.youCanFinishSetupUnlockAnytime)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.cancel)
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.confirm)
+
+        try await subject.tapAction(title: Localizations.cancel)
+        XCTAssertFalse(actionCalled)
+
+        try await subject.tapAction(title: Localizations.confirm)
+        XCTAssertTrue(actionCalled)
+    }
+
     /// `switchToExistingAccount(action:)` builds an `Alert` for switching to an existing account.
     func test_switchToExistingAccount() async throws {
         var actionCalled = false

--- a/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AlertAuthTests.swift
@@ -174,7 +174,7 @@ class AlertAuthTests: BitwardenTestCase {
         }
 
         XCTAssertEqual(subject.title, Localizations.setUpLaterQuestion)
-        XCTAssertEqual(subject.message, Localizations.youCanFinishSetupUnlockAnytime)
+        XCTAssertEqual(subject.message, Localizations.youCanFinishSetupUnlockAnytimeDescriptionLong)
         XCTAssertEqual(subject.preferredStyle, .alert)
         XCTAssertEqual(subject.alertActions.count, 2)
         XCTAssertEqual(subject.alertActions[0].title, Localizations.cancel)

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupAction.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupAction.swift
@@ -3,9 +3,6 @@
 /// Actions that can be processed by a `VaultUnlockSetupProcessor`.
 ///
 enum VaultUnlockSetupAction: Equatable {
-    /// The continue button was tapped.
-    case continueFlow
-
     /// The set up later button was tapped.
     case setUpLater
 }

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupEffect.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupEffect.swift
@@ -3,6 +3,9 @@
 /// Effects handled by the `VaultUnlockSetupProcessor`.
 ///
 enum VaultUnlockSetupEffect: Equatable {
+    /// The continue button was tapped.
+    case continueFlow
+
     /// Any initial data for the view should be loaded.
     case loadData
 

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupView.swift
@@ -43,8 +43,8 @@ struct VaultUnlockSetupView: View {
             .clipShape(RoundedRectangle(cornerRadius: 10))
 
             VStack(spacing: 12) {
-                Button(Localizations.continue) {
-                    store.send(.continueFlow)
+                AsyncButton(Localizations.continue) {
+                    await store.perform(.continueFlow)
                 }
                 .buttonStyle(.primary())
                 .disabled(!store.state.isContinueButtonEnabled)

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupViewTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupViewTests.swift
@@ -31,11 +31,11 @@ class VaultUnlockSetupViewTests: BitwardenTestCase {
 
     /// Tapping the continue button dispatches the continue flow action.
     @MainActor
-    func test_continue_tap() throws {
+    func test_continue_tap() async throws {
         processor.state.biometricsStatus = .available(.faceID, enabled: true, hasValidIntegrity: true)
-        let button = try subject.inspect().find(button: Localizations.continue)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .continueFlow)
+        let button = try subject.inspect().find(asyncButton: Localizations.continue)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .continueFlow)
     }
 
     /// The continue button is enabled when one or more unlock methods are enabled.

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -976,5 +976,5 @@
 "RemovePasskey" = "Remove passkey";
 "PasskeyRemoved" = "Passkey removed";
 "SetUpLaterQuestion" = "Set up later?";
-"YouCanFinishSetupUnlockAnytime" = "You can finish setup anytime in Account Security under Settings. You’ll use your master password to unlock until you set up another method.";
+"YouCanFinishSetupUnlockAnytimeDescriptionLong" = "You can finish setup anytime in Account Security under Settings. You’ll use your master password to unlock until you set up another method.";
 "Confirm" = "Confirm";

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -975,3 +975,6 @@
 "PleaseRestartRegistrationOrTryLoggingInYouMayAlreadyHaveAnAccount" = "Please restart registration or try logging in. You may already have an account.";
 "RemovePasskey" = "Remove passkey";
 "PasskeyRemoved" = "Passkey removed";
+"SetUpLaterQuestion" = "Set up later?";
+"YouCanFinishSetupUnlockAnytime" = "You can finish setup anytime in Account Security under Settings. You’ll use your master password to unlock until you set up another method.";
+"Confirm" = "Confirm";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10270](https://bitwarden.atlassian.net/browse/PM-10270)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for setting up an unlock method later. Tapping the "Set up later" button will show an alert asking the user to confirm that they want to set up unlock later.

I also added a `needsVaultUnlockSetup` key in user defaults to determine whether the user has finished setting up unlock. A future PR will set this when the account is created, and then this can be used to determine whether to prompt the user at a future time to set up unlock methods.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="559" alt="Screenshot 2024-08-27 at 10 51 19 AM" src="https://github.com/user-attachments/assets/886383e7-e266-4e58-a1f1-7918f6ba3ec2">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10270]: https://bitwarden.atlassian.net/browse/PM-10270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ