### PR TITLE
[PM-13027] Allowing longpress copy on textfields

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
@@ -62,7 +62,7 @@ struct BitwardenTextValueField<AccessoryContent>: View where AccessoryContent: V
         titleAccessibilityIdentifier: String? = "ItemName",
         value: String,
         valueAccessibilityIdentifier: String? = "ItemValue",
-        textSelectionEnabled: Bool = false,
+        textSelectionEnabled: Bool = true,
         @ViewBuilder accessoryContent: () -> AccessoryContent
     ) {
         self.textSelectionEnabled = textSelectionEnabled
@@ -92,7 +92,7 @@ extension BitwardenTextValueField where AccessoryContent == EmptyView {
         titleAccessibilityIdentifier: String? = "ItemName",
         value: String,
         valueAccessibilityIdentifier: String? = "ItemValue",
-        textSelectionEnabled: Bool = false
+        textSelectionEnabled: Bool = true
     ) {
         self.init(
             title: title,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -186,7 +186,7 @@ struct ViewItemDetailsView: View { // swiftlint:disable:this type_body_length
     @ViewBuilder private var notesSection: some View {
         if !store.state.notes.isEmpty {
             SectionView(Localizations.notes) {
-                BitwardenTextValueField(value: store.state.notes, textSelectionEnabled: true)
+                BitwardenTextValueField(value: store.state.notes)
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("CipherNotesLabel")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13027

## 📔 Objective
Setting `textSelectionEnabled` on  `BitwardenTextValueField` as `true` in order to allow user to long press copy all textfields

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
