### PR TITLE
PM-10524: Persist user's autofill and vault unlock setup progress in create account flow

### DIFF
--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
@@ -45,6 +45,7 @@ class MockAuthService: AuthService {
     var loginWithMasterPasswordPassword: String?
     var loginWithMasterPasswordUsername: String?
     var loginWithMasterPasswordCaptchaToken: String?
+    var loginWithMasterPasswordIsNewAccount = false
     var loginWithMasterPasswordResult: Result<Void, Error> = .success(())
 
     var loginWithSingleSignOnCode: String?
@@ -125,10 +126,16 @@ class MockAuthService: AuthService {
         return try loginWithDeviceResult.get()
     }
 
-    func loginWithMasterPassword(_ password: String, username: String, captchaToken: String?) async throws {
+    func loginWithMasterPassword(
+        _ password: String,
+        username: String,
+        captchaToken: String?,
+        isNewAccount: Bool
+    ) async throws {
         loginWithMasterPasswordPassword = password
         loginWithMasterPasswordUsername = username
         loginWithMasterPasswordCaptchaToken = captchaToken
+        loginWithMasterPasswordIsNewAccount = isNewAccount
         try loginWithMasterPasswordResult.get()
     }
 

--- a/BitwardenShared/Core/Platform/Models/Enum/AccountSetupProgress.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/AccountSetupProgress.swift
@@ -1,0 +1,14 @@
+// MARK: - AccountSetupProgress
+
+/// An enum to represent a user's progress towards setting up new account functionality.
+///
+enum AccountSetupProgress: Int, Codable {
+    /// The user hasn't yet made any progress.
+    case incomplete = 0
+
+    /// The user choose to set up the functionality later.
+    case setUpLater = 1
+
+    /// The user has completed the set up.
+    case complete = 2
+}

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -53,6 +53,20 @@ protocol StateService: AnyObject {
     /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
     func getAccountHasBeenUnlockedInteractively(userId: String?) async throws -> Bool
 
+    /// Gets the user's progress for setting up autofill.
+    ///
+    /// - Parameter userId: The user ID associated with the autofill setup progress.
+    /// - Returns: The user's autofill setup progress.
+    ///
+    func getAccountSetupAutofill(userId: String?) async throws -> AccountSetupProgress?
+
+    /// Gets the user's progress for setting up vault unlock.
+    ///
+    /// - Parameter userId: The user ID associated with the vault unlock setup progress.
+    /// - Returns: The user's vault unlock setup progress.
+    ///
+    func getAccountSetupVaultUnlock(userId: String?) async throws -> AccountSetupProgress?
+
     /// Gets all accounts.
     ///
     /// - Returns: The known user accounts.
@@ -346,6 +360,22 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///   - value: Whether the user has unlocked their account in the current session.
     func setAccountHasBeenUnlockedInteractively(userId: String?, value: Bool) async throws
+
+    /// Sets the user's progress for setting up autofill.
+    ///
+    /// - Parameters:
+    ///   - autofillSetup: The user's autofill setup progress.
+    ///   - userId: The user ID associated with the autofill setup progress.
+    ///
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String?) async throws
+
+    /// Sets the user's progress for setting up vault unlock.
+    ///
+    /// - Parameters:
+    ///   - autofillSetup: The user's vault unlock setup progress.
+    ///   - userId: The user ID associated with the vault unlock setup progress.
+    ///
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?, userId: String?) async throws
 
     /// Sets the active account.
     ///
@@ -663,6 +693,22 @@ extension StateService {
         try await getAccount(userId: userId).profile.userId
     }
 
+    /// Gets the active user's progress for setting up autofill.
+    ///
+    /// - Returns: The user's autofill setup progress.
+    ///
+    func getAccountSetupAutofill() async throws -> AccountSetupProgress? {
+        try await getAccountSetupAutofill(userId: nil)
+    }
+
+    /// Gets the active user's progress for setting up vault unlock.
+    ///
+    /// - Returns: The user's vault unlock setup progress.
+    ///
+    func getAccountSetupVaultUnlock() async throws -> AccountSetupProgress? {
+        try await getAccountSetupVaultUnlock(userId: nil)
+    }
+
     /// Gets the active account id.
     ///
     /// - Returns: The active user id.
@@ -885,6 +931,22 @@ extension StateService {
     /// - Parameter value: Whether the user has unlocked their account in the current session
     func setAccountHasBeenUnlockedInteractively(value: Bool) async throws {
         try await setAccountHasBeenUnlockedInteractively(userId: nil, value: value)
+    }
+
+    /// Sets the active user's progress for setting up autofill.
+    ///
+    /// - Parameter autofillSetup: The user's autofill setup progress.
+    ///
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?) async throws {
+        try await setAccountSetupAutofill(autofillSetup, userId: nil)
+    }
+
+    /// Sets the active user's progress for setting up vault unlock.
+    ///
+    /// - Parameter vaultUnlockSetup: The user's vault unlock setup progress.
+    ///
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?) async throws {
+        try await setAccountSetupVaultUnlock(vaultUnlockSetup, userId: nil)
     }
 
     /// Sets the allow sync on refresh value for the active account.
@@ -1182,6 +1244,16 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         return accountVolatileData[userId]?.hasBeenUnlockedInteractively == true
     }
 
+    func getAccountSetupAutofill(userId: String?) async throws -> AccountSetupProgress? {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.accountSetupAutofill(userId: userId)
+    }
+
+    func getAccountSetupVaultUnlock(userId: String?) async throws -> AccountSetupProgress? {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.accountSetupVaultUnlock(userId: userId)
+    }
+
     func getAccounts() throws -> [Account] {
         guard let accounts = appSettingsStore.state?.accounts else {
             throw StateServiceError.noAccounts
@@ -1408,6 +1480,16 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
             userId,
             default: AccountVolatileData()
         ].hasBeenUnlockedInteractively = value
+    }
+
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setAccountSetupAutofill(autofillSetup, userId: userId)
+    }
+
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setAccountSetupVaultUnlock(vaultUnlockSetup, userId: userId)
     }
 
     func setActiveAccount(userId: String) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -218,13 +218,6 @@ protocol StateService: AnyObject {
     ///
     func getMasterPasswordHash(userId: String?) async throws -> String?
 
-    /// Gets whether the user needs to set up vault unlock methods.
-    ///
-    /// - Parameter userId: The user ID associated with the value.
-    /// - Returns: Whether the user needs to set up vault unlock methods.
-    ///
-    func getNeedsVaultUnlockSetup(userId: String?) async throws -> Bool
-
     /// Gets the last notifications registration date for a user ID.
     ///
     /// - Parameter userId: The user ID of the account. Defaults to the active account if `nil`.
@@ -500,14 +493,6 @@ protocol StateService: AnyObject {
     ///   - userId: The user ID associated with the master password hash.
     ///
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws
-
-    /// Sets whether the user needs to set up vault unlock methods.
-    ///
-    /// - Parameters:
-    ///   - needsVaultUnlockSetup: Whether the user needs to set up vault unlock methods.
-    ///   - userId: The user ID associated with the value.
-    ///
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String?) async throws
 
     /// Sets the last notifications registration date for a user ID.
     ///
@@ -811,14 +796,6 @@ extension StateService {
         try await getMasterPasswordHash(userId: nil)
     }
 
-    /// Gets whether the active account needs to set up vault unlock methods.
-    ///
-    /// - Returns: Whether the user needs to set up vault unlock methods.
-    ///
-    func getNeedsVaultUnlockSetup() async throws -> Bool {
-        try await getNeedsVaultUnlockSetup(userId: nil)
-    }
-
     /// Gets the last notifications registration date for the active account.
     ///
     /// - Returns: The last notifications registration date for the active account.
@@ -1019,14 +996,6 @@ extension StateService {
     ///
     func setMasterPasswordHash(_ hash: String?) async throws {
         try await setMasterPasswordHash(hash, userId: nil)
-    }
-
-    /// Sets whether the active account needs to set up vault unlock methods.
-    ///
-    /// - Parameter needsVaultUnlockSetup: Whether the user needs to set up vault unlock methods.
-    ///
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool) async throws {
-        try await setNeedsVaultUnlockSetup(needsVaultUnlockSetup, userId: nil)
     }
 
     /// Sets the last notifications registration date for the active account.
@@ -1343,11 +1312,6 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         return appSettingsStore.masterPasswordHash(userId: userId)
     }
 
-    func getNeedsVaultUnlockSetup(userId: String?) async throws -> Bool {
-        let userId = try userId ?? getActiveAccountUserId()
-        return appSettingsStore.needsVaultUnlockSetup(userId: userId)
-    }
-
     func getNotificationsLastRegistrationDate(userId: String?) async throws -> Date? {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.notificationsLastRegistrationDate(userId: userId)
@@ -1577,11 +1541,6 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setMasterPasswordHash(hash, userId: userId)
-    }
-
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String?) async throws {
-        let userId = try userId ?? getActiveAccountUserId()
-        appSettingsStore.setNeedsVaultUnlockSetup(needsVaultUnlockSetup, userId: userId)
     }
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -300,6 +300,44 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         }
     }
 
+    /// `getAccountSetupAutofill()` returns the user's autofill setup progress.
+    func test_getAccountSetupAutofill() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        let initialValue = try await subject.getAccountSetupAutofill()
+        XCTAssertNil(initialValue)
+
+        appSettingsStore.accountSetupAutofill["1"] = .setUpLater
+        let setUpLater = try await subject.getAccountSetupAutofill()
+        XCTAssertEqual(setUpLater, .setUpLater)
+    }
+
+    /// `getAccountSetupAutofill()` throws an error if there isn't an active account.
+    func test_getAccountSetupAutofill_noAccount() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.getAccountSetupAutofill()
+        }
+    }
+
+    /// `getAccountSetupVaultUnlock()` returns the user's vault unlock setup progress.
+    func test_getAccountSetupVaultUnlock() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        let initialValue = try await subject.getAccountSetupVaultUnlock()
+        XCTAssertNil(initialValue)
+
+        appSettingsStore.accountSetupVaultUnlock["1"] = .setUpLater
+        let setUpLater = try await subject.getAccountSetupVaultUnlock()
+        XCTAssertEqual(setUpLater, .setUpLater)
+    }
+
+    /// `getAccountSetupVaultUnlock()` throws an error if there isn't an active account.
+    func test_getAccountSetupVaultUnlock_noAccount() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.getAccountSetupVaultUnlock()
+        }
+    }
+
     /// `getActiveAccount()` returns the active account.
     func test_getActiveAccount() async throws {
         let account = Account.fixture(profile: .fixture(userId: "2"))
@@ -1490,6 +1528,28 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
             _ = try await subject.setAccountHasBeenUnlockedInteractively(value: true)
         }
+    }
+
+    /// `setAccountSetupAutofill(_:)` sets the user's autofill setup progress.
+    func test_setAccountSetupAutofill() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        try await subject.setAccountSetupAutofill(.incomplete)
+        XCTAssertEqual(appSettingsStore.accountSetupAutofill, ["1": .incomplete])
+
+        try await subject.setAccountSetupAutofill(.complete, userId: "1")
+        XCTAssertEqual(appSettingsStore.accountSetupAutofill, ["1": .complete])
+    }
+
+    /// `setAccountSetupVaultUnlock(_:)` sets the user's vault unlock setup progress.
+    func test_setAccountSetupVaultUnlock() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        try await subject.setAccountSetupVaultUnlock(.incomplete)
+        XCTAssertEqual(appSettingsStore.accountSetupVaultUnlock, ["1": .incomplete])
+
+        try await subject.setAccountSetupVaultUnlock(.complete, userId: "1")
+        XCTAssertEqual(appSettingsStore.accountSetupVaultUnlock, ["1": .complete])
     }
 
     /// `setActiveAccount(userId: )` succeeds if there is a matching account

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -675,25 +675,6 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         }
     }
 
-    /// `getNeedsVaultUnlockSetup()` returns whether the user needs to set up vault unlock methods.
-    func test_getNeedsVaultUnlockSetup() async throws {
-        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
-
-        let initialValue = try await subject.getNeedsVaultUnlockSetup()
-        XCTAssertFalse(initialValue)
-
-        appSettingsStore.needsVaultUnlockSetup["1"] = true
-        let needsVaultUnlockSetup = try await subject.getNeedsVaultUnlockSetup()
-        XCTAssertTrue(needsVaultUnlockSetup)
-    }
-
-    /// `getNeedsVaultUnlockSetup()` throws an error if there isn't an active account.
-    func test_getNeedsVaultUnlockSetup_noAccount() async throws {
-        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
-            _ = try await subject.getNeedsVaultUnlockSetup()
-        }
-    }
-
     /// `getNotificationsLastRegistrationDate()` returns the user's last notifications registration date.
     func test_getNotificationsLastRegistrationDate() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
@@ -1612,17 +1593,6 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.setMasterPasswordHash("1234", userId: "1")
         XCTAssertEqual(appSettingsStore.masterPasswordHashes, ["1": "1234"])
-    }
-
-    /// `setNeedsVaultUnlockSetup(_:)` sets whether the user needs to set up vault unlock methods.
-    func test_setNeedsVaultUnlockSetup() async throws {
-        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
-
-        try await subject.setNeedsVaultUnlockSetup(true)
-        XCTAssertEqual(appSettingsStore.needsVaultUnlockSetup, ["1": true])
-
-        try await subject.setNeedsVaultUnlockSetup(false, userId: "1")
-        XCTAssertEqual(appSettingsStore.needsVaultUnlockSetup, ["1": false])
     }
 
     /// `setNotificationsLastRegistrationDate(_:)` sets the last notifications registration date for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -59,6 +59,20 @@ protocol AppSettingsStore: AnyObject {
     /// The app's account state.
     var state: State? { get set }
 
+    /// The user's progress for setting up autofill.
+    ///
+    /// - Parameter userId: The user ID associated with the stored autofill setup progress.
+    /// - Returns: The user's autofill setup progress.
+    ///
+    func accountSetupAutofill(userId: String) -> AccountSetupProgress?
+
+    /// The user's progress for setting up vault unlock.
+    ///
+    /// - Parameter userId: The user ID associated with the stored vault unlock setup progress.
+    /// - Returns: The user's vault unlock setup progress.
+    ///
+    func accountSetupVaultUnlock(userId: String) -> AccountSetupProgress?
+
     /// Whether the vault should sync on refreshing.
     ///
     /// - Parameter userId: The user ID associated with the sync on refresh setting.
@@ -195,6 +209,22 @@ protocol AppSettingsStore: AnyObject {
     /// - Parameter userId: The user ID associated with the server config.
     /// - Returns: The server config for that user ID.
     func serverConfig(userId: String) -> ServerConfig?
+
+    /// Sets the user's progress for autofill setup.
+    ///
+    /// - Parameters:
+    ///   - autofillSetup: The user's autofill setup progress.
+    ///   - userId: The user ID associated with the stored autofill setup progress.
+    ///
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String)
+
+    /// Sets the user's progress for vault unlock setup.
+    ///
+    /// - Parameters:
+    ///   - vaultUnlockSetup: The user's vault unlock setup progress.
+    ///   - userId: The user ID associated with the stored autofill setup progress.
+    ///
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?, userId: String)
 
     /// Whether the vault should sync on refreshing.
     ///
@@ -578,6 +608,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     /// The keys used to store their associated values.
     ///
     enum Keys {
+        case accountSetupAutofill(userId: String)
+        case accountSetupVaultUnlock(userId: String)
         case addSitePromptShown
         case allowSyncOnRefresh(userId: String)
         case appId
@@ -624,6 +656,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         var storageKey: String {
             let key: String
             switch self {
+            case let .accountSetupAutofill(userId):
+                key = "accountSetupAutofill_\(userId)"
+            case let .accountSetupVaultUnlock(userId):
+                key = "accountSetupVaultUnlock_\(userId)"
             case .addSitePromptShown:
                 key = "addSitePromptShown"
             case let .allowSyncOnRefresh(userId):
@@ -789,6 +825,14 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         }
     }
 
+    func accountSetupAutofill(userId: String) -> AccountSetupProgress? {
+        fetch(for: .accountSetupAutofill(userId: userId))
+    }
+
+    func accountSetupVaultUnlock(userId: String) -> AccountSetupProgress? {
+        fetch(for: .accountSetupVaultUnlock(userId: userId))
+    }
+
     func allowSyncOnRefresh(userId: String) -> Bool {
         fetch(for: .allowSyncOnRefresh(userId: userId))
     }
@@ -872,6 +916,14 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func serverConfig(userId: String) -> ServerConfig? {
         fetch(for: .serverConfig(userId: userId))
+    }
+
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String) {
+        store(autofillSetup, for: .accountSetupAutofill(userId: userId))
+    }
+
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?, userId: String) {
+        store(vaultUnlockSetup, for: .accountSetupVaultUnlock(userId: userId))
     }
 
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -176,13 +176,6 @@ protocol AppSettingsStore: AnyObject {
     ///
     func masterPasswordHash(userId: String) -> String?
 
-    /// Gets whether the user needs to set up vault unlock methods.
-    ///
-    /// - Parameter userId: The user ID associated with the value.
-    /// - Returns: Whether the user needs to set up vault unlock methods.
-    ///
-    func needsVaultUnlockSetup(userId: String) -> Bool
-
     /// Gets the last date the user successfully registered for push notifications.
     ///
     /// - Parameter userId: The user ID associated with the last notifications registration date.
@@ -341,14 +334,6 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the master password hash.
     ///
     func setMasterPasswordHash(_ hash: String?, userId: String)
-
-    /// Sets whether the user needs to set up vault unlock methods.
-    ///
-    /// - Parameters:
-    ///   - needsVaultUnlockSetup: Whether the user needs to set up vault unlock methods.
-    ///   - userId: The user ID associated with the value.
-    ///
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String)
 
     /// Sets the last notifications registration date for a user ID.
     ///
@@ -634,7 +619,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case loginRequest
         case masterPasswordHash(userId: String)
         case migrationVersion
-        case needsVaultUnlockSetup(userId: String)
         case notificationsLastRegistrationDate(userId: String)
         case passwordGenerationOptions(userId: String)
         case pinProtectedUserKey(userId: String)
@@ -708,8 +692,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "keyHash_\(userId)"
             case .migrationVersion:
                 key = "migrationVersion"
-            case let .needsVaultUnlockSetup(userId):
-                key = "needsVaultUnlockSetup_\(userId)"
             case let .notificationsLastRegistrationDate(userId):
                 key = "pushLastRegistrationDate_\(userId)"
             case let .passwordGenerationOptions(userId):
@@ -898,10 +880,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .masterPasswordHash(userId: userId))
     }
 
-    func needsVaultUnlockSetup(userId: String) -> Bool {
-        fetch(for: .needsVaultUnlockSetup(userId: userId))
-    }
-
     func notificationsLastRegistrationDate(userId: String) -> Date? {
         fetch(for: .notificationsLastRegistrationDate(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
@@ -986,10 +964,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setMasterPasswordHash(_ hash: String?, userId: String) {
         store(hash, for: .masterPasswordHash(userId: userId))
-    }
-
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String) {
-        store(needsVaultUnlockSetup, for: .needsVaultUnlockSetup(userId: userId))
     }
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -547,23 +547,6 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(userDefaults.double(forKey: "bwPreferencesStorage:pushLastRegistrationDate_2"), 1_696_204_800.0)
     }
 
-    /// `needsVaultUnlockSetup(userId:)` returns `false` if there isn't a previously stored value.
-    func test_needsVaultUnlockSetup_isInitiallyFalse() {
-        XCTAssertFalse(subject.needsVaultUnlockSetup(userId: "-1"))
-    }
-
-    /// `needsVaultUnlockSetup(userId:)` can be used to get whether the user needs to set up vault
-    /// unlock methods.
-    func test_needsVaultUnlockSetup__withValue() {
-        subject.setNeedsVaultUnlockSetup(true, userId: "1")
-        subject.setNeedsVaultUnlockSetup(false, userId: "2")
-
-        XCTAssertTrue(subject.needsVaultUnlockSetup(userId: "1"))
-        XCTAssertFalse(subject.needsVaultUnlockSetup(userId: "2"))
-        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:needsVaultUnlockSetup_1"))
-        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:needsVaultUnlockSetup_2"))
-    }
-
     /// `passwordGenerationOptions(userId:)` returns `nil` if there isn't a previously stored value.
     func test_passwordGenerationOptions_isInitiallyNil() {
         XCTAssertNil(subject.passwordGenerationOptions(userId: "-1"))

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -38,6 +38,38 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     // MARK: Tests
 
+    /// `accountSetupAutofill(userId:)` returns `nil` if there isn't a previously stored value.
+    func test_accountSetupAutofill_isInitiallyNil() {
+        XCTAssertNil(subject.accountSetupAutofill(userId: "-1"))
+    }
+
+    /// `accountSetupAutofill(userId:)` can be used to get the user's progress for autofill setup.
+    func test_accountSetupAutofill_withValue() {
+        subject.setAccountSetupAutofill(.setUpLater, userId: "1")
+        subject.setAccountSetupAutofill(.complete, userId: "2")
+
+        XCTAssertEqual(subject.accountSetupAutofill(userId: "1"), .setUpLater)
+        XCTAssertEqual(subject.accountSetupAutofill(userId: "2"), .complete)
+        XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:accountSetupAutofill_1"), 1)
+        XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:accountSetupAutofill_2"), 2)
+    }
+
+    /// `accountSetupVaultUnlock(userId:)` returns `nil` if there isn't a previously stored value.
+    func test_accountSetupVaultUnlock_isInitiallyFalse() {
+        XCTAssertNil(subject.accountSetupVaultUnlock(userId: "-1"))
+    }
+
+    /// `accountSetupVaultUnlock(userId:)` can be used to get the user's progress for vault unlock setup.
+    func test_accountSetupVaultUnlock_withValue() {
+        subject.setAccountSetupVaultUnlock(.setUpLater, userId: "1")
+        subject.setAccountSetupVaultUnlock(.complete, userId: "2")
+
+        XCTAssertEqual(subject.accountSetupVaultUnlock(userId: "1"), .setUpLater)
+        XCTAssertEqual(subject.accountSetupVaultUnlock(userId: "2"), .complete)
+        XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:accountSetupVaultUnlock_1"), 1)
+        XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:accountSetupVaultUnlock_2"), 2)
+    }
+
     /// `addSitePromptShown` returns `false` if there isn't a previously stored value.
     func test_addSitePromptShown_isInitiallyFalse() {
         XCTAssertFalse(subject.addSitePromptShown)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -4,6 +4,8 @@ import Foundation
 @testable import BitwardenShared
 
 class MockAppSettingsStore: AppSettingsStore {
+    var accountSetupAutofill = [String: AccountSetupProgress]()
+    var accountSetupVaultUnlock = [String: AccountSetupProgress]()
     var addSitePromptShown = false
     var allowSyncOnRefreshes = [String: Bool]()
     var appId: String?
@@ -53,6 +55,14 @@ class MockAppSettingsStore: AppSettingsStore {
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
     lazy var activeIdSubject = CurrentValueSubject<String?, Never>(self.state?.activeUserId)
+
+    func accountSetupAutofill(userId: String) -> AccountSetupProgress? {
+        accountSetupAutofill[userId]
+    }
+
+    func accountSetupVaultUnlock(userId: String) -> AccountSetupProgress? {
+        accountSetupVaultUnlock[userId]
+    }
 
     func allowSyncOnRefresh(userId: String) -> Bool {
         allowSyncOnRefreshes[userId] ?? false
@@ -124,6 +134,14 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func serverConfig(userId: String) -> ServerConfig? {
         serverConfig[userId]
+    }
+
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String) {
+        accountSetupAutofill[userId] = autofillSetup
+    }
+
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?, userId: String) {
+        accountSetupVaultUnlock[userId] = vaultUnlockSetup
     }
 
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -35,7 +35,6 @@ class MockAppSettingsStore: AppSettingsStore {
     var lastActiveTime = [String: Date]()
     var lastSyncTimeByUserId = [String: Date]()
     var masterPasswordHashes = [String: String]()
-    var needsVaultUnlockSetup = [String: Bool]()
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKey = [String: String]()
@@ -110,10 +109,6 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func masterPasswordHash(userId: String) -> String? {
         masterPasswordHashes[userId]
-    }
-
-    func needsVaultUnlockSetup(userId: String) -> Bool {
-        needsVaultUnlockSetup[userId] ?? false
     }
 
     func notificationsLastRegistrationDate(userId: String) -> Date? {
@@ -202,10 +197,6 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String) {
         notificationsLastRegistrationDates[userId] = date
-    }
-
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String) {
-        self.needsVaultUnlockSetup[userId] = needsVaultUnlockSetup
     }
 
     func setPasswordGenerationOptions(_ options: PasswordGenerationOptions?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -51,7 +51,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lastUserShouldConnectToWatch = false
     var masterPasswordHashes = [String: String]()
-    var needsVaultUnlockSetup = [String: Bool]()
     var notificationsLastRegistrationDates = [String: Date]()
     var notificationsLastRegistrationError: Error?
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
@@ -243,11 +242,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func getMasterPasswordHash(userId: String?) async throws -> String? {
         let userId = try unwrapUserId(userId)
         return masterPasswordHashes[userId]
-    }
-
-    func getNeedsVaultUnlockSetup(userId: String?) async throws -> Bool {
-        let userId = try unwrapUserId(userId)
-        return needsVaultUnlockSetup[userId] ?? false
     }
 
     func getNotificationsLastRegistrationDate(userId: String?) async throws -> Date? {
@@ -455,11 +449,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         masterPasswordHashes[userId] = hash
-    }
-
-    func setNeedsVaultUnlockSetup(_ needsVaultUnlockSetup: Bool, userId: String?) async throws {
-        let userId = try unwrapUserId(userId)
-        self.needsVaultUnlockSetup[userId] = needsVaultUnlockSetup
     }
 
     func setNotificationsLastRegistrationDate(_ date: Date?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -5,6 +5,8 @@ import Foundation
 
 class MockStateService: StateService { // swiftlint:disable:this type_body_length
     var accountEncryptionKeys = [String: AccountEncryptionKeys]()
+    var accountSetupAutofill = [String: AccountSetupProgress]()
+    var accountSetupVaultUnlock = [String: AccountSetupProgress]()
     var accountTokens: Account.AccountTokens?
     var accountVolatileData: [String: AccountVolatileData] = [:]
     var accountsAdded = [Account]()
@@ -142,6 +144,16 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
             throw StateServiceError.noAccounts
         }
         return accounts
+    }
+
+    func getAccountSetupAutofill(userId: String?) async throws -> AccountSetupProgress? {
+        let userId = try unwrapUserId(userId)
+        return accountSetupAutofill[userId]
+    }
+
+    func getAccountSetupVaultUnlock(userId: String?) async throws -> AccountSetupProgress? {
+        let userId = try unwrapUserId(userId)
+        return accountSetupVaultUnlock[userId]
     }
 
     func getAccountIdOrActiveId(userId: String?) async throws -> String {
@@ -335,6 +347,16 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func setAccountHasBeenUnlockedInteractively(userId: String?, value: Bool) async throws {
         setAccountHasBeenUnlockedInteractivelyHasBeenCalled = true
         try setAccountHasBeenUnlockedInteractivelyResult.get()
+    }
+
+    func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        accountSetupAutofill[userId] = autofillSetup
+    }
+
+    func setAccountSetupVaultUnlock(_ vaultUnlockSetup: AccountSetupProgress?, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        accountSetupVaultUnlock[userId] = vaultUnlockSetup
     }
 
     func setActiveAccount(userId: String) async throws {

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -179,8 +179,8 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             showLanding()
         case let .landingSoftLoggedOut(email):
             showLanding(email: email)
-        case let .login(username):
-            showLogin(username)
+        case let .login(username, isNewAccount):
+            showLogin(username, isNewAccount: isNewAccount)
         case let .showLoginDecryptionOptions(organizationIdentifier):
             showLoginDecryptionOptions(organizationIdentifier)
         case let .loginWithDevice(email, type, isAuthenticated):
@@ -469,9 +469,11 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     /// Shows the login screen. If the create account flow is being presented it will be dismissed
     /// and the login screen will be pushed
     ///
-    /// - Parameter username: The user's username.
+    /// - Parameters:
+    ///   - username: The user's username.
+    ///   - isNewAccount: Whether the user is logging into a newly created account.
     ///
-    private func showLogin(_ username: String) {
+    private func showLogin(_ username: String, isNewAccount: Bool) {
         guard let stackNavigator else { return }
         let isPresenting = stackNavigator.rootViewController?.presentedViewController != nil
 
@@ -480,6 +482,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         )
 
         let state = LoginState(
+            isNewAccount: isNewAccount,
             serverURLString: environmentUrls.webVaultURL.host ?? "",
             username: username
         )

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -823,7 +823,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             vaultUnlockSetupHelper: DefaultVaultUnlockSetupHelper(services: services)
         )
         let view = VaultUnlockSetupView(store: Store(processor: processor))
-        stackNavigator?.push(view)
+        stackNavigator?.replace(view)
     }
 
     /// Show the WebAuthn two factor authentication view.

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -527,7 +527,7 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_vaultUnlockSetup() throws {
         subject.navigate(to: .vaultUnlockSetup)
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .pushed)
+        XCTAssertEqual(stackNavigator.actions.last?.type, .replaced)
         XCTAssertTrue(stackNavigator.actions.last?.view is VaultUnlockSetupView)
     }
 

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -301,6 +301,25 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(state.serverURLString, "vault.bitwarden.eu")
     }
 
+    /// `navigate(to:)` with `.login` pushes the login view onto the stack navigator and hides the back button.
+    @MainActor
+    func test_navigate_login_newAccount() throws {
+        appSettingsStore.preAuthEnvironmentUrls = EnvironmentUrlData.defaultEU
+        subject.navigate(to: .login(username: "username", isNewAccount: true))
+
+        XCTAssertEqual(stackNavigator.actions.last?.type, .pushed)
+        let viewController = try XCTUnwrap(
+            stackNavigator.actions.last?.view as? UIHostingController<LoginView>
+        )
+        XCTAssertTrue(viewController.navigationItem.hidesBackButton)
+
+        let view = viewController.rootView
+        let state = view.store.state
+        XCTAssertTrue(state.isNewAccount)
+        XCTAssertEqual(state.username, "username")
+        XCTAssertEqual(state.serverURLString, "vault.bitwarden.eu")
+    }
+
     /// `navigate(to:)` with `.login`, when using a self-hosted environment,
     /// pushes the login view onto the stack navigator and hides the back button.
     /// It also initializes `LoginState` with the self-hosted URL host.

--- a/BitwardenShared/UI/Auth/AuthRoute.swift
+++ b/BitwardenShared/UI/Auth/AuthRoute.swift
@@ -80,9 +80,11 @@ public enum AuthRoute: Equatable {
 
     /// A route to the login screen.
     ///
-    /// - Parameter username: The username to display on the login screen.
+    /// - Parameters:
+    ///   - username: The username to display on the login screen.
+    ///   - isNewAccount: Whether the user is logging into a newly created account.
     ///
-    case login(username: String)
+    case login(username: String, isNewAccount: Bool = false)
 
     /// A route to the login decryption options screen.
     ///

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -220,11 +220,12 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.autofillSetup` if the user still
     /// needs to set up autofill.
     func test_handleAndRoute_didCompleteAuth_incompleteAutofill() async {
-        authRepository.activeAccount = .fixture()
-        stateService.activeAccount = .fixture()
-        stateService.accountSetupAutofill["1"] = .incomplete
-        let route = await subject.handleAndRoute(.didCompleteAuth)
-        XCTAssertEqual(route, .autofillSetup)
+        // TODO: PM-10278 Add autofill setup screen
+//        authRepository.activeAccount = .fixture()
+//        stateService.activeAccount = .fixture()
+//        stateService.accountSetupAutofill["1"] = .incomplete
+//        let route = await subject.handleAndRoute(.didCompleteAuth)
+//        XCTAssertEqual(route, .autofillSetup)
     }
 
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.vaultUnlockSetup` if the user still

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -217,6 +217,26 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(route, .complete)
     }
 
+    /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.autofillSetup` if the user still
+    /// needs to set up autofill.
+    func test_handleAndRoute_didCompleteAuth_incompleteAutofill() async {
+        authRepository.activeAccount = .fixture()
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupAutofill["1"] = .incomplete
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+        XCTAssertEqual(route, .autofillSetup)
+    }
+
+    /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.vaultUnlockSetup` if the user still
+    /// needs to set up a vault unlock method.
+    func test_handleAndRoute_didCompleteAuth_incompleteVaultSetup() async {
+        authRepository.activeAccount = .fixture()
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupVaultUnlock["1"] = .incomplete
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+        XCTAssertEqual(route, .vaultUnlockSetup)
+    }
+
     /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.landing` when there are no accounts.
     func test_handleAndRoute_didCompleteAuth_noAccounts() async {
         let route = await subject.handleAndRoute(.didCompleteAuth)

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -219,7 +219,8 @@ class CompleteRegistrationProcessor: StateProcessor<
             try await services.authService.loginWithMasterPassword(
                 state.passwordText,
                 username: state.userEmail,
-                captchaToken: captchaToken
+                captchaToken: captchaToken,
+                isNewAccount: true
             )
 
             try await services.authRepository.unlockVaultWithPassword(password: state.passwordText)
@@ -232,7 +233,7 @@ class CompleteRegistrationProcessor: StateProcessor<
                 // If an error occurs after the account was created, dismiss the view and navigate
                 // the user to the login screen to complete login.
                 coordinator.navigate(to: .dismissWithAction(DismissAction {
-                    self.coordinator.navigate(to: .login(username: self.state.userEmail))
+                    self.coordinator.navigate(to: .login(username: self.state.userEmail, isNewAccount: true))
                     self.coordinator.showToast(Localizations.accountSuccessfullyCreated)
                 }))
                 return

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -226,6 +226,7 @@ class CompleteRegistrationProcessor: StateProcessor<
             try await services.authRepository.unlockVaultWithPassword(password: state.passwordText)
 
             await coordinator.handleEvent(.didCompleteAuth)
+            coordinator.navigate(to: .dismiss)
         } catch let error as CompleteRegistrationError {
             showCompleteRegistrationErrorAlert(error)
         } catch {

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -510,7 +510,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         }
         dismissAction?.action()
         XCTAssertEqual(coordinator.routes.count, 2)
-        XCTAssertEqual(coordinator.routes[1], .login(username: "email@example.com"))
+        XCTAssertEqual(coordinator.routes[1], .login(username: "email@example.com", isNewAccount: true))
         XCTAssertEqual(coordinator.toastsShown, [Localizations.accountSuccessfullyCreated])
     }
 
@@ -541,7 +541,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         }
         dismissAction?.action()
         XCTAssertEqual(coordinator.routes.count, 2)
-        XCTAssertEqual(coordinator.routes[1], .login(username: "email@example.com"))
+        XCTAssertEqual(coordinator.routes[1], .login(username: "email@example.com", isNewAccount: true))
         XCTAssertEqual(coordinator.toastsShown, [Localizations.accountSuccessfullyCreated])
     }
 
@@ -631,6 +631,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         XCTAssertEqual(authService.loginWithMasterPasswordPassword, "password1234")
         XCTAssertNil(authService.loginWithMasterPasswordCaptchaToken)
         XCTAssertEqual(authService.loginWithMasterPasswordUsername, "email@example.com")
+        XCTAssertTrue(authService.loginWithMasterPasswordIsNewAccount)
 
         XCTAssertEqual(client.requests.count, 2)
         XCTAssertEqual(client.requests[0].url, URL(string: "https://example.com/identity/accounts/register/finish"))

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -34,8 +34,9 @@ extension AuthRouter {
             return .updateMasterPassword
         } else if await (try? services.stateService.getAccountSetupVaultUnlock()) == .incomplete {
             return .vaultUnlockSetup
-        } else if await (try? services.stateService.getAccountSetupAutofill()) == .incomplete {
-            return .autofillSetup
+            // TODO: PM-10278 Add autofill setup screen
+//        } else if await (try? services.stateService.getAccountSetupAutofill()) == .incomplete {
+//            return .autofillSetup
         } else {
             await setCarouselShownIfEnabled()
             return .complete

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -1,5 +1,7 @@
 // MARK: AuthRouterRedirects
 
+// swiftlint:disable file_length
+
 extension AuthRouter {
     /// Configures the app with an active account.
     ///
@@ -30,6 +32,10 @@ extension AuthRouter {
         }
         if account.profile.forcePasswordResetReason != nil {
             return .updateMasterPassword
+        } else if await (try? services.stateService.getAccountSetupVaultUnlock()) == .incomplete {
+            return .vaultUnlockSetup
+        } else if await (try? services.stateService.getAccountSetupAutofill()) == .incomplete {
+            return .autofillSetup
         } else {
             await setCarouselShownIfEnabled()
             return .complete

--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -140,7 +140,8 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
             try await services.authService.loginWithMasterPassword(
                 state.masterPassword,
                 username: state.username,
-                captchaToken: captchaToken
+                captchaToken: captchaToken,
+                isNewAccount: state.isNewAccount
             )
 
             // Unlock the vault.

--- a/BitwardenShared/UI/Auth/Login/LoginState.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginState.swift
@@ -14,6 +14,9 @@ struct LoginState: Equatable {
     /// A flag indicating if the login with device button should be displayed or not.
     var isLoginWithDeviceVisible: Bool = false
 
+    /// Whether the user is logging into a newly created account.
+    var isNewAccount = false
+
     /// The password visibility icon used in the view's text field.
     var passwordVisibleIcon: ImageAsset {
         isMasterPasswordRevealed ? Asset.Images.hidden : Asset.Images.visible

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessor.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessor.swift
@@ -71,7 +71,7 @@ class VaultUnlockSetupProcessor: StateProcessor<VaultUnlockSetupState, VaultUnlo
     ///
     private func continueFlow() async {
         do {
-            try await services.stateService.setNeedsVaultUnlockSetup(false)
+            try await services.stateService.setAccountSetupVaultUnlock(.complete)
         } catch {
             services.errorReporter.log(error: error)
         }
@@ -94,6 +94,11 @@ class VaultUnlockSetupProcessor: StateProcessor<VaultUnlockSetupState, VaultUnlo
     ///
     private func showSetUpLaterAlert() {
         coordinator.showAlert(.setUpUnlockMethodLater {
+            do {
+                try await self.services.stateService.setAccountSetupVaultUnlock(.setUpLater)
+            } catch {
+                self.services.errorReporter.log(error: error)
+            }
             self.coordinator.navigate(to: .autofillSetup)
         })
     }

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessor.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessor.swift
@@ -75,7 +75,7 @@ class VaultUnlockSetupProcessor: StateProcessor<VaultUnlockSetupState, VaultUnlo
         } catch {
             services.errorReporter.log(error: error)
         }
-        coordinator.navigate(to: .autofillSetup)
+        await coordinator.handleEvent(.didCompleteAuth)
     }
 
     /// Load any initial data for the view.
@@ -99,7 +99,7 @@ class VaultUnlockSetupProcessor: StateProcessor<VaultUnlockSetupState, VaultUnlo
             } catch {
                 self.services.errorReporter.log(error: error)
             }
-            self.coordinator.navigate(to: .autofillSetup)
+            await self.coordinator.handleEvent(.didCompleteAuth)
         })
     }
 

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessorTests.swift
@@ -55,7 +55,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
 
         await subject.perform(.continueFlow)
 
-        XCTAssertEqual(coordinator.routes, [.autofillSetup])
+        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
         XCTAssertEqual(stateService.accountSetupVaultUnlock["1"], .complete)
     }
 
@@ -65,7 +65,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
     func test_perform_continueFlow_error() async {
         await subject.perform(.continueFlow)
 
-        XCTAssertEqual(coordinator.routes, [.autofillSetup])
+        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 
@@ -186,7 +186,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
         XCTAssertTrue(coordinator.routes.isEmpty)
 
         try await alert.tapAction(title: Localizations.confirm)
-        XCTAssertEqual(coordinator.routes, [.autofillSetup])
+        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
 
         XCTAssertEqual(stateService.accountSetupVaultUnlock["1"], .setUpLater)
     }
@@ -200,7 +200,7 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
         XCTAssertEqual(alert, .setUpUnlockMethodLater {})
 
         try await alert.tapAction(title: Localizations.confirm)
-        XCTAssertEqual(coordinator.routes, [.autofillSetup])
+        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
 
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupProcessorTests.swift
@@ -52,7 +52,6 @@ class VaultUnlockSetupProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_continueFlow() async {
         stateService.activeAccount = .fixture()
-        stateService.needsVaultUnlockSetup["1"] = true
 
         await subject.perform(.continueFlow)
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10524](https://bitwarden.atlassian.net/browse/PM-10524)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds support for persisting the user's progress for setting up unlock methods and enabling autofill during the create account flow. This is used to bring them back to these screens after vault unlock if the app is restarted and if they choose to set up either of these things later.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10524]: https://bitwarden.atlassian.net/browse/PM-10524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ