### PR TITLE
PM-10281: Set custom app theme on splash window

### DIFF
--- a/Bitwarden/Application/SceneDelegate.swift
+++ b/Bitwarden/Application/SceneDelegate.swift
@@ -60,6 +60,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             await appProcessor.start(
                 appContext: .mainApp,
                 navigator: rootViewController,
+                splashWindow: splashWindow,
                 window: appWindow
             )
             hideSplash()

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -127,12 +127,14 @@ public class AppProcessor {
     ///   - initialRoute: The initial route to navigate to. If `nil` this, will navigate to the
     ///     unlock or landing auth route based on if there's an active account. Defaults to `nil`.
     ///   - navigator: The object that will be used to navigate between routes.
+    ///   - splashWindow: The splash window to use to set the app's theme.
     ///   - window: The window to use to set the app's theme.
     ///
     public func start(
         appContext: AppContext,
         initialRoute: AppRoute? = nil,
         navigator: RootNavigator,
+        splashWindow: UIWindow? = nil,
         window: UIWindow?
     ) async {
         let coordinator = appModule.makeAppCoordinator(appContext: appContext, navigator: navigator)
@@ -142,6 +144,7 @@ public class AppProcessor {
         Task {
             for await appTheme in await services.stateService.appThemePublisher().values {
                 navigator.appTheme = appTheme
+                splashWindow?.overrideUserInterfaceStyle = appTheme.userInterfaceStyle
                 window?.overrideUserInterfaceStyle = appTheme.userInterfaceStyle
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10281](https://bitwarden.atlassian.net/browse/PM-10281)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Applies an overridden light/dark mode theme to the splash screen. There's still a brief portion of the app launch that we can't override, but the splash screen should have the correct theme after that.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

App launch:
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/b1889c68-7f8d-4d88-8459-cf7525324526" /> | <video src="https://github.com/user-attachments/assets/a466ee40-84b3-4832-afbc-16a757917671" /> |

App switcher:
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4f339d0b-6bb6-4699-8b58-b482bdab9b69" /> | <video src="https://github.com/user-attachments/assets/6cd42b31-faa8-4d26-8330-c58e445b80f4" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10281]: https://bitwarden.atlassian.net/browse/PM-10281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ