### PR TITLE
PM-11159: Add vault sync for importing logins

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -170,6 +170,7 @@
 "ItemUpdated" = "Item saved";
 "Submitting" = "Submitting...";
 "Syncing" = "Syncing...";
+"SyncingLogins" = "Syncing logins...";
 "SyncingComplete" = "Syncing complete";
 "SyncingFailed" = "Syncing failed";
 "SyncVaultNow" = "Sync vault now";

--- a/BitwardenShared/UI/Platform/Application/Utilities/Navigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Navigator.swift
@@ -27,14 +27,14 @@ extension Navigator {
     ///
     func showLoadingOverlay(_ state: LoadingOverlayState) {
         guard let rootViewController else { return }
-        LoadingOverlayDisplayHelper.show(in: rootViewController, state: state)
+        LoadingOverlayDisplayHelper.show(in: rootViewController.topmostViewController(), state: state)
     }
 
     /// Hides the loading overlay view.
     ///
     func hideLoadingOverlay() {
         guard let rootViewController else { return }
-        LoadingOverlayDisplayHelper.hide(from: rootViewController)
+        LoadingOverlayDisplayHelper.hide(from: rootViewController.topmostViewController())
     }
 
     /// Shows the toast.

--- a/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsAction.swift
@@ -3,9 +3,6 @@
 /// Actions that can be processed by a `ImportLoginsProcessor`.
 ///
 enum ImportLoginsAction: Equatable {
-    /// Advance to the next page of instructions.
-    case advanceNextPage
-
     /// Advance to the previous page of instructions.
     case advancePreviousPage
 

--- a/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsEffect.swift
@@ -3,6 +3,9 @@
 /// Effects handled by the `ImportLoginsProcessor`.
 ///
 enum ImportLoginsEffect: Equatable {
+    /// Advance to the next page of instructions.
+    case advanceNextPage
+
     /// The view appeared on screen.
     case appeared
 

--- a/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsView.swift
+++ b/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsView.swift
@@ -132,8 +132,8 @@ struct ImportLoginsView: View {
             .tint(Asset.Colors.textInteraction.swiftUIColor)
 
             VStack(spacing: 12) {
-                Button(Localizations.continue) {
-                    store.send(.advanceNextPage)
+                AsyncButton(Localizations.continue) {
+                    await store.perform(.advanceNextPage)
                 }
                 .buttonStyle(.primary())
 

--- a/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsViewTests.swift
@@ -64,11 +64,11 @@ class ImportLoginsViewTests: BitwardenTestCase {
 
     /// Tapping the continue button for a step dispatches the `advanceNextPage` action.
     @MainActor
-    func test_step_continue_tap() throws {
+    func test_step_continue_tap() async throws {
         processor.state.page = .step1
-        let button = try subject.inspect().find(button: Localizations.continue)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .advanceNextPage)
+        let button = try subject.inspect().find(asyncButton: Localizations.continue)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .advanceNextPage)
     }
 
     // MARK: Snapshots

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -71,6 +71,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
         & HasFido2UserInterfaceHelper
         & HasLocalAuthService
         & HasNotificationService
+        & HasSettingsRepository
         & HasStateService
         & HasTimeProvider
         & HasVaultRepository


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11159](https://bitwarden.atlassian.net/browse/PM-11159)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

On the last import logins page, hitting Continue should sync the user's vault. This adds the sync call and loading overlay. Navigation to the success page will be in a separate PR.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/fe63a071-d75f-478f-aeca-53e3ae138cf4

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11159]: https://bitwarden.atlassian.net/browse/PM-11159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ