### PR TITLE
PM-12243: Fix organization permissions JSON decoding errors for removed properties

### DIFF
--- a/BitwardenShared/Core/Vault/Models/API/Fixtures/Permissions+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/API/Fixtures/Permissions+Fixtures.swift
@@ -2,36 +2,12 @@
 
 extension Permissions {
     static func fixture(
-        accessEventLogs: Bool = false,
-        accessImportExport: Bool = false,
-        accessReports: Bool = false,
-        createNewCollections: Bool = false,
-        deleteAnyCollection: Bool = false,
-        deleteAssignedCollections: Bool = false,
-        editAnyCollection: Bool = false,
-        editAssignedCollections: Bool = false,
-        manageGroups: Bool = false,
         managePolicies: Bool = false,
-        manageResetPassword: Bool = false,
-        manageScim: Bool = false,
-        manageSso: Bool = false,
-        manageUsers: Bool = false
+        manageResetPassword: Bool = false
     ) -> Permissions {
         self.init(
-            accessEventLogs: accessEventLogs,
-            accessImportExport: accessImportExport,
-            accessReports: accessReports,
-            createNewCollections: createNewCollections,
-            deleteAnyCollection: deleteAnyCollection,
-            deleteAssignedCollections: deleteAssignedCollections,
-            editAnyCollection: editAnyCollection,
-            editAssignedCollections: editAssignedCollections,
-            manageGroups: manageGroups,
             managePolicies: managePolicies,
-            manageResetPassword: manageResetPassword,
-            manageScim: manageScim,
-            manageSso: manageSso,
-            manageUsers: manageUsers
+            manageResetPassword: manageResetPassword
         )
     }
 }

--- a/BitwardenShared/Core/Vault/Models/API/Permissions.swift
+++ b/BitwardenShared/Core/Vault/Models/API/Permissions.swift
@@ -3,47 +3,11 @@
 struct Permissions: Codable, Equatable, Hashable {
     // MARK: Properties
 
-    /// Whether the user can access event logs.
-    let accessEventLogs: Bool
-
-    /// Whether the user can access import and export.
-    let accessImportExport: Bool
-
-    /// Whether the user can access reports.
-    let accessReports: Bool
-
-    /// Whether the user can create new collections.
-    let createNewCollections: Bool
-
-    /// Whether the user can delete any collection.
-    let deleteAnyCollection: Bool
-
-    /// Whether the user can delete assigned collections.
-    let deleteAssignedCollections: Bool
-
-    /// Whether the user can edit any collection.
-    let editAnyCollection: Bool
-
-    /// Whether the user can edit assigned collections.
-    let editAssignedCollections: Bool
-
-    /// Whether the user can manage groups.
-    let manageGroups: Bool
-
     /// Whether the user can manage policies.
     let managePolicies: Bool
 
     /// Whether the user can manage reset password.
     let manageResetPassword: Bool
-
-    /// Whether the user can manage SCIM.
-    let manageScim: Bool
-
-    /// Whether the user can manage SSO.
-    let manageSso: Bool
-
-    /// Whether the user can manager users.
-    let manageUsers: Bool
 }
 
 extension Permissions {
@@ -51,20 +15,8 @@ extension Permissions {
     ///
     init() {
         self.init(
-            accessEventLogs: false,
-            accessImportExport: false,
-            accessReports: false,
-            createNewCollections: false,
-            deleteAnyCollection: false,
-            deleteAssignedCollections: false,
-            editAnyCollection: false,
-            editAssignedCollections: false,
-            manageGroups: false,
             managePolicies: false,
-            manageResetPassword: false,
-            manageScim: false,
-            manageSso: false,
-            manageUsers: false
+            manageResetPassword: false
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12243](https://bitwarden.atlassian.net/browse/PM-12243)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a decoding error for an organization's Permissions data model since `editAssignedCollections` and `deleteAssignedCollections` have been removed from the API. Most of the existing permissions properties aren't used by mobile so I removed the unused properties to prevent errors like this in the future.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
