### PR TITLE
PM-11883: Improve handling of biometric unlock errors

### DIFF
--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
@@ -173,11 +173,9 @@ class DefaultBiometricsRepository: BiometricsRepository {
                      kLAErrorUserFallback:
                     throw BiometricsServiceError.biometryFailed
                 default:
-                    throw BiometricsServiceError.getAuthKeyFailed
+                    throw error
                 }
             }
-        } catch {
-            throw BiometricsServiceError.getAuthKeyFailed
         }
     }
 }

--- a/BitwardenShared/Core/Platform/Services/ErrorReporter/BitwardenError.swift
+++ b/BitwardenShared/Core/Platform/Services/ErrorReporter/BitwardenError.swift
@@ -45,14 +45,17 @@ enum BitwardenError {
     /// - Parameters:
     ///   - type: The type of error. This is used to group the errors in the Crashlytics dashboard.
     ///   - message: A message describing the error that occurred.
+    ///   - error: An optional underlying error that caused the error.
     ///
-    static func generalError(type: String, message: String) -> NSError {
-        NSError(
+    static func generalError(type: String, message: String, error: Error? = nil) -> NSError {
+        var userInfo: [String: Any] = ["ErrorMessage": message]
+        if let error {
+            userInfo[NSUnderlyingErrorKey] = error
+        }
+        return NSError(
             domain: "General Error: \(type)",
             code: Code.generalError.rawValue,
-            userInfo: [
-                "ErrorMessage": message,
-            ]
+            userInfo: userInfo
         )
     }
 

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
@@ -487,6 +487,21 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(attemptsInUserDefaults, 0)
     }
 
+    /// `perform(_:)` with `.unlockVaultWithBiometrics` logs the user out if biometrics is locked
+    /// due to too many failed attempts.
+    @MainActor
+    func test_perform_unlockWithBiometrics_biometryLocked() async throws {
+        stateService.activeAccount = .fixture()
+        biometricsRepository.biometricUnlockStatus = .success(
+            .available(.touchID, enabled: true, hasValidIntegrity: true)
+        )
+        authRepository.unlockVaultWithBiometricsResult = .failure(BiometricsServiceError.biometryLocked)
+
+        await subject.perform(.unlockVaultWithBiometrics)
+        XCTAssertNil(coordinator.routes.last)
+        XCTAssertEqual(coordinator.events, [.action(.logout(userId: nil, userInitiated: true))])
+    }
+
     /// `perform(_:)` with `.unlockVaultWithBiometrics` shows the KDF warning in an extension if the
     /// KDF memory is potentially too high.
     @MainActor
@@ -521,6 +536,7 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         await subject.perform(.unlockVaultWithBiometrics)
         let route = try XCTUnwrap(coordinator.routes.last)
         XCTAssertEqual(route, .landing)
+        XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 
     /// `perform(_:)` with `.unlockWithBiometrics` requires a set user preference.
@@ -573,6 +589,12 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         await subject.perform(.unlockVaultWithBiometrics)
         XCTAssertNil(coordinator.routes.last)
         XCTAssertEqual(1, subject.state.unsuccessfulUnlockAttemptsCount)
+
+        XCTAssertEqual(errorReporter.errors.count, 1)
+        XCTAssertEqual(
+            (errorReporter.errors[0] as NSError).domain,
+            "General Error: VaultUnlock: Biometrics Unlock Error"
+        )
     }
 
     /// `perform(_:)` with `.unlockWithBiometrics` requires successful biometrics.
@@ -593,6 +615,12 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
             .action(
                 .logout(userId: nil, userInitiated: true)
             )
+        )
+
+        XCTAssertEqual(errorReporter.errors.count, 1)
+        XCTAssertEqual(
+            (errorReporter.errors[0] as NSError).domain,
+            "General Error: VaultUnlock: Biometrics Unlock Error"
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11883](https://bitwarden.atlassian.net/browse/PM-11883)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This improves the handling of errors during Face ID unlock to hopefully fix the issue of Face ID being deactivated due to any errors other than the auth key not being found. `BiometricsServiceError.getAuthKeyFailed` was being thrown for any unhandled errors, but this is also used to determine if Face ID should be deactivated if the auth key doesn't exist. This also adds error logging to Crashlytics for the `getAuthKeyFailed` and other errors to give more context if this doesn't solve the issue.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11883]: https://bitwarden.atlassian.net/browse/PM-11883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ