### PR TITLE
PM-11653: Migrate app extension integrity state values for biometrics

### DIFF
--- a/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/MigrationServiceTests.swift
@@ -2,9 +2,10 @@ import XCTest
 
 @testable import BitwardenShared
 
-class MigrationServiceTests: BitwardenTestCase {
+class MigrationServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
+    var appGroupUserDefaults: UserDefaults!
     var appSettingsStore: MockAppSettingsStore!
     var errorReporter: MockErrorReporter!
     var keychainRepository: MockKeychainRepository!
@@ -20,12 +21,16 @@ class MigrationServiceTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        appGroupUserDefaults = UserDefaults(suiteName: "test-app-group")
         appSettingsStore = MockAppSettingsStore()
         errorReporter = MockErrorReporter()
         keychainRepository = MockKeychainRepository()
         keychainService = MockKeychainService()
         standardUserDefaults = UserDefaults(suiteName: "test")
 
+        for key in appGroupUserDefaults.dictionaryRepresentation().map(\.key) {
+            appGroupUserDefaults.removeObject(forKey: key)
+        }
         standardUserDefaults.removeObject(forKey: "MSAppCenterCrashesIsEnabled")
         SecItemDelete(
             [
@@ -35,6 +40,7 @@ class MigrationServiceTests: BitwardenTestCase {
         )
 
         subject = DefaultMigrationService(
+            appGroupUserDefaults: appGroupUserDefaults,
             appSettingsStore: appSettingsStore,
             errorReporter: errorReporter,
             keychainRepository: keychainRepository,
@@ -47,6 +53,7 @@ class MigrationServiceTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        appGroupUserDefaults = nil
         appSettingsStore = nil
         errorReporter = nil
         keychainRepository = nil
@@ -221,5 +228,163 @@ class MigrationServiceTests: BitwardenTestCase {
         XCTAssertEqual(item2[kSecValueData] as? Data, Data("password".utf8))
 
         XCTAssertEqual(appSettingsStore.migrationVersion, 2)
+    }
+
+    /// `performMigrations()` for migration 3 migrates the integrity state values.
+    func test_performMigrations_3() async throws {
+        appGroupUserDefaults.set(
+            "integrity-state-autofill",
+            forKey: "bwPreferencesStorage:iOSAutoFillBiometricIntegritySource"
+        )
+        appGroupUserDefaults.set(
+            "integrity-state-extension",
+            forKey: "bwPreferencesStorage:iOSExtensionBiometricIntegritySource"
+        )
+        appGroupUserDefaults.set(
+            "integrity-state-share-extension",
+            forKey: "bwPreferencesStorage:iOSShareExtensionBiometricIntegritySource"
+        )
+        appSettingsStore.state = State(
+            accounts: [
+                "1": .fixture(),
+                "2": .fixture(profile: .fixture(userId: "2")),
+            ],
+            activeUserId: "1"
+        )
+
+        try await subject.performMigration(version: 3)
+
+        func newKey(userId: String, extensionName: String) -> String {
+            "bwPreferencesStorage:biometricIntegritySource_\(userId)_\(Bundle.main.appIdentifier).\(extensionName)"
+        }
+
+        for userId in 1 ... 2 {
+            let userId = String(userId)
+
+            let autofillKey = newKey(userId: userId, extensionName: "autofill")
+            XCTAssertEqual(appGroupUserDefaults.string(forKey: autofillKey), "integrity-state-autofill")
+
+            let extensionKey = newKey(userId: userId, extensionName: "find-login-action-extension")
+            XCTAssertEqual(appGroupUserDefaults.string(forKey: extensionKey), "integrity-state-extension")
+
+            let shareExtensionKey = newKey(userId: userId, extensionName: "share-extension")
+            XCTAssertEqual(appGroupUserDefaults.string(forKey: shareExtensionKey), "integrity-state-share-extension")
+        }
+
+        // Previous values are removed.
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSAutoFillBiometricIntegritySource")
+        )
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSExtensionBiometricIntegritySource")
+        )
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSShareExtensionBiometricIntegritySource")
+        )
+    }
+
+    /// `performMigrations()` for migration 3 removes the previous values if there's no accounts to migrate.
+    func test_performMigrations_3_noAccounts() async throws {
+        appGroupUserDefaults.set(
+            "integrity-state-autofill",
+            forKey: "bwPreferencesStorage:iOSAutoFillBiometricIntegritySource"
+        )
+        appGroupUserDefaults.set(
+            "integrity-state-extension",
+            forKey: "bwPreferencesStorage:iOSExtensionBiometricIntegritySource"
+        )
+        appGroupUserDefaults.set(
+            "integrity-state-share-extension",
+            forKey: "bwPreferencesStorage:iOSShareExtensionBiometricIntegritySource"
+        )
+
+        try await subject.performMigration(version: 3)
+
+        // Previous values are removed.
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSAutoFillBiometricIntegritySource")
+        )
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSExtensionBiometricIntegritySource")
+        )
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSShareExtensionBiometricIntegritySource")
+        )
+    }
+
+    /// `performMigrations()` for migration 3 migrates the integrity state values, skipping any
+    /// keys which have new values.
+    func test_performMigrations_3_skipsNewKeys() async throws { // swiftlint:disable:this function_body_length
+        func newKey(userId: String, extensionName: String) -> String {
+            "bwPreferencesStorage:biometricIntegritySource_\(userId)_\(Bundle.main.appIdentifier).\(extensionName)"
+        }
+
+        appGroupUserDefaults.set(
+            "integrity-state-autofill",
+            forKey: "bwPreferencesStorage:iOSAutoFillBiometricIntegritySource"
+        )
+        appGroupUserDefaults.set(
+            "integrity-state-extension",
+            forKey: "bwPreferencesStorage:iOSExtensionBiometricIntegritySource"
+        )
+        appGroupUserDefaults.set(
+            "integrity-state-share-extension",
+            forKey: "bwPreferencesStorage:iOSShareExtensionBiometricIntegritySource"
+        )
+
+        // User 1 already has new integrity state values set.
+        appGroupUserDefaults.set(
+            "new-integrity-state-autofill",
+            forKey: newKey(userId: "1", extensionName: "autofill")
+        )
+        appGroupUserDefaults.set(
+            "new-integrity-state-extension",
+            forKey: newKey(userId: "1", extensionName: "find-login-action-extension")
+        )
+        appGroupUserDefaults.set(
+            "new-integrity-state-share-extension",
+            forKey: newKey(userId: "1", extensionName: "share-extension")
+        )
+
+        appSettingsStore.state = State(
+            accounts: [
+                "1": .fixture(),
+                "2": .fixture(profile: .fixture(userId: "2")),
+            ],
+            activeUserId: "1"
+        )
+
+        try await subject.performMigration(version: 3)
+
+        // User 1 keeps newer values.
+        let autofillKey1 = newKey(userId: "1", extensionName: "autofill")
+        XCTAssertEqual(appGroupUserDefaults.string(forKey: autofillKey1), "new-integrity-state-autofill")
+
+        let extensionKey1 = newKey(userId: "1", extensionName: "find-login-action-extension")
+        XCTAssertEqual(appGroupUserDefaults.string(forKey: extensionKey1), "new-integrity-state-extension")
+
+        let shareExtensionKey1 = newKey(userId: "1", extensionName: "share-extension")
+        XCTAssertEqual(appGroupUserDefaults.string(forKey: shareExtensionKey1), "new-integrity-state-share-extension")
+
+        // User 2 gets migrated values.
+        let autofillKey2 = newKey(userId: "2", extensionName: "autofill")
+        XCTAssertEqual(appGroupUserDefaults.string(forKey: autofillKey2), "integrity-state-autofill")
+
+        let extensionKey2 = newKey(userId: "2", extensionName: "find-login-action-extension")
+        XCTAssertEqual(appGroupUserDefaults.string(forKey: extensionKey2), "integrity-state-extension")
+
+        let shareExtensionKey2 = newKey(userId: "2", extensionName: "share-extension")
+        XCTAssertEqual(appGroupUserDefaults.string(forKey: shareExtensionKey2), "integrity-state-share-extension")
+
+        // Previous values are removed.
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSAutoFillBiometricIntegritySource")
+        )
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSExtensionBiometricIntegritySource")
+        )
+        XCTAssertNil(
+            appGroupUserDefaults.string(forKey: "bwPreferencesStorage:iOSShareExtensionBiometricIntegritySource")
+        )
     }
 }

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -489,6 +489,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         )
 
         let migrationService = DefaultMigrationService(
+            appGroupUserDefaults: UserDefaults(suiteName: Bundle.main.groupIdentifier)!,
             appSettingsStore: appSettingsStore,
             errorReporter: errorReporter,
             keychainRepository: keychainRepository,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11653](https://bitwarden.atlassian.net/browse/PM-11653)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a migration to migrate any integrity state values from MAUI for the app extensions. We were previously doing this for the app, but not the extensions.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11653]: https://bitwarden.atlassian.net/browse/PM-11653?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ