### PR TITLE
[BITAU-118] [BITAU-159] Setup New Shared App Group Entitlements and Feature Flag

### DIFF
--- a/Bitwarden/Application/Support/Bitwarden.entitlements
+++ b/Bitwarden/Application/Support/Bitwarden.entitlements
@@ -26,6 +26,7 @@
 	<key>com.apple.security.application-groups</key>
 	<array>
 		<string>group.$(BASE_BUNDLE_ID)</string>
+		<string>group.$(SHARED_GROUP_ORGANIZATION_IDENTIFIER).bitwarden-authenticator</string>
 	</array>
 	<key>keychain-access-groups</key>
 	<array>

--- a/Bitwarden/Application/Support/Info.plist
+++ b/Bitwarden/Application/Support/Info.plist
@@ -150,5 +150,7 @@
 	</array>
 	<key>XSAppIconAssets</key>
 	<string>Resources/Assets.xcassets/AppIcons.appiconset</string>
+	<key>BitwardenAuthenticatorSharedAppGroup</key>
+	<string>group.${SHARED_GROUP_ORGANIZATION_IDENTIFIER}.bitwarden-authenticator</string>
 </dict>
 </plist>

--- a/BitwardenShared/Core/Platform/Extensions/Bundle+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/Bundle+Extensions.swift
@@ -24,8 +24,8 @@ extension Bundle {
     /// Return's the app's app identifier.
     var appIdentifier: String {
         infoDictionary?["BitwardenAppIdentifier"] as? String
-            ?? bundleIdentifier
-            ?? "com.x8bit.bitwarden"
+        ?? bundleIdentifier
+        ?? "com.x8bit.bitwarden"
     }
 
     /// Return's the app's app group identifier.
@@ -36,5 +36,11 @@ extension Bundle {
     /// Return's the app's access group identifier for storing keychain items.
     var keychainAccessGroup: String {
         infoDictionary?["BitwardenKeychainAccessGroup"] as? String ?? appIdentifier
+    }
+
+    /// Return's the shared app group identifier. This App Group is shared between the
+    /// main Bitwarden app and the Authenticator app.
+    var sharedAppGroupIdentifier: String {
+        infoDictionary?["BitwardenAuthenticatorSharedAppGroup"] as? String ?? "groupIdentifier"
     }
 }

--- a/BitwardenShared/Core/Platform/Extensions/Bundle+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/Bundle+Extensions.swift
@@ -41,6 +41,6 @@ extension Bundle {
     /// Return's the shared app group identifier. This App Group is shared between the
     /// main Bitwarden app and the Authenticator app.
     var sharedAppGroupIdentifier: String {
-        infoDictionary?["BitwardenAuthenticatorSharedAppGroup"] as? String ?? "groupIdentifier"
+        infoDictionary?["BitwardenAuthenticatorSharedAppGroup"] as? String ?? groupIdentifier
     }
 }

--- a/BitwardenShared/Core/Platform/Extensions/Bundle+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/Bundle+Extensions.swift
@@ -24,8 +24,8 @@ extension Bundle {
     /// Return's the app's app identifier.
     var appIdentifier: String {
         infoDictionary?["BitwardenAppIdentifier"] as? String
-        ?? bundleIdentifier
-        ?? "com.x8bit.bitwarden"
+            ?? bundleIdentifier
+            ?? "com.x8bit.bitwarden"
     }
 
     /// Return's the app's app group identifier.

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -5,6 +5,9 @@ import Foundation
 /// An enum to represent a feature flag sent by the server
 ///
 enum FeatureFlag: String, Codable {
+    /// Flag to enable/disable the ability to sync TOTP codes with the Authenticator app.
+    case authenticatorSyncEnabled = "authenticator-sync-enabled"
+
     /// Flag to enable/disable email verification during registration
     /// This flag introduces a new flow for account creation
     case emailVerification = "email-verification"
@@ -28,7 +31,8 @@ enum FeatureFlag: String, Codable {
     /// Whether this feature can be enabled remotely.
     var isRemotelyConfigured: Bool {
         switch self {
-        case .nativeCarouselFlow,
+        case .authenticatorSyncEnabled,
+             .nativeCarouselFlow,
              .nativeCreateAccountFlow,
              .testLocalFeatureFlag:
             false

--- a/Configs/Common.xcconfig
+++ b/Configs/Common.xcconfig
@@ -1,6 +1,7 @@
 CODE_SIGN_STYLE = Automatic
 DEVELOPMENT_TEAM = LTZ2PFU5D6
 ORGANIZATION_IDENTIFIER = com.8bit
+SHARED_GROUP_ORGANIZATION_IDENTIFIER = com.bitwarden
 BASE_BUNDLE_ID = $(ORGANIZATION_IDENTIFIER).bitwarden
 APPICON_NAME = AppIcon
 
@@ -11,6 +12,7 @@ APPICON_NAME = AppIcon
 //
 //    DEVELOPMENT_TEAM = <Your team ID>
 //    ORGANIZATION_IDENTIFIER = <Your reversed domain name>
+//    SHARED_GROUP_ORGANIZATION_IDENTIFIER = <Your reversed domain name>
 //    BASE_BUNDLE_ID = <Your bundle ID>
 //    APPICON_NAME = <Your App Icon's Name in the asset catalogue>
 //    PROVISIONING_PROFILE_SPECIFIER = <Optional provisioning profile specifier for the main app>


### PR DESCRIPTION
## 🎟️ Tracking

- [BITAU-118](https://livefront.atlassian.net/browse/BITAU-118) Setup App Group Entitlements
- [BITAU-159](https://livefront.atlassian.net/browse/BITAU-159) Add Local Feature Flag for Sync

## 📔 Objective

This PR:
- Adds support for adding the new shared App Group (`group.com.bitwarden.bitwarden-authenticator`) to the existing entitlements. 
-  Adds a new build property to Common.xcconfig `SHARED_GROUP_ORGANIZATION_IDENTIFIER`. 
   - This allows the App Group identifier to be created at build time.
   - This allows others to use Local.xcconfig to sign development builds and with their own app group during development.
- Adds this group identifier to the Info.plist and a Bundle extension to fetch it.
   - This is currently unused but will be needed once we start sharing items via the App Group.
- Adds a local feature flag for future use.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
