### PR TITLE
PM-13856 - After enabling Autofill in Device Settings, user is stuck in a loop/does not see the all set screen

### DIFF
--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -196,6 +196,23 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(route, .autofillSetup)
     }
 
+    /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.complete` if the user still
+    /// needs to set up autofill but is within the app extension.
+    @MainActor
+    func test_handleAndRoute_didCompleteAuth_incompleteAutofill_withinAppExtension() async {
+        subject = AuthRouter(
+            isInAppExtension: true,
+            services: ServiceContainer.withMocks(
+                authRepository: authRepository
+            )
+        )
+        authRepository.activeAccount = .fixture()
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupAutofill["1"] = .incomplete
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+        XCTAssertEqual(route, .complete)
+    }
+
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.vaultUnlockSetup` if the user still
     /// needs to set up a vault unlock method.
     func test_handleAndRoute_didCompleteAuth_incompleteVaultSetup() async {
@@ -204,6 +221,23 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         stateService.accountSetupVaultUnlock["1"] = .incomplete
         let route = await subject.handleAndRoute(.didCompleteAuth)
         XCTAssertEqual(route, .vaultUnlockSetup(.createAccount))
+    }
+
+    /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.complete` if the user still
+    /// needs to set up a vault unlock method but is within the app extension.
+    @MainActor
+    func test_handleAndRoute_didCompleteAuth_incomplete_withinAppExtension() async {
+        subject = AuthRouter(
+            isInAppExtension: true,
+            services: ServiceContainer.withMocks(
+                authRepository: authRepository
+            )
+        )
+        authRepository.activeAccount = .fixture()
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupVaultUnlock["1"] = .incomplete
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+        XCTAssertEqual(route, .complete)
     }
 
     /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.landing` when there are no accounts.

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -28,16 +28,21 @@ extension AuthRouter {
         guard let account = try? await services.authRepository.getAccount() else {
             return .landing
         }
+
         if account.profile.forcePasswordResetReason != nil {
             return .updateMasterPassword
-        } else if await (try? services.stateService.getAccountSetupVaultUnlock()) == .incomplete {
-            return .vaultUnlockSetup(.createAccount)
-        } else if await (try? services.stateService.getAccountSetupAutofill()) == .incomplete {
-            return .autofillSetup
-        } else {
-            await setCarouselShownIfEnabled()
-            return .complete
         }
+
+        if !isInAppExtension {
+            if await (try? services.stateService.getAccountSetupVaultUnlock()) == .incomplete {
+                return .vaultUnlockSetup(.createAccount)
+            } else if await (try? services.stateService.getAccountSetupAutofill()) == .incomplete {
+                return .autofillSetup
+            }
+        }
+
+        await setCarouselShownIfEnabled()
+        return .complete
     }
 
     /// Handles the `.didDeleteAccount`route and redirects the user to the correct screen


### PR DESCRIPTION
## 🎟️ Tracking


[PM-13856](https://bitwarden.atlassian.net/browse/PM-13856)
[PM-10280 - Parent ticket](https://bitwarden.atlassian.net/browse/PM-10280)

## 📔 Objective
- After completing the new account creation and onboarding process, when the user opts to enable autofill, they are redirected to the Autofill section of the Passwords settings. However, upon unlocking the vault, the app incorrectly presented the PasswordAutoFillView again instead of displaying the expected completion screen.
- This fix ensures that, when within the app extension, these checks are bypassed, allowing the correct completion screen to be shown as expected.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
