### PR TITLE
[PM-9328] CODEOWNERS - Mobile team owns all .github folder changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@
 * @bitwarden/team-ios @matt-livefront @phil-livefront @victor-livefront @brant-livefront
 
 # Actions and workflow changes.
-.github/workflows @bitwarden/dept-development-mobile
+.github/ @bitwarden/dept-development-mobile
 
 # Auth
 # BitwardenShared/Core/Auth @bitwarden/team-auth-dev


### PR DESCRIPTION
## 🎟️ Tracking

[PM-9328](https://bitwarden.atlassian.net/browse/PM-9328)

## 📔 Objective

Updating CODEOWNERS so the mobile team owns all of the .github 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9328]: https://bitwarden.atlassian.net/browse/PM-9328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ