### PR TITLE
PM-13691: Fix managed EU base URL setting returns US environment URLs

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift
@@ -42,6 +42,13 @@ extension EnvironmentUrls {
     /// - Parameter environmentUrlData: The environment URLs used to initialize `EnvironmentUrls`.
     ///
     init(environmentUrlData: EnvironmentUrlData) {
+        // Use the default URLs if the region matches US or EU.
+        let environmentUrlData: EnvironmentUrlData = switch environmentUrlData.region {
+        case .europe: .defaultEU
+        case .unitedStates: .defaultUS
+        case .selfHosted: environmentUrlData
+        }
+
         if environmentUrlData.region == .selfHosted, let base = environmentUrlData.base {
             apiURL = base.appendingPathComponent("api")
             baseURL = base

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
@@ -72,6 +72,50 @@ class EnvironmentUrlsTests: BitwardenTestCase {
         )
     }
 
+    /// `init(environmentUrlData:)` defaults to the pre-defined EU URLs if the base URL matches the EU environment.
+    func test_init_environmentUrlData_baseUrl_europe() {
+        let subject = EnvironmentUrls(
+            environmentUrlData: EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.eu")!)
+        )
+        XCTAssertEqual(
+            subject,
+            EnvironmentUrls(
+                apiURL: URL(string: "https://api.bitwarden.eu")!,
+                baseURL: URL(string: "https://vault.bitwarden.eu")!,
+                eventsURL: URL(string: "https://events.bitwarden.eu")!,
+                iconsURL: URL(string: "https://icons.bitwarden.eu")!,
+                identityURL: URL(string: "https://identity.bitwarden.eu")!,
+                importItemsURL: URL(string: "https://vault.bitwarden.eu/#/tools/import")!,
+                recoveryCodeURL: URL(string: "https://vault.bitwarden.eu/#/recover-2fa")!,
+                sendShareURL: URL(string: "https://vault.bitwarden.eu/#/send")!,
+                settingsURL: URL(string: "https://vault.bitwarden.eu/#/settings")!,
+                webVaultURL: URL(string: "https://vault.bitwarden.eu")!
+            )
+        )
+    }
+
+    /// `init(environmentUrlData:)` defaults to the pre-defined US URLs if the base URL matches the US environment.
+    func test_init_environmentUrlData_baseUrl_unitedStates() {
+        let subject = EnvironmentUrls(
+            environmentUrlData: EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.com")!)
+        )
+        XCTAssertEqual(
+            subject,
+            EnvironmentUrls(
+                apiURL: URL(string: "https://api.bitwarden.com")!,
+                baseURL: URL(string: "https://vault.bitwarden.com")!,
+                eventsURL: URL(string: "https://events.bitwarden.com")!,
+                iconsURL: URL(string: "https://icons.bitwarden.net")!,
+                identityURL: URL(string: "https://identity.bitwarden.com")!,
+                importItemsURL: URL(string: "https://vault.bitwarden.com/#/tools/import")!,
+                recoveryCodeURL: URL(string: "https://vault.bitwarden.com/#/recover-2fa")!,
+                sendShareURL: URL(string: "https://send.bitwarden.com/#")!,
+                settingsURL: URL(string: "https://vault.bitwarden.com/#/settings")!,
+                webVaultURL: URL(string: "https://vault.bitwarden.com")!
+            )
+        )
+    }
+
     /// `init(environmentUrlData:)` sets the URLs from the base URL which includes a trailing slash.
     func test_init_environmentUrlData_baseUrlWithTrailingSlash() {
         let subject = EnvironmentUrls(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-13691](https://bitwarden.atlassian.net/browse/PM-13691) - Managed base URL setting of EU returns US environment URLs
[PM-13443](https://bitwarden.atlassian.net/browse/PM-13443) - User lands on empty SSO identifier screen even with claimed domain

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Previously, if the managed base URL or a self-hosted base URL was set to the EU server (https://vault.bitwarden.eu), the app would still use US environment URLs. If the URLs are for a self-hosted region, the app uses the self-hosted base URL to construct the URLs. Otherwise, we were assuming `EnvironmentUrlData` was fully populated. If only the base URL was set, it would default to the US URLs instead of constructing the URLs based on the base URL.

Instead, if the URL's region is for US or EU, we should use the default US or EU URLs rather than relying on the passed in URLs.

https://github.com/bitwarden/ios/blob/b64b56b04179b0da4a3b9ca9cc445224096f7c57/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift#L52-L65

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13691]: https://bitwarden.atlassian.net/browse/PM-13691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-13443]: https://bitwarden.atlassian.net/browse/PM-13443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ