### PR TITLE
PM-13885: Handle empty vault after import logins

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -50,6 +50,9 @@ class MockVaultRepository: VaultRepository {
 
     var getDisableAutoTotpCopyResult: Result<Bool, Error> = .success(false)
 
+    var isVaultEmptyCalled = false
+    var isVaultEmptyResult: Result<Bool, Error> = .success(false)
+
     var needsSyncCalled = false
     var needsSyncResult: Result<Bool, Error> = .success(false)
 
@@ -192,6 +195,11 @@ class MockVaultRepository: VaultRepository {
     func needsSync() async throws -> Bool {
         needsSyncCalled = true
         return try needsSyncResult.get()
+    }
+
+    func isVaultEmpty() async throws -> Bool {
+        isVaultEmptyCalled = true
+        return try isVaultEmptyResult.get()
     }
 
     func organizationsPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[Organization], Error>> {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -101,6 +101,12 @@ public protocol VaultRepository: AnyObject {
     ///
     func getDisableAutoTotpCopy() async throws -> Bool
 
+    /// Returns whether the user's vault is empty.
+    ///
+    /// - Returns: Whether the user's vault is empty.
+    ///
+    func isVaultEmpty() async throws -> Bool
+
     /// Regenerates the TOTP code for a given key.
     ///
     /// - Parameter key: The key for a TOTP code.
@@ -1040,6 +1046,10 @@ extension DefaultVaultRepository: VaultRepository {
 
     func getDisableAutoTotpCopy() async throws -> Bool {
         try await stateService.getDisableAutoTotpCopy()
+    }
+
+    func isVaultEmpty() async throws -> Bool {
+        try await cipherService.fetchAllCiphers().isEmpty
     }
 
     func needsSync() async throws -> Bool {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -1049,7 +1049,7 @@ extension DefaultVaultRepository: VaultRepository {
     }
 
     func isVaultEmpty() async throws -> Bool {
-        try await cipherService.fetchAllCiphers().isEmpty
+        try await cipherService.cipherCount() == 0
     }
 
     func needsSync() async throws -> Bool {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -762,7 +762,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `isVaultEmpty()` throws an error if one occurs.
     func test_isVaultEmpty_error() async {
-        cipherService.fetchAllCiphersResult = .failure(BitwardenTestError.example)
+        cipherService.cipherCountResult = .failure(BitwardenTestError.example)
         await assertAsyncThrows(error: BitwardenTestError.example) {
             _ = try await subject.isVaultEmpty()
         }
@@ -770,13 +770,14 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `isVaultEmpty()` returns `false` if the user's vault is not empty.
     func test_isVaultEmpty_false() async throws {
-        cipherService.fetchAllCiphersResult = .success([.fixture()])
+        cipherService.cipherCountResult = .success(2)
         let isEmpty = try await subject.isVaultEmpty()
         XCTAssertFalse(isEmpty)
     }
 
     /// `isVaultEmpty()` returns `true` if the user's vault is empty.
     func test_isVaultEmpty_true() async throws {
+        cipherService.cipherCountResult = .success(0)
         let isEmpty = try await subject.isVaultEmpty()
         XCTAssertTrue(isEmpty)
     }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -760,6 +760,27 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertTrue(isDisabled)
     }
 
+    /// `isVaultEmpty()` throws an error if one occurs.
+    func test_isVaultEmpty_error() async {
+        cipherService.fetchAllCiphersResult = .failure(BitwardenTestError.example)
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await subject.isVaultEmpty()
+        }
+    }
+
+    /// `isVaultEmpty()` returns `false` if the user's vault is not empty.
+    func test_isVaultEmpty_false() async throws {
+        cipherService.fetchAllCiphersResult = .success([.fixture()])
+        let isEmpty = try await subject.isVaultEmpty()
+        XCTAssertFalse(isEmpty)
+    }
+
+    /// `isVaultEmpty()` returns `true` if the user's vault is empty.
+    func test_isVaultEmpty_true() async throws {
+        let isEmpty = try await subject.isVaultEmpty()
+        XCTAssertTrue(isEmpty)
+    }
+
     /// `refreshTOTPCode(:)` rethrows errors.
     func test_refreshTOTPCode_error() async throws {
         clientService.mockVault.generateTOTPCodeResult = .failure(BitwardenTestError.example)

--- a/BitwardenShared/Core/Vault/Services/CipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherService.swift
@@ -13,6 +13,10 @@ protocol CipherService {
     ///
     func addCipherWithServer(_ cipher: Cipher) async throws
 
+    /// Returns the count of ciphers in the data store for the current user.
+    ///
+    func cipherCount() async throws -> Int
+
     /// Delete a cipher's attachment for the current user both in the backend and in local storage.
     ///
     /// - Parameters:
@@ -189,6 +193,11 @@ extension DefaultCipherService {
 
         // Add the cipher in local storage.
         try await cipherDataStore.upsertCipher(Cipher(responseModel: response), userId: userId)
+    }
+
+    func cipherCount() async throws -> Int {
+        let userId = try await stateService.getActiveAccountId()
+        return try await cipherDataStore.cipherCount(userId: userId)
     }
 
     func deleteAttachmentWithServer(attachmentId: String, cipherId: String) async throws -> Cipher? {

--- a/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
@@ -70,6 +70,26 @@ class CipherServiceTests: BitwardenTestCase {
         XCTAssertEqual(cipherDataStore.upsertCipherValue?.id, "3792af7a-4441-11ee-be56-0242ac120002")
     }
 
+    /// `cipherCount()` returns the number of ciphers in the data store.
+    func test_ciphersCount() async throws {
+        stateService.activeAccount = .fixture()
+
+        cipherDataStore.cipherCountResult = .success(0)
+        var count = try await subject.cipherCount()
+        XCTAssertEqual(count, 0)
+
+        cipherDataStore.cipherCountResult = .success(3)
+        count = try await subject.cipherCount()
+        XCTAssertEqual(count, 3)
+    }
+
+    /// `cipherCount()` throws an error if one occurs getting the count of ciphers.
+    func test_ciphersCount_error() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.cipherCount()
+        }
+    }
+
     /// `ciphersPublisher()` returns a publisher that emits data as the data store changes.
     func test_ciphersPublisher() async throws {
         stateService.activeAccount = .fixtureAccountLogin()

--- a/BitwardenShared/Core/Vault/Services/Stores/CipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CipherDataStore.swift
@@ -7,6 +7,12 @@ import CoreData
 /// A protocol for a data store that handles performing data requests for ciphers.
 ///
 protocol CipherDataStore: AnyObject {
+    /// Returns the count of ciphers in the data store belonging to the specified user ID.
+    ///
+    /// - Parameter userId: The user ID of the user associated with the ciphers.
+    ///
+    func cipherCount(userId: String) async throws -> Int
+
     /// Deletes all `Cipher` objects for a specific user.
     ///
     /// - Parameter userId: The user ID of the user associated with the objects to delete.
@@ -62,6 +68,13 @@ protocol CipherDataStore: AnyObject {
 }
 
 extension DataStore: CipherDataStore {
+    func cipherCount(userId: String) async throws -> Int {
+        try await backgroundContext.perform {
+            let fetchRequest = CipherData.fetchByUserIdRequest(userId: userId)
+            return try self.backgroundContext.count(for: fetchRequest)
+        }
+    }
+
     func deleteAllCiphers(userId: String) async throws {
         try await executeBatchDelete(CipherData.deleteByUserIdRequest(userId: userId))
     }

--- a/BitwardenShared/Core/Vault/Services/Stores/CipherDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CipherDataStoreTests.swift
@@ -31,6 +31,18 @@ class CipherDataStoreTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `cipherCount(userId:)` returns the count of ciphers in the data store.
+    func test_cipherCount() async throws {
+        var count = try await subject.cipherCount(userId: "1")
+        XCTAssertEqual(count, 0)
+
+        try await insertCiphers(ciphers, userId: "1")
+        try await insertCiphers(ciphers, userId: "2")
+
+        count = try await subject.cipherCount(userId: "1")
+        XCTAssertEqual(count, 3)
+    }
+
     /// `cipherPublisher(userId:)` returns a publisher for a user's cipher objects.
     func test_cipherPublisher() async throws {
         var publishedValues = [[Cipher]]()

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
@@ -4,6 +4,9 @@ import Combine
 @testable import BitwardenShared
 
 class MockCipherDataStore: CipherDataStore {
+    var cipherCountUserId: String?
+    var cipherCountResult: Result<Int, Error> = .success(0)
+
     var deleteAllCiphersUserId: String?
 
     var deleteCipherId: String?
@@ -22,6 +25,11 @@ class MockCipherDataStore: CipherDataStore {
 
     var upsertCipherValue: Cipher?
     var upsertCipherUserId: String?
+
+    func cipherCount(userId: String) async throws -> Int {
+        cipherCountUserId = userId
+        return try cipherCountResult.get()
+    }
 
     func deleteAllCiphers(userId: String) async throws {
         deleteAllCiphersUserId = userId

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockCipherService.swift
@@ -8,6 +8,8 @@ class MockCipherService: CipherService {
     var addCipherWithServerCiphers = [Cipher]()
     var addCipherWithServerResult: Result<Void, Error> = .success(())
 
+    var cipherCountResult: Result<Int, Error> = .success(0)
+
     var ciphersSubject = CurrentValueSubject<[Cipher], Error>([])
 
     var deleteAttachmentWithServerAttachmentId: String?
@@ -61,6 +63,10 @@ class MockCipherService: CipherService {
     func addCipherWithServer(_ cipher: Cipher) async throws {
         addCipherWithServerCiphers.append(cipher)
         try addCipherWithServerResult.get()
+    }
+
+    func cipherCount() async throws -> Int {
+        try cipherCountResult.get()
     }
 
     func deleteAttachmentWithServer(attachmentId: String, cipherId _: String) async throws -> Cipher? {

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1047,3 +1047,5 @@
 "AllowAuthenticatorSyncing" = "Allow authenticator syncing";
 "AuthenticatorSync" = "Authenticator sync";
 "NoAccountFoundPleaseLogInAgainIfYouContinueToSeeThisError" = "No account found. Please log in again if you continue to see this error.";
+"ImportError" = "Import error";
+"NoLoginsWereImported" = "No logins were imported";

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -109,6 +109,26 @@ extension Alert {
         )
     }
 
+    /// An alert informing the user that no logins were imported.
+    ///
+    /// - Parameter action: The action taken when the user taps import logins later.
+    /// - Returns: An alert informing the user that no logins were imported.
+    ///
+    static func importLoginsEmpty(
+        action: @escaping () async -> Void
+    ) -> Alert {
+        Alert(
+            title: Localizations.importError,
+            message: Localizations.noLoginsWereImported,
+            alertActions: [
+                AlertAction(title: Localizations.tryAgain, style: .cancel),
+                AlertAction(title: Localizations.importLoginsLater, style: .default) { _ in
+                    await action()
+                },
+            ]
+        )
+    }
+
     /// An alert confirming that the user wants to import logins later in settings.
     ///
     /// - Parameter action: The action taken when the user taps on Confirm to import logins later

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -81,6 +81,26 @@ class AlertVaultTests: BitwardenTestCase {
         XCTAssertTrue(actionCalled)
     }
 
+    /// `importLoginsEmpty(action:)` constructs an `Alert` that informs the user that no logins
+    /// were imported.
+    func test_importLoginsEmpty() async throws {
+        var actionCalled = false
+        let subject = Alert.importLoginsEmpty { actionCalled = true }
+
+        XCTAssertEqual(subject.title, Localizations.importError)
+        XCTAssertEqual(subject.message, Localizations.noLoginsWereImported)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.tryAgain)
+        XCTAssertEqual(subject.alertActions[0].style, .cancel)
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.importLoginsLater)
+        XCTAssertEqual(subject.alertActions[1].style, .default)
+
+        try await subject.tapAction(title: Localizations.tryAgain)
+        XCTAssertFalse(actionCalled)
+
+        try await subject.tapAction(title: Localizations.importLoginsLater)
+        XCTAssertTrue(actionCalled)
+    }
+
     /// `static importLoginsLater(action:)` constructs an `Alert` that confirms that the user
     /// wants to import logins later in settings.
     func test_importLoginsLater() async throws {

--- a/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/ImportLogins/ImportLoginsProcessorTests.swift
@@ -10,6 +10,7 @@ class ImportLoginsProcessorTests: BitwardenTestCase {
     var settingsRepository: MockSettingsRepository!
     var stateService: MockStateService!
     var subject: ImportLoginsProcessor!
+    var vaultRepository: MockVaultRepository!
 
     // MARK: Setup & Teardown
 
@@ -20,13 +21,15 @@ class ImportLoginsProcessorTests: BitwardenTestCase {
         errorReporter = MockErrorReporter()
         settingsRepository = MockSettingsRepository()
         stateService = MockStateService()
+        vaultRepository = MockVaultRepository()
 
         subject = ImportLoginsProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 errorReporter: errorReporter,
                 settingsRepository: settingsRepository,
-                stateService: stateService
+                stateService: stateService,
+                vaultRepository: vaultRepository
             ),
             state: ImportLoginsState()
         )
@@ -40,6 +43,7 @@ class ImportLoginsProcessorTests: BitwardenTestCase {
         settingsRepository = nil
         stateService = nil
         subject = nil
+        vaultRepository = nil
     }
 
     // MARK: Tests
@@ -89,6 +93,53 @@ class ImportLoginsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
         XCTAssertTrue(settingsRepository.fetchSyncCalled)
         XCTAssertNil(stateService.accountSetupImportLogins["1"])
+    }
+
+    /// `perform(_:)` with `.advanceNextPage` syncs the user's vault and shows an alert if the
+    /// user's vault is still empty. Tapping set up later sets the user's progress and dismisses
+    /// the view.
+    @MainActor
+    func test_perform_advanceNextPage_sync_vaultEmpty_setUpLater() async throws {
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupImportLogins["1"] = .incomplete
+        subject.state.page = .step3
+        vaultRepository.isVaultEmptyResult = .success(true)
+
+        await subject.perform(.advanceNextPage)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .importLoginsEmpty {})
+        try await alert.tapAction(title: Localizations.importLoginsLater)
+
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.syncingLogins)])
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(coordinator.routes, [.dismiss])
+        XCTAssertTrue(settingsRepository.fetchSyncCalled)
+        XCTAssertEqual(stateService.accountSetupImportLogins["1"], .setUpLater)
+    }
+
+    /// `perform(_:)` with `.advanceNextPage` syncs the user's vault and shows an alert if the
+    /// user's vault is still empty. Tapping try again dismisses the alert.
+    @MainActor
+    func test_perform_advanceNextPage_sync_vaultEmpty_tryAgain() async throws {
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupImportLogins["1"] = .incomplete
+        subject.state.page = .step3
+        vaultRepository.isVaultEmptyResult = .success(true)
+
+        await subject.perform(.advanceNextPage)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert, .importLoginsEmpty {})
+
+        vaultRepository.isVaultEmptyResult = .success(false)
+        try await alert.tapAction(title: Localizations.tryAgain)
+
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.syncingLogins)])
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertTrue(coordinator.routes.isEmpty)
+        XCTAssertTrue(settingsRepository.fetchSyncCalled)
+        XCTAssertEqual(stateService.accountSetupImportLogins["1"], .incomplete)
     }
 
     /// `perform(_:)` with `.advanceNextPage` initiates a vault sync when on the last page and


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-13885](https://bitwarden.atlassian.net/browse/PM-13885)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This handles the case where a user navigates through the import login flow and after syncing, the user's vault is still empty. An alert is shown asking the user if they want to try again or import logins later.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/8ceaf161-8231-4323-b345-2479d7d363a6


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13885]: https://bitwarden.atlassian.net/browse/PM-13885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ