### PR TITLE
PM-12782: Handle email verification feature flag when navigating from the intro carousel

### DIFF
--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -449,6 +449,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     private func showIntroCarousel() {
         let processor = IntroCarouselProcessor(
             coordinator: asAnyCoordinator(),
+            services: services,
             state: IntroCarouselState()
         )
         let view = IntroCarouselView(store: Store(processor: processor))

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselAction.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselAction.swift
@@ -3,9 +3,6 @@
 /// Actions that can be processed by a `IntroCarouselProcessor`.
 ///
 enum IntroCarouselAction: Equatable {
-    /// The create account button was tapped.
-    case createAccount
-
     /// The current page index has changed.
     case currentPageIndexChanged(Int)
 

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselEffect.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselEffect.swift
@@ -1,0 +1,8 @@
+// MARK: - IntroCarouselEffect
+
+/// Effects that can be processed by a `IntroCarouselProcessor`.
+///
+enum IntroCarouselEffect {
+    /// The create account button was tapped.
+    case createAccount
+}

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselView.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselView.swift
@@ -12,7 +12,7 @@ struct IntroCarouselView: View {
     @Environment(\.verticalSizeClass) var verticalSizeClass
 
     /// The `Store` for this view.
-    @ObservedObject var store: Store<IntroCarouselState, IntroCarouselAction, Void>
+    @ObservedObject var store: Store<IntroCarouselState, IntroCarouselAction, IntroCarouselEffect>
 
     // MARK: View
 
@@ -32,8 +32,8 @@ struct IntroCarouselView: View {
             .animation(.default, value: store.state.currentPageIndex)
 
             VStack(spacing: 12) {
-                Button(Localizations.createAccount) {
-                    store.send(.createAccount)
+                AsyncButton(Localizations.createAccount) {
+                    await store.perform(.createAccount)
                 }
                 .buttonStyle(.primary())
 

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselViewTests.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class IntroCarouselViewTests: BitwardenTestCase {
     // MARK: Properties
 
-    var processor: MockProcessor<IntroCarouselState, IntroCarouselAction, Void>!
+    var processor: MockProcessor<IntroCarouselState, IntroCarouselAction, IntroCarouselEffect>!
     var subject: IntroCarouselView!
 
     // MARK: Setup & Teardown
@@ -29,12 +29,12 @@ class IntroCarouselViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// Tapping the create account button dispatches the create account action.
+    /// Tapping the create account button performs the create account effect.
     @MainActor
-    func test_createAccount_tap() throws {
-        let button = try subject.inspect().find(button: Localizations.createAccount)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .createAccount)
+    func test_createAccount_tap() async throws {
+        let button = try subject.inspect().find(asyncButton: Localizations.createAccount)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .createAccount)
     }
 
     /// Tapping the log in button dispatches the login action.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12782](https://bitwarden.atlassian.net/browse/PM-12782)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If email verification is enabled, the intro carousel will open the start registration view instead of the previous create account flow.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/4fae9abf-3878-4304-9d3c-3c9cc41f0915


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12782]: https://bitwarden.atlassian.net/browse/PM-12782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ