### PR TITLE
Clean up references to the beta

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,16 +8,16 @@ body:
         Thanks for taking the time to fill out this bug report!
 
         > [!WARNING]
-        > This is the new native Bitwarden Beta app repository. For the pubicly available apps in App Store / Play Store, submit your report in [bitwarden/mobile](https://github.com/bitwarden/mobile)
+        > This is the new native Bitwarden app repository. For the pubicly available apps in App Store / Play Store, submit your report in [bitwarden/mobile](https://github.com/bitwarden/mobile)
 
 
         Please do not submit feature requests. The [Community Forums](https://community.bitwarden.com) has a section for submitting, voting for, and discussing product feature requests.
   - type: checkboxes
-    id: beta
+    id: app
     attributes:
-      label: Bitwarden Beta
+      label: Bitwarden app
       options:
-        - label: "I'm using the new native Bitwarden Beta app and I'm aware that legacy .NET app bugs should be reported in [bitwarden/mobile](https://github.com/bitwarden/mobile)"
+        - label: "I'm using the new native Bitwarden app and I'm aware that legacy .NET app bugs should be reported in [bitwarden/mobile](https://github.com/bitwarden/mobile)"
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -7,19 +7,7 @@ body:
       value: |
         Thanks for taking the time to fill out this bug report!
 
-        > [!WARNING]
-        > This is the new native Bitwarden app repository. For the pubicly available apps in App Store / Play Store, submit your report in [bitwarden/mobile](https://github.com/bitwarden/mobile)
-
-
         Please do not submit feature requests. The [Community Forums](https://community.bitwarden.com) has a section for submitting, voting for, and discussing product feature requests.
-  - type: checkboxes
-    id: app
-    attributes:
-      label: Bitwarden app
-      options:
-        - label: "I'm using the new native Bitwarden app and I'm aware that legacy .NET app bugs should be reported in [bitwarden/mobile](https://github.com/bitwarden/mobile)"
-    validations:
-      required: true
   - type: textarea
     id: reproduce
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,5 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Legacy Android Bug Reports
-    url: https://github.com/bitwarden/mobile/issues
-    about: Bugs found in the publicly available .NET MAUI app should be reported in [bitwarden/mobile](https://github.com/bitwarden/mobile)
   - name: Feature Requests
     url: https://community.bitwarden.com/c/feature-requests/
     about: Request new features using the Community Forums. Please search existing feature requests before making a new one.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Bitwarden iOS (BETA)
+# Bitwarden iOS
 
 > [!TIP]
-> This repo has the new native iOS app, currently in [Beta](https://community.bitwarden.com/t/about-the-beta-program/39185). Looking for the legacy .NET MAUI apps? Head on over to [bitwarden/mobile](https://github.com/bitwarden/mobile)
+> This repo has the new native iOS app. Looking for the legacy .NET MAUI apps? Head on over to [bitwarden/mobile](https://github.com/bitwarden/mobile)
 
 ## Contents
 


### PR DESCRIPTION
## 📔 Objective

Now that the app is released on the app store, and not in beta, we should remove references to it being in beta.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
