### PR TITLE
Use Task Wrapper for `refreshConfig()` to Improve UI Responsiveness on Slow Connections

### DIFF
--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -233,6 +233,9 @@ extension LandingProcessor: RegionDelegate {
         guard !urls.isEmpty else { return }
         await services.environmentService.setPreAuthURLs(urls: urls)
         state.region = region
-        await refreshConfig()
+
+        Task {
+            await refreshConfig()
+        }
     }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -234,6 +234,10 @@ extension LandingProcessor: RegionDelegate {
         await services.environmentService.setPreAuthURLs(urls: urls)
         state.region = region
 
+        /// - Using `Task` for `refreshConfig` ensures that this call doesn’t delay other operations,
+        ///   such as closing the Self-host settings view or triggering `.appeared` events. These issues
+        ///   arose because `refreshConfig` was awaited directly, leading to delays when internet speed
+        ///   was low.
         Task {
             await refreshConfig()
         }


### PR DESCRIPTION
## 📔 Objective

- @fedemkr brought this to my attention from this [PR](https://github.com/bitwarden/ios/pull/1072#discussion_r1815809464). 
- Wrapped `refreshConfig()` in a Task to prevent UI delays on slow internet connections. This avoids blocking critical actions (e.g., .appeared refresh calls, closing the Self-host settings view) that were previously held up by awaiting refreshConfig(). For features that require configuration data, fallback flows ensure functionality even if refreshConfig() isn’t instantly loaded.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
