### PR TITLE
PM-11473: Fix vault list filter title not updating

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ConfigServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ConfigServiceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-final class ConfigServiceTests: BitwardenTestCase {
+final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var client: MockHTTPClient!

--- a/BitwardenShared/UI/Auth/AuthRoute.swift
+++ b/BitwardenShared/UI/Auth/AuthRoute.swift
@@ -105,7 +105,7 @@ public enum AuthRoute: Equatable {
     ///
     /// - Parameter username: The username to display on the password hint screen.
     case masterPasswordHint(username: String)
-    
+
     /// A route to the prevent account lock view.
     case preventAccountLock
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -110,6 +110,31 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.toast?.text, Localizations.itemRestored)
     }
 
+    /// `init()` has default values set in the state.
+    @MainActor
+    func test_init_defaultValues() {
+        XCTAssertEqual(
+            subject.state.searchVaultFilterState,
+            SearchVaultFilterRowState(
+                canShowVaultFilter: true,
+                isPersonalOwnershipDisabled: false,
+                organizations: [],
+                searchVaultFilterType: .allVaults
+            )
+        )
+        XCTAssertEqual(subject.state.searchVaultFilterType, .allVaults)
+        XCTAssertEqual(
+            subject.state.vaultFilterState,
+            SearchVaultFilterRowState(
+                canShowVaultFilter: true,
+                isPersonalOwnershipDisabled: false,
+                organizations: [],
+                searchVaultFilterType: .allVaults
+            )
+        )
+        XCTAssertEqual(subject.state.vaultFilterType, .allVaults)
+    }
+
     /// `perform(_:)` with `.appeared` starts listening for updates with the vault repository.
     @MainActor
     func test_perform_appeared() async {
@@ -1008,11 +1033,21 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     @MainActor
     func test_receive_searchVaultFilterChanged() {
         let organization = Organization.fixture()
-
+        subject.state.organizations = [organization]
         subject.state.searchVaultFilterType = .myVault
+
         subject.receive(.searchVaultFilterChanged(.organization(organization)))
 
         XCTAssertEqual(subject.state.searchVaultFilterType, .organization(organization))
+        XCTAssertEqual(
+            subject.state.searchVaultFilterState,
+            SearchVaultFilterRowState(
+                canShowVaultFilter: true,
+                isPersonalOwnershipDisabled: false,
+                organizations: [organization],
+                searchVaultFilterType: .organization(organization)
+            )
+        )
     }
 
     /// `receive(_:)` with `.toastShown` updates the state's toast value.
@@ -1040,10 +1075,20 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     @MainActor
     func test_receive_vaultFilterChanged() {
         let organization = Organization.fixture()
-
+        subject.state.organizations = [organization]
         subject.state.vaultFilterType = .myVault
+
         subject.receive(.vaultFilterChanged(.organization(organization)))
 
         XCTAssertEqual(subject.state.vaultFilterType, .organization(organization))
+        XCTAssertEqual(
+            subject.state.vaultFilterState,
+            SearchVaultFilterRowState(
+                canShowVaultFilter: true,
+                isPersonalOwnershipDisabled: false,
+                organizations: [organization],
+                searchVaultFilterType: .organization(organization)
+            )
+        )
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
@@ -57,13 +57,23 @@ struct VaultListState: Equatable {
         }
     }
 
+    /// The state for showing the vault filter in search.
+    var searchVaultFilterState: SearchVaultFilterRowState {
+        SearchVaultFilterRowState(
+            canShowVaultFilter: canShowVaultFilter,
+            isPersonalOwnershipDisabled: isPersonalOwnershipDisabled,
+            organizations: organizations,
+            searchVaultFilterType: searchVaultFilterType
+        )
+    }
+
     /// The state for showing the vault filter.
     var vaultFilterState: SearchVaultFilterRowState {
         SearchVaultFilterRowState(
             canShowVaultFilter: canShowVaultFilter,
             isPersonalOwnershipDisabled: isPersonalOwnershipDisabled,
             organizations: organizations,
-            searchVaultFilterType: searchVaultFilterType
+            searchVaultFilterType: vaultFilterType
         )
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -128,7 +128,7 @@ private struct SearchableVaultListView: View {
     private var searchVaultFilterRow: some View {
         SearchVaultFilterRowView(
             hasDivider: true, store: store.child(
-                state: \.vaultFilterState,
+                state: \.searchVaultFilterState,
                 mapAction: { action in
                     switch action {
                     case let .searchVaultFilterChanged(type):


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11473](https://bitwarden.atlassian.net/browse/PM-11473)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes an issue where changing the vault filter in the vault list would filter the vault items but wouldn't update the title of the filter row. The filter state used to draw that row was being shared between the list and search filters, but these should have been separate states.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After | 
| --- | --- |
| <video src="https://github.com/user-attachments/assets/76e2ee95-3acf-411b-a3a2-3dba231aab7e" > | <video src="https://github.com/user-attachments/assets/a07094ed-981c-4045-84a8-440af3fece7a" > |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11473]: https://bitwarden.atlassian.net/browse/PM-11473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ