### PR TITLE
[PM-13280] Fix isPreAuth flag on login with device.

### DIFF
--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -504,7 +504,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         let appId = await appIdService.getOrCreateAppId()
 
         // Initiate the login request and cache the result.
-        let loginWithDeviceData = try await clientService.auth().newAuthRequest(email: email)
+        let loginWithDeviceData = try await clientService.auth(isPreAuth: true).newAuthRequest(email: email)
         let loginRequest = try await authAPIService.initiateLoginWithDevice(LoginWithDeviceRequestModel(
             email: email,
             publicKey: loginWithDeviceData.publicKey,

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -272,6 +272,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         // Verify the results.
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertEqual(clientService.mockAuth.newAuthRequestEmail, "email@example.com")
+        XCTAssertTrue(clientService.mockAuthIsPreAuth)
         XCTAssertEqual(result.authRequestResponse, authRequestResponse)
         XCTAssertEqual(result.requestId, LoginRequest.fixture().id)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-13280](https://bitwarden.atlassian.net/browse/PM-13280)

## 📔 Objective

Based on [this Crashlytics report](https://console.firebase.google.com/project/bitwarden-c2b35/crashlytics/app/ios:com.8bit.bitwarden/issues/b77dd77f85ac1aaf077debe2294a887a?time=last-seven-days&versions=2024.9.2%20(1106)&sessionEventKey=c40822bf5c3748e4a7efeb0124637617_2001491588821595139), on Login with device we should pass `isPreAuth: true` for auth SDK client.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13280]: https://bitwarden.atlassian.net/browse/PM-13280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ