### PR TITLE
[PM-11740] Fix to disable smart dashes in password field

### DIFF
--- a/Bitwarden/Application/Support/Settings.bundle/Acknowledgements.plist
+++ b/Bitwarden/Application/Support/Settings.bundle/Acknowledgements.plist
@@ -164,6 +164,14 @@
 		</dict>
 		<dict>
 			<key>File</key>
+			<string>Acknowledgements/SwiftUI-Introspect</string>
+			<key>Title</key>
+			<string>swiftui-introspect</string>
+			<key>Type</key>
+			<string>PSChildPaneSpecifier</string>
+		</dict>
+		<dict>
+			<key>File</key>
 			<string>Acknowledgements/ViewInspector</string>
 			<key>Title</key>
 			<string>ViewInspector</string>

--- a/Bitwarden/Application/Support/Settings.bundle/Acknowledgements/SwiftUI-Introspect.plist
+++ b/Bitwarden/Application/Support/Settings.bundle/Acknowledgements/SwiftUI-Introspect.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PreferenceSpecifiers</key>
+	<array>
+		<dict>
+			<key>FooterText</key>
+			<string>Copyright 2019 Timber Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</string>
+			<key>License</key>
+			<string>MIT</string>
+			<key>Type</key>
+			<string>PSGroupSpecifier</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import SwiftUIIntrospect
 
 // MARK: - BitwardenTextField
 
@@ -6,6 +7,7 @@ import SwiftUI
 /// configured to act as a password field with visibility toggling, and supports
 /// displaying additional content on the trailing edge of the text field.
 ///
+@MainActor
 struct BitwardenTextField<TrailingContent: View>: View {
     // MARK: Private Properties
 
@@ -99,6 +101,9 @@ struct BitwardenTextField<TrailingContent: View>: View {
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
                     .hidden(!isPasswordVisible && isPassword)
                     .id(title)
+                    .introspect(.textField, on: .iOS(.v15, .v16, .v17, .v18)) { textField in
+                        textField.smartDashesType = isPassword ? .no : .default
+                    }
                 if isPassword, !isPasswordVisible {
                     SecureField(placeholder, text: $text)
                         .focused($isSecureFieldFocused)

--- a/project.yml
+++ b/project.yml
@@ -26,6 +26,9 @@ packages:
     exactVersion: 10.24.0
   Networking:
     path: Networking
+  SwiftUIIntrospect:
+    url: https://github.com/siteline/SwiftUI-Introspect
+    exactVersion: 1.3.0
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
     exactVersion: 1.15.4
@@ -350,6 +353,7 @@ targets:
     dependencies:
       - package: BitwardenSdk
       - package: Networking
+      - package: SwiftUIIntrospect
     preBuildScripts:
       - name: SwiftGen
         script: |


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11740](https://bitwarden.atlassian.net/browse/PM-11740)

## 📔 Objective

Smart punctuation was acting into password fields (unmasked) so when the user wanted to input two dashes in a row, it was being transformed into a dash. This disables smart dashes so the automatic transformation is not applied.

### Notes

This PR adds [SwiftUI-Introspect](https://github.com/siteline/swiftui-introspect) package in order to be able to change the [smartDashesType](https://developer.apple.com/documentation/uikit/uitextinputtraits/2866013-smartdashestype) given that it's not directly available in the SwiftUI TextField. 


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11740]: https://bitwarden.atlassian.net/browse/PM-11740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ