### PR TITLE
PM-12565: Don't fail login if setting account setup progress fails

### DIFF
--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -272,6 +272,9 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
     /// The service used by the application to manage the environment settings.
     private let environmentService: EnvironmentService
 
+    /// The service used by the application to report non-fatal errors.
+    private let errorReporter: ErrorReporter
+
     /// The repository used to manages keychain items.
     private let keychainRepository: KeychainRepository
 
@@ -314,6 +317,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
     ///   - credentialIdentityStore: The store which makes credential identities available to the
     ///     system for AutoFill suggestions.
     ///   - environmentService: The service used by the application to manage the environment settings.
+    ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - keychainRepository: The repository used to manages keychain items.
     ///   - policyService: The service used by the application to manage the policy.
     ///   - stateService: The object used by the application to retrieve information about this device.
@@ -328,6 +332,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         configService: ConfigService,
         credentialIdentityStore: CredentialIdentityStore = ASCredentialIdentityStore.shared,
         environmentService: EnvironmentService,
+        errorReporter: ErrorReporter,
         keychainRepository: KeychainRepository,
         policyService: PolicyService,
         stateService: StateService,
@@ -341,6 +346,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         self.configService = configService
         self.credentialIdentityStore = credentialIdentityStore
         self.environmentService = environmentService
+        self.errorReporter = errorReporter
         self.keychainRepository = keychainRepository
         self.policyService = policyService
         self.stateService = stateService
@@ -593,9 +599,13 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         }
 
         if isNewAccount, await configService.getFeatureFlag(.nativeCreateAccountFlow) {
-            let isAutofillEnabled = await credentialIdentityStore.isAutofillEnabled()
-            try await stateService.setAccountSetupAutofill(isAutofillEnabled ? .complete : .incomplete)
-            try await stateService.setAccountSetupVaultUnlock(.incomplete)
+            do {
+                let isAutofillEnabled = await credentialIdentityStore.isAutofillEnabled()
+                try await stateService.setAccountSetupAutofill(isAutofillEnabled ? .complete : .incomplete)
+                try await stateService.setAccountSetupVaultUnlock(.incomplete)
+            } catch {
+                errorReporter.log(error: error)
+            }
         }
     }
 

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -472,6 +472,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             clientService: clientService,
             configService: configService,
             environmentService: environmentService,
+            errorReporter: errorReporter,
             keychainRepository: keychainRepository,
             policyService: policyService,
             stateService: stateService,

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -153,14 +153,12 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         return accounts
     }
 
-    func getAccountSetupAutofill(userId: String?) async throws -> AccountSetupProgress? {
-        let userId = try unwrapUserId(userId)
-        return accountSetupAutofill[userId]
+    func getAccountSetupAutofill(userId: String) async -> AccountSetupProgress? {
+        accountSetupAutofill[userId]
     }
 
-    func getAccountSetupVaultUnlock(userId: String?) async throws -> AccountSetupProgress? {
-        let userId = try unwrapUserId(userId)
-        return accountSetupVaultUnlock[userId]
+    func getAccountSetupVaultUnlock(userId: String) async -> AccountSetupProgress? {
+        accountSetupVaultUnlock[userId]
     }
 
     func getAccountIdOrActiveId(userId: String?) async throws -> String {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12565](https://bitwarden.atlassian.net/browse/PM-12565)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This addresses a comment @fedemkr made here: https://github.com/bitwarden/ios/pull/972/files#r1777654377

If setting the user's account setup progress fails as part of login, we should log the error rather than throw which would cause the login to fail.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12565]: https://bitwarden.atlassian.net/browse/PM-12565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ