### PR TITLE
[BITAU-159] Authenticator Sync Feature Flag Name Change

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -5,12 +5,12 @@ import Foundation
 /// An enum to represent a feature flag sent by the server
 ///
 enum FeatureFlag: String, Codable {
-    /// Flag to enable/disable the ability to sync TOTP codes with the Authenticator app.
-    case authenticatorSyncEnabled = "enable-authenticator-sync-ios"
-
     /// Flag to enable/disable email verification during registration
     /// This flag introduces a new flow for account creation
     case emailVerification = "email-verification"
+
+    /// Flag to enable/disable the ability to sync TOTP codes with the Authenticator app.
+    case enableAuthenticatorSync = "enable-authenticator-sync-ios"
 
     /// A feature flag for the intro carousel flow.
     case nativeCarouselFlow = "native-carousel-flow"
@@ -31,7 +31,7 @@ enum FeatureFlag: String, Codable {
     /// Whether this feature can be enabled remotely.
     var isRemotelyConfigured: Bool {
         switch self {
-        case .authenticatorSyncEnabled,
+        case .enableAuthenticatorSync,
              .nativeCarouselFlow,
              .nativeCreateAccountFlow,
              .testLocalFeatureFlag:

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -6,7 +6,7 @@ import Foundation
 ///
 enum FeatureFlag: String, Codable {
     /// Flag to enable/disable the ability to sync TOTP codes with the Authenticator app.
-    case authenticatorSyncEnabled = "authenticator-sync-enabled"
+    case authenticatorSyncEnabled = "enable-authenticator-sync-ios"
 
     /// Flag to enable/disable email verification during registration
     /// This flag introduces a new flow for account creation


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-159](https://livefront.atlassian.net/browse/BITAU-159)

## 📔 Objective

This PR brings the feature flag key inline with the naming we just discussed in our feature flag meeting - `enable-authenticator-sync-ios`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
