### PR TITLE
PM-11434: Remember SSO org identifier even if redirected

### DIFF
--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -90,13 +90,15 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
         case ASWebAuthenticationSessionError.canceledLogin:
             break
         case let IdentityTokenRequestError.twoFactorRequired(authMethodsData, _, _):
-            coordinator.navigate(to: .twoFactor(state.email, nil, authMethodsData, state.identifierText))
+            rememberOrgIdentifierAndNavigate(to: .twoFactor(state.email, nil, authMethodsData, state.identifierText))
         case AuthError.requireSetPassword:
-            coordinator.navigate(to: .setMasterPassword(organizationIdentifier: state.identifierText))
+            rememberOrgIdentifierAndNavigate(to: .setMasterPassword(organizationIdentifier: state.identifierText))
         case AuthError.requireUpdatePassword:
-            coordinator.navigate(to: .updateMasterPassword)
+            rememberOrgIdentifierAndNavigate(to: .updateMasterPassword)
         case AuthError.requireDecryptionOptions:
-            coordinator.navigate(to: .showLoginDecryptionOptions(organizationIdentifier: state.identifierText))
+            rememberOrgIdentifierAndNavigate(to: .showLoginDecryptionOptions(
+                organizationIdentifier: state.identifierText
+            ))
         default:
             coordinator.showAlert(.networkResponseError(error, tryAgain))
             services.errorReporter.log(error: error)
@@ -153,6 +155,15 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
         } catch {
             services.errorReporter.log(error: error)
         }
+    }
+
+    /// Remembers the org identifier for future logins and navigates to the specified route.
+    ///
+    /// - Parameter route: The route to navigate to after saving the org identifier.
+    ///
+    private func rememberOrgIdentifierAndNavigate(to route: AuthRoute) {
+        services.stateService.rememberedOrgIdentifier = state.identifierText
+        coordinator.navigate(to: route)
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11434](https://bitwarden.atlassian.net/browse/PM-11434)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Previously, we were only persisting the SSO org identifier if you completed SSO and were immediately taken to vault unlock. This changes that to also persist this if the user is redirected to two factor, set/update master password, or the TDE login options.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11434]: https://bitwarden.atlassian.net/browse/PM-11434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ