### PR TITLE
PM-13949: Dismiss vault unlock action card when backing out of set up unlock with unlock method enabled

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -173,6 +173,10 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
             if state.shouldShowAuthenticatorSyncSection {
                 state.isAuthenticatorSyncEnabled = try await services.stateService.getSyncToAuthenticator()
             }
+
+            if state.biometricUnlockStatus.isEnabled || state.isUnlockWithPINCodeOn {
+                await completeAccountSetupVaultUnlockIfNeeded()
+            }
         } catch {
             services.errorReporter.log(error: error)
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-13949](https://bitwarden.atlassian.net/browse/PM-13949)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

From Settings > Account security > Set up unlock, if you enable a vault unlock method, but back out of the view instead of tapping the Continue button, the action card wasn't being cleared. This clears the card when navigating back to Account security screen if an unlock method has been enabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d37ef27f-0ea1-4202-ad6c-54a690d1a2e4" /> | <video src="https://github.com/user-attachments/assets/9b19326e-999a-4329-bce1-b96373b7185a" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13949]: https://bitwarden.atlassian.net/browse/PM-13949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ