### PR TITLE
PM-14011: Show settings badge and action card when dismissing import logins action card from vault

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -386,11 +386,11 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     @MainActor
     func test_perform_dismissSetUpUnlockActionCard() async {
         stateService.activeAccount = .fixture()
-        stateService.accountSetupImportLogins["1"] = .setUpLater
+        stateService.accountSetupImportLogins["1"] = .incomplete
 
         await subject.perform(.dismissImportLoginsActionCard)
 
-        XCTAssertEqual(stateService.accountSetupImportLogins["1"], .complete)
+        XCTAssertEqual(stateService.accountSetupImportLogins["1"], .setUpLater)
     }
 
     /// `perform(_:)` with `.dismissImportLoginsActionCard` logs an error and shows an alert if an
@@ -399,7 +399,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     func test_perform_dismissSetUpUnlockActionCard_error() async {
         await subject.perform(.dismissImportLoginsActionCard)
 
-        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
+        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(error: StateServiceError.noActiveAccount)])
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -104,6 +104,7 @@ private struct SearchableVaultListView: View {
 
                     Spacer()
                 }
+                .animation(.easeInOut, value: store.state.importLoginsSetupProgress == .setUpLater)
                 .animation(.easeInOut, value: store.state.importLoginsSetupProgress == .complete)
                 .padding(.horizontal, 16)
                 .frame(minHeight: reader.size.height)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14011](https://bitwarden.atlassian.net/browse/PM-14011)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Dismissing the vault's import logins action card should hide the card and then show the settings badge and action card for import logins.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/6c49a4c4-864a-4cbd-b611-6422a26610c6

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
