### PR TITLE
PM-10740: Configure PIN key after biometrics unlock if require unlocking with MP

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1319,6 +1319,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.accountEncryptionKeys = [
             "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
         ]
+        stateService.encryptedPinByUserId["1"] = "ENCRYPTED_PIN"
 
         await assertAsyncDoesNotThrow {
             try await subject.unlockVaultWithPassword(password: "password")
@@ -1336,6 +1337,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
         XCTAssertTrue(organizationService.initializeOrganizationCryptoCalled)
         XCTAssertEqual(authService.hashPasswordPassword, "password")
+        XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "ENCRYPTED_USER_KEY")
         XCTAssertEqual(stateService.masterPasswordHashes["1"], "hashed")
         XCTAssertFalse(biometricsRepository.didConfigureBiometricIntegrity)
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
@@ -1462,10 +1464,14 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             ),
         ]
         stateService.activeAccount = .fixture()
+        stateService.encryptedPinByUserId["1"] = "ENCRYPTED_PIN"
         clientService.mockCrypto.initializeUserCryptoResult = .success(())
+
         await assertAsyncDoesNotThrow {
             try await subject.unlockVaultWithBiometrics()
         }
+
+        XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "ENCRYPTED_USER_KEY")
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10740](https://bitwarden.atlassian.net/browse/PM-10740)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an issue where the user has PIN unlock enabled, but it's toggled off in the app's settings.

The following conditions need to be true for this:

- PIN unlock is enabled and MP is required upon app restart.
- Biometrics unlock is also enabled. 

When the app restarts, unlocking with biometrics instead of MP causes the PIN unlock toggle to be turned off. When unlocking with biometrics, we weren't deriving the user's pin key and storing it in memory so it could be used to unlock the user's vault with their PIN.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10740]: https://bitwarden.atlassian.net/browse/PM-10740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ