### PR TITLE
[PM-11213] Update Snapshot Testing

### DIFF
--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationViewTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationViewTests.swift
@@ -151,7 +151,7 @@ class CompleteRegistrationViewTests: BitwardenTestCase {
     /// Tests the view renders correctly when the text fields are all empty.
     @MainActor
     func test_snapshot_empty() {
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 
     /// Tests the view renders correctly when text fields are hidden.
@@ -164,7 +164,7 @@ class CompleteRegistrationViewTests: BitwardenTestCase {
         processor.state.passwordHintText = "wink wink"
         processor.state.passwordStrengthScore = 0
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when the text fields are all populated.
@@ -177,7 +177,7 @@ class CompleteRegistrationViewTests: BitwardenTestCase {
         processor.state.passwordHintText = "wink wink"
         processor.state.passwordStrengthScore = 0
 
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 
     /// Tests the view renders correctly when the toggles are on.
@@ -185,7 +185,7 @@ class CompleteRegistrationViewTests: BitwardenTestCase {
     func test_snapshot_toggles_on() throws {
         processor.state.isCheckDataBreachesToggleOn = true
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when the feature flag for native create account is on.

--- a/BitwardenShared/UI/Auth/CompleteRegistration/ExpiredLink/ExpiredLinkViewTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/ExpiredLink/ExpiredLinkViewTests.swift
@@ -56,6 +56,6 @@ class ExpiredLinkViewTests: BitwardenTestCase {
     /// Tests the view renders correctly.
     @MainActor
     func test_snapshot_toggles_on() throws {
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 }

--- a/BitwardenShared/UI/Auth/CreateAccount/CreateAccountViewTests.swift
+++ b/BitwardenShared/UI/Auth/CreateAccount/CreateAccountViewTests.swift
@@ -121,7 +121,7 @@ class CreateAccountViewTests: BitwardenTestCase {
     /// Tests the view renders correctly when the text fields are all empty.
     @MainActor
     func test_snapshot_empty() {
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when text fields are hidden.
@@ -134,7 +134,7 @@ class CreateAccountViewTests: BitwardenTestCase {
         processor.state.passwordHintText = "wink wink"
         processor.state.passwordStrengthScore = 0
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when the text fields are all populated.
@@ -147,7 +147,7 @@ class CreateAccountViewTests: BitwardenTestCase {
         processor.state.passwordHintText = "wink wink"
         processor.state.passwordStrengthScore = 0
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when the toggles are on.
@@ -156,6 +156,6 @@ class CreateAccountViewTests: BitwardenTestCase {
         processor.state.isTermsAndPrivacyToggleOn = true
         processor.state.isCheckDataBreachesToggleOn = true
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingViewTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingViewTests.swift
@@ -98,21 +98,21 @@ class LandingViewTests: BitwardenTestCase {
     /// Check the snapshot for the empty state.
     @MainActor
     func test_snapshot_empty() {
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot when the email text field has a value.
     @MainActor
     func test_snapshot_email_value() {
         processor.state.email = "email@example.com"
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot when the remember me toggle is on.
     @MainActor
     func test_snapshot_isRememberMeOn_true() {
         processor.state.isRememberMeOn = true
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot for the profiles visible
@@ -130,7 +130,7 @@ class LandingViewTests: BitwardenTestCase {
             allowLockAndLogout: true,
             isVisible: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot for the profiles closed
@@ -148,6 +148,6 @@ class LandingViewTests: BitwardenTestCase {
             allowLockAndLogout: true,
             isVisible: false
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Auth/Login/LoginViewTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginViewTests.swift
@@ -127,7 +127,7 @@ class LoginViewTests: BitwardenTestCase {
     func test_snapshot_empty() {
         processor.state.username = "user@bitwarden.com"
         processor.state.serverURLString = "bitwarden.com"
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -136,7 +136,7 @@ class LoginViewTests: BitwardenTestCase {
         processor.state.masterPassword = "Password"
         processor.state.serverURLString = "bitwarden.com"
         processor.state.isMasterPasswordRevealed = false
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -145,7 +145,7 @@ class LoginViewTests: BitwardenTestCase {
         processor.state.masterPassword = "Password"
         processor.state.serverURLString = "bitwarden.com"
         processor.state.isMasterPasswordRevealed = true
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -160,6 +160,6 @@ class LoginViewTests: BitwardenTestCase {
         processor.state.username = "user@bitwarden.com"
         processor.state.isLoginWithDeviceVisible = true
         processor.state.serverURLString = "bitwarden.com"
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnViewTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnViewTests.swift
@@ -58,13 +58,13 @@ class SingleSignOnViewTests: BitwardenTestCase {
 
     /// Tests the view renders correctly when the text field is empty.
     func test_snapshot_empty() {
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 
     /// Tests the view renders correctly when the text field is populated.
     @MainActor
     func test_snapshot_populated() {
         processor.state.identifierText = "Insert cool identifier here"
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 }

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRowTests.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherRowTests.swift
@@ -36,7 +36,7 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
 
     /// Snapshot test for the add account row
     func test_snapshot_addAccount() throws {
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Snapshot test for the active account row
@@ -47,7 +47,7 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
             showDivider: true,
             rowType: .active(.fixtureUnlocked)
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Snapshot test for the active account row without a divider
@@ -58,7 +58,7 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
             showDivider: false,
             rowType: .active(.fixtureUnlocked)
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Snapshot test for the alternate unlocked account row
@@ -68,7 +68,7 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
             shouldTakeAccessibilityFocus: false,
             rowType: .alternate(.fixtureUnlocked)
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Snapshot test for the alternate locked account row
@@ -78,7 +78,7 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
             shouldTakeAccessibilityFocus: false,
             rowType: .alternate(.fixtureLocked)
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Snapshot test for the alternate logged out row.
@@ -88,6 +88,6 @@ final class ProfileSwitcherRowTests: BitwardenTestCase {
             shouldTakeAccessibilityFocus: false,
             rowType: .alternate(.fixtureLoggedOut)
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarViewTests.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarViewTests.swift
@@ -62,7 +62,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
     func test_snapshot_empty() {
         processor.state = .empty()
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "Empty State"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -78,7 +78,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
             isVisible: true
         )
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "No Active Account"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -87,7 +87,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
 
     func test_snapshot_singleAccount() {
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "Single Account"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -111,7 +111,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
             isVisible: true
         )
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "Multi Account"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -135,7 +135,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
             isVisible: true
         )
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "Black Icon Color"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -159,7 +159,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
             isVisible: true
         )
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "Blue Icon Color"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -183,7 +183,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
             isVisible: true
         )
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "White Icon Color"
             ),
             as: .portrait(heightMultiple: 0.1)
@@ -207,7 +207,7 @@ final class ProfileSwitcherToolbarViewTests: BitwardenTestCase {
             isVisible: true
         )
         assertSnapshot(
-            matching: snapshotSubject(
+            of: snapshotSubject(
                 title: "Yellow Icon Color"
             ),
             as: .portrait(heightMultiple: 0.1)

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherViewTests.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherViewTests.swift
@@ -236,7 +236,7 @@ class ProfileSwitcherViewTests: BitwardenTestCase { // swiftlint:disable:this ty
     // MARK: Snapshots
 
     func test_snapshot_singleAccount() {
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -267,19 +267,19 @@ class ProfileSwitcherViewTests: BitwardenTestCase { // swiftlint:disable:this ty
             allowLockAndLogout: true,
             isVisible: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
     func test_snapshot_multiAccount_unlocked_atMaximum() {
         processor.state = ProfileSwitcherState.maximumAccounts
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
     func test_snapshot_multiAccount_unlocked_atMaximum_largeText() {
         processor.state = ProfileSwitcherState.maximumAccounts
-        assertSnapshot(matching: subject, as: .defaultPortraitAX5)
+        assertSnapshot(of: subject, as: .defaultPortraitAX5)
     }
 
     @MainActor
@@ -310,7 +310,7 @@ class ProfileSwitcherViewTests: BitwardenTestCase { // swiftlint:disable:this ty
             allowLockAndLogout: true,
             isVisible: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -347,14 +347,14 @@ class ProfileSwitcherViewTests: BitwardenTestCase { // swiftlint:disable:this ty
             allowLockAndLogout: true,
             isVisible: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Test a snapshot of the ProfileSwitcherView previews.
     func test_snapshot_profileSwitcherView_previews() {
         for preview in ProfileSwitcherView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [.defaultPortrait]
             )
         }

--- a/BitwardenShared/UI/Auth/StartRegistration/CheckEmail/CheckEmailViewTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/CheckEmail/CheckEmailViewTests.swift
@@ -42,6 +42,6 @@ class CheckEmailViewTests: BitwardenTestCase {
 
     /// Tests the view renders correctly.
     func test_snapshot_empty() {
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 }

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationViewTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationViewTests.swift
@@ -92,14 +92,14 @@ class StartRegistrationViewTests: BitwardenTestCase {
     /// Tests the view renders correctly when the text fields are all empty.
     @MainActor
     func test_snapshot_empty() {
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly for the native create account feature flag.
     @MainActor
     func test_snapshot_nativeCreateAccountFeatureFlag() {
         processor.state.isCreateAccountFeatureFlagEnabled = true
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when the text fields are all populated.
@@ -108,7 +108,7 @@ class StartRegistrationViewTests: BitwardenTestCase {
         processor.state.emailText = "email@example.com"
         processor.state.nameText = "user name"
 
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 
     /// Tests the view renders correctly when the text fields are all populated with long text.
@@ -117,7 +117,7 @@ class StartRegistrationViewTests: BitwardenTestCase {
         processor.state.emailText = "emailmmmmmmmmmmmmmmmmmmmmm@exammmmmmmmmmmmmmmmmmmmmmmmmmmmmmmple.com"
         processor.state.nameText = "user name name name name name name name name name name name name name name"
 
-        assertSnapshots(matching: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 
     /// Tests the view renders correctly when the toggles are on.
@@ -125,7 +125,7 @@ class StartRegistrationViewTests: BitwardenTestCase {
     func test_snapshot_toggles_on() throws {
         processor.state.isReceiveMarketingToggleOn = true
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests the view renders correctly when the marketing toggle is hidden.
@@ -133,6 +133,6 @@ class StartRegistrationViewTests: BitwardenTestCase {
     func test_snapshot_marketingToggle_hidden() throws {
         processor.state.showReceiveMarketingToggle = false
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
@@ -129,7 +129,7 @@ class VaultUnlockViewTests: BitwardenTestCase {
 
     /// Test a snapshot of the empty view.
     func test_snapshot_vaultUnlock_empty() {
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Test a snapshot of the view with face id biometrics available.
@@ -140,7 +140,7 @@ class VaultUnlockViewTests: BitwardenTestCase {
             enabled: true,
             hasValidIntegrity: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Tests that we show the red alert message when we don't have a valid integrity but biometrics is available.
@@ -151,14 +151,14 @@ class VaultUnlockViewTests: BitwardenTestCase {
             enabled: true,
             hasValidIntegrity: false
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Test a snapshot of the view with biometrics unavailable.
     @MainActor
     func test_snapshot_vaultUnlock_withBiometrics_notAvailable() {
         processor.state.biometricUnlockStatus = .notAvailable
-        assertSnapshot(matching: subject, as: .defaultLandscape)
+        assertSnapshot(of: subject, as: .defaultLandscape)
     }
 
     /// Test a snapshot of the view with touch id biometrics available.
@@ -169,7 +169,7 @@ class VaultUnlockViewTests: BitwardenTestCase {
             enabled: true,
             hasValidIntegrity: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Test a snapshot of the view when the password is hidden.
@@ -177,7 +177,7 @@ class VaultUnlockViewTests: BitwardenTestCase {
     func test_snapshot_vaultUnlock_passwordHidden() {
         processor.state.masterPassword = "Password"
         processor.state.isMasterPasswordRevealed = false
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Test a snapshot of the view when the password is revealed.
@@ -185,7 +185,7 @@ class VaultUnlockViewTests: BitwardenTestCase {
     func test_snapshot_vaultUnlock_passwordRevealed() {
         processor.state.masterPassword = "Password"
         processor.state.isMasterPasswordRevealed = true
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot for the profiles visible
@@ -203,21 +203,21 @@ class VaultUnlockViewTests: BitwardenTestCase {
             allowLockAndLogout: true,
             isVisible: true
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot for the profiles visible
     @MainActor
     func test_snapshot_profilesVisible_max() {
         processor.state.profileSwitcherState = .maximumAccounts
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     /// Check the snapshot for the profiles visible
     @MainActor
     func test_snapshot_profilesVisible_max_largeText() {
         processor.state.profileSwitcherState = .maximumAccounts
-        assertSnapshot(matching: subject, as: .defaultPortraitAX5)
+        assertSnapshot(of: subject, as: .defaultPortraitAX5)
     }
 
     /// Check the snapshot for the profiles closed
@@ -235,6 +235,6 @@ class VaultUnlockViewTests: BitwardenTestCase {
             allowLockAndLogout: true,
             isVisible: false
         )
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Appearance/StyleGuideFontTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/StyleGuideFontTests.swift
@@ -10,7 +10,7 @@ final class StyleGuideFontTests: BitwardenTestCase {
     func test_snapshot_styleGuideFont() {
         for preview in StyleGuideFont_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [.defaultPortrait]
             )
         }
@@ -20,7 +20,7 @@ final class StyleGuideFontTests: BitwardenTestCase {
     func test_snapshot_styleGuideFont_largeText() {
         for preview in StyleGuideFont_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [.defaultPortraitAX5]
             )
         }

--- a/BitwardenShared/UI/Platform/Application/Views/EmptyContentViewTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/EmptyContentViewTests.swift
@@ -28,6 +28,6 @@ final class EmptyContentViewTests: BitwardenTestCase {
             }
         }
 
-        assertSnapshots(matching: SnapshotView(), as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+        assertSnapshots(of: SnapshotView(), as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Views/LoadingOverlayViewTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/LoadingOverlayViewTests.swift
@@ -9,7 +9,7 @@ class LoadingOverlayViewTests: BitwardenTestCase {
     /// Test a snapshot of the loading overlay.
     func test_snapshot_loadingOverlay() {
         assertSnapshots(
-            matching: LoadingOverlayView(state: .init(title: "Loading...")),
+            of: LoadingOverlayView(state: .init(title: "Loading...")),
             as: [.defaultPortrait, .defaultPortraitDark]
         )
     }

--- a/BitwardenShared/UI/Platform/Application/Views/PasswordStrengthIndicatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/PasswordStrengthIndicatorTests.swift
@@ -100,6 +100,6 @@ class PasswordStrengthIndicatorTests: BitwardenTestCase {
             }
         }
 
-        assertSnapshots(matching: SnapshotView(), as: [.defaultPortrait, .defaultPortraitDark])
+        assertSnapshots(of: SnapshotView(), as: [.defaultPortrait, .defaultPortraitDark])
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Views/SectionViewTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/SectionViewTests.swift
@@ -10,7 +10,7 @@ class SectionViewTests: BitwardenTestCase {
     func test_snapshot_sectionView() {
         for preview in SectionView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [.defaultPortrait]
             )
         }

--- a/BitwardenShared/UI/Platform/Application/Views/ToastViewTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/ToastViewTests.swift
@@ -10,7 +10,7 @@ final class ToastViewTests: BitwardenTestCase {
     func test_snapshot_toastView_previews() {
         for preview in ToastView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5]
             )
         }

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuViewTests.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuViewTests.swift
@@ -81,6 +81,6 @@ class DebugMenuViewTests: BitwardenTestCase {
                 isEnabled: false
             ),
         ]
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderViewTests.swift
@@ -87,7 +87,7 @@ class AddEditFolderViewTests: BitwardenTestCase {
     /// Tests the view renders correctly when the text field is empty.
     func test_snapshot_add_empty() {
         assertSnapshots(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5]
         )
     }
@@ -97,7 +97,7 @@ class AddEditFolderViewTests: BitwardenTestCase {
     func test_snapshot_add_populated() {
         processor.state.folderName = "Super cool folder name"
         assertSnapshots(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5]
         )
     }
@@ -108,7 +108,7 @@ class AddEditFolderViewTests: BitwardenTestCase {
         processor.state.mode = .edit(.fixture())
         processor.state.folderName = "Super cool folder name"
         assertSnapshots(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5]
         )
     }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorViewTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorViewTests.swift
@@ -194,7 +194,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.generatedValue = "pa11w0rd"
         processor.state.showCopiedValueToast()
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -204,7 +204,7 @@ class GeneratorViewTests: BitwardenTestCase {
     func test_snapshot_generatorViewPassphrase() {
         processor.state.passwordState.passwordGeneratorType = .passphrase
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -214,7 +214,7 @@ class GeneratorViewTests: BitwardenTestCase {
     func test_snapshot_generatorViewPassword() {
         processor.state.passwordState.passwordGeneratorType = .password
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -232,7 +232,7 @@ class GeneratorViewTests: BitwardenTestCase {
     func test_snapshot_generatorViewPassword_policyInEffect() {
         processor.state.isPolicyInEffect = true
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -243,7 +243,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.generatorType = .username
         processor.state.usernameState.usernameGeneratorType = .catchAllEmail
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -254,7 +254,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.generatorType = .username
         processor.state.usernameState.usernameGeneratorType = .forwardedEmail
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -265,7 +265,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.generatorType = .username
         processor.state.usernameState.usernameGeneratorType = .plusAddressedEmail
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }
@@ -276,7 +276,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.generatorType = .username
         processor.state.usernameState.usernameGeneratorType = .plusAddressedEmail
         processor.state.presentationMode = .inPlace
-        assertSnapshot(matching: subject.navStackWrapped, as: .defaultPortrait)
+        assertSnapshot(of: subject.navStackWrapped, as: .defaultPortrait)
     }
 
     /// Test a snapshot of the random word username generation view.
@@ -285,7 +285,7 @@ class GeneratorViewTests: BitwardenTestCase {
         processor.state.generatorType = .username
         processor.state.usernameState.usernameGeneratorType = .randomWord
         assertSnapshot(
-            matching: subject.navStackWrapped,
+            of: subject.navStackWrapped,
             as: .defaultPortrait
         )
     }

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListViewTests.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListViewTests.swift
@@ -66,7 +66,7 @@ class PasswordHistoryListViewTests: BitwardenTestCase {
     /// Test a snapshot of the generator history view's empty state.
     func test_snapshot_generatorHistoryViewEmpty() {
         assertSnapshot(
-            matching: subject,
+            of: subject,
             as: .defaultPortrait
         )
     }
@@ -90,7 +90,7 @@ class PasswordHistoryListViewTests: BitwardenTestCase {
             ),
         ]
         assertSnapshots(
-            matching: subject,
+            of: subject,
             as: [.defaultPortrait, .defaultPortraitAX5]
         )
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
@@ -176,7 +176,7 @@ class VaultListViewTests: BitwardenTestCase {
         processor.state.profileSwitcherState.isVisible = false
         processor.state.loadingState = .data([])
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -184,7 +184,7 @@ class VaultListViewTests: BitwardenTestCase {
         processor.state.profileSwitcherState.isVisible = true
         processor.state.loadingState = .data([])
 
-        assertSnapshot(matching: subject, as: .defaultPortrait)
+        assertSnapshot(of: subject, as: .defaultPortrait)
     }
 
     @MainActor
@@ -295,7 +295,7 @@ class VaultListViewTests: BitwardenTestCase {
     func test_snapshot_vaultListView_previews() {
         for preview in VaultListView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [.defaultPortrait]
             )
         }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemViewTests.swift
@@ -11,7 +11,7 @@ class AddEditCardItemViewTests: BitwardenTestCase {
     func test_snapshot_addEditCardItemView() {
         for preview in AddEditCardItemView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [
                     .defaultPortrait,
                     .defaultPortraitDark,

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemViewTests.swift
@@ -796,7 +796,7 @@ class AddEditItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_snapshot_previews_addEditItemView() {
         for preview in AddEditItemView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [
                     .tallPortrait,
                     .tallPortraitAX5(heightMultiple: 5),

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditLoginItem/AddEditLoginItemViewTests.swift
@@ -10,7 +10,7 @@ class AddEditLoginItemViewTests: BitwardenTestCase {
     func test_snapshot_addEditLoginItemView() {
         for preview in AddEditLoginItemView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [
                     .defaultPortrait,
                     .defaultPortraitDark,

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
@@ -71,7 +71,7 @@ class ManualEntryViewTests: BitwardenTestCase {
     /// Test a snapshot of the ProfileSwitcherView empty state.
     func test_snapshot_manualEntryView_empty() {
         assertSnapshot(
-            matching: ManualEntryView_Previews.empty,
+            of: ManualEntryView_Previews.empty,
             as: .defaultPortrait
         )
     }
@@ -79,7 +79,7 @@ class ManualEntryViewTests: BitwardenTestCase {
     /// Test a snapshot of the ProfileSwitcherView empty state.
     func test_snapshot_manualEntryView_empty_landscape() {
         assertSnapshot(
-            matching: ManualEntryView_Previews.empty,
+            of: ManualEntryView_Previews.empty,
             as: .defaultLandscape
         )
     }
@@ -87,7 +87,7 @@ class ManualEntryViewTests: BitwardenTestCase {
     /// Test a snapshot of the ProfileSwitcherView in dark mode.
     func test_snapshot_manualEntryView_text_dark() {
         assertSnapshot(
-            matching: ManualEntryView_Previews.textAdded,
+            of: ManualEntryView_Previews.textAdded,
             as: .defaultPortraitDark
         )
     }
@@ -95,7 +95,7 @@ class ManualEntryViewTests: BitwardenTestCase {
     /// Test a snapshot of the ProfileSwitcherView with large text.
     func test_snapshot_manualEntryView_text_largeText() {
         assertSnapshot(
-            matching: ManualEntryView_Previews.textAdded,
+            of: ManualEntryView_Previews.textAdded,
             as: .tallPortraitAX5(heightMultiple: 1.75)
         )
     }
@@ -103,7 +103,7 @@ class ManualEntryViewTests: BitwardenTestCase {
     /// Test a snapshot of the ProfileSwitcherView in light mode.
     func test_snapshot_manualEntryView_text_light() {
         assertSnapshot(
-            matching: ManualEntryView_Previews.textAdded,
+            of: ManualEntryView_Previews.textAdded,
             as: .defaultPortrait
         )
     }

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
@@ -47,7 +47,7 @@ class ScanCodeViewTests: BitwardenTestCase {
     func test_snapshot_scanCodeView_previews() {
         for preview in ScanCodeView_Previews._allPreviews {
             assertSnapshots(
-                matching: preview.content,
+                of: preview.content,
                 as: [
                     .defaultPortrait,
                     .defaultLandscape,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewCardItem/ViewCardItemViewTests.swift
@@ -10,7 +10,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_empty() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.emptyPreview,
+            of: ViewCardItemView_Previews.emptyPreview,
             as: [
                 .defaultPortrait,
             ]
@@ -21,7 +21,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_full() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.fullPreview,
+            of: ViewCardItemView_Previews.fullPreview,
             as: [
                 .defaultPortrait,
             ]
@@ -32,7 +32,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_full_dark() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.fullPreview,
+            of: ViewCardItemView_Previews.fullPreview,
             as: [
                 .defaultPortraitDark,
             ]
@@ -43,7 +43,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_full_largeFont() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.fullPreview,
+            of: ViewCardItemView_Previews.fullPreview,
             as: [
                 .tallPortraitAX5(heightMultiple: 1.75),
             ]
@@ -54,7 +54,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_hiddenCode() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.hiddenCodePreview,
+            of: ViewCardItemView_Previews.hiddenCodePreview,
             as: [
                 .defaultPortrait,
             ]
@@ -65,7 +65,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_noExpirationState() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.noExpiration,
+            of: ViewCardItemView_Previews.noExpiration,
             as: [
                 .defaultPortrait,
             ]
@@ -76,7 +76,7 @@ class ViewCardItemViewTests: BitwardenTestCase {
     ///
     func test_snapshot_viewCardItemView_partialExpirationState() {
         assertSnapshots(
-            matching: ViewCardItemView_Previews.yearOnlyExpiration,
+            of: ViewCardItemView_Previews.yearOnlyExpiration,
             as: [
                 .defaultPortrait,
             ]

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemViewTests.swift
@@ -352,7 +352,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_snapshot_previews_card() {
         assertSnapshot(
-            matching: ViewItemView_Previews.cardPreview,
+            of: ViewItemView_Previews.cardPreview,
             as: .defaultPortrait
         )
     }
@@ -361,7 +361,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_snapshot_previews_card_dark() {
         assertSnapshot(
-            matching: ViewItemView_Previews.cardPreview,
+            of: ViewItemView_Previews.cardPreview,
             as: .defaultPortraitDark
         )
     }
@@ -370,7 +370,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_snapshot_previews_card_largeText() {
         assertSnapshot(
-            matching: ViewItemView_Previews.cardPreview,
+            of: ViewItemView_Previews.cardPreview,
             as: .tallPortraitAX5(heightMultiple: 3)
         )
     }
@@ -379,7 +379,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_snapshot_previews_login() {
         assertSnapshot(
-            matching: ViewItemView_Previews.loginPreview,
+            of: ViewItemView_Previews.loginPreview,
             as: .tallPortrait
         )
     }
@@ -388,7 +388,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_snapshot_previews_login_dark() {
         assertSnapshot(
-            matching: ViewItemView_Previews.loginPreview,
+            of: ViewItemView_Previews.loginPreview,
             as: .portraitDark(heightMultiple: 2)
         )
     }
@@ -397,7 +397,7 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_snapshot_previews_login_largeText() {
         assertSnapshot(
-            matching: ViewItemView_Previews.loginPreview,
+            of: ViewItemView_Previews.loginPreview,
             as: .tallPortraitAX5(heightMultiple: 4)
         )
     }

--- a/BitwardenShared/UI/Vault/Views/CircularProgressShapeTests.swift
+++ b/BitwardenShared/UI/Vault/Views/CircularProgressShapeTests.swift
@@ -39,6 +39,6 @@ final class CircularProgressShapeTests: BitwardenTestCase {
             .frame(width: 30, height: 30)
         }
 
-        assertSnapshot(matching: stack, as: .portrait(heightMultiple: 0.1))
+        assertSnapshot(of: stack, as: .portrait(heightMultiple: 0.1))
     }
 }

--- a/project.yml
+++ b/project.yml
@@ -35,7 +35,7 @@ packages:
     exactVersion: 1.3.0
   SnapshotTesting:
     url: https://github.com/pointfreeco/swift-snapshot-testing
-    exactVersion: 1.15.4
+    exactVersion: 1.17.5
   ViewInspector:
     url: https://github.com/nalexn/ViewInspector
     exactVersion: 0.10.0


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11213

## 📔 Objective

This updates [Snapshot Testing](https://github.com/pointfreeco/swift-snapshot-testing) to version 1.17.5, which is currently the latest version. This also updates to the newer API, instead of using deprecated methods. While not necessary for Xcode 16, it is a helpful improvement along the way.

This is part of the greater Xcode 16 / iOS 18 / Swift 6 effort.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
