### PR TITLE
[BITAU-177] Add Default for accountDomain

### DIFF
--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
@@ -205,7 +205,7 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
 
         return decryptedCiphers.map { cipher in
             AuthenticatorBridgeItemDataView(
-                accountDomain: account.settings.environmentUrls?.webVaultHost,
+                accountDomain: account.settings.environmentUrls?.webVaultHost ?? Constants.defaultWebVaultHost,
                 accountEmail: account.profile.email,
                 favorite: false,
                 id: cipher.id ?? UUID().uuidString,


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-177](https://livefront.atlassian.net/browse/BITAU-177)

## 📔 Objective

In the Authenticator app, we use `accountEmail` and `accountDomain` to format the user's section heading to show them where the specifics codes came from in the PM app. As we were building that, I noticed that `accountEmail` should really never be `nil` and made the change to fetch it so that it always has a value. Similarly, `account.settings.environmentUrls?.webVaultHost` should likely not be `nil`, but elsewhere in the app we additionally add a fallback value of `Constants.defaultWebVaultHost`. 

I had made a Jira ticket to move both `accountEmail` and `accountDomain` to be non-optional in our data model. However, I don't think we need to take that drastic a step and it would cause issues with the temporary item implementation. But I did want to put up this PR to make sure we provide the fallback value just in case.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
