### PR TITLE
[PM-12242] Updated default US and EU region URLs

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlData.swift
@@ -82,9 +82,24 @@ extension EnvironmentUrlData {
         subpageUrl(additionalPath: "recover-2fa")
     }
 
+    /// Gets the region depending on the base url.
+    var region: RegionType {
+        switch base {
+        case EnvironmentUrlData.defaultUS.base:
+            .unitedStates
+        case EnvironmentUrlData.defaultEU.base:
+            .europe
+        default:
+            .selfHosted
+        }
+    }
+
     /// The base url for send sharing.
     var sendShareURL: URL? {
-        subpageUrl(additionalPath: "send")
+        guard region != .unitedStates else {
+            return URL(string: "https://send.bitwarden.com/#")!
+        }
+        return subpageUrl(additionalPath: "send")
     }
 
     /// The base url for the settings screen.
@@ -118,8 +133,24 @@ extension EnvironmentUrlData {
 
 extension EnvironmentUrlData {
     /// The default URLs for the US region.
-    static let defaultUS = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.com")!)
+    static let defaultUS = EnvironmentUrlData(
+        api: URL(string: "https://api.bitwarden.com")!,
+        base: URL(string: "https://vault.bitwarden.com")!,
+        events: URL(string: "https://events.bitwarden.com")!,
+        icons: URL(string: "https://icons.bitwarden.net")!,
+        identity: URL(string: "https://identity.bitwarden.com")!,
+        notifications: URL(string: "https://notifications.bitwarden.com")!,
+        webVault: URL(string: "https://vault.bitwarden.com")!
+    )
 
     /// The default URLs for the EU region.
-    static let defaultEU = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.eu")!)
+    static let defaultEU = EnvironmentUrlData(
+        api: URL(string: "https://api.bitwarden.eu")!,
+        base: URL(string: "https://vault.bitwarden.eu")!,
+        events: URL(string: "https://events.bitwarden.eu")!,
+        icons: URL(string: "https://icons.bitwarden.net")!,
+        identity: URL(string: "https://identity.bitwarden.eu")!,
+        notifications: URL(string: "https://notifications.bitwarden.eu")!,
+        webVault: URL(string: "https://vault.bitwarden.eu")!
+    )
 }

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlData.swift
@@ -148,7 +148,7 @@ extension EnvironmentUrlData {
         api: URL(string: "https://api.bitwarden.eu")!,
         base: URL(string: "https://vault.bitwarden.eu")!,
         events: URL(string: "https://events.bitwarden.eu")!,
-        icons: URL(string: "https://icons.bitwarden.net")!,
+        icons: URL(string: "https://icons.bitwarden.eu")!,
         identity: URL(string: "https://identity.bitwarden.eu")!,
         notifications: URL(string: "https://notifications.bitwarden.eu")!,
         webVault: URL(string: "https://vault.bitwarden.eu")!

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
@@ -31,7 +31,7 @@ class EnvironmentUrlDataTests: XCTestCase {
                 api: URL(string: "https://api.bitwarden.eu")!,
                 base: URL(string: "https://vault.bitwarden.eu")!,
                 events: URL(string: "https://events.bitwarden.eu")!,
-                icons: URL(string: "https://icons.bitwarden.net")!,
+                icons: URL(string: "https://icons.bitwarden.eu")!,
                 identity: URL(string: "https://identity.bitwarden.eu")!,
                 notifications: URL(string: "https://notifications.bitwarden.eu")!,
                 webVault: URL(string: "https://vault.bitwarden.eu")!

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
@@ -76,7 +76,7 @@ class EnvironmentUrlDataTests: XCTestCase {
         XCTAssertFalse(EnvironmentUrlData(webVault: .example).isEmpty)
     }
 
-    /// `region` returns `.unitedStates` if base url is the same as teh default for US.
+    /// `region` returns `.unitedStates` if base url is the same as the default for US.
     func test_region_unitedStates() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.com")!)
         XCTAssertTrue(subject.region == .unitedStates)

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
@@ -5,6 +5,40 @@ import XCTest
 class EnvironmentUrlDataTests: XCTestCase {
     // MARK: Tests
 
+    /// `defaultUS` returns the properly configured `EnvironmentUrlData`
+    /// with the deafult Urls for united states region.
+    func test_defaultUS() {
+        XCTAssertEqual(
+            EnvironmentUrlData.defaultUS,
+            EnvironmentUrlData(
+                api: URL(string: "https://api.bitwarden.com")!,
+                base: URL(string: "https://vault.bitwarden.com")!,
+                events: URL(string: "https://events.bitwarden.com")!,
+                icons: URL(string: "https://icons.bitwarden.net")!,
+                identity: URL(string: "https://identity.bitwarden.com")!,
+                notifications: URL(string: "https://notifications.bitwarden.com")!,
+                webVault: URL(string: "https://vault.bitwarden.com")!
+            )
+        )
+    }
+
+    /// `defaultEU` returns the properly configured `EnvironmentUrlData`
+    /// with the deafult Urls for europe region.
+    func test_defaultEU() {
+        XCTAssertEqual(
+            EnvironmentUrlData.defaultEU,
+            EnvironmentUrlData(
+                api: URL(string: "https://api.bitwarden.eu")!,
+                base: URL(string: "https://vault.bitwarden.eu")!,
+                events: URL(string: "https://events.bitwarden.eu")!,
+                icons: URL(string: "https://icons.bitwarden.net")!,
+                identity: URL(string: "https://identity.bitwarden.eu")!,
+                notifications: URL(string: "https://notifications.bitwarden.eu")!,
+                webVault: URL(string: "https://vault.bitwarden.eu")!
+            )
+        )
+    }
+
     /// `importItemsURL` returns the import items url for the base url.
     func test_importItemsURL_baseURL() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
@@ -40,6 +74,36 @@ class EnvironmentUrlDataTests: XCTestCase {
         XCTAssertFalse(EnvironmentUrlData(identity: .example).isEmpty)
         XCTAssertFalse(EnvironmentUrlData(notifications: .example).isEmpty)
         XCTAssertFalse(EnvironmentUrlData(webVault: .example).isEmpty)
+    }
+
+    /// `region` returns `.unitedStates` if base url is the same as teh default for US.
+    func test_region_unitedStates() {
+        let subject = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.com")!)
+        XCTAssertTrue(subject.region == .unitedStates)
+    }
+
+    /// `region` returns `.europe` if base url is the same as the default for EU.
+    func test_region_europe() {
+        let subject = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.eu")!)
+        XCTAssertTrue(subject.region == .europe)
+    }
+
+    /// `region` returns `.selfHosted` if base url is neither the default for US nor for EU.
+    func test_region_selfHost() {
+        let subject = EnvironmentUrlData(base: URL(string: "https://example.com")!)
+        XCTAssertTrue(subject.region == .selfHosted)
+    }
+
+    /// `sendShareURL` returns the send url for the united states region.
+    func test_sendShareURL_unitedStates() {
+        let subject = EnvironmentUrlData.defaultUS
+        XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://send.bitwarden.com/#")
+    }
+
+    /// `sendShareURL` returns the send url for the europe region.
+    func test_sendShareURL_europe() {
+        let subject = EnvironmentUrlData.defaultEU
+        XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://vault.bitwarden.eu/#/send")
     }
 
     /// `sendShareURL` returns the send url for the base url.

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift
@@ -42,7 +42,7 @@ extension EnvironmentUrls {
     /// - Parameter environmentUrlData: The environment URLs used to initialize `EnvironmentUrls`.
     ///
     init(environmentUrlData: EnvironmentUrlData) {
-        if let base = environmentUrlData.base {
+        if environmentUrlData.region == .selfHosted, let base = environmentUrlData.base {
             apiURL = base.appendingPathComponent("api")
             baseURL = base
             eventsURL = base.appendingPathComponent("events")

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
@@ -38,7 +38,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 apiURL: URL(string: "https://api.bitwarden.eu")!,
                 baseURL: URL(string: "https://vault.bitwarden.eu")!,
                 eventsURL: URL(string: "https://events.bitwarden.eu")!,
-                iconsURL: URL(string: "https://icons.bitwarden.net")!,
+                iconsURL: URL(string: "https://icons.bitwarden.eu")!,
                 identityURL: URL(string: "https://identity.bitwarden.eu")!,
                 importItemsURL: URL(string: "https://vault.bitwarden.eu/#/tools/import")!,
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.eu/#/recover-2fa")!,

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
@@ -5,7 +5,52 @@ import XCTest
 class EnvironmentUrlsTests: BitwardenTestCase {
     // MARK: Tests
 
-    /// `init(environmentUrlData:)` sets the URLs from the base URL if one is set.
+    /// `init(environmentUrlData:)` sets the URLs from the passed data when such data is the default US.
+    func test_init_environmentUrlData_defaultUS() {
+        let subject = EnvironmentUrls(
+            environmentUrlData: EnvironmentUrlData.defaultUS
+        )
+        XCTAssertEqual(
+            subject,
+            EnvironmentUrls(
+                apiURL: URL(string: "https://api.bitwarden.com")!,
+                baseURL: URL(string: "https://vault.bitwarden.com")!,
+                eventsURL: URL(string: "https://events.bitwarden.com")!,
+                iconsURL: URL(string: "https://icons.bitwarden.net")!,
+                identityURL: URL(string: "https://identity.bitwarden.com")!,
+                importItemsURL: URL(string: "https://vault.bitwarden.com/#/tools/import")!,
+                recoveryCodeURL: URL(string: "https://vault.bitwarden.com/#/recover-2fa")!,
+                sendShareURL: URL(string: "https://send.bitwarden.com/#")!,
+                settingsURL: URL(string: "https://vault.bitwarden.com/#/settings")!,
+                webVaultURL: URL(string: "https://vault.bitwarden.com")!
+            )
+        )
+    }
+
+    /// `init(environmentUrlData:)` sets the URLs from the passed data when such data is the default EU.
+    func test_init_environmentUrlData_defaultEU() {
+        let subject = EnvironmentUrls(
+            environmentUrlData: EnvironmentUrlData.defaultEU
+        )
+        XCTAssertEqual(
+            subject,
+            EnvironmentUrls(
+                apiURL: URL(string: "https://api.bitwarden.eu")!,
+                baseURL: URL(string: "https://vault.bitwarden.eu")!,
+                eventsURL: URL(string: "https://events.bitwarden.eu")!,
+                iconsURL: URL(string: "https://icons.bitwarden.net")!,
+                identityURL: URL(string: "https://identity.bitwarden.eu")!,
+                importItemsURL: URL(string: "https://vault.bitwarden.eu/#/tools/import")!,
+                recoveryCodeURL: URL(string: "https://vault.bitwarden.eu/#/recover-2fa")!,
+                sendShareURL: URL(string: "https://vault.bitwarden.eu/#/send")!,
+                settingsURL: URL(string: "https://vault.bitwarden.eu/#/settings")!,
+                webVaultURL: URL(string: "https://vault.bitwarden.eu")!
+            )
+        )
+    }
+
+    /// `init(environmentUrlData:)` sets the URLs from the base URL if one is set and is not
+    /// `.unitedStates` nor `.europe` region type.
     func test_init_environmentUrlData_baseUrl() {
         let subject = EnvironmentUrls(
             environmentUrlData: EnvironmentUrlData(base: URL(string: "https://example.com")!)

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -36,13 +36,13 @@ class EnvironmentServiceTests: XCTestCase {
 
     /// The default US URLs are returned if the URLs haven't been loaded.
     func test_defaultUrls() {
-        XCTAssertEqual(subject.apiURL, URL(string: "https://vault.bitwarden.com/api"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://vault.bitwarden.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://vault.bitwarden.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://vault.bitwarden.com/identity"))
+        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
+        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
+        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
+        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
         XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.bitwarden.com/#/send"))
+        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
     }
@@ -77,10 +77,10 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://vault.bitwarden.eu/api"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://vault.bitwarden.eu/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://vault.bitwarden.eu/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://vault.bitwarden.eu/identity"))
+        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.eu"))
+        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.eu"))
+        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
+        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.eu"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.eu/#/tools/import"))
         XCTAssertEqual(subject.region, .europe)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.bitwarden.eu/#/send"))
@@ -124,13 +124,13 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://vault.bitwarden.com/api"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://vault.bitwarden.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://vault.bitwarden.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://vault.bitwarden.com/identity"))
+        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
+        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
+        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
+        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
         XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.bitwarden.com/#/send"))
+        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
 
@@ -143,13 +143,13 @@ class EnvironmentServiceTests: XCTestCase {
     func test_loadURLsForActiveAccount_noAccount() async {
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://vault.bitwarden.com/api"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://vault.bitwarden.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://vault.bitwarden.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://vault.bitwarden.com/identity"))
+        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
+        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
+        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
+        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
         XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.bitwarden.com/#/send"))
+        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, .defaultUS)

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -79,7 +79,7 @@ class EnvironmentServiceTests: XCTestCase {
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.eu"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.eu"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
+        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.eu"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.eu"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.eu/#/tools/import"))
         XCTAssertEqual(subject.region, .europe)

--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -199,8 +199,12 @@ class DefaultSendRepository: SendRepository {
 
     func shareURL(for sendView: SendView) async throws -> URL? {
         guard let accessId = sendView.accessId, let key = sendView.key else { return nil }
-        let sharePath = "/\(accessId)/\(key)"
-        let url = URL(string: environmentService.sendShareURL.absoluteString.appending(sharePath))
+        let sharePath = "\(accessId)/\(key)"
+        var sendShareUrlString = environmentService.sendShareURL.absoluteString
+        if !sendShareUrlString.hasSuffix("#") {
+            sendShareUrlString = sendShareUrlString.appending("/")
+        }
+        let url = URL(string: sendShareUrlString.appending(sharePath))
         return url
     }
 

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -344,10 +344,18 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `shareURL()` successfully generates a share url for the send view.
     func test_shareURL() async throws {
         let sendView = SendView.fixture(accessId: "ACCESS_ID", key: "KEY")
-        environmentService.webVaultURL = .example
         let url = try await subject.shareURL(for: sendView)
 
         XCTAssertEqual(url?.absoluteString, "https://example.com/#/send/ACCESS_ID/KEY")
+    }
+
+    /// `shareURL()` successfully generates a share url for the send view when the `sendShareURL` ends with a "#".
+    func test_shareURL_poundSignSuffix() async throws {
+        let sendView = SendView.fixture(accessId: "ACCESS_ID", key: "KEY")
+        environmentService.sendShareURL = URL(string: "https://send.bitwarden.com/#")!
+        let url = try await subject.shareURL(for: sendView)
+
+        XCTAssertEqual(url?.absoluteString, "https://send.bitwarden.com/#ACCESS_ID/KEY")
     }
 
     /// `updateSend()` successfully encrypts the send view and uses the send service to update it.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12242](https://bitwarden.atlassian.net/browse/PM-12242)

## 📔 Objective

Update default US and EU region URLs to not use append suffix logic as in Self-host but fixed set URLs.

Check [MAUI code](https://github.com/bitwarden/mobile/blob/main/src/Core/Models/Data/EnvironmentUrlData.cs#L9) as reference.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12242]: https://bitwarden.atlassian.net/browse/PM-12242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ