### PR TITLE
PM-11424: Handle create account with login failure

### DIFF
--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationState.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationState.swift
@@ -21,6 +21,9 @@ struct CompleteRegistrationState: Equatable, Sendable {
         }
     }
 
+    /// Whether the user's account has been created when completing registration.
+    var didCreateAccount = false
+
     /// Token needed to complete registration
     var emailVerificationToken: String
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11424](https://bitwarden.atlassian.net/browse/PM-11424)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In the new email verification flow, if the request to create the account succeeds but the app fails to log the user in, the app should navigate to the login screen so the user can complete login and vault unlock.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/b9e83603-759b-41f8-920c-596061c547ab



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
