### PR TITLE
PM-10676 - Fill in generated passphrase

### DIFF
--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -185,9 +185,9 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         case let .loginWithDevice(email, type, isAuthenticated):
             showLoginWithDevice(email: email, type: type, isAuthenticated: isAuthenticated)
         case .masterPasswordGenerator:
-            showMasterPasswordGenerator()
+            showMasterPasswordGenerator(delegate: context as? MasterPasswordUpdateDelegate)
         case .masterPasswordGuidance:
-            showMasterPasswordGuidance()
+            showMasterPasswordGuidance(delegate: context as? MasterPasswordUpdateDelegate)
         case let .masterPasswordHint(username):
             showMasterPasswordHint(for: username)
         case .preventAccountLock:
@@ -548,9 +548,10 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
 
     /// Shows the generate master password screen.
     ///
-    private func showMasterPasswordGenerator() {
+    private func showMasterPasswordGenerator(delegate: MasterPasswordUpdateDelegate?) {
         let processor = MasterPasswordGeneratorProcessor(
             coordinator: asAnyCoordinator(),
+            delegate: delegate,
             services: services
         )
         let store = Store(processor: processor)
@@ -562,8 +563,11 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
 
     /// Shows the master password guidance screen.
     ///
-    private func showMasterPasswordGuidance() {
-        let processor = MasterPasswordGuidanceProcessor(coordinator: asAnyCoordinator())
+    private func showMasterPasswordGuidance(delegate: MasterPasswordUpdateDelegate?) {
+        let processor = MasterPasswordGuidanceProcessor(
+            coordinator: asAnyCoordinator(),
+            delegate: delegate
+        )
         let store = Store(processor: processor)
         let view = MasterPasswordGuidanceView(store: store)
         let viewController = UIHostingController(rootView: view)

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -361,6 +361,5 @@ extension CompleteRegistrationProcessor: MasterPasswordUpdateDelegate {
     func didUpdateMasterPassword(password: String) {
         state.passwordText = password
         state.retypePasswordText = password
-        coordinator.navigate(to: .dismissPresented)
     }
 }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -687,6 +687,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     func test_receive_learnMoreTapped() {
         subject.receive(.learnMoreTapped)
         XCTAssertEqual(coordinator.routes.last, .masterPasswordGuidance)
+        XCTAssertNotNil(coordinator.contexts.last as? CompleteRegistrationProcessor)
     }
 
     /// `receive(_:)` with `.passwordHintTextChanged(_:)` updates the state to reflect the change.

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -736,6 +736,13 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         XCTAssertEqual(authRepository.passwordStrengthPassword, "TestPassword1234567890!@#")
     }
 
+    /// `receive(_:)` with `.preventAccountLockTapped` navigates to the right route.
+    @MainActor
+    func test_receive_preventAccountLock() {
+        subject.receive(.preventAccountLockTapped)
+        XCTAssertEqual(coordinator.routes.last, .preventAccountLock)
+    }
+
     /// `receive(_:)` with `.retypePasswordTextChanged(_:)` updates the state to reflect the change.
     @MainActor
     func test_receive_retypePasswordTextChanged() {
@@ -779,6 +786,16 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     func test_receive_showToast() {
         subject.receive(.toastShown(Toast(text: "example")))
         XCTAssertEqual(subject.state.toast?.text, "example")
+    }
+
+    /// Tests `didUpdateMasterPassword` correctly updates the state and navigates correctly.
+    @MainActor
+    func test_didUpdateMasterPassword() {
+        let expectedPassword = "215-Go-Birds-🦅"
+        subject.didUpdateMasterPassword(password: expectedPassword)
+        XCTAssertEqual(subject.state.passwordText, expectedPassword)
+        XCTAssertEqual(subject.state.retypePasswordText, expectedPassword)
+        XCTAssertEqual(coordinator.routes.last, .dismissPresented)
     }
     // swiftlint:disable:next file_length
 }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -795,7 +795,6 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         subject.didUpdateMasterPassword(password: expectedPassword)
         XCTAssertEqual(subject.state.passwordText, expectedPassword)
         XCTAssertEqual(subject.state.retypePasswordText, expectedPassword)
-        XCTAssertEqual(coordinator.routes.last, .dismissPresented)
     }
     // swiftlint:disable:next file_length
 }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessor.swift
@@ -52,6 +52,7 @@ class MasterPasswordGeneratorProcessor: StateProcessor<
             await generatePassword()
         case .save:
             delegate?.didUpdateMasterPassword(password: state.generatedPassword)
+            coordinator.navigate(to: .dismissPresented)
         }
     }
 

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessor.swift
@@ -17,6 +17,9 @@ class MasterPasswordGeneratorProcessor: StateProcessor<
     /// The coordinator that handles navigation.
     private let coordinator: AnyCoordinator<AuthRoute, AuthEvent>
 
+    /// The delegate used to communiate saving a new generated password.
+    private weak var delegate: MasterPasswordUpdateDelegate?
+
     /// The services used by this processor.
     private var services: Services
 
@@ -26,13 +29,16 @@ class MasterPasswordGeneratorProcessor: StateProcessor<
     ///
     /// - Parameters:
     ///   - coordinator: The coordinator that handles navigation.
+    ///   - delegate: The delegate for the processor to notifiy saving a generated password.
     ///   - services: The services required by this processor.
     ///
     init(
         coordinator: AnyCoordinator<AuthRoute, AuthEvent>,
+        delegate: MasterPasswordUpdateDelegate?,
         services: Services
     ) {
         self.coordinator = coordinator
+        self.delegate = delegate
         self.services = services
         super.init(state: MasterPasswordGeneratorState())
     }
@@ -45,9 +51,7 @@ class MasterPasswordGeneratorProcessor: StateProcessor<
              .loadData:
             await generatePassword()
         case .save:
-            // https://bitwarden.atlassian.net/browse/PM-10676
-            // Hook up logic to fill in the generated password
-            coordinator.navigate(to: .dismissPresented)
+            delegate?.didUpdateMasterPassword(password: state.generatedPassword)
         }
     }
 

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessorTests.swift
@@ -95,12 +95,13 @@ class MasterPasswordGeneratorProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.generatedPassword, updatedPassword)
     }
 
-    /// `receive(_:)` with `.save` dismisses the view and calls the delegate to update.
+    /// `receive(_:)` with `.save` dismisses the view and calls the delegate to update and dismisses the view.
     @MainActor
     func test_receive_save() async {
         subject.state.generatedPassword = "NickbackRulez!"
         await subject.perform(.save)
         XCTAssertEqual(subject.state.generatedPassword, delegate.updatedPassword)
         XCTAssertTrue(delegate.updateMasterPasswordCalled)
+        XCTAssertEqual(coordinator.routes.last, .dismissPresented)
     }
 }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/TestHelpers/MockMasterPasswordUpdateDeleagate.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/TestHelpers/MockMasterPasswordUpdateDeleagate.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+@testable import BitwardenShared
+
+class MockMasterPasswordUpdateDelegate: MasterPasswordUpdateDelegate {
+    var updatedPassword: String = ""
+    var updateMasterPasswordCalled = false
+
+    func didUpdateMasterPassword(password: String) {
+        updatedPassword = password
+        updateMasterPasswordCalled = true
+    }
+}

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGuidance/MasterPasswordGuidanceProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGuidance/MasterPasswordGuidanceProcessor.swift
@@ -12,14 +12,23 @@ class MasterPasswordGuidanceProcessor: StateProcessor<
     /// The coordinator that handles navigation.
     private let coordinator: AnyCoordinator<AuthRoute, AuthEvent>
 
+    /// The delegate used to communiate saving a new generated password.
+    private weak var delegate: MasterPasswordUpdateDelegate?
+
     // MARK: Initialization
 
     /// Creates a new `CompleteRegistrationProcessor`.
     ///
-    /// - Parameter coordinator: The coordinator that handles navigation.
+    /// - Parameters:
+    ///   - coordinator: The coordinator that handles navigation.
+    ///   - delegate: The delegate for the processor to notifiy saving a generated password.
     ///
-    init(coordinator: AnyCoordinator<AuthRoute, AuthEvent>) {
+    init(
+        coordinator: AnyCoordinator<AuthRoute, AuthEvent>,
+        delegate: MasterPasswordUpdateDelegate?
+    ) {
         self.coordinator = coordinator
+        self.delegate = delegate
         super.init(state: ())
     }
 
@@ -30,7 +39,10 @@ class MasterPasswordGuidanceProcessor: StateProcessor<
         case .dismiss:
             coordinator.navigate(to: .dismissPresented)
         case .generatePasswordPressed:
-            coordinator.navigate(to: .masterPasswordGenerator)
+            coordinator.navigate(
+                to: .masterPasswordGenerator,
+                context: delegate
+            )
         }
     }
 }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGuidance/MasterPasswordGuidanceProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGuidance/MasterPasswordGuidanceProcessorTests.swift
@@ -6,6 +6,7 @@ class MasterPasswordGuidanceProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<AuthRoute, AuthEvent>!
+    var delegate: MockMasterPasswordUpdateDelegate!
     var subject: MasterPasswordGuidanceProcessor!
 
     // MARK: Setup & Teardown
@@ -14,14 +15,18 @@ class MasterPasswordGuidanceProcessorTests: BitwardenTestCase {
         super.setUp()
 
         coordinator = MockCoordinator()
-
-        subject = MasterPasswordGuidanceProcessor(coordinator: coordinator.asAnyCoordinator())
+        delegate = MockMasterPasswordUpdateDelegate()
+        subject = MasterPasswordGuidanceProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            delegate: delegate
+        )
     }
 
     override func tearDown() {
         super.tearDown()
 
         coordinator = nil
+        delegate = nil
         subject = nil
     }
 
@@ -39,5 +44,6 @@ class MasterPasswordGuidanceProcessorTests: BitwardenTestCase {
     func test_receive_generatePasswordPressed() {
         subject.receive(.generatePasswordPressed)
         XCTAssertEqual(coordinator.routes.last, .masterPasswordGenerator)
+        XCTAssertNotNil(coordinator.contexts.last as? MasterPasswordUpdateDelegate)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-10676](https://bitwarden.atlassian.net/browse/PM-10676)

## 📔 Objective

- After generating a new passphrase, we need to be able to save it when creating a new Master Password during account creation.
- Used delegation to communicate between the CompleteRegistrationProcessor and the MasterPasswordGeneratorProcessor via the MasterPasswordUpdateDelegate.

## 📸 Screenshots

https://github.com/user-attachments/assets/ddba74b3-1028-43f1-923b-70ee27a8e74e

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10676]: https://bitwarden.atlassian.net/browse/PM-10676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ