### PR TITLE
PM-11720 - TDE User Without MP Cannot Enable Autofill For Account

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -1021,15 +1021,11 @@ extension DefaultAuthRepository: AuthRepository {
     }
 
     private func configureBiometricUnlockIfRequired() async throws {
-        let biometricUnlockStatus = try? await biometricsRepository.getBiometricUnlockStatus()
-        switch biometricUnlockStatus {
-        case .available(_, true, false):
+        if case .available(_, true, false) = try? await biometricsRepository.getBiometricUnlockStatus() {
             try await biometricsRepository.configureBiometricIntegrity()
             try await biometricsRepository.setBiometricUnlockKey(
                 authKey: clientService.crypto().getUserEncryptionKey()
             )
-        default:
-            break
         }
     }
 }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -1015,11 +1015,24 @@ extension DefaultAuthRepository: AuthRepository {
         try await stateService.setForcePasswordResetReason(nil)
     }
 
+    /// Returns the provided user ID if it exists, otherwise fetches the active account's ID.
+    ///
+    /// - Parameter maybeId: The optional user ID to check.
+    /// - Returns: The user ID if provided, otherwise the active account's ID.
+    /// - Throws: An error if fetching the active account ID fails.
+    ///
     private func userIdOrActive(_ maybeId: String?) async throws -> String {
         if let maybeId { return maybeId }
         return try await stateService.getActiveAccountId()
     }
 
+
+    /// This method checks the biometric unlock status, and if biometric unlock is available but not
+    /// fully configured (i.e., it doesn't have a valid integrity), it sets up biometric integrity and configures
+    /// the biometric unlock key.
+    ///
+    /// - Throws: An error if configuring biometric integrity or setting the biometric unlock key fails.
+    ///
     private func configureBiometricUnlockIfRequired() async throws {
         if case .available(_, true, false) = try? await biometricsRepository.getBiometricUnlockStatus() {
             try await biometricsRepository.configureBiometricIntegrity()

--- a/BitwardenShared/UI/Auth/AuthRouter.swift
+++ b/BitwardenShared/UI/Auth/AuthRouter.swift
@@ -6,6 +6,7 @@ final class AuthRouter: NSObject, Router {
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasBiometricsRepository
         & HasClientService
         & HasConfigService
         & HasErrorReporter

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -125,8 +125,17 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `handleAndRoute(_ :)` redirects `.accountBecameActive()` to `.enterpriseSingleSignOn`
     ///     when the account is unlocked.
     func test_handleAndRoute_accountBecameActive_noMpAndTDE_withBiometricsEnabled() async {
-        let active = Account.fixture()
+        let active = Account.fixture(
+            profile: .fixture(
+                userDecryptionOptions: UserDecryptionOptions(
+                    hasMasterPassword: false,
+                    keyConnectorOption: nil,
+                    trustedDeviceOption: nil
+                )
+            )
+        )
         stateService.activeAccount = active
+
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: false)
         )

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -355,8 +355,9 @@ extension AuthRouter {
                 }
 
                 let biometricUnlockStatus = try await services.biometricsRepository.getBiometricUnlockStatus()
+                let hasMasterPassword = activeAccount.profile.userDecryptionOptions?.hasMasterPassword ?? false
 
-                if case let .available(_, enabled, validIntegrity) = biometricUnlockStatus, enabled, !validIntegrity {
+                if case .available(_, true, false) = biometricUnlockStatus, !hasMasterPassword {
                     return .enterpriseSingleSignOn(email: activeAccount.profile.email)
                 } else {
                     return .vaultUnlock(


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11720](https://bitwarden.atlassian.net/browse/PM-11720)
## 📔 Objective

- When a user doesn't have a MP set but has a TDE account, they should be brought to a SSO flow (if biometrics are enabled to authenticate). 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11720]: https://bitwarden.atlassian.net/browse/PM-11720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ