### PR TITLE
PM-12988 - Fix close navigation on `CheckEmailView`

### DIFF
--- a/BitwardenShared/UI/Auth/StartRegistration/CheckEmail/CheckEmailProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/CheckEmail/CheckEmailProcessor.swift
@@ -28,10 +28,10 @@ class CheckEmailProcessor: StateProcessor<CheckEmailState, CheckEmailAction, Voi
 
     override func receive(_ action: CheckEmailAction) {
         switch action {
-        case .dismissTapped,
-             .logInTapped:
+        case .logInTapped:
             coordinator.navigate(to: .dismiss)
-        case .goBackTapped:
+        case .dismissTapped,
+             .goBackTapped:
             coordinator.navigate(to: .dismissPresented)
         }
     }

--- a/BitwardenShared/UI/Auth/StartRegistration/CheckEmail/CheckEmailProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/CheckEmail/CheckEmailProcessorTests.swift
@@ -35,7 +35,7 @@ class CheckEmailProcessorTests: BitwardenTestCase {
     @MainActor
     func test_receive_dismissTapped() {
         subject.receive(.dismissTapped)
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(coordinator.routes.last, .dismissPresented)
     }
 
     /// `receive(_:)` with `.goBackTapped` dismisses the view.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12988](https://bitwarden.atlassian.net/browse/PM-12988)

## 📔 Objective

- Using `dismissPresented` when closing out the `CheckEmailView` so the close/swipe down ux match.
- When QA was testing this ticket they found that the dismiss navigation on the `CheckEmailView` didn't match the swipe down dismiss.  This is because this was missed in the original PR [here](https://github.com/bitwarden/ios/pull/1010).

## 📸 Screenshots

https://github.com/user-attachments/assets/a84c0d8c-0346-4bac-a0a6-9a2b7f1c6ae9

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12988]: https://bitwarden.atlassian.net/browse/PM-12988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ