### PR TITLE
PM-11697: Fix potential crash when creating a new account

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -590,7 +590,8 @@ extension DefaultAuthRepository: AuthRepository {
     }
 
     func passwordStrength(email: String, password: String) async throws -> UInt8 {
-        try await clientService.auth().passwordStrength(password: password, email: email, additionalInputs: [])
+        try await clientService.auth(isPreAuth: true)
+            .passwordStrength(password: password, email: email, additionalInputs: [])
     }
 
     func sessionTimeoutAction(userId: String?) async throws -> SessionTimeoutAction {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -106,9 +106,11 @@ protocol AuthRepository: AnyObject {
     /// - Parameters:
     ///   - email: The user's email.
     ///   - password: The user's password.
+    ///   - isPreAuth: Whether the client is being used for a user prior to authentication (when
+    ///     the user's ID doesn't yet exist).
     /// - Returns: The password strength of the password.
     ///
-    func passwordStrength(email: String, password: String) async throws -> UInt8
+    func passwordStrength(email: String, password: String, isPreAuth: Bool) async throws -> UInt8
 
     /// Gets the profiles state for a user.
     ///
@@ -589,8 +591,8 @@ extension DefaultAuthRepository: AuthRepository {
         await vaultTimeoutService.remove(userId: userId)
     }
 
-    func passwordStrength(email: String, password: String) async throws -> UInt8 {
-        try await clientService.auth(isPreAuth: true)
+    func passwordStrength(email: String, password: String, isPreAuth: Bool) async throws -> UInt8 {
+        try await clientService.auth(isPreAuth: isPreAuth)
             .passwordStrength(password: password, email: email, additionalInputs: [])
     }
 

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1113,6 +1113,9 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             clientService.mockAuth.passwordStrengthPassword,
             "ghu65zQ0*TjP@ij74g*&FykWss#Kgv8L8j8XmC03"
         )
+
+        XCTAssertTrue(clientService.mockAuthIsPreAuth)
+        XCTAssertNil(clientService.mockAuthUserId)
     }
 
     /// `sessionTimeoutAction()` returns the session timeout action for a user.

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1097,15 +1097,21 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `passwordStrength(email:password)` returns the calculated password strength.
     func test_passwordStrength() async throws {
         clientService.mockAuth.passwordStrengthResult = 0
-        let weakPasswordStrength = try await subject.passwordStrength(email: "user@bitwarden.com", password: "password")
+        let weakPasswordStrength = try await subject.passwordStrength(
+            email: "user@bitwarden.com",
+            password: "password",
+            isPreAuth: false
+        )
         XCTAssertEqual(weakPasswordStrength, 0)
         XCTAssertEqual(clientService.mockAuth.passwordStrengthEmail, "user@bitwarden.com")
         XCTAssertEqual(clientService.mockAuth.passwordStrengthPassword, "password")
+        XCTAssertFalse(clientService.mockAuthIsPreAuth)
 
         clientService.mockAuth.passwordStrengthResult = 4
         let strongPasswordStrength = try await subject.passwordStrength(
             email: "user@bitwarden.com",
-            password: "ghu65zQ0*TjP@ij74g*&FykWss#Kgv8L8j8XmC03"
+            password: "ghu65zQ0*TjP@ij74g*&FykWss#Kgv8L8j8XmC03",
+            isPreAuth: true
         )
         XCTAssertEqual(strongPasswordStrength, 4)
         XCTAssertEqual(clientService.mockAuth.passwordStrengthEmail, "user@bitwarden.com")

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -34,6 +34,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var migrateUserToKeyConnectorPassword: String?
     var migrateUserToKeyConnectorResult: Result<Void, Error> = .success(())
     var passwordStrengthEmail: String?
+    var passwordStrengthIsPreAuth = false
     var passwordStrengthPassword: String?
     var passwordStrengthResult: UInt8 = 0
     var pinProtectedUserKey = "123"
@@ -174,9 +175,10 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
         try isPinUnlockAvailableResult.get()
     }
 
-    func passwordStrength(email: String, password: String) async -> UInt8 {
+    func passwordStrength(email: String, password: String, isPreAuth: Bool) async -> UInt8 {
         passwordStrengthEmail = email
         passwordStrengthPassword = password
+        passwordStrengthIsPreAuth = isPreAuth
         return passwordStrengthResult
     }
 

--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -537,7 +537,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         let response = try await accountAPIService.preLogin(email: username)
 
         // Get the identity token to log in to Bitwarden.
-        let hashedPassword = try await clientService.auth().hashPassword(
+        let hashedPassword = try await clientService.auth(isPreAuth: true).hashPassword(
             email: username,
             password: masterPassword,
             kdfParams: response.sdkKdf,

--- a/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
@@ -40,6 +40,8 @@ final class ClientServiceTests: BitwardenTestCase {
 
     /// `auth(for:)` returns a new `ClientAuthProtocol` for every user.
     func test_auth() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let auth = try await subject.auth()
         XCTAssertIdentical(auth, clientBuilder.clients.first?.clientAuth)
 
@@ -47,12 +49,25 @@ final class ClientServiceTests: BitwardenTestCase {
         XCTAssertNotIdentical(auth, user2Auth)
     }
 
+    /// `client(for:)` called concurrently doesn't crash.
+    func test_client_calledConcurrently() async throws {
+        // Calling `client(for:)` concurrently shouldn't throw an exception due to simultaneous
+        // access to shared state. Since it's a race condition, running it repeatedly should expose
+        // the failure if it's going to fail.
+        for _ in 0 ..< 5 {
+            async let concurrentTask1 = subject.auth(for: "1")
+            async let concurrentTask2 = subject.auth(for: "1")
+
+            _ = try await (concurrentTask1, concurrentTask2)
+        }
+    }
+
     /// Tests that `client(for:)` creates a new client if there is no active user/if there are no users.
     /// Also tests that `client(for:)` returns a user's existing client.
     /// Also tests that a `client(for:)` creates a new client if a user doesn't  have one.
     func test_client_multiple_users() async throws {
         // No active user.
-        let noActiveUserAuth = try await subject.auth()
+        let noActiveUserAuth = try await subject.auth(isPreAuth: true)
         let auth = clientBuilder.clients.first?.clientAuth
         XCTAssertIdentical(noActiveUserAuth, auth)
 
@@ -72,55 +87,83 @@ final class ClientServiceTests: BitwardenTestCase {
 
     /// `crypto(for:)` returns a new `ClientCryptoProtocol` for every user.
     func test_crypto() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let crypto = try await subject.crypto()
 
         XCTAssertIdentical(crypto, clientBuilder.clients.first?.clientCrypto)
-        let user2Crypto = try await subject.crypto(for: "1")
+        let user2Crypto = try await subject.crypto(for: "2")
         XCTAssertNotIdentical(crypto, user2Crypto)
     }
 
     /// `exporters(for:)` returns a new `ClientExportersProtocol` for every user.
     func test_exporters() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let exporters = try await subject.exporters()
         XCTAssertIdentical(exporters, clientBuilder.clients.first?.clientExporters)
 
-        let user2Exporters = try await subject.exporters(for: "1")
+        let user2Exporters = try await subject.exporters(for: "2")
         XCTAssertNotIdentical(exporters, user2Exporters)
     }
 
     /// `generators(for:)` returns a new `ClientGeneratorsProtocol` for every user.
     func test_generators() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let generators = try await subject.generators()
         XCTAssertIdentical(generators, clientBuilder.clients.first?.clientGenerators)
 
-        let user2Generators = try await subject.generators(for: "1")
+        let user2Generators = try await subject.generators(for: "2")
         XCTAssertNotIdentical(generators, user2Generators)
     }
 
     /// `platform(for:)` returns a new `ClientPlatformProtocol` for every user.
     func test_platform() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let platform = try await subject.platform()
         XCTAssertIdentical(platform, clientBuilder.clients.first?.clientPlatform)
 
-        let user2Platform = try await subject.platform(for: "1")
+        let user2Platform = try await subject.platform(for: "2")
         XCTAssertNotIdentical(platform, user2Platform)
+    }
+
+    /// `removeClient(for:)` removes a cached client for a user.
+    func test_removeClient() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
+        let crypto = try await subject.crypto()
+        let crypto2 = try await subject.crypto()
+        // The same client should be returned for subsequent requests.
+        XCTAssertIdentical(crypto, crypto2)
+
+        try await subject.removeClient()
+        // After removing the client, a new client should be returned for the user.
+        let cryptoAfterRemoving = try await subject.crypto()
+
+        XCTAssertNotIdentical(crypto, cryptoAfterRemoving)
     }
 
     /// `sends(for:)` returns a new `ClientVaultProtocol` for every user.
     func test_sends() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let sends = try await subject.sends()
         XCTAssertIdentical(sends, clientBuilder.clients.first?.clientSends)
 
-        let user2Sends = try await subject.sends(for: "1")
+        let user2Sends = try await subject.sends(for: "2")
         XCTAssertNotIdentical(sends, user2Sends)
     }
 
     /// `vault(for:)` returns a new `ClientVaultProtocol` for every user.
     func test_vault() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+
         let vault = try await subject.vault()
         XCTAssertIdentical(vault, clientBuilder.clients.first?.clientVault)
 
-        let user2Vault = try await subject.vault(for: "1")
+        let user2Vault = try await subject.vault(for: "2")
         XCTAssertNotIdentical(vault, user2Vault)
     }
 }

--- a/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
@@ -49,6 +49,17 @@ final class ClientServiceTests: BitwardenTestCase {
         XCTAssertNotIdentical(auth, user2Auth)
     }
 
+    /// `auth(for:)` logs an error if there's no accounts and the `isPreAuth` flag isn't set.
+    func test_auth_noAccountsNotPreAuth() async throws {
+        let auth1 = try await subject.auth()
+        let auth2 = try await subject.auth()
+        XCTAssertNotIdentical(auth1, auth2)
+
+        XCTAssertEqual(errorReporter.errors.count, 2)
+        XCTAssertEqual((errorReporter.errors[0] as NSError).domain, "General Error: Missing isPreAuth")
+        XCTAssertEqual((errorReporter.errors[1] as NSError).domain, "General Error: Missing isPreAuth")
+    }
+
     /// `client(for:)` called concurrently doesn't crash.
     func test_client_calledConcurrently() async throws {
         // Calling `client(for:)` concurrently shouldn't throw an exception due to simultaneous

--- a/BitwardenShared/Core/Platform/Services/ErrorReporter/BitwardenError.swift
+++ b/BitwardenShared/Core/Platform/Services/ErrorReporter/BitwardenError.swift
@@ -19,6 +19,9 @@ enum BitwardenError {
 
         /// An error occurred with data from the API.
         case dataError = 3000
+
+        /// A general-purpose error.
+        case generalError = 4000
     }
 
     // MARK: Errors
@@ -31,6 +34,22 @@ enum BitwardenError {
         NSError(
             domain: "Data Error",
             code: Code.dataError.rawValue,
+            userInfo: [
+                "ErrorMessage": message,
+            ]
+        )
+    }
+
+    /// A general-purpose error.
+    ///
+    /// - Parameters:
+    ///   - type: The type of error. This is used to group the errors in the Crashlytics dashboard.
+    ///   - message: A message describing the error that occurred.
+    ///
+    static func generalError(type: String, message: String) -> NSError {
+        NSError(
+            domain: "General Error: \(type)",
+            code: Code.generalError.rawValue,
             userInfo: [
                 "ErrorMessage": message,
             ]

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockClientService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockClientService.swift
@@ -4,6 +4,8 @@ import BitwardenSdk
 
 class MockClientService: ClientService {
     var mockAuth: MockClientAuth
+    var mockAuthIsPreAuth = false
+    var mockAuthUserId: String?
     var mockCrypto: MockClientCrypto
     var mockExporters: MockClientExporters
     var mockGenerators: MockClientGenerators
@@ -30,8 +32,10 @@ class MockClientService: ClientService {
         mockVault = vault
     }
 
-    func auth(for userId: String?) -> ClientAuthProtocol {
-        mockAuth
+    func auth(for userId: String?, isPreAuth: Bool) -> ClientAuthProtocol {
+        mockAuthIsPreAuth = isPreAuth
+        mockAuthUserId = userId
+        return mockAuth
     }
 
     func crypto(for userId: String?) -> ClientCryptoProtocol {

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -162,13 +162,13 @@ class CompleteRegistrationProcessor: StateProcessor<
     private func createAccount(captchaToken: String?) async throws {
         let kdfConfig = KdfConfig()
 
-        let keys = try await services.clientService.auth().makeRegisterKeys(
+        let keys = try await services.clientService.auth(isPreAuth: true).makeRegisterKeys(
             email: state.userEmail,
             password: state.passwordText,
             kdf: kdfConfig.sdkKdf
         )
 
-        let hashedPassword = try await services.clientService.auth().hashPassword(
+        let hashedPassword = try await services.clientService.auth(isPreAuth: true).hashPassword(
             email: state.userEmail,
             password: state.passwordText,
             kdfParams: kdfConfig.sdkKdf,

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -272,7 +272,8 @@ class CompleteRegistrationProcessor: StateProcessor<
         Task {
             state.passwordStrengthScore = try? await services.authRepository.passwordStrength(
                 email: state.userEmail,
-                password: state.passwordText
+                password: state.passwordText,
+                isPreAuth: true
             )
         }
     }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -626,6 +626,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         waitFor(subject.state.passwordStrengthScore == 0)
         XCTAssertEqual(subject.state.passwordStrengthScore, 0)
         XCTAssertEqual(authRepository.passwordStrengthEmail, "user@bitwarden.com")
+        XCTAssertTrue(authRepository.passwordStrengthIsPreAuth)
         XCTAssertEqual(authRepository.passwordStrengthPassword, "T")
 
         authRepository.passwordStrengthResult = 4
@@ -633,6 +634,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         waitFor(subject.state.passwordStrengthScore == 4)
         XCTAssertEqual(subject.state.passwordStrengthScore, 4)
         XCTAssertEqual(authRepository.passwordStrengthEmail, "user@bitwarden.com")
+        XCTAssertTrue(authRepository.passwordStrengthIsPreAuth)
         XCTAssertEqual(authRepository.passwordStrengthPassword, "TestPassword1234567890!@#")
     }
 

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
@@ -192,13 +192,13 @@ class CreateAccountProcessor: StateProcessor<CreateAccountState, CreateAccountAc
 
             let kdf: Kdf = .pbkdf2(iterations: NonZeroU32(KdfConfig().kdfIterations))
 
-            let keys = try await services.clientService.auth().makeRegisterKeys(
+            let keys = try await services.clientService.auth(isPreAuth: true).makeRegisterKeys(
                 email: email,
                 password: state.passwordText,
                 kdf: kdf
             )
 
-            let hashedPassword = try await services.clientService.auth().hashPassword(
+            let hashedPassword = try await services.clientService.auth(isPreAuth: true).hashPassword(
                 email: email,
                 password: state.passwordText,
                 kdfParams: kdf,

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessor.swift
@@ -284,7 +284,8 @@ class CreateAccountProcessor: StateProcessor<CreateAccountState, CreateAccountAc
         Task {
             state.passwordStrengthScore = try? await services.authRepository.passwordStrength(
                 email: state.emailText,
-                password: state.passwordText
+                password: state.passwordText,
+                isPreAuth: true
             )
         }
     }

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountProcessorTests.swift
@@ -702,6 +702,7 @@ class CreateAccountProcessorTests: BitwardenTestCase {
         waitFor(subject.state.passwordStrengthScore == 0)
         XCTAssertEqual(subject.state.passwordStrengthScore, 0)
         XCTAssertEqual(authRepository.passwordStrengthEmail, "user@bitwarden.com")
+        XCTAssertTrue(authRepository.passwordStrengthIsPreAuth)
         XCTAssertEqual(authRepository.passwordStrengthPassword, "T")
 
         authRepository.passwordStrengthResult = 4
@@ -709,6 +710,7 @@ class CreateAccountProcessorTests: BitwardenTestCase {
         waitFor(subject.state.passwordStrengthScore == 4)
         XCTAssertEqual(subject.state.passwordStrengthScore, 4)
         XCTAssertEqual(authRepository.passwordStrengthEmail, "user@bitwarden.com")
+        XCTAssertTrue(authRepository.passwordStrengthIsPreAuth)
         XCTAssertEqual(authRepository.passwordStrengthPassword, "TestPassword1234567890!@#")
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessor.swift
@@ -172,7 +172,8 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
         Task {
             state.filePasswordStrengthScore = try? await services.authRepository.passwordStrength(
                 email: "",
-                password: state.filePasswordText
+                password: state.filePasswordText,
+                isPreAuth: false
             )
         }
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultProcessorTests.swift
@@ -361,12 +361,14 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         authRepository.passwordStrengthResult = 1
         subject.receive(.filePasswordTextChanged("file"))
         waitFor(subject.state.filePasswordStrengthScore == 1)
+        XCTAssertFalse(authRepository.passwordStrengthIsPreAuth)
         XCTAssertEqual(authRepository.passwordStrengthPassword, "file")
         XCTAssertEqual(subject.state.filePasswordStrengthScore, 1)
 
         authRepository.passwordStrengthResult = 4
         subject.receive(.filePasswordTextChanged("file password"))
         waitFor(subject.state.filePasswordStrengthScore == 4)
+        XCTAssertFalse(authRepository.passwordStrengthIsPreAuth)
         XCTAssertEqual(authRepository.passwordStrengthPassword, "file password")
         XCTAssertEqual(subject.state.filePasswordStrengthScore, 4)
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11697](https://bitwarden.atlassian.net/browse/PM-11697)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When creating a new account on a device that has at least one existing account, it's possible for the app to crash when checking the strength of the new account's password.

The root cause is that `DefaultClientService` maintains a cache of the SDK client as a dictionary, mapping a user ID to their SDK. It's possible for this dictionary to be modified from multiple threads. Making the service an actor fixes the concurrency issue.

I also noticed another issue here. When adding a new account, a user ID doesn't exist for the account yet, so we have some logic that returns a new SDK for these calls, and this SDK doesn't end up being cached. If there's an existing account on the device when adding a new account, that existing account is still considered the active user, so we end up using the existing account's SDK for some operations for the new account. To fix this, I added a `isPreAuth` property that can be used when getting a SDK client so we always return a new SDK instead of potentially using an SDK for an existing account.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11697]: https://bitwarden.atlassian.net/browse/PM-11697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ