### PR TITLE
[PM-16213] feat: Reduce the required fingers to open the debug menu to 1

### DIFF
--- a/Bitwarden/Application/SceneDelegate.swift
+++ b/Bitwarden/Application/SceneDelegate.swift
@@ -50,7 +50,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = appWindow
 
         #if DEBUG_MENU
-        addTripleTapGestureRecognizer(to: appWindow)
+        addTapGestureRecognizer(to: appWindow)
         #endif
 
         // Splash window. This is initially visible until the app's processor has finished starting.
@@ -153,22 +153,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
 
     #if DEBUG_MENU
-    /// Handle the triple-tap gesture and launch the debug menu.
+    /// Handle the tap gesture and launch the debug menu.
     @objc
-    private func handleTripleTapGesture() {
+    private func handleTapGesture() {
         appProcessor?.showDebugMenu()
     }
     #endif
 
     #if DEBUG_MENU
-    /// Add the triple-tap gesture recognizer to the window.
-    private func addTripleTapGestureRecognizer(to window: UIWindow) {
+    /// Add the tap gesture recognizer to the window.
+    private func addTapGestureRecognizer(to window: UIWindow) {
         let tapGesture = UITapGestureRecognizer(
             target: self,
-            action: #selector(handleTripleTapGesture)
+            action: #selector(handleTapGesture)
         )
         tapGesture.numberOfTapsRequired = 3
-        tapGesture.numberOfTouchesRequired = 3
+        tapGesture.numberOfTouchesRequired = 1
         window.addGestureRecognizer(tapGesture)
     }
     #endif


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16213

## 📔 Objective

Currently, the debug menu can be opened by shaking the device or triple tapping with 3 fingers. The latter isn’t possible to do in a Simulator and requires two hands while using a physical device. 

This PR addresses that by reducing the number of required fingers to 1.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
