### PR TITLE
[PM-11373] passwordGenerator policy should not exempt organization from policies

### DIFF
--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -94,6 +94,10 @@ actor DefaultPolicyService: PolicyService {
     /// - Returns: Whether the organization is exempt from the policy.
     ///
     private func isOrganization(_ organization: Organization, exemptFrom policyType: PolicyType) -> Bool {
+        if policyType == .passwordGenerator {
+            return false
+        }
+
         if policyType == .maximumVaultTimeout {
             return organization.type == .owner
         }

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -96,7 +96,7 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertTrue(appliedPolicy)
     }
 
-    /// `applyPasswordGenerationOptions()` returns `false` if the user is exempt from policies in the organization.
+    /// `applyPasswordGenerationOptions()` returns `true` if the user is owner in the organization.
     func test_applyPasswordGenerationOptions_exemptUser() async throws {
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture(type: .owner)])
@@ -105,7 +105,7 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         var options = PasswordGenerationOptions(type: .password)
         let appliedPolicy = try await subject.applyPasswordGenerationPolicy(options: &options)
 
-        XCTAssertFalse(appliedPolicy)
+        XCTAssertTrue(appliedPolicy)
     }
 
     /// `applyPasswordGenerationOptions(options:)` applies the password generation policy to the


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11373

## 📔 Objective

PasswordGenerator policies are not being enforced to owners, admins and users that have access to policies. All users should have the password generator policies applied.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
