### PR TITLE
[BITAU-171] Fix SPM Package file to expose the correct name - AuthenticatorBridgeKit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,24 +9,24 @@ let package = Package(
     ],
     products: [
         .library(
-            name: "AuthenticatorSyncKit",
+            name: "AuthenticatorBridgeKit",
             targets: [
-                "AuthenticatorSyncKit",
+                "AuthenticatorBridgeKit",
             ]
         ),
     ],
     targets: [
         .target(
-            name: "AuthenticatorSyncKit",
-            path: "AuthenticatorSyncKit",
+            name: "AuthenticatorBridgeKit",
+            path: "AuthenticatorBridgeKit",
             exclude: [
                 "Tests/",
             ]
         ),
         .testTarget(
-            name: "AuthenticatorSyncKitTests",
-            dependencies: ["AuthenticatorSyncKit"],
-            path: "AuthenticatorSyncKit/Tests/"
+            name: "AuthenticatorBridgeKitTests",
+            dependencies: ["AuthenticatorBridgeKit"],
+            path: "AuthenticatorBridgeKit/Tests/"
         ),
     ]
 )


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-171](https://livefront.atlassian.net/browse/BITAU-171)

## 📔 Objective

In the previous PR, I missed the Package.swift reference that exposes the package name. This PR is simply to fix that one file to expose the correct name - `AuthenticatorBridgeKit`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
