### PR TITLE
PM-13835: Improve JSON decoding flexibility

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/CreateAccountResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/CreateAccountResponseModel.swift
@@ -6,8 +6,6 @@ import Networking
 /// The response returned from the API upon creating an account.
 ///
 struct CreateAccountResponseModel: JSONResponse {
-    static let decoder = JSONDecoder()
-
     // MARK: Properties
 
     /// The captcha bypass token returned in this response.

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
@@ -9,7 +9,7 @@ struct IdentityTokenResponseModel: Equatable, JSONResponse, KdfConfigProtocol {
     // MARK: Account Properties
 
     /// Whether the app needs to force a password reset.
-    let forcePasswordReset: Bool
+    @DefaultFalse var forcePasswordReset: Bool
 
     /// The type of KDF algorithm to use.
     let kdf: KdfType

--- a/BitwardenShared/Core/Auth/Models/Response/KnownDeviceResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/KnownDeviceResponseModel.swift
@@ -5,8 +5,6 @@ import Networking
 
 /// An object containing a value defining if this device has previously logged into this account or not.
 struct KnownDeviceResponseModel: JSONResponse {
-    static let decoder = JSONDecoder()
-
     // MARK: Properties
 
     /// A flag indicating if this device is known or not.

--- a/BitwardenShared/Core/Auth/Models/Response/PreLoginResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/PreLoginResponseModel.swift
@@ -8,10 +8,6 @@ import Networking
 /// Contains information necessary for encrypting the user's password for login.
 ///
 struct PreLoginResponseModel: Equatable, JSONResponse, KdfConfigProtocol {
-    // MARK: Static Properties
-
-    static let decoder = JSONDecoder()
-
     // MARK: Properties
 
     /// The type of kdf algorithm to use for encryption.

--- a/BitwardenShared/Core/Auth/Models/Response/PreValidateSingleSignOnResponse.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/PreValidateSingleSignOnResponse.swift
@@ -6,8 +6,6 @@ import Networking
 /// The response returned from the API upon pre-validating the single-sign on.
 ///
 struct PreValidateSingleSignOnResponse: JSONResponse, Equatable {
-    static let decoder = JSONDecoder()
-
     // MARK: Properties
 
     /// The token returned in this response.

--- a/BitwardenShared/Core/Auth/Models/Response/RegisterFinishResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/RegisterFinishResponseModel.swift
@@ -6,8 +6,6 @@ import Networking
 /// The response returned from the API upon creating an account.
 ///
 struct RegisterFinishResponseModel: JSONResponse {
-    static let decoder = JSONDecoder()
-
     // MARK: Properties
 
     /// The captcha bypass token returned in this response.

--- a/BitwardenShared/Core/Platform/Models/Domain/ServerConfig.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/ServerConfig.swift
@@ -29,10 +29,10 @@ struct ServerConfig: Equatable, Codable, Sendable {
         environment = responseModel.environment.map(EnvironmentServerConfig.init)
         self.date = date
         let features: [(FeatureFlag, AnyCodable)]
-        features = responseModel.featureStates.compactMap { key, value in
+        features = responseModel.featureStates?.compactMap { key, value in
             guard let flag = FeatureFlag(rawValue: key) else { return nil }
             return (flag, value)
-        }
+        } ?? []
         featureStates = Dictionary(uniqueKeysWithValues: features)
 
         gitHash = responseModel.gitHash

--- a/BitwardenShared/Core/Platform/Services/API/Extensions/JSONResponse+Bitwarden.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Extensions/JSONResponse+Bitwarden.swift
@@ -3,5 +3,5 @@ import Networking
 
 extension JSONResponse {
     /// The decoder used by default to decode JSON responses from the API.
-    static var decoder: JSONDecoder { .defaultDecoder }
+    static var decoder: JSONDecoder { .pascalOrSnakeCaseDecoder }
 }

--- a/BitwardenShared/Core/Platform/Services/API/Response/ConfigResponseModel.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Response/ConfigResponseModel.swift
@@ -12,7 +12,7 @@ struct ConfigResponseModel: Equatable, JSONResponse {
     let environment: EnvironmentServerConfigResponseModel?
 
     /// Feature flags to configure the client.
-    let featureStates: [String: AnyCodable]
+    let featureStates: [String: AnyCodable]?
 
     /// The git hash of the server.
     let gitHash: String

--- a/BitwardenShared/Core/Platform/Utilities/DefaultFalse.swift
+++ b/BitwardenShared/Core/Platform/Utilities/DefaultFalse.swift
@@ -1,0 +1,47 @@
+/// A property wrapper that will default the wrapped value to `false` if decoding fails. This is
+/// useful for decoding a boolean value which may not be present in the response.
+///
+@propertyWrapper
+struct DefaultFalse: Codable, Hashable {
+    // MARK: Properties
+
+    /// The wrapped value.
+    let wrappedValue: Bool
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultFalse` with a wrapped value.
+    ///
+    /// - Parameter wrappedValue: The value that is contained in the property wrapper.
+    ///
+    init(wrappedValue: Bool) {
+        self.wrappedValue = wrappedValue
+    }
+
+    // MARK: Decodable
+
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        wrappedValue = try container.decode(Bool.self)
+    }
+
+    // MARK: Encodable
+
+    func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+// MARK: - KeyedDecodingContainer
+
+extension KeyedDecodingContainer {
+    /// When decoding a `DefaultFalse` wrapped value, if the property doesn't exist, default to `false`.
+    ///
+    /// - Parameters:
+    ///   - type: The type of value to attempt to decode.
+    ///   - key: The key used to decode the value.
+    ///
+    func decode(_ type: DefaultFalse.Type, forKey key: Key) throws -> DefaultFalse {
+        try decodeIfPresent(type, forKey: key) ?? DefaultFalse(wrappedValue: false)
+    }
+}

--- a/BitwardenShared/Core/Platform/Utilities/DefaultFalseTests.swift
+++ b/BitwardenShared/Core/Platform/Utilities/DefaultFalseTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class DefaultFalseTests: BitwardenTestCase {
+    // MARK: Types
+
+    struct Model: Codable, Equatable {
+        @DefaultFalse var value: Bool
+    }
+
+    // MARK: Tests
+
+    /// `DefaultFalse` encodes a `false` wrapped value.
+    func test_encode_false() throws {
+        let subject = Model(value: false)
+        let data = try JSONEncoder().encode(subject)
+        XCTAssertEqual(String(data: data, encoding: .utf8), #"{"value":false}"#)
+    }
+
+    /// `DefaultFalse` encodes a `true` wrapped value.
+    func test_encode_true() throws {
+        let subject = Model(value: true)
+        let data = try JSONEncoder().encode(subject)
+        XCTAssertEqual(String(data: data, encoding: .utf8), #"{"value":true}"#)
+    }
+
+    /// Decoding a `DefaultFalse` wrapped value will decode a `false` value from the JSON.
+    func test_decode_false() throws {
+        let json = #"{"value": true}"#
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let subject = try JSONDecoder().decode(Model.self, from: data)
+        XCTAssertEqual(subject, Model(value: true))
+    }
+
+    /// Decoding a `DefaultFalse` wrapped value will default the value to `false` if the key is
+    /// missing from the JSON.
+    func test_decode_missing() throws {
+        let json = #"{}"#
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let subject = try JSONDecoder().decode(Model.self, from: data)
+        XCTAssertEqual(subject, Model(value: false))
+    }
+
+    /// Decoding a `DefaultFalse` wrapped value will default the value to `false` if the value is
+    /// `null` in the JSON.
+    func test_decode_null() throws {
+        let json = #"{"value": null}"#
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let subject = try JSONDecoder().decode(Model.self, from: data)
+        XCTAssertEqual(subject, Model(value: false))
+    }
+
+    /// Decoding a `DefaultFalse` wrapped value will decode a `true` value from the JSON.
+    func test_decode_true() throws {
+        let json = #"{"value": true}"#
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let subject = try JSONDecoder().decode(Model.self, from: data)
+        XCTAssertEqual(subject, Model(value: true))
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Response/ProfileResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/ProfileResponseModel.swift
@@ -39,7 +39,7 @@ struct ProfileResponseModel: Codable, Equatable {
     let premium: Bool
 
     /// Whether the user has a premium account from their organization.
-    let premiumFromOrganization: Bool
+    @DefaultFalse var premiumFromOrganization: Bool
 
     /// The user's private key.
     let privateKey: String?
@@ -51,5 +51,5 @@ struct ProfileResponseModel: Codable, Equatable {
     let twoFactorEnabled: Bool
 
     /// Whether the user uses key connector.
-    let usesKeyConnector: Bool
+    @DefaultFalse var usesKeyConnector: Bool
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-13835](https://bitwarden.atlassian.net/browse/PM-13835)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Improves the flexibility of JSON decoding by supporting pascal or camel case keys. Also, allows for decoding a few bools which may not always be present.

This should fix the following errors in Crashlytics:
- NSCocoaErrorDomain (4865): No value associated with key CodingKeys(stringValue: "ciphers", intValue: nil) ("ciphers").
- NSCocoaErrorDomain (4865): No value associated with key CodingKeys(stringValue: "kdf", intValue: nil) ("kdf").
- NSCocoaErrorDomain (4865): No value associated with key CodingKeys(stringValue: "forcePasswordReset", intValue: nil) ("forcePasswordReset").
- NSCocoaErrorDomain (4865): No value associated with key CodingKeys(stringValue: "featureStates", intValue: nil) ("featureStates").

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13835]: https://bitwarden.atlassian.net/browse/PM-13835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ