### PR TITLE
PM-12313: Update account setup progress when enabling autofill or vault unlock methods

### DIFF
--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -13,6 +13,10 @@ protocol AutofillCredentialServiceDelegate: AnyObject {
 /// A service which manages the ciphers exposed to the system for AutoFill suggestions.
 ///
 protocol AutofillCredentialService: AnyObject {
+    /// Returns whether autofilling credentials via the extension is enabled.
+    ///
+    func isAutofillCredentialsEnabled() async -> Bool
+
     /// Returns a `ASPasswordCredential` that matches the user-requested credential which can be
     /// used for autofill.
     ///
@@ -263,6 +267,10 @@ class DefaultAutofillCredentialService {
 }
 
 extension DefaultAutofillCredentialService: AutofillCredentialService {
+    func isAutofillCredentialsEnabled() async -> Bool {
+        await identityStore.state().isEnabled
+    }
+
     func provideCredential(
         for id: String,
         autofillCredentialServiceDelegate: AutofillCredentialServiceDelegate,

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -77,6 +77,17 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
 
     // MARK: Tests
 
+    /// `isAutofillCredentialsEnabled()` returns whether autofilling credentials is enabled.
+    func test_isAutofillCredentialsEnabled() async {
+        identityStore.state.mockIsEnabled = false
+        var isEnabled = await subject.isAutofillCredentialsEnabled()
+        XCTAssertFalse(isEnabled)
+
+        identityStore.state.mockIsEnabled = true
+        isEnabled = await subject.isAutofillCredentialsEnabled()
+        XCTAssertTrue(isEnabled)
+    }
+
     /// `provideCredential(for:)` returns the credential containing the username and password for
     /// the specified ID.
     func test_provideCredential() async throws {

--- a/BitwardenShared/Core/Autofill/Services/TestHelpers/MockAutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/TestHelpers/MockAutofillCredentialService.swift
@@ -6,9 +6,14 @@ import BitwardenSdk
 // MARK: - MockAutofillCredentialService
 
 class MockAutofillCredentialService: AutofillCredentialService {
+    var isAutofillCredentialsEnabled = false
     var provideCredentialPasswordCredential: ASPasswordCredential?
     var provideCredentialError: Error?
     var provideFido2CredentialResult: Result<PasskeyAssertionCredential, Error> = .failure(BitwardenTestError.example)
+
+    func isAutofillCredentialsEnabled() async -> Bool {
+        isAutofillCredentialsEnabled
+    }
 
     func provideCredential(
         for id: String,

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -6,6 +6,7 @@ import Foundation
 class MockStateService: StateService { // swiftlint:disable:this type_body_length
     var accountEncryptionKeys = [String: AccountEncryptionKeys]()
     var accountSetupAutofill = [String: AccountSetupProgress]()
+    var accountSetupAutofillError: Error?
     var accountSetupVaultUnlock = [String: AccountSetupProgress]()
     var accountTokens: Account.AccountTokens?
     var accountVolatileData: [String: AccountVolatileData] = [:]
@@ -350,6 +351,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
+        if let accountSetupAutofillError {
+            throw accountSetupAutofillError
+        }
         accountSetupAutofill[userId] = autofillSetup
     }
 

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -147,6 +147,7 @@ public class AppProcessor {
         await services.migrationService.performMigrations()
         await services.environmentService.loadURLsForActiveAccount()
         _ = await services.configService.getConfig()
+        await completeAutofillAccountSetupIfEnabled()
 
         if let initialRoute {
             coordinator.navigate(to: initialRoute)
@@ -195,6 +196,27 @@ public class AppProcessor {
     }
 
     // MARK: Autofill Methods
+
+    /// If the native create account feature flag and the autofill extension are enabled, this marks
+    /// any user's autofill account setup completed. This should be called on app startup.
+    ///
+    func completeAutofillAccountSetupIfEnabled() async {
+        guard await services.configService.getFeatureFlag(.nativeCreateAccountFlow),
+              await services.autofillCredentialService.isAutofillCredentialsEnabled()
+        else { return }
+        do {
+            let accounts = try await services.stateService.getAccounts()
+            for account in accounts {
+                let userId = account.profile.userId
+                guard let progress = try await services.stateService.getAccountSetupAutofill(userId: userId),
+                      progress != .complete
+                else { continue }
+                try await services.stateService.setAccountSetupAutofill(.complete, userId: userId)
+            }
+        } catch {
+            services.errorReporter.log(error: error)
+        }
+    }
 
     /// Returns a `ASPasswordCredential` that matches the user-requested credential which can be
     /// used for autofill.

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -662,11 +662,12 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         configService.featureFlagsBool[.nativeCreateAccountFlow] = true
         stateService.accounts = [.fixture()]
         stateService.accountSetupAutofill["1"] = .setUpLater
+        stateService.accountSetupAutofillError = BitwardenTestError.example
 
         let rootNavigator = MockRootNavigator()
         await subject.start(appContext: .mainApp, navigator: rootNavigator, window: nil)
 
-        XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
         XCTAssertEqual(stateService.accountSetupAutofill, ["1": .setUpLater])
     }
 

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -50,6 +50,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasAuthRepository
         & HasAuthService
         & HasBiometricsRepository
+        & HasConfigService
         & HasEnvironmentService
         & HasErrorReporter
         & HasExportVaultService


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12313](https://bitwarden.atlassian.net/browse/PM-12313)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

During the new create account flow, if the user chooses to set up unlock methods and autofill later, enabling either of these in settings should update the stored value so that any future badging no longer appears.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12313]: https://bitwarden.atlassian.net/browse/PM-12313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ