### PR TITLE
[PM-12655] Fix vault tab endless loading when in slow connection

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -1044,7 +1044,7 @@ extension DefaultVaultRepository: VaultRepository {
 
     func needsSync() async throws -> Bool {
         let userId = try await stateService.getActiveAccountId()
-        return try await syncService.needsSync(for: userId)
+        return try await syncService.needsSync(for: userId, onlyCheckLocalData: true)
     }
 
     func refreshTOTPCode(for key: TOTPKeyModel) async throws -> LoginTOTPState {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -760,6 +760,33 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertTrue(isDisabled)
     }
 
+    /// `needsSync()` Calls the sync service to check it.
+    func test_needsSync() async throws {
+        stateService.activeAccount = .fixture()
+        syncService.needsSyncResult = .success(true)
+        let needsSync = try await subject.needsSync()
+        XCTAssertTrue(needsSync)
+        XCTAssertTrue(syncService.needsSyncOnlyCheckLocalData)
+    }
+
+    /// `needsSync()` throws when no active account.
+    func test_needsSync_throwsNoActiveAccount() async throws {
+        stateService.activeAccount = nil
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.needsSync()
+        }
+    }
+
+    /// `needsSync()` throws when sync service throws.
+    func test_needsSync_throwsSyncService() async throws {
+        stateService.activeAccount = .fixture()
+        syncService.needsSyncResult = .failure(BitwardenTestError.example)
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await subject.needsSync()
+        }
+        XCTAssertTrue(syncService.needsSyncOnlyCheckLocalData)
+    }
+
     /// `refreshTOTPCode(:)` rethrows errors.
     func test_refreshTOTPCode_error() async throws {
         clientService.mockVault.generateTOTPCodeResult = .failure(BitwardenTestError.example)

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -92,14 +92,6 @@ protocol SyncServiceDelegate: AnyObject {
     func setMasterPassword(orgIdentifier: String) async
 }
 
-// MARK: - SyncService extension
-
-extension SyncService {
-    func needsSync(for userId: String) async throws -> Bool {
-        try await needsSync(for: userId, onlyCheckLocalData: false)
-    }
-}
-
 // MARK: - DefaultSyncService
 
 /// A default implementation of a `SyncService` which manages syncing vault data with the API.

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -727,6 +727,19 @@ class SyncServiceTests: BitwardenTestCase {
         try await subject.fetchUpsertSyncSend(data: notification)
         XCTAssertEqual(sendService.syncSendWithServerId, "id")
     }
+
+    /// `needsSync(forceSync:onlyCheckLocalData:userId:)` returns `true` when
+    /// only checking local data and not enough time hasn't passed since the last sync.
+    func test_needsSync_onlyCheckLocalData() async throws {
+        stateService.activeAccount = .fixture()
+        let lastSync = timeProvider.presentTime.addingTimeInterval(-(Constants.minimumSyncInterval + 1))
+        stateService.lastSyncTimeByUserId["1"] = try XCTUnwrap(
+            lastSync
+        )
+        let needsSync = try await subject.needsSync(for: "1", onlyCheckLocalData: true)
+        XCTAssertTrue(needsSync)
+        XCTAssertTrue(client.requests.isEmpty)
+    }
 }
 
 class MockSyncServiceDelegate: SyncServiceDelegate {

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
@@ -27,6 +27,7 @@ class MockSyncService: SyncService {
     var fetchUpsertSyncSendResult: Result<Void, Error> = .success(())
 
     var needsSyncResult: Result<Bool, Error> = .success(false)
+    var needsSyncOnlyCheckLocalData: Bool = false
 
     func fetchSync(forceSync: Bool) async throws {
         didFetchSync = true
@@ -64,7 +65,8 @@ class MockSyncService: SyncService {
         return try fetchUpsertSyncSendResult.get()
     }
 
-    func needsSync(for userId: String) async throws -> Bool {
-        try needsSyncResult.get()
+    func needsSync(for userId: String, onlyCheckLocalData: Bool) async throws -> Bool {
+        needsSyncOnlyCheckLocalData = onlyCheckLocalData
+        return try needsSyncResult.get()
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-12655](https://bitwarden.atlassian.net/browse/PM-12655)

## 📔 Objective

In a slow connection scenario the vault tab was displaying the loading indicator for a long time (potentially until request timeout) so it could seem that the app hangs.
This attempts to fix this on the scenario where the vault has local data to display, so it immediately displays such data while the sync happens in the background. This was happening because of a request being sent to check whether sync was needed before streaming the local vault data; now this check is done only with local data on the streaming vault list items process.

## 📸 Screenshots

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/7ccd7b59-d66b-436b-81a3-9d6bb78781db" /> | <video src="https://github.com/user-attachments/assets/9ef7a40d-e7aa-456e-a16c-fab39d2ed333" /> |



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12655]: https://bitwarden.atlassian.net/browse/PM-12655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ