### PR TITLE
[PM-11894] update password generator policy

### DIFF
--- a/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptions.swift
@@ -50,7 +50,7 @@ struct PasswordGenerationOptions: Codable, Equatable {
     var wordSeparator: String?
 
     /// Whether the password type should be enforced or not
-    var overridePasswordType: Bool = false
+    var overridePasswordType: Bool?
 }
 
 extension PasswordGenerationOptions {

--- a/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptions.swift
@@ -48,6 +48,9 @@ struct PasswordGenerationOptions: Codable, Equatable {
 
     /// The separator to put between words in the passphrase.
     var wordSeparator: String?
+
+    /// Whether the password type should be enforced or not
+    var overridePasswordType: Bool?
 }
 
 extension PasswordGenerationOptions {

--- a/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptions.swift
@@ -50,7 +50,7 @@ struct PasswordGenerationOptions: Codable, Equatable {
     var wordSeparator: String?
 
     /// Whether the password type should be enforced or not
-    var overridePasswordType: Bool?
+    var overridePasswordType: Bool = false
 }
 
 extension PasswordGenerationOptions {

--- a/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/PasswordGenerationOptionsTests.swift
@@ -23,7 +23,8 @@ class PasswordGenerationOptionsTests: BitwardenTestCase {
           "special": true,
           "type": "passphrase",
           "uppercase": true,
-          "wordSeparator": "-"
+          "wordSeparator": "-",
+          "overridePasswordType": false
         }
         """
         let data = try XCTUnwrap(json.data(using: .utf8))
@@ -45,7 +46,8 @@ class PasswordGenerationOptionsTests: BitwardenTestCase {
                 special: true,
                 type: .passphrase,
                 uppercase: true,
-                wordSeparator: "-"
+                wordSeparator: "-",
+                overridePasswordType: false
             )
         )
     }

--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
@@ -10,7 +10,7 @@ enum PolicyOptionType: String {
     case capitalize
 
     /// A policy option for the default type of the password generator.
-    case defaultType
+    case overridePasswordType
 
     /// A policy option for whether to include a number in a passphrase.
     case includeNumber

--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
@@ -9,7 +9,7 @@ enum PolicyOptionType: String {
     /// A policy option for whether to capitalize the passphrase words.
     case capitalize
 
-    /// A policy option for the default type of the password generator.
+    /// A policy option for the enforced type of the password generator.
     case overridePasswordType
 
     /// A policy option for whether to include a number in a passphrase.

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -183,16 +183,14 @@ extension DefaultPolicyService {
         for policy in policies {
             if let overridePasswordTypeString = policy[.overridePasswordType]?.stringValue,
                let overridePasswordType = PasswordGeneratorType(rawValue: overridePasswordTypeString),
-               generatorType != .password,
-               options.overridePasswordType != true {
+               generatorType != .password {
                 // If there's multiple policies with different default types, the password type
                 // should take priority. Use `generateType` as opposed to `options.type` to ignore
                 // the existing type in the options.
                 generatorType = overridePasswordType
+                options.overridePasswordType = true
             }
-            // if the stringValue is NOT emptu or null, overridePasswordType should be true
-            options.overridePasswordType = !(policy[.overridePasswordType]?.stringValue?.isEmpty ?? true)
-
+        
             if let minLength = policy[.minLength]?.intValue {
                 options.setMinLength(minLength)
             }

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -179,15 +179,19 @@ extension DefaultPolicyService {
         // When determining the generator type, ignore the existing option's type to find the preferred
         // default type based on the policies. Then set it on `options` below.
         var generatorType: PasswordGeneratorType?
+        options.overridePasswordType = false
         for policy in policies {
-            if let defaultTypeString = policy[.defaultType]?.stringValue,
-               let defaultType = PasswordGeneratorType(rawValue: defaultTypeString),
-               generatorType != .password {
+            if let overridePasswordTypeString = policy[.overridePasswordType]?.stringValue,
+               let overridePasswordType = PasswordGeneratorType(rawValue: overridePasswordTypeString),
+               generatorType != .password,
+               options.overridePasswordType != true {
                 // If there's multiple policies with different default types, the password type
                 // should take priority. Use `generateType` as opposed to `options.type` to ignore
                 // the existing type in the options.
-                generatorType = defaultType
+                generatorType = overridePasswordType
             }
+            // if the stringValue is NOT emptu or null, overridePasswordType should be true
+            options.overridePasswordType = !(policy[.overridePasswordType]?.stringValue?.isEmpty ?? true)
 
             if let minLength = policy[.minLength]?.intValue {
                 options.setMinLength(minLength)

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -190,7 +190,7 @@ extension DefaultPolicyService {
                 generatorType = overridePasswordType
                 options.overridePasswordType = true
             }
-        
+
             if let minLength = policy[.minLength]?.intValue {
                 options.setMinLength(minLength)
             }

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -158,13 +158,19 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
         policyDataStore.fetchPoliciesResult = .success(
             [
+                passwordGeneratorPolicy,
                 .fixture(
                     data: [
-                        PolicyOptionType.overridePasswordType.rawValue: .string("password"),
+                        PolicyOptionType.overridePasswordType.rawValue: .string(PasswordGeneratorType.password.rawValue),
                     ],
                     type: .passwordGenerator
                 ),
-                passwordGeneratorPolicy,
+                .fixture(
+                    data: [
+                        PolicyOptionType.overridePasswordType.rawValue: .string(PasswordGeneratorType.passphrase.rawValue),
+                    ],
+                    type: .passwordGenerator
+                ),
             ]
         )
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -348,9 +348,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
         var passwordOptions = state.passwordState.passwordGenerationOptions
         state.isPolicyInEffect = await (try? services.policyService
             .applyPasswordGenerationPolicy(options: &passwordOptions)) ?? false
-        // When updating the state, don't update the password generator type or it can override the
-        // user's current selection.
-        state.passwordState.update(with: passwordOptions, shouldUpdateGeneratorType: false)
+        state.passwordState.update(with: passwordOptions, shouldUpdateGeneratorType: true)
 
         var policyOptions = PasswordGenerationOptions()
         _ = try? await services.policyService.applyPasswordGenerationPolicy(options: &policyOptions)

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -247,7 +247,7 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     }
 
     /// Generating a new password applies any policies to the options before generating the value,
-    /// but doesn't override the generator type.
+    /// and overrides the generator type.
     @MainActor
     func test_generatePassword_appliesPolicies_generatorTypeChange() throws {
         waitFor(subject.didLoadGeneratorOptions)
@@ -260,9 +260,9 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         subject.state.passwordState.passwordGeneratorType = .passphrase
 
         subject.receive(.refreshGeneratedValue)
-        waitFor { generatorRepository.passphraseGeneratorRequest != nil }
+        waitFor { generatorRepository.passwordGeneratorRequest != nil }
 
-        XCTAssertEqual(subject.state.passwordState.passwordGeneratorType, .passphrase)
+        XCTAssertEqual(subject.state.passwordState.passwordGeneratorType, .password)
     }
 
     /// If an error occurs generating an username, an alert is shown.

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView.swift
@@ -100,7 +100,7 @@ struct GeneratorView: View {
                 case let .menuPasswordGeneratorType(menuField):
                     FormMenuFieldView(field: menuField) { newValue in
                         store.send(.passwordGeneratorTypeChanged(newValue))
-                    }
+                    }.disabled(store.state.policyOptions?.overridePasswordType ?? false)
                 case let .menuUsernameForwardedEmailService(menuField):
                     FormMenuFieldView(field: menuField) { newValue in
                         store.send(.usernameForwardedEmailServiceChanged(newValue))


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-11894

## 📔 Objective

Renaming property `defaultValue` to `overridePasswordType` as it is the name used on the other clients
Updating the behaviour so that it forces the user to use the `overridePasswordType` on the password generator

## 📸 Screenshots

https://github.com/user-attachments/assets/4f021f4d-fd13-45fb-be9e-f709cb54a117

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
