### PR TITLE
PM-12735: Navigate back to settings after enabling autofill

### DIFF
--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -33,6 +33,9 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     HasRouter {
     // MARK: Types
 
+    /// The module types required by this coordinator for creating child coordinators.
+    typealias Module = PasswordAutoFillModule
+
     typealias Router = AnyRouter<AuthEvent, AuthRoute>
 
     typealias Services = HasAccountAPIService
@@ -71,6 +74,9 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     /// the auth flow should be dismissed.
     private weak var delegate: (any AuthCoordinatorDelegate)?
 
+    /// The module used to create child coordinators.
+    private let module: Module
+
     /// A delegate used to communicate the WebAuthn result when the auth has been completed. This is assigned
     /// on a webAuthn navigation casted from the provided context.
     private weak var webAuthnFlowDelegate: (any WebAuthnFlowDelegate)?
@@ -94,6 +100,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     /// - Parameters:
     ///   - appExtensionDelegate: A delegate used to communicate with the app extension.
     ///   - delegate: The delegate for this coordinator. Used to signal when auth has been completed.
+    ///   - module: The module used to create child coordinators.
     ///   - rootNavigator: The root navigator used to display this coordinator's interface.
     ///   - router: The router used by this coordinator to handle events.
     ///   - services: The services used by this coordinator.
@@ -102,6 +109,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     init(
         appExtensionDelegate: AppExtensionDelegate?,
         delegate: AuthCoordinatorDelegate?,
+        module: Module,
         rootNavigator: RootNavigator?,
         router: AnyRouter<AuthEvent, AuthRoute>,
         services: Services,
@@ -109,6 +117,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     ) {
         self.appExtensionDelegate = appExtensionDelegate
         self.delegate = delegate
+        self.module = module
         self.rootNavigator = rootNavigator
         self.router = router
         self.services = services
@@ -273,14 +282,13 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     /// Shows the password autofill screen.
     ///
     private func showAutoFillSetup() {
-        let processor = PasswordAutoFillProcessor(
-            coordinator: asAnyCoordinator(),
-            services: services,
-            state: .init(mode: .onboarding)
+        guard let stackNavigator else { return }
+        let coordinator = module.makePasswordAutoFillCoordinator(
+            delegate: self,
+            stackNavigator: stackNavigator
         )
-
-        let view = PasswordAutoFillView(store: Store(processor: processor))
-        stackNavigator?.replace(view)
+        coordinator.start()
+        coordinator.navigate(to: .passwordAutofill(mode: .onboarding))
     }
 
     /// Shows the captcha screen.
@@ -1023,5 +1031,13 @@ extension AuthCoordinator: ASAuthorizationControllerDelegate {
     /// Handle errors during the creation of the attestation
     func authorizationController(controller _: ASAuthorizationController, didCompleteWithError error: Error) {
         webAuthnFlowDelegate?.webAuthnErrored(error: error)
+    }
+}
+
+// MARK: PasswordAutoFillCoordinatorDelegate
+
+extension AuthCoordinator: PasswordAutoFillCoordinatorDelegate {
+    func didCompleteAuth() {
+        delegate?.didCompleteAuth()
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Auth/AuthModule.swift
+++ b/BitwardenShared/UI/Auth/AuthModule.swift
@@ -37,6 +37,7 @@ extension DefaultAppModule: AuthModule {
         AuthCoordinator(
             appExtensionDelegate: appExtensionDelegate,
             delegate: delegate,
+            module: self,
             rootNavigator: rootNavigator,
             router: makeAuthRouter(),
             services: services,

--- a/BitwardenShared/UI/Platform/Application/AppModuleTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppModuleTests.swift
@@ -89,6 +89,19 @@ class AppModuleTests: BitwardenTestCase {
         XCTAssertTrue(navigationController.viewControllers[0] is UIHostingController<ImportLoginsView>)
     }
 
+    /// `makePasswordAutoFillCoordinator` builds the password autofill coordinator.
+    @MainActor
+    func test_makePasswordAutoFillCoordinator() {
+        let navigationController = UINavigationController()
+        let coordinator = subject.makePasswordAutoFillCoordinator(
+            delegate: MockPasswordAutoFillCoordinatorDelegate(),
+            stackNavigator: navigationController
+        )
+        coordinator.navigate(to: .passwordAutofill(mode: .onboarding))
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertTrue(navigationController.viewControllers[0] is UIHostingController<PasswordAutoFillView>)
+    }
+
     /// `makeSendCoordinator()` builds the send coordinator.
     @MainActor
     func test_makeSendCoordinator() {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillCoordinator.swift
@@ -1,0 +1,90 @@
+import SwiftUI
+
+// MARK: - PasswordAutoFillCoordinatorDelegate
+
+/// An object that is notified when external navigation actions need to occur from within the
+/// password autofill flow.
+///
+protocol PasswordAutoFillCoordinatorDelegate: AnyObject {
+    /// The user has completed authentication.
+    ///
+    func didCompleteAuth()
+}
+
+// MARK: - PasswordAutoFillCoordinator
+
+/// A coordinator that manages navigation for the password autofill flow.
+///
+class PasswordAutoFillCoordinator: NSObject, Coordinator, HasStackNavigator {
+    // MARK: Types
+
+    typealias Services = HasAutofillCredentialService
+        & HasConfigService
+        & HasErrorReporter
+        & HasNotificationCenterService
+        & HasStateService
+
+    // MARK: Private Properties
+
+    /// The delegate for this coordinator, used to notify when external navigation actions need to occur.
+    private weak var delegate: PasswordAutoFillCoordinatorDelegate?
+
+    /// The services used by this coordinator.
+    private let services: Services
+
+    /// The stack navigator that is managed by this coordinator.
+    private(set) weak var stackNavigator: StackNavigator?
+
+    // MARK: Initialization
+
+    /// Creates a new `VaultCoordinator`.
+    ///
+    /// - Parameters:
+    ///   - delegate: The delegate for this coordinator, used to notify when external navigation
+    ///     actions need to occur.
+    ///   - module: The module used by this coordinator to create child coordinators.
+    ///   - services: The services used by this coordinator.
+    ///   - stackNavigator: The stack navigator that is managed by this coordinator.
+    ///
+    init(
+        delegate: PasswordAutoFillCoordinatorDelegate?,
+        services: Services,
+        stackNavigator: StackNavigator
+    ) {
+        self.delegate = delegate
+        self.services = services
+        self.stackNavigator = stackNavigator
+    }
+
+    func handleEvent(_ event: PasswordAutofillEvent, context: AnyObject?) async {
+        switch event {
+        case .didCompleteAuth:
+            delegate?.didCompleteAuth()
+        }
+    }
+
+    func navigate(to route: PasswordAutofillRoute, context: AnyObject?) {
+        switch route {
+        case .dismiss:
+            stackNavigator?.pop()
+        case let .passwordAutofill(mode):
+            showPasswordAutoFill(mode: mode)
+        }
+    }
+
+    func start() {}
+
+    // MARK: Private Methods
+
+    /// Shows the password auto-fill screen.
+    ///
+    private func showPasswordAutoFill(mode: PasswordAutoFillState.Mode) {
+        let processor = PasswordAutoFillProcessor(
+            coordinator: asAnyCoordinator(),
+            services: services,
+            state: PasswordAutoFillState(mode: mode)
+        )
+        let view = PasswordAutoFillView(store: Store(processor: processor))
+        stackNavigator?.push(view)
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillCoordinatorTests.swift
@@ -1,0 +1,79 @@
+import SwiftUI
+import XCTest
+
+@testable import BitwardenShared
+
+class PasswordAutoFillCoordinatorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var delegate: MockPasswordAutoFillCoordinatorDelegate!
+    var stackNavigator: MockStackNavigator!
+    var subject: PasswordAutoFillCoordinator!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        delegate = MockPasswordAutoFillCoordinatorDelegate()
+        stackNavigator = MockStackNavigator()
+
+        subject = PasswordAutoFillCoordinator(
+            delegate: delegate,
+            services: ServiceContainer.withMocks(),
+            stackNavigator: stackNavigator
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        delegate = nil
+        stackNavigator = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `handleEvent(_:context:)` with `.didCompleteAuth` notifies the delegate that the user
+    /// completed auth.
+    @MainActor
+    func test_handleEvent_didCompleteAuth() async {
+        await subject.handleEvent(.didCompleteAuth)
+        XCTAssertTrue(delegate.didCompleteAuthCalled)
+    }
+
+    /// `navigate(to:)` with `.dismiss` pops the most recently pushed view in the stack navigator.
+    @MainActor
+    func test_navigate_dismiss() throws {
+        subject.navigate(to: .dismiss)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .popped)
+    }
+
+    /// `navigate(to:)` with `.passwordAutofill(mode:)` pushes the password autofill view onto the
+    /// stack navigator.
+    @MainActor
+    func test_navigateTo_passwordAutofill() throws {
+        subject.navigate(to: .passwordAutofill(mode: .onboarding))
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .pushed)
+        XCTAssertTrue(action.view is PasswordAutoFillView)
+    }
+
+    /// `start()` has no effect.
+    @MainActor
+    func test_start() {
+        subject.start()
+        XCTAssertTrue(stackNavigator.actions.isEmpty)
+    }
+}
+
+class MockPasswordAutoFillCoordinatorDelegate: PasswordAutoFillCoordinatorDelegate {
+    var didCompleteAuthCalled = false
+
+    func didCompleteAuth() {
+        didCompleteAuthCalled = true
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillModule.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillModule.swift
@@ -1,0 +1,33 @@
+// MARK: - PasswordAutoFillModule
+
+/// An object that builds coordinators for the password autofill flow.
+///
+@MainActor
+protocol PasswordAutoFillModule {
+    /// Initializes a coordinator for navigating between `PasswordAutofillRoute`s.
+    ///
+    /// - Parameters:
+    ///   - delegate: The delegate for the coordinator, used to notify when external navigation
+    ///     needs to occur.
+    ///   - stackNavigator: The stack navigator that will be used to navigate between routes.
+    /// - Returns: A coordinator that can navigate to `PasswordAutofillRoute`s.
+    ///
+    func makePasswordAutoFillCoordinator(
+        delegate: PasswordAutoFillCoordinatorDelegate?,
+        stackNavigator: StackNavigator
+    ) -> AnyCoordinator<PasswordAutofillRoute, PasswordAutofillEvent>
+}
+
+extension DefaultAppModule: PasswordAutoFillModule {
+    func makePasswordAutoFillCoordinator(
+        delegate: PasswordAutoFillCoordinatorDelegate?,
+        stackNavigator: StackNavigator
+    ) -> AnyCoordinator<PasswordAutofillRoute, PasswordAutofillEvent> {
+        PasswordAutoFillCoordinator(
+            delegate: delegate,
+            services: services,
+            stackNavigator: stackNavigator
+        )
+        .asAnyCoordinator()
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillProcessor.swift
@@ -17,7 +17,7 @@ final class PasswordAutoFillProcessor: StateProcessor<PasswordAutoFillState, Voi
     // MARK: Private Properties
 
     /// The coordinator that handles navigation.
-    private let coordinator: AnyCoordinator<AuthRoute, AuthEvent>?
+    private let coordinator: AnyCoordinator<PasswordAutofillRoute, PasswordAutofillEvent>?
 
     /// The services used by this processor.
     private let services: Services
@@ -32,7 +32,7 @@ final class PasswordAutoFillProcessor: StateProcessor<PasswordAutoFillState, Voi
     ///   - state: The initial state of the processor.
     ///
     init(
-        coordinator: AnyCoordinator<AuthRoute, AuthEvent>? = nil,
+        coordinator: AnyCoordinator<PasswordAutofillRoute, PasswordAutofillEvent>,
         services: Services,
         state: PasswordAutoFillState
     ) {
@@ -84,8 +84,6 @@ final class PasswordAutoFillProcessor: StateProcessor<PasswordAutoFillState, Voi
     /// it completes the account setup process and triggers the appropriate event.
     ///
     private func monitorAutofillCompletionDuringOnboarding() async {
-        guard state.mode == .onboarding else { return }
-
         for await _ in services.notificationCenterService.willEnterForegroundPublisher() {
             await checkAutofillCompletion()
         }
@@ -104,6 +102,11 @@ final class PasswordAutoFillProcessor: StateProcessor<PasswordAutoFillState, Voi
             services.errorReporter.log(error: error)
         }
 
-        await coordinator?.handleEvent(.didCompleteAuth)
+        switch state.mode {
+        case .onboarding:
+            await coordinator?.handleEvent(.didCompleteAuth)
+        case .settings:
+            coordinator?.navigate(to: .dismiss)
+        }
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutofillEvent.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutofillEvent.swift
@@ -1,0 +1,8 @@
+// MARK: - PasswordAutofillEvent
+
+/// A set of events that can be emitted from `PasswordAutoFillProcessor`.
+///
+enum PasswordAutofillEvent: Equatable {
+    /// An event to handle when auth has completed.
+    case didCompleteAuth
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutofillRoute.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutofillRoute.swift
@@ -1,0 +1,11 @@
+// MARK: - PasswordAutofillRoute
+
+/// A set of routes that can be navigated to from `PasswordAutoFillProcessor`.
+///
+enum PasswordAutofillRoute: Equatable {
+    /// A route that dismisses the current view.
+    case dismiss
+
+    /// A route to the password auto-fill screen.
+    case passwordAutofill(mode: PasswordAutoFillState.Mode)
+}

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -51,6 +51,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     typealias Module = AuthModule
         & ImportLoginsModule
         & LoginRequestModule
+        & PasswordAutoFillModule
 
     typealias Services = HasAccountAPIService
         & HasAuthRepository
@@ -403,14 +404,13 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     /// Shows the password auto-fill screen.
     ///
     private func showPasswordAutoFill() {
-        let processor = PasswordAutoFillProcessor(
-            services: services,
-            state: .init(mode: .settings)
+        guard let stackNavigator else { return }
+        let coordinator = module.makePasswordAutoFillCoordinator(
+            delegate: nil,
+            stackNavigator: stackNavigator
         )
-        let view = PasswordAutoFillView(store: Store(processor: processor))
-        let viewController = UIHostingController(rootView: view)
-        viewController.navigationItem.largeTitleDisplayMode = .never
-        stackNavigator?.push(viewController, navigationTitle: Localizations.passwordAutofill)
+        coordinator.start()
+        coordinator.navigate(to: .passwordAutofill(mode: .settings))
     }
 
     /// Shows the pending login requests screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -260,9 +260,10 @@ class SettingsCoordinatorTests: BitwardenTestCase {
     func test_navigateTo_passwordAutoFill() throws {
         subject.navigate(to: .passwordAutoFill)
 
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .pushed)
-        XCTAssertTrue(action.view is UIHostingController<PasswordAutoFillView>)
+        XCTAssertTrue(module.passwordAutoFillCoordinator.isStarted)
+        XCTAssertEqual(module.passwordAutoFillCoordinator.routes, [.passwordAutofill(mode: .settings)])
+        XCTAssertNil(module.passwordAutoFillCoordinatorDelegate)
+        XCTAssertIdentical(module.passwordAutoFillCoordinatorStackNavigator, stackNavigator)
     }
 
     /// `navigate(to:)` with `.pendingLoginRequests()` presents the pending login requests view.

--- a/GlobalTestHelpers/MockAppModule.swift
+++ b/GlobalTestHelpers/MockAppModule.swift
@@ -11,6 +11,7 @@ class MockAppModule:
     GeneratorModule,
     ImportLoginsModule,
     LoginRequestModule,
+    PasswordAutoFillModule,
     PasswordHistoryModule,
     SendModule,
     SendItemModule,
@@ -28,6 +29,10 @@ class MockAppModule:
     var generatorCoordinator = MockCoordinator<GeneratorRoute, Void>()
     var importLoginsCoordinator = MockCoordinator<ImportLoginsRoute, ImportLoginsEvent>()
     var loginRequestCoordinator = MockCoordinator<LoginRequestRoute, Void>()
+    var passwordAutoFillCoordinator = MockCoordinator<PasswordAutofillRoute, PasswordAutofillEvent>()
+    var passwordAutoFillCoordinatorDelegate: PasswordAutoFillCoordinatorDelegate?
+    // swiftlint:disable:next weak_navigator identifier_name
+    var passwordAutoFillCoordinatorStackNavigator: StackNavigator?
     var passwordHistoryCoordinator = MockCoordinator<PasswordHistoryRoute, Void>()
     var sendCoordinator = MockCoordinator<SendRoute, Void>()
     var sendItemCoordinator = MockCoordinator<SendItemRoute, AuthAction>()
@@ -94,6 +99,15 @@ class MockAppModule:
         stackNavigator _: StackNavigator
     ) -> AnyCoordinator<LoginRequestRoute, Void> {
         loginRequestCoordinator.asAnyCoordinator()
+    }
+
+    func makePasswordAutoFillCoordinator(
+        delegate: PasswordAutoFillCoordinatorDelegate?,
+        stackNavigator: StackNavigator
+    ) -> AnyCoordinator<PasswordAutofillRoute, PasswordAutofillEvent> {
+        passwordAutoFillCoordinatorDelegate = delegate
+        passwordAutoFillCoordinatorStackNavigator = stackNavigator
+        return passwordAutoFillCoordinator.asAnyCoordinator()
     }
 
     func makePasswordHistoryCoordinator(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12735](https://bitwarden.atlassian.net/browse/PM-12735)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Currently, when you enable autofill from settings, when returning to the app after autofill has been enabled, you are still on the "Set up autofill" screen. This changes it so the "Set up autofill" screen will be dismissed once autofill has been enabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/e1837213-ff1a-4fde-935f-7e46524c77b5



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12735]: https://bitwarden.atlassian.net/browse/PM-12735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ