### PR TITLE
PM-12783: Trim whitespace from email during registration

### DIFF
--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -165,7 +165,7 @@ class StartRegistrationProcessor: StateProcessor<
                !token.isEmpty {
                 coordinator.navigate(to: .completeRegistration(
                     emailVerificationToken: token,
-                    userEmail: state.emailText
+                    userEmail: email
                 ))
             } else {
                 guard let preAuthUrls = await services.stateService.getPreAuthEnvironmentUrls() else {
@@ -173,7 +173,7 @@ class StartRegistrationProcessor: StateProcessor<
                 }
 
                 await services.stateService.setAccountCreationEnvironmentUrls(urls: preAuthUrls, email: email)
-                coordinator.navigate(to: .checkEmail(email: state.emailText))
+                coordinator.navigate(to: .checkEmail(email: email))
             }
         } catch let error as StartRegistrationError {
             showStartRegistrationErrorAlert(error)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12783](https://bitwarden.atlassian.net/browse/PM-12783)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The user's entered email wasn't being trimmed previously, which led to incorrect formatting on the check email screen.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/f31c5074-dfae-4737-986c-1b1411ec0e51



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
