### PR TITLE
PM-11522 - Large gap at the top of the autofill list after canceling a search

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -186,31 +186,39 @@ private struct VaultAutofillListSearchableView: View {
     /// The content displayed in the view.
     @ViewBuilder
     private func contentView() -> some View {
-        if isSearching {
-            searchContentView()
-        } else {
-            if store.state.vaultListSections.isEmpty {
-                EmptyContentView(
-                    image: Asset.Images.openSource.swiftUIImage,
-                    text: store.state.emptyViewMessage
-                ) {
-                    Button {
-                        store.send(.addTapped(fromToolbar: false))
-                    } label: {
-                        Label {
-                            Text(store.state.emptyViewButtonText)
-                        } icon: {
-                            Asset.Images.plus.swiftUIImage
-                                .imageStyle(.accessoryIcon(
-                                    color: Asset.Colors.textPrimaryInverted.swiftUIColor,
-                                    scaleWithFont: true
-                                ))
+        ZStack {
+            let isSearching = isSearching
+                || !store.state.searchText.isEmpty
+                || !store.state.ciphersForSearch.isEmpty
+
+            Group {
+                if store.state.vaultListSections.isEmpty {
+                    EmptyContentView(
+                        image: Asset.Images.openSource.swiftUIImage,
+                        text: store.state.emptyViewMessage
+                    ) {
+                        Button {
+                            store.send(.addTapped(fromToolbar: false))
+                        } label: {
+                            Label {
+                                Text(store.state.emptyViewButtonText)
+                            } icon: {
+                                Asset.Images.plus.swiftUIImage
+                                    .imageStyle(.accessoryIcon(
+                                        color: Asset.Colors.textPrimaryInverted.swiftUIColor,
+                                        scaleWithFont: true
+                                    ))
+                            }
                         }
                     }
+                } else {
+                    cipherListView(store.state.vaultListSections)
                 }
-            } else {
-                cipherListView(store.state.vaultListSections)
             }
+            .hidden(isSearching)
+
+            searchContentView()
+                .hidden(!isSearching)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11522](https://bitwarden.atlassian.net/browse/PM-11522)

## 📔 Objective

- Aligned the logic in VaultListView for showing and hiding the search view. 
- Collaborated with @matt-livefront, who was able to replicate the issue, and confirmed that syncing the view logic resolved the problem.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 

[PM-11522]: https://bitwarden.atlassian.net/browse/PM-11522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ