### PR TITLE
[PM-13029] add copy button items to more fields

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/AccessoryButton.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/AccessoryButton.swift
@@ -20,6 +20,9 @@ struct AccessoryButton: View {
     /// The accessibility label of the button.
     var accessibilityLabel: String
 
+    /// The accessibility label of the button.
+    var accessibilityIdentifier: String = ""
+
     /// The action to perform when the user interacts with this button.
     var action: Action
 
@@ -36,6 +39,7 @@ struct AccessoryButton: View {
             }
             .buttonStyle(.accessory)
             .accessibilityLabel(Text(accessibilityLabel))
+            .accessibilityIdentifier(accessibilityIdentifier)
         case let .sync(action):
             Button(action: action) {
                 asset.swiftUIImage
@@ -44,6 +48,7 @@ struct AccessoryButton: View {
             }
             .buttonStyle(.accessory)
             .accessibilityLabel(Text(accessibilityLabel))
+            .accessibilityIdentifier(accessibilityIdentifier)
         }
     }
 
@@ -57,7 +62,10 @@ struct AccessoryButton: View {
     ///   - accessibilityLabel: The accessibility label of the button.
     ///   - action: The action to perform when the user triggers the button.
     ///
-    init(asset: ImageAsset, accessibilityLabel: String, action: @escaping () -> Void) {
+    init(asset: ImageAsset,
+         accessibilityLabel: String,
+         action: @escaping () -> Void,
+         accessibilityIdentifier: String = "") {
         self.accessibilityLabel = accessibilityLabel
         self.action = .sync(action)
         self.asset = asset
@@ -71,10 +79,14 @@ struct AccessoryButton: View {
     ///   - accessibilityLabel: The accessibility label of the button.
     ///   - action: The action to perform when the user triggers the button.
     ///
-    init(asset: ImageAsset, accessibilityLabel: String, action: @escaping () async -> Void) {
+    init(asset: ImageAsset,
+         accessibilityLabel: String,
+         action: @escaping () async -> Void,
+         accessibilityIdentifier: String = "") {
         self.accessibilityLabel = accessibilityLabel
         self.action = .async(action)
         self.asset = asset
+        self.accessibilityIdentifier = accessibilityIdentifier
     }
 }
 

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
@@ -106,6 +106,49 @@ extension BitwardenTextValueField where AccessoryContent == EmptyView {
     }
 }
 
+extension BitwardenTextValueField where AccessoryContent == AccessoryButton {
+    /// Creates a new `BitwardenTextValueField` with a button as accessory content.
+    ///
+    /// - Parameters:
+    ///   - title: The (optional) title of the field.
+    ///   - titleAccessibilityIdentifier: The (optional) accessibility identifier to apply
+    ///     to the title of the field (if it exists).
+    ///   - value: The text value to display in this field.
+    ///   - valueAccessibilityIdentifier: The (optional) accessibility identifier to apply
+    ///     to the displayed value of the field.
+    ///   - textSelectionEnabled: Whether text selection is enabled.
+    ///   - copyButtonAction: The action to perform when the button is pressed.
+    ///   - buttonAccessibilityLabel: The (optional) accessibility label to apply to the button.
+    ///   - copyButtonAccessibilityIdentifier: The (optional) accessibility identifier to apply
+    ///     to the button.
+    init(
+        title: String? = nil,
+        titleAccessibilityIdentifier: String? = "ItemName",
+        value: String,
+        valueAccessibilityIdentifier: String? = "ItemValue",
+        textSelectionEnabled: Bool = true,
+        copyButtonAction: @escaping () -> Void,
+        copyButtonAccessibilityIdentifier: String
+    ) {
+        // Initialize the BitwardenTextValueField with the button as the accessory content
+        self.init(
+            title: title,
+            titleAccessibilityIdentifier: titleAccessibilityIdentifier,
+            value: value,
+            valueAccessibilityIdentifier: valueAccessibilityIdentifier,
+            textSelectionEnabled: textSelectionEnabled,
+            accessoryContent: {
+                AccessoryButton(
+                    asset: Asset.Images.copy,
+                    accessibilityLabel: Localizations.copy,
+                    action: copyButtonAction,
+                    accessibilityIdentifier: copyButtonAccessibilityIdentifier
+                )
+            }
+        )
+    }
+}
+
 // MARK: Previews
 
 #if DEBUG

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewIdentityItem/ViewIdentityItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewIdentityItem/ViewIdentityItemView.swift
@@ -12,82 +12,109 @@ struct ViewIdentityItemView: View {
 
     var body: some View {
         if !store.state.identityName.isEmpty {
+            let identityName = store.state.identityName
             BitwardenTextValueField(
                 title: Localizations.identityName,
-                value: store.state.identityName,
-                valueAccessibilityIdentifier: "ItemNameEntry"
+                value: identityName,
+                valueAccessibilityIdentifier: "ItemNameEntry",
+                copyButtonAction: { store.send(.copyPressed(value: identityName, field: .identityName)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyNameButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.userName.isEmpty {
+            let username = store.state.userName
             BitwardenTextValueField(
                 title: Localizations.username,
-                value: store.state.userName,
-                valueAccessibilityIdentifier: "IdentityUsernameEntry"
+                value: username,
+                valueAccessibilityIdentifier: "IdentityUsernameEntry",
+                copyButtonAction: { store.send(.copyPressed(value: username, field: .username)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyUsernameButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.company.isEmpty {
+            let company = store.state.company
             BitwardenTextValueField(
                 title: Localizations.company,
-                value: store.state.company,
-                valueAccessibilityIdentifier: "IdentityCompanyEntry"
+                value: company,
+                valueAccessibilityIdentifier: "IdentityCompanyEntry",
+                copyButtonAction: { store.send(.copyPressed(value: company, field: .company)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyCompanyButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.socialSecurityNumber.isEmpty {
+            let socialSecurityNumber = store.state.socialSecurityNumber
             BitwardenTextValueField(
                 title: Localizations.ssn,
-                value: store.state.socialSecurityNumber,
-                valueAccessibilityIdentifier: "IdentitySsnEntry"
+                value: socialSecurityNumber,
+                valueAccessibilityIdentifier: "IdentitySsnEntry",
+                copyButtonAction: { store.send(.copyPressed(value: socialSecurityNumber, field: .socialSecurityNumber)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopySocialSecurityNumberButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.passportNumber.isEmpty {
+            let passportNumber = store.state.passportNumber
             BitwardenTextValueField(
                 title: Localizations.passportNumber,
-                value: store.state.passportNumber,
-                valueAccessibilityIdentifier: "IdentityPassportNumberEntry"
+                value: passportNumber,
+                valueAccessibilityIdentifier: "IdentityPassportNumberEntry",
+                copyButtonAction: { store.send(.copyPressed(value: passportNumber, field: .passportNumber)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyPassportNumberButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.licenseNumber.isEmpty {
+            let licenseNumber = store.state.licenseNumber
             BitwardenTextValueField(
                 title: Localizations.licenseNumber,
-                value: store.state.licenseNumber,
-                valueAccessibilityIdentifier: "IdentityLicenseNumberEntry"
+                value: licenseNumber,
+                valueAccessibilityIdentifier: "IdentityLicenseNumberEntry",
+                copyButtonAction: { store.send(.copyPressed(value: licenseNumber, field: .licenseNumber)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyLicenseNumberButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.email.isEmpty {
+            let email = store.state.email
             BitwardenTextValueField(
-                title: Localizations.email,
+                title: email,
                 value: store.state.email,
-                valueAccessibilityIdentifier: "IdentityEmailEntry"
+                valueAccessibilityIdentifier: "IdentityEmailEntry",
+                copyButtonAction: { store.send(.copyPressed(value: email, field: .email)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyEmailButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.phone.isEmpty {
+            let phone = store.state.phone
             BitwardenTextValueField(
                 title: Localizations.phone,
-                value: store.state.phone,
-                valueAccessibilityIdentifier: "IdentityPhoneEntry"
+                value: phone,
+                valueAccessibilityIdentifier: "IdentityPhoneEntry",
+                copyButtonAction: { store.send(.copyPressed(value: phone, field: .phone)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyPhoneButton"
             )
             .accessibilityElement(children: .contain)
         }
 
         if !store.state.fullAddress.isEmpty {
+            let fullAddress = store.state.fullAddress
             BitwardenTextValueField(
                 title: Localizations.address,
-                value: store.state.fullAddress,
-                valueAccessibilityIdentifier: "IdentityAddressOneEntry"
+                value: fullAddress,
+                valueAccessibilityIdentifier: "IdentityAddressOneEntry",
+                copyButtonAction: { store.send(.copyPressed(value: fullAddress, field: .fullAddress)) },
+                copyButtonAccessibilityIdentifier: "IdentityCopyFullAddressButton"
             )
             .accessibilityElement(children: .contain)
         }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -103,6 +103,33 @@ enum CopyableField {
     /// The username field.
     case username
 
+    /// The identity name field.
+    case identityName
+
+    /// The company field.
+    case company
+
+    /// The social security number field.
+    case socialSecurityNumber
+
+    /// The passport number field.
+    case passportNumber
+
+    /// The license number field.
+    case licenseNumber
+
+    /// The email field.
+    case email
+
+    /// The identity phone field.
+    case phone
+
+    /// The identity address field.
+    case fullAddress
+
+    /// The identity address field.
+    case notes
+
     /// The event to collect when copying the field.
     var eventOnCopy: EventType? {
         switch self {
@@ -129,7 +156,16 @@ enum CopyableField {
              .sshPrivateKey,
              .totp:
             true
-        case .customTextField,
+        case .company,
+             .customTextField,
+             .email,
+             .fullAddress,
+             .identityName,
+             .licenseNumber,
+             .notes,
+             .passportNumber,
+             .phone,
+             .socialSecurityNumber,
              .sshKeyFingerprint,
              .sshPublicKey,
              .uri,
@@ -162,6 +198,24 @@ enum CopyableField {
             Localizations.uri
         case .username:
             Localizations.username
+        case .identityName:
+            Localizations.identityName
+        case .company:
+            Localizations.company
+        case .socialSecurityNumber:
+            Localizations.ssn
+        case .passportNumber:
+            Localizations.passportNumber
+        case .licenseNumber:
+            Localizations.licenseNumber
+        case .email:
+            Localizations.email
+        case .phone:
+            Localizations.phone
+        case .fullAddress:
+            Localizations.address
+        case .notes:
+            Localizations.notes
         }
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -185,8 +185,11 @@ struct ViewItemDetailsView: View { // swiftlint:disable:this type_body_length
     /// The notes section.
     @ViewBuilder private var notesSection: some View {
         if !store.state.notes.isEmpty {
+            let notes = store.state.notes
             SectionView(Localizations.notes) {
-                BitwardenTextValueField(value: store.state.notes)
+                BitwardenTextValueField(value: notes,
+                                        copyButtonAction: { store.send(.copyPressed(value: notes, field: .notes)) },
+                                        copyButtonAccessibilityIdentifier: "CopyNotesButton")
             }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("CipherNotesLabel")


### PR DESCRIPTION
## 🎟️ Tracking
https://bitwarden.atlassian.net/browse/PM-13029

## 📔 Objective
Added copy button to itemview Identity and note fields

## 📸 Screenshots
<img width="314" alt="notes with copy button" src="https://github.com/user-attachments/assets/1a9d12c4-5d26-48cb-ad75-e4be052eaf6a">
<img width="314" alt="identity with copy buttons" src="https://github.com/user-attachments/assets/30b94673-ba94-4e7b-846c-80da62261128">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
