### PR TITLE
[PM-12012] Save region during account creation

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/APITestData+Auth.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/APITestData+Auth.swift
@@ -4,6 +4,7 @@ extension APITestData {
     static let authRequestSuccess = loadFromJsonBundle(resource: "AuthRequest")
     static let authRequestsSuccess = loadFromJsonBundle(resource: "AuthRequests")
     static let emptyResponse = APITestData(data: "{}".data(using: .utf8)!)
+    static let nilResponse = APITestData(data: "".data(using: .utf8)!)
     static let identityTokenSuccess = loadFromJsonBundle(resource: "IdentityTokenSuccess")
     static let identityTokenWithMasterPasswordPolicy = loadFromJsonBundle(
         resource: "IdentityTokenWithMasterPasswordPolicy"

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -224,6 +224,13 @@ protocol StateService: AnyObject {
     ///
     func getPreAuthEnvironmentUrls() async -> EnvironmentUrlData?
 
+    /// Gets the environment URLs for a given email during account creation.
+    ///
+    /// - Parameter email: The email used to start the account creation.
+    /// - Returns: The environment URLs used prior to start the account creation.
+    ///
+    func getPreAuthEnvironmentUrlsByEmail(email: String) async -> EnvironmentUrlData?
+
     /// Gets the server config used by the app prior to the user authenticating.
     /// - Returns: The server config used prior to user authentication.
     func getPreAuthServerConfig() async -> ServerConfig?
@@ -504,6 +511,13 @@ protocol StateService: AnyObject {
     /// - Parameter urls: The environment URLs used prior to user authentication.
     ///
     func setPreAuthEnvironmentUrls(_ urls: EnvironmentUrlData) async
+
+    /// Sets the environment URLs for a given email during account creation.
+    /// - Parameters:
+    ///   - urls: The environment urls used to start the account creation.
+    ///   - email: The email used to start the account creation.
+    ///
+    func setPreAuthEnvironmentUrlsByEmail(urls: EnvironmentUrlData, email: String) async
 
     /// Sets the server config used prior to user authentication
     /// - Parameter config: The server config to use prior to user authentication.
@@ -1254,6 +1268,10 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appSettingsStore.preAuthEnvironmentUrls
     }
 
+    func getPreAuthEnvironmentUrlsByEmail(email: String) async -> EnvironmentUrlData? {
+        appSettingsStore.preAuthEnvironmentUrlsByEmail(email: email)
+    }
+
     func getPreAuthServerConfig() async -> ServerConfig? {
         appSettingsStore.preAuthServerConfig
     }
@@ -1493,6 +1511,13 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
 
     func setPreAuthEnvironmentUrls(_ urls: EnvironmentUrlData) async {
         appSettingsStore.preAuthEnvironmentUrls = urls
+    }
+
+    func setPreAuthEnvironmentUrlsByEmail(urls: EnvironmentUrlData, email: String) async {
+        appSettingsStore.setPreAuthEnvironmentUrlsByEmail(
+            environmentUrlData: urls,
+            email: email
+        )
     }
 
     func setPreAuthServerConfig(config: ServerConfig) async {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -236,7 +236,7 @@ protocol StateService: AnyObject {
     /// - Parameter email: The email used to start the account creation.
     /// - Returns: The environment URLs used prior to start the account creation.
     ///
-    func getPreAuthEnvironmentUrlsByEmail(email: String) async -> EnvironmentUrlData?
+    func getAccountCreationEnvironmentUrls(email: String) async -> EnvironmentUrlData?
 
     /// Gets the server config used by the app prior to the user authenticating.
     /// - Returns: The server config used prior to user authentication.
@@ -532,7 +532,7 @@ protocol StateService: AnyObject {
     ///   - urls: The environment urls used to start the account creation.
     ///   - email: The email used to start the account creation.
     ///
-    func setPreAuthEnvironmentUrlsByEmail(urls: EnvironmentUrlData, email: String) async
+    func setAccountCreationEnvironmentUrls(urls: EnvironmentUrlData, email: String) async
 
     /// Sets the server config used prior to user authentication
     /// - Parameter config: The server config to use prior to user authentication.
@@ -1304,8 +1304,8 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appSettingsStore.preAuthEnvironmentUrls
     }
 
-    func getPreAuthEnvironmentUrlsByEmail(email: String) async -> EnvironmentUrlData? {
-        appSettingsStore.preAuthEnvironmentUrlsByEmail(email: email)
+    func getAccountCreationEnvironmentUrls(email: String) async -> EnvironmentUrlData? {
+        appSettingsStore.accountCreationEnvironmentUrls(email: email)
     }
 
     func getPreAuthServerConfig() async -> ServerConfig? {
@@ -1554,8 +1554,8 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appSettingsStore.preAuthEnvironmentUrls = urls
     }
 
-    func setPreAuthEnvironmentUrlsByEmail(urls: EnvironmentUrlData, email: String) async {
-        appSettingsStore.setPreAuthEnvironmentUrlsByEmail(
+    func setAccountCreationEnvironmentUrls(urls: EnvironmentUrlData, email: String) async {
+        appSettingsStore.setAccountCreationEnvironmentUrls(
             environmentUrlData: urls,
             email: email
         )

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -688,6 +688,21 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertNil(urls)
     }
 
+    /// `getPreAuthEnvironmentUrlsByEmail` returns the saved pre-auth URLs.
+    func test_getPreAuthEnvironmentUrlsByEmail() async {
+        let email = "example@email.com"
+        let urls = EnvironmentUrlData(base: .example)
+        appSettingsStore.setPreAuthEnvironmentUrlsByEmail(environmentUrlData: urls, email: email)
+        let preAuthUrls = await subject.getPreAuthEnvironmentUrlsByEmail(email: email)
+        XCTAssertEqual(preAuthUrls, urls)
+    }
+
+    /// `getPreAuthEnvironmentUrlsByEmail` returns `nil` if the URLs haven't been set.
+    func test_getPreAuthEnvironmentUrlsByEmail_notSet() async {
+        let urls = await subject.getPreAuthEnvironmentUrlsByEmail(email: "example@email.com")
+        XCTAssertNil(urls)
+    }
+
     /// `getPreAuthServerConfig` returns the saved pre-auth server config.
     func test_getPreAuthServerConfig() async {
         let config = ServerConfig(
@@ -1574,6 +1589,14 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let urls = EnvironmentUrlData(base: .example)
         await subject.setPreAuthEnvironmentUrls(urls)
         XCTAssertEqual(appSettingsStore.preAuthEnvironmentUrls, urls)
+    }
+
+    /// `setPreAuthEnvironmentUrls` saves the pre-auth URLs for email.
+    func test_setPreAuthEnvironmentUrlsByEmail() async {
+        let email = "example@email.com"
+        let urls = EnvironmentUrlData(base: .example)
+        await subject.setPreAuthEnvironmentUrlsByEmail(urls: urls, email: email)
+        XCTAssertEqual(appSettingsStore.preAuthEnvironmentUrlsByEmail(email: email), urls)
     }
 
     /// `setPreAuthServerConfig(config:)` saves the pre-auth server config.

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -707,7 +707,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertNil(urls)
     }
 
-    /// `getPreAuthEnvironmentUrlsByEmail` returns the saved pre-auth URLs.
+    /// `getPreAuthEnvironmentUrlsByEmail` returns the saved pre-auth URLs for a given email.
     func test_getPreAuthEnvironmentUrlsByEmail() async {
         let email = "example@email.com"
         let urls = EnvironmentUrlData(base: .example)
@@ -716,7 +716,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(preAuthUrls, urls)
     }
 
-    /// `getPreAuthEnvironmentUrlsByEmail` returns `nil` if the URLs haven't been set.
+    /// `getPreAuthEnvironmentUrlsByEmail` returns `nil` if the URLs haven't been set for a given email.
     func test_getPreAuthEnvironmentUrlsByEmail_notSet() async {
         let urls = await subject.getPreAuthEnvironmentUrlsByEmail(email: "example@email.com")
         XCTAssertNil(urls)
@@ -1621,7 +1621,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.preAuthEnvironmentUrls, urls)
     }
 
-    /// `setPreAuthEnvironmentUrls` saves the pre-auth URLs for email.
+    /// `test_setPreAuthEnvironmentUrlsByEmail` saves the pre-auth URLs for email for a given email.
     func test_setPreAuthEnvironmentUrlsByEmail() async {
         let email = "example@email.com"
         let urls = EnvironmentUrlData(base: .example)

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -707,18 +707,18 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertNil(urls)
     }
 
-    /// `getPreAuthEnvironmentUrlsByEmail` returns the saved pre-auth URLs for a given email.
-    func test_getPreAuthEnvironmentUrlsByEmail() async {
+    /// `getAccountCreationEnvironmentUrls` returns the saved pre-auth URLs for a given email.
+    func test_getAccountCreationEnvironmentUrls() async {
         let email = "example@email.com"
         let urls = EnvironmentUrlData(base: .example)
-        appSettingsStore.setPreAuthEnvironmentUrlsByEmail(environmentUrlData: urls, email: email)
-        let preAuthUrls = await subject.getPreAuthEnvironmentUrlsByEmail(email: email)
+        appSettingsStore.setAccountCreationEnvironmentUrls(environmentUrlData: urls, email: email)
+        let preAuthUrls = await subject.getAccountCreationEnvironmentUrls(email: email)
         XCTAssertEqual(preAuthUrls, urls)
     }
 
-    /// `getPreAuthEnvironmentUrlsByEmail` returns `nil` if the URLs haven't been set for a given email.
-    func test_getPreAuthEnvironmentUrlsByEmail_notSet() async {
-        let urls = await subject.getPreAuthEnvironmentUrlsByEmail(email: "example@email.com")
+    /// `getAccountCreationEnvironmentUrls` returns `nil` if the URLs haven't been set for a given email.
+    func test_getAccountCreationEnvironmentUrls_notSet() async {
+        let urls = await subject.getAccountCreationEnvironmentUrls(email: "example@email.com")
         XCTAssertNil(urls)
     }
 
@@ -1621,12 +1621,12 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(appSettingsStore.preAuthEnvironmentUrls, urls)
     }
 
-    /// `test_setPreAuthEnvironmentUrlsByEmail` saves the pre-auth URLs for email for a given email.
-    func test_setPreAuthEnvironmentUrlsByEmail() async {
+    /// `test_setAccountCreationEnvironmentUrls` saves the pre-auth URLs for email for a given email.
+    func test_setAccountCreationEnvironmentUrls() async {
         let email = "example@email.com"
         let urls = EnvironmentUrlData(base: .example)
-        await subject.setPreAuthEnvironmentUrlsByEmail(urls: urls, email: email)
-        XCTAssertEqual(appSettingsStore.preAuthEnvironmentUrlsByEmail(email: email), urls)
+        await subject.setAccountCreationEnvironmentUrls(urls: urls, email: email)
+        XCTAssertEqual(appSettingsStore.accountCreationEnvironmentUrls(email: email), urls)
     }
 
     /// `setPreAuthServerConfig(config:)` saves the pre-auth server config.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -193,7 +193,8 @@ protocol AppSettingsStore: AnyObject {
     /// Gets the environment URLs used to start the account creation flow.
     ///
     /// - Parameters:
-    ///  - email: The user's email address.
+    ///  - email: The email used to start the account creation.
+    /// - Returns: The environment URLs used prior to start the account creation.
     ///
     func preAuthEnvironmentUrlsByEmail(email: String) -> EnvironmentUrlData?
 

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -196,7 +196,7 @@ protocol AppSettingsStore: AnyObject {
     ///  - email: The email used to start the account creation.
     /// - Returns: The environment URLs used prior to start the account creation.
     ///
-    func preAuthEnvironmentUrlsByEmail(email: String) -> EnvironmentUrlData?
+    func accountCreationEnvironmentUrls(email: String) -> EnvironmentUrlData?
 
     /// The server configuration.
     ///
@@ -358,7 +358,7 @@ protocol AppSettingsStore: AnyObject {
     ///  - email: The user's email address.
     ///  - environmentUrlData: The environment data to be saved.
     ///
-    func setPreAuthEnvironmentUrlsByEmail(environmentUrlData: EnvironmentUrlData, email: String)
+    func setAccountCreationEnvironmentUrls(environmentUrlData: EnvironmentUrlData, email: String)
 
     /// Sets the server config.
     ///
@@ -623,7 +623,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case passwordGenerationOptions(userId: String)
         case pinProtectedUserKey(userId: String)
         case preAuthEnvironmentUrls
-        case preAuthEnvironmentUrlsByEmail(email: String)
+        case accountCreationEnvironmentUrls(email: String)
         case preAuthServerConfig
         case rememberedEmail
         case rememberedOrgIdentifier
@@ -699,8 +699,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "pinKeyEncryptedUserKey_\(userId)"
             case .preAuthEnvironmentUrls:
                 key = "preAuthEnvironmentUrls"
-            case let .preAuthEnvironmentUrlsByEmail(email):
-                key = "preAuthEnvironmentUrlsByEmail_\(email)"
+            case let .accountCreationEnvironmentUrls(email):
+                key = "accountCreationEnvironmentUrls_\(email)"
             case .preAuthServerConfig:
                 key = "preAuthServerConfig"
             case .rememberedEmail:
@@ -889,9 +889,9 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .pinProtectedUserKey(userId: userId))
     }
 
-    func preAuthEnvironmentUrlsByEmail(email: String) -> EnvironmentUrlData? {
+    func accountCreationEnvironmentUrls(email: String) -> EnvironmentUrlData? {
         fetch(
-            for: .preAuthEnvironmentUrlsByEmail(email: email)
+            for: .accountCreationEnvironmentUrls(email: email)
         )
     }
 
@@ -977,8 +977,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         store(key, for: .pinProtectedUserKey(userId: userId))
     }
 
-    func setPreAuthEnvironmentUrlsByEmail(environmentUrlData: EnvironmentUrlData, email: String) {
-        store(environmentUrlData, for: .preAuthEnvironmentUrlsByEmail(email: email))
+    func setAccountCreationEnvironmentUrls(environmentUrlData: EnvironmentUrlData, email: String) {
+        store(environmentUrlData, for: .accountCreationEnvironmentUrls(email: email))
     }
 
     func setServerConfig(_ config: ServerConfig?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -183,6 +183,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func pinProtectedUserKey(userId: String) -> String?
 
+    /// Gets the environment URLs used to start the account creation flow.
+    ///
+    /// - Parameters:
+    ///  - email: The user's email address.
+    ///
+    func preAuthEnvironmentUrlsByEmail(email: String) -> EnvironmentUrlData?
+
     /// The server configuration.
     ///
     /// - Parameter userId: The user ID associated with the server config.
@@ -328,6 +335,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID.
     ///
     func setPinProtectedUserKey(key: String?, userId: String)
+
+    /// Sets the environment URLs used to start the account creation flow.
+    ///
+    /// - Parameters:
+    ///  - email: The user's email address.
+    ///  - environmentUrlData: The environment data to be saved.
+    ///
+    func setPreAuthEnvironmentUrlsByEmail(environmentUrlData: EnvironmentUrlData, email: String)
 
     /// Sets the server config.
     ///
@@ -591,6 +606,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case passwordGenerationOptions(userId: String)
         case pinProtectedUserKey(userId: String)
         case preAuthEnvironmentUrls
+        case preAuthEnvironmentUrlsByEmail(email: String)
         case preAuthServerConfig
         case rememberedEmail
         case rememberedOrgIdentifier
@@ -664,6 +680,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "pinKeyEncryptedUserKey_\(userId)"
             case .preAuthEnvironmentUrls:
                 key = "preAuthEnvironmentUrls"
+            case let .preAuthEnvironmentUrlsByEmail(email):
+                key = "preAuthEnvironmentUrlsByEmail_\(email)"
             case .preAuthServerConfig:
                 key = "preAuthServerConfig"
             case .rememberedEmail:
@@ -848,6 +866,12 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .pinProtectedUserKey(userId: userId))
     }
 
+    func preAuthEnvironmentUrlsByEmail(email: String) -> EnvironmentUrlData? {
+        fetch(
+            for: .preAuthEnvironmentUrlsByEmail(email: email)
+        )
+    }
+
     func serverConfig(userId: String) -> ServerConfig? {
         fetch(for: .serverConfig(userId: userId))
     }
@@ -924,6 +948,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setPinProtectedUserKey(key: String?, userId: String) {
         store(key, for: .pinProtectedUserKey(userId: userId))
+    }
+
+    func setPreAuthEnvironmentUrlsByEmail(environmentUrlData: EnvironmentUrlData, email: String) {
+        store(environmentUrlData, for: .preAuthEnvironmentUrlsByEmail(email: email))
     }
 
     func setServerConfig(_ config: ServerConfig?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -599,6 +599,43 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
+    /// `preAuthEnvironmentUrlsByEmail` returns `nil` if there isn't a previously stored value.
+    func test_preAuthEnvironmentUrlsByEmail_isInitiallyNil() {
+        XCTAssertNil(subject.preAuthEnvironmentUrlsByEmail(email: "example@email.com"))
+    }
+
+    /// `preAuthEnvironmentUrlsByEmail` can be used to get and set the persisted value in user defaults.
+    func test_preAuthEnvironmentUrlsByEmail_withValue() {
+        let email = "example@email.com"
+        subject.setPreAuthEnvironmentUrlsByEmail(environmentUrlData: .defaultUS, email: email)
+        XCTAssertEqual(subject.preAuthEnvironmentUrlsByEmail(email: email), .defaultUS)
+        try XCTAssertEqual(
+            JSONDecoder().decode(
+                EnvironmentUrlData.self,
+                from: XCTUnwrap(
+                    userDefaults
+                        .string(forKey: "bwPreferencesStorage:preAuthEnvironmentUrlsByEmail_\(email)")?
+                        .data(using: .utf8)
+                )
+            ),
+            .defaultUS
+        )
+
+        subject.setPreAuthEnvironmentUrlsByEmail(environmentUrlData: .defaultEU, email: email)
+        XCTAssertEqual(subject.preAuthEnvironmentUrlsByEmail(email: email), .defaultEU)
+        try XCTAssertEqual(
+            JSONDecoder().decode(
+                EnvironmentUrlData.self,
+                from: XCTUnwrap(
+                    userDefaults
+                        .string(forKey: "bwPreferencesStorage:preAuthEnvironmentUrlsByEmail_\(email)")?
+                        .data(using: .utf8)
+                )
+            ),
+            .defaultEU
+        )
+    }
+
     /// `preAuthServerConfig` is initially `nil`
     func test_preAuthServerConfig_isInitiallyNil() {
         XCTAssertNil(subject.preAuthServerConfig)

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -616,36 +616,36 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
-    /// `preAuthEnvironmentUrlsByEmail` returns `nil` if there isn't a previously stored value.
-    func test_preAuthEnvironmentUrlsByEmail_isInitiallyNil() {
-        XCTAssertNil(subject.preAuthEnvironmentUrlsByEmail(email: "example@email.com"))
+    /// `accountCreationEnvironmentUrls` returns `nil` if there isn't a previously stored value.
+    func test_accountCreationEnvironmentUrls_isInitiallyNil() {
+        XCTAssertNil(subject.accountCreationEnvironmentUrls(email: "example@email.com"))
     }
 
-    /// `preAuthEnvironmentUrlsByEmail` can be used to get and set the persisted value in user defaults.
-    func test_preAuthEnvironmentUrlsByEmail_withValue() {
+    /// `accountCreationEnvironmentUrls` can be used to get and set the persisted value in user defaults.
+    func test_accountCreationEnvironmentUrls_withValue() {
         let email = "example@email.com"
-        subject.setPreAuthEnvironmentUrlsByEmail(environmentUrlData: .defaultUS, email: email)
-        XCTAssertEqual(subject.preAuthEnvironmentUrlsByEmail(email: email), .defaultUS)
+        subject.setAccountCreationEnvironmentUrls(environmentUrlData: .defaultUS, email: email)
+        XCTAssertEqual(subject.accountCreationEnvironmentUrls(email: email), .defaultUS)
         try XCTAssertEqual(
             JSONDecoder().decode(
                 EnvironmentUrlData.self,
                 from: XCTUnwrap(
                     userDefaults
-                        .string(forKey: "bwPreferencesStorage:preAuthEnvironmentUrlsByEmail_\(email)")?
+                        .string(forKey: "bwPreferencesStorage:accountCreationEnvironmentUrls_\(email)")?
                         .data(using: .utf8)
                 )
             ),
             .defaultUS
         )
 
-        subject.setPreAuthEnvironmentUrlsByEmail(environmentUrlData: .defaultEU, email: email)
-        XCTAssertEqual(subject.preAuthEnvironmentUrlsByEmail(email: email), .defaultEU)
+        subject.setAccountCreationEnvironmentUrls(environmentUrlData: .defaultEU, email: email)
+        XCTAssertEqual(subject.accountCreationEnvironmentUrls(email: email), .defaultEU)
         try XCTAssertEqual(
             JSONDecoder().decode(
                 EnvironmentUrlData.self,
                 from: XCTUnwrap(
                     userDefaults
-                        .string(forKey: "bwPreferencesStorage:preAuthEnvironmentUrlsByEmail_\(email)")?
+                        .string(forKey: "bwPreferencesStorage:accountCreationEnvironmentUrls_\(email)")?
                         .data(using: .utf8)
                 )
             ),

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -36,6 +36,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKey = [String: String]()
+    var preAuthEnvironmentUrlsByEmail = [String: EnvironmentUrlData]()
     var serverConfig = [String: ServerConfig]()
     var shouldTrustDevice = [String: Bool?]()
     var timeoutAction = [String: Int]()
@@ -111,6 +112,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func pinProtectedUserKey(userId: String) -> String? {
         pinProtectedUserKey[userId]
+    }
+
+    func preAuthEnvironmentUrlsByEmail(email: String) -> BitwardenShared.EnvironmentUrlData? {
+        preAuthEnvironmentUrlsByEmail[email]
     }
 
     func twoFactorToken(email: String) -> String? {
@@ -191,6 +196,10 @@ class MockAppSettingsStore: AppSettingsStore {
 
     func setPinProtectedUserKey(key: String?, userId: String) {
         pinProtectedUserKey[userId] = key
+    }
+
+    func setPreAuthEnvironmentUrlsByEmail(environmentUrlData: BitwardenShared.EnvironmentUrlData, email: String) {
+        preAuthEnvironmentUrlsByEmail[email] = environmentUrlData
     }
 
     func setServerConfig(_ config: ServerConfig?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -37,7 +37,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKey = [String: String]()
-    var preAuthEnvironmentUrlsByEmail = [String: EnvironmentUrlData]()
+    var accountCreationEnvironmentUrls = [String: EnvironmentUrlData]()
     var serverConfig = [String: ServerConfig]()
     var shouldTrustDevice = [String: Bool?]()
     var timeoutAction = [String: Int]()
@@ -119,8 +119,8 @@ class MockAppSettingsStore: AppSettingsStore {
         pinProtectedUserKey[userId]
     }
 
-    func preAuthEnvironmentUrlsByEmail(email: String) -> BitwardenShared.EnvironmentUrlData? {
-        preAuthEnvironmentUrlsByEmail[email]
+    func accountCreationEnvironmentUrls(email: String) -> BitwardenShared.EnvironmentUrlData? {
+        accountCreationEnvironmentUrls[email]
     }
 
     func twoFactorToken(email: String) -> String? {
@@ -207,8 +207,8 @@ class MockAppSettingsStore: AppSettingsStore {
         pinProtectedUserKey[userId] = key
     }
 
-    func setPreAuthEnvironmentUrlsByEmail(environmentUrlData: BitwardenShared.EnvironmentUrlData, email: String) {
-        preAuthEnvironmentUrlsByEmail[email] = environmentUrlData
+    func setAccountCreationEnvironmentUrls(environmentUrlData: BitwardenShared.EnvironmentUrlData, email: String) {
+        accountCreationEnvironmentUrls[email] = environmentUrlData
     }
 
     func setServerConfig(_ config: ServerConfig?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -55,7 +55,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKeyValue = [String: String]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
-    var preAuthEnvironmentUrlsByEmail = [String: EnvironmentUrlData]()
+    var accountCreationEnvironmentUrls = [String: EnvironmentUrlData]()
     var preAuthServerConfig: ServerConfig?
     var rememberedOrgIdentifier: String?
     var showWebIcons = true
@@ -256,8 +256,8 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         preAuthEnvironmentUrls
     }
 
-    func getPreAuthEnvironmentUrlsByEmail(email: String) async -> EnvironmentUrlData? {
-        preAuthEnvironmentUrlsByEmail[email]
+    func getAccountCreationEnvironmentUrls(email: String) async -> EnvironmentUrlData? {
+        accountCreationEnvironmentUrls[email]
     }
 
     func getPreAuthServerConfig() async -> BitwardenShared.ServerConfig? {
@@ -484,8 +484,8 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         preAuthEnvironmentUrls = urls
     }
 
-    func setPreAuthEnvironmentUrlsByEmail(urls: BitwardenShared.EnvironmentUrlData, email: String) async {
-        preAuthEnvironmentUrlsByEmail[email] = urls
+    func setAccountCreationEnvironmentUrls(urls: BitwardenShared.EnvironmentUrlData, email: String) async {
+        accountCreationEnvironmentUrls[email] = urls
     }
 
     func setPreAuthServerConfig(config: BitwardenShared.ServerConfig) async {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -54,6 +54,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKeyValue = [String: String]()
     var preAuthEnvironmentUrls: EnvironmentUrlData?
+    var preAuthEnvironmentUrlsByEmail = [String: EnvironmentUrlData]()
     var preAuthServerConfig: ServerConfig?
     var rememberedOrgIdentifier: String?
     var showWebIcons = true
@@ -247,6 +248,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func getPreAuthEnvironmentUrls() async -> EnvironmentUrlData? {
         preAuthEnvironmentUrls
+    }
+
+    func getPreAuthEnvironmentUrlsByEmail(email: String) async -> EnvironmentUrlData? {
+        preAuthEnvironmentUrlsByEmail[email]
     }
 
     func getPreAuthServerConfig() async -> BitwardenShared.ServerConfig? {
@@ -466,6 +471,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func setPreAuthEnvironmentUrls(_ urls: BitwardenShared.EnvironmentUrlData) async {
         preAuthEnvironmentUrls = urls
+    }
+
+    func setPreAuthEnvironmentUrlsByEmail(urls: BitwardenShared.EnvironmentUrlData, email: String) async {
+        preAuthEnvironmentUrlsByEmail[email] = urls
     }
 
     func setPreAuthServerConfig(config: BitwardenShared.ServerConfig) async {

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -255,7 +255,7 @@ class CompleteRegistrationProcessor: StateProcessor<
                 return
             }
 
-            guard let urls = await services.stateService.getPreAuthEnvironmentUrlsByEmail(email: state.userEmail) else {
+            guard let urls = await services.stateService.getAccountCreationEnvironmentUrls(email: state.userEmail) else {
                 throw CompleteRegistrationError.preAuthUrlsEmpty
             }
 

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -63,6 +63,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         configService = nil
         errorReporter = nil
         subject = nil
+        stateService = nil
     }
 
     // MARK: Tests

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -99,7 +99,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: "another_email@example.com")
         await subject.perform(.appeared)
         XCTAssertEqual(
-            coordinator.alertShown.last,
+            coordinator.alertShown[0],
             .defaultAlert(
                 title: Localizations.anErrorHasOccurred,
                 message: Localizations.theRegionForTheGivenEmailCouldNotBeLoaded

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -19,6 +19,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     var environmentService: MockEnvironmentService!
     var errorReporter: MockErrorReporter!
     var subject: CompleteRegistrationProcessor!
+    var stateService: MockStateService!
 
     // MARK: Setup & Teardown
 
@@ -32,6 +33,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         coordinator = MockCoordinator<AuthRoute, AuthEvent>()
         environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
+        stateService = MockStateService()
         subject = CompleteRegistrationProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
@@ -41,7 +43,8 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
                 configService: configService,
                 environmentService: environmentService,
                 errorReporter: errorReporter,
-                httpClient: client
+                httpClient: client,
+                stateService: stateService
             ),
             state: CompleteRegistrationState(
                 emailVerificationToken: "emailVerificationToken",
@@ -67,18 +70,41 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     /// `perform(.appeared)` with EU region in state.
     @MainActor
     func test_perform_appeared_setRegion_europe() async {
-        subject.state.region = .europe
+        let email = "email@example.com"
+        subject.state.userEmail = email
+        subject.state.fromEmail = true
+        await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: email)
         await subject.perform(.appeared)
-        XCTAssertEqual(subject.state.region, .europe)
         XCTAssertEqual(environmentService.setPreAuthEnvironmentUrlsData, .defaultEU)
     }
 
-    /// `perform(.appeared)` with nil region in state.
+    /// `perform(.appeared)` fromEmail false  returns.
     @MainActor
-    func test_perform_appeared_setRegion_return() async {
-        subject.state.region = nil
+    func test_perform_appeared_setRegion_notFromEmail_returns() async throws {
+        let email = "email@example.com"
+        subject.state.userEmail = email
+        subject.state.fromEmail = false
+        await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: email)
         await subject.perform(.appeared)
-        XCTAssertEqual(subject.state.region, nil)
+        XCTAssertNil(coordinator.alertShown.last)
+        XCTAssertEqual(environmentService.setPreAuthEnvironmentUrlsData, nil)
+    }
+
+    /// `perform(.appeared)` fromEmail true and no saved region for given email shows alert.
+    @MainActor
+    func test_perform_appeared_setRegion_noRegion_alert() async throws {
+        let email = "email@example.com"
+        subject.state.userEmail = email
+        subject.state.fromEmail = true
+        await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: "another_email@example.com")
+        await subject.perform(.appeared)
+        XCTAssertEqual(
+            coordinator.alertShown.last,
+            .defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.theRegionForTheGivenEmailCouldNotBeLoaded
+            )
+        )
         XCTAssertEqual(environmentService.setPreAuthEnvironmentUrlsData, nil)
     }
 

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -74,7 +74,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         let email = "email@example.com"
         subject.state.userEmail = email
         subject.state.fromEmail = true
-        await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: email)
+        await stateService.setAccountCreationEnvironmentUrls(urls: .defaultEU, email: email)
         await subject.perform(.appeared)
         XCTAssertEqual(environmentService.setPreAuthEnvironmentUrlsData, .defaultEU)
     }
@@ -85,7 +85,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         let email = "email@example.com"
         subject.state.userEmail = email
         subject.state.fromEmail = false
-        await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: email)
+        await stateService.setAccountCreationEnvironmentUrls(urls: .defaultEU, email: email)
         await subject.perform(.appeared)
         XCTAssertNil(coordinator.alertShown.last)
         XCTAssertEqual(environmentService.setPreAuthEnvironmentUrlsData, nil)
@@ -97,7 +97,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         let email = "email@example.com"
         subject.state.userEmail = email
         subject.state.fromEmail = true
-        await stateService.setPreAuthEnvironmentUrlsByEmail(urls: .defaultEU, email: "another_email@example.com")
+        await stateService.setAccountCreationEnvironmentUrls(urls: .defaultEU, email: "another_email@example.com")
         await subject.perform(.appeared)
         XCTAssertEqual(
             coordinator.alertShown[0],

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -27,6 +27,9 @@ enum StartRegistrationError: Error {
 
     /// The email is invalid.
     case invalidEmail
+
+    /// The pre auth environment urls are nill.
+    case preAuthUrlsEmpty
 }
 
 // MARK: - StartRegistrationProcessor
@@ -165,6 +168,11 @@ class StartRegistrationProcessor: StateProcessor<
                     userEmail: state.emailText
                 ))
             } else {
+                guard let preAuthUrls = await services.stateService.getPreAuthEnvironmentUrls() else {
+                    throw StartRegistrationError.preAuthUrlsEmpty
+                }
+
+                await services.stateService.setPreAuthEnvironmentUrlsByEmail(urls: preAuthUrls, email: email)
                 coordinator.navigate(to: .checkEmail(email: state.emailText))
             }
         } catch let error as StartRegistrationError {
@@ -188,6 +196,8 @@ class StartRegistrationProcessor: StateProcessor<
             coordinator.showAlert(.validationFieldRequired(fieldName: Localizations.email))
         case .invalidEmail:
             coordinator.showAlert(.invalidEmail)
+        case .preAuthUrlsEmpty:
+            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
         }
     }
 }

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -172,7 +172,7 @@ class StartRegistrationProcessor: StateProcessor<
                     throw StartRegistrationError.preAuthUrlsEmpty
                 }
 
-                await services.stateService.setPreAuthEnvironmentUrlsByEmail(urls: preAuthUrls, email: email)
+                await services.stateService.setAccountCreationEnvironmentUrls(urls: preAuthUrls, email: email)
                 coordinator.navigate(to: .checkEmail(email: state.emailText))
             }
         } catch let error as StartRegistrationError {

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -28,7 +28,7 @@ enum StartRegistrationError: Error {
     /// The email is invalid.
     case invalidEmail
 
-    /// The pre auth environment urls are nill.
+    /// The pre auth environment urls are nil.
     case preAuthUrlsEmpty
 }
 
@@ -197,7 +197,10 @@ class StartRegistrationProcessor: StateProcessor<
         case .invalidEmail:
             coordinator.showAlert(.invalidEmail)
         case .preAuthUrlsEmpty:
-            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+            coordinator.showAlert(.defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.thePreAuthUrlsCouldNotBeLoadedToStartTheAccountCreation
+            ))
         }
     }
 }

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -95,6 +95,63 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .europe))
     }
 
+    /// `perform(_:)` with `.startRegistration` sets preAuthUrls for the given email and navigates to check email.
+    @MainActor
+    func test_perform_startRegistration_setPreAuthUrls_checkEmail() async throws {
+        subject.state = .fixture()
+        client.result = .httpSuccess(testData: .nilResponse)
+        stateService.preAuthEnvironmentUrls = .defaultEU
+
+        await subject.perform(.startRegistration)
+
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(
+            client.requests[0].url,
+            URL(string: "https://example.com/identity/accounts/register/send-verification-email")
+        )
+        XCTAssertEqual(coordinator.routes.last, .checkEmail(
+            email: "example@email.com"
+        ))
+
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(
+            coordinator.loadingOverlaysShown,
+            [
+                LoadingOverlayState(title: Localizations.creatingAccount),
+            ]
+        )
+    }
+
+    /// `perform(_:)` with `.startRegistration` fails if preAuthUrls cannot be loaded.
+    @MainActor
+    func test_perform_startRegistration_setPreAuthUrls_checkEmail_noUrls() async throws {
+        subject.state = .fixture()
+        client.result = .httpSuccess(testData: .nilResponse)
+        stateService.preAuthEnvironmentUrls = nil
+
+        await subject.perform(.startRegistration)
+
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(
+            client.requests[0].url,
+            URL(string: "https://example.com/identity/accounts/register/send-verification-email")
+        )
+        XCTAssertEqual(
+            coordinator.alertShown.last,
+            .defaultAlert(
+                title: Localizations.anErrorHasOccurred
+            )
+        )
+
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(
+            coordinator.loadingOverlaysShown,
+            [
+                LoadingOverlayState(title: Localizations.creatingAccount),
+            ]
+        )
+    }
+
     /// `perform(_:)` with `.startRegistration` presents an alert when the email has already been taken.
     @MainActor
     func test_perform_startRegistration_emailExists() async {

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -139,7 +139,8 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(
             coordinator.alertShown.last,
             .defaultAlert(
-                title: Localizations.anErrorHasOccurred
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.thePreAuthUrlsCouldNotBeLoadedToStartTheAccountCreation
             )
         )
 

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -975,3 +975,4 @@
 "PleaseRestartRegistrationOrTryLoggingInYouMayAlreadyHaveAnAccount" = "Please restart registration or try logging in. You may already have an account.";
 "RemovePasskey" = "Remove passkey";
 "PasskeyRemoved" = "Passkey removed";
+"TheRegionForTheGivenEmailCouldNotBeLoaded" = "The region for the given email could not be loaded.";

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -979,3 +979,4 @@
 "SetUpLaterQuestion" = "Set up later?";
 "YouCanFinishSetupUnlockAnytimeDescriptionLong" = "You can finish setup anytime in Account Security under Settings. You’ll use your master password to unlock until you set up another method.";
 "Confirm" = "Confirm";
+"ThePreAuthUrlsCouldNotBeLoadedToStartTheAccountCreation" = "The Pre Auth Urls could not be loaded to start the account creation.";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-12012](https://bitwarden.atlassian.net/browse/PM-12012)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This update addresses an issue with the account creation process, which is divided into two steps. Currently, users can change the application region before completing the second step, potentially leading to registration in a different environment from where they began.

To resolve this, we are now saving pre-authentication URLs alongside the email address in the application state. These URLs will be loaded when the user initiates the completion of their registration, ensuring a consistent experience throughout the process.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/8930d4c3-f436-4693-9d2a-cae4b1828184

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12012]: https://bitwarden.atlassian.net/browse/PM-12012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ