### PR TITLE
PM-12312: Update autofill setup progress when account is created and autofill is enabled

### DIFF
--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -268,7 +268,7 @@ class DefaultAutofillCredentialService {
 
 extension DefaultAutofillCredentialService: AutofillCredentialService {
     func isAutofillCredentialsEnabled() async -> Bool {
-        await identityStore.state().isEnabled
+        await identityStore.isAutofillEnabled()
     }
 
     func provideCredential(
@@ -475,6 +475,14 @@ protocol CredentialIdentityStore {
     /// - Returns: The state of the credential identity store.
     ///
     func state() async -> ASCredentialIdentityStoreState
+}
+
+extension CredentialIdentityStore {
+    /// Returns whether autofilling credentials via the extension is enabled.
+    ///
+    func isAutofillEnabled() async -> Bool {
+        await state().isEnabled
+    }
 }
 
 // MARK: - ASCredentialIdentityStore+CredentialIdentityStore


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12312](https://bitwarden.atlassian.net/browse/PM-12312)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

During the new create account flow, if a new account is created and autofill is already enabled for the app, the setup autofill screen should not be shown to the user. This bypasses the autofill screen by setting the user's autofill setup progress to complete when the account is created.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12312]: https://bitwarden.atlassian.net/browse/PM-12312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ