### PR TITLE
PM-13694: Set carousel shown prior to account setup screens

### DIFF
--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -178,6 +178,21 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertTrue(stateService.introCarouselShown)
     }
 
+    /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.vaultUnlockSetup` and sets the
+    /// carousel shown flag if the carousel feature flag is on and the carousel hasn't been shown yet.
+    @MainActor
+    func test_handleAndRoute_didCompleteAuth_carouselShown_vaultUnlockSetup() async {
+        authRepository.activeAccount = .fixture()
+        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        stateService.activeAccount = .fixture()
+        stateService.accountSetupVaultUnlock["1"] = .incomplete
+
+        let route = await subject.handleAndRoute(.didCompleteAuth)
+
+        XCTAssertEqual(route, .vaultUnlockSetup(.createAccount))
+        XCTAssertTrue(stateService.introCarouselShown)
+    }
+
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to complete the auth flow if the account
     /// doesn't require an updated password.
     func test_handleAndRoute_didCompleteAuth_complete() async {

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -29,6 +29,8 @@ extension AuthRouter {
             return .landing
         }
 
+        await setCarouselShownIfEnabled()
+
         if account.profile.forcePasswordResetReason != nil {
             return .updateMasterPassword
         }
@@ -41,7 +43,6 @@ extension AuthRouter {
             }
         }
 
-        await setCarouselShownIfEnabled()
         return .complete
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-13694](https://bitwarden.atlassian.net/browse/PM-13694)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This sets the carousel shown flag prior to navigating the user to any account setup screens after an account has been created. This prevents the possibility of the carousel being shown again if the app is restarted before account setup has completed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13694]: https://bitwarden.atlassian.net/browse/PM-13694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ