### PR TITLE
[PM-13205] Fix CI-main builds by updating brew

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -308,6 +308,7 @@ jobs:
 
       - name: Install Fastlane, Mint
         run: |
+          brew update
           brew install fastlane mint
 
       - name: Install Mint packages


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13205](https://bitwarden.atlassian.net/browse/PM-13205)

## 📔 Objective

CI-main was failing while updating release notes due to a change in Apple services last week. Fastlane fixed it in https://github.com/fastlane/fastlane/pull/22256 which was [released in 2.223.1](https://github.com/fastlane/fastlane/issues/22248#issuecomment-2378489778), but our brew is still getting 2.220.0. 

By updating brew we should now get fastlane >=2.224.0.  

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13205]: https://bitwarden.atlassian.net/browse/PM-13205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ