### PR TITLE
Fix issue where non-SSO users are forced into an SSO flow

### DIFF
--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -155,6 +155,43 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(route, .enterpriseSingleSignOn(email: "user@bitwarden.com"))
     }
 
+    /// `handleAndRoute(_ :)` redirects `.accountBecameActive()` to `.vaultUnlock`
+    /// when the user profile has no user decryption options.
+    func test_handleAndRoute_accountBecameActive_noUserDecryptionOptions() async {
+        let active = Account.fixture(
+            profile: .fixture(
+                userDecryptionOptions: nil
+            )
+        )
+        stateService.activeAccount = active
+
+        biometricsRepository.biometricUnlockStatus = .success(
+            .available(.faceID, enabled: true, hasValidIntegrity: false)
+        )
+        stateService.isAuthenticated = [
+            active.profile.userId: true,
+        ]
+        authRepository.isLockedResult = .success(true)
+
+        let route = await subject.handleAndRoute(
+            .accountBecameActive(
+                active,
+                animated: true,
+                attemptAutomaticBiometricUnlock: true,
+                didSwitchAccountAutomatically: false
+            )
+        )
+        XCTAssertEqual(
+            route,
+            .vaultUnlock(
+                active,
+                animated: true,
+                attemptAutomaticBiometricUnlock: true,
+                didSwitchAccountAutomatically: false
+            )
+        )
+    }
+
     /// `handleAndRoute(_ :)` redirects `.accountBecameActive()` to `.vaultUnlock` when checking if
     /// an account is authenticated fails.
     func test_handleAndRoute_accountBecameActive_logout_isAuthenticatedError() async {

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -357,7 +357,7 @@ extension AuthRouter {
                     return .landingSoftLoggedOut(email: activeAccount.profile.email)
                 }
 
-                let hasMasterPassword = activeAccount.profile.userDecryptionOptions?.hasMasterPassword == true
+                let hasMasterPassword = activeAccount.profile.userDecryptionOptions?.hasMasterPassword ?? true
 
                 if !hasMasterPassword {
                     let biometricUnlockStatus = try await services.biometricsRepository.getBiometricUnlockStatus()

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -328,7 +328,7 @@ extension AuthRouter {
     /// - Parameters:
     ///    - activeAccount: The active account.
     ///    - animated: If the suggested route can be animated, use this value.
-    ///    - shouldAttemptAutomaticBiometricUnlock: If the route uses automatic bioemtrics unlock,
+    ///    - shouldAttemptAutomaticBiometricUnlock: If the route uses automatic biometrics unlock,
     ///      this value enables or disables the feature.
     ///    - shouldAttemptAccountSwitch: Should the application automatically switch accounts for the user?
     /// - Returns: A suggested route for the active account with state pre-configured.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-12343

## 📔 Objective

Users who aren't SSO users are being forced into the SSO flow, particularly with the extension. This is likely because somehow their account in UserDefaults doesn't have user decryption options set. With this change, if we can't find those options, we assume the user has a master password, so we won't go into the SSO flow.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
