### PR TITLE
PM-11979: Allow PIN unlock to configure biometric integrity if needed

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -959,8 +959,7 @@ extension DefaultAuthRepository: AuthRepository {
 
             try await configureBiometricUnlockIfRequired()
         case .pin:
-            // No-op: nothing extra to do for pin unlock.
-            break
+            try await configureBiometricUnlockIfRequired()
         }
 
         _ = try await trustDeviceService.trustDeviceIfNeeded()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11979](https://bitwarden.atlassian.net/browse/PM-11979)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If a user has PIN unlock enabled without requiring a master password on app restart, the unlocking with a PIN should configure biometric integrity if needed so biometrics can be used on future extension invocations.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/7b16368f-3ff4-43ec-859a-5f4784d9d502



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11979]: https://bitwarden.atlassian.net/browse/PM-11979?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ