### PR TITLE
[PM-11213] Use iPhone 16 Pro test device and finish updating builds for Xcode 16.1

### DIFF
--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -19,7 +19,6 @@ on:
         description: "Distribute to TestFlight"
         type: boolean
 env:
-  XCODE_VERSION: '15.4'
   DISTRIBUTE_TO_TESTFLIGHT: ${{ github.event_name == 'push' || inputs.distribute }}
   INTERNAL_BETA_PATCH_NUMBER: 999
 
@@ -30,7 +29,7 @@ jobs:
     outputs:
       version_name: ${{ steps.version_info.outputs.version_name }}
       version_number: ${{ steps.version_info.outputs.version_number }}
-      xcode_version: ${{ env.XCODE_VERSION }}
+      xcode_version: ${{ steps.xcode_version.outputs.xcode_version }}
       distribute_to_testflight: ${{ env.DISTRIBUTE_TO_TESTFLIGHT }}
       internal_beta_version_name: ${{ steps.internal_versions.outputs.internal_beta_version_name}}
     steps:
@@ -42,6 +41,11 @@ jobs:
           echo '${{ toJson(inputs) }}' >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
           echo "</details>" >> $GITHUB_STEP_SUMMARY
+
+      - name: Read default Xcode version
+        id: xcode_version
+        run: |
+          echo "xcode_version=$(cat .xcode-version | tr -d '\n')" >> "$GITHUB_OUTPUT"
 
       - name: Calculate version
         if: ${{ inputs.build-number == '' || inputs.build-version == '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -347,7 +347,7 @@ jobs:
       - name: Upload IPA & dSYM files
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: Bitwarden iOS ${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }}) ${{ env.BUILD_VARIANT }} ${{ env.XCODE_VERSION }}
+          name: Bitwarden iOS ${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }}) ${{ env.BUILD_VARIANT }} ${{ env.XCODE_VERSION || env.DEFAULT_XCODE_VERSION }}
           path: export
           if-no-files-found: error
 

--- a/.test-simulator-device-name
+++ b/.test-simulator-device-name
@@ -1,1 +1,1 @@
-iPhone 15 Pro
+iPhone 16 Pro

--- a/GlobalTestHelpers/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers/Support/BitwardenTestCase.swift
@@ -9,10 +9,10 @@ open class BitwardenTestCase: XCTestCase {
 
     @MainActor
     override open class func setUp() {
-        if UIDevice.current.name != "iPhone 15 Pro" || UIDevice.current.systemVersion != "18.1" {
+        if UIDevice.current.name != "iPhone 16 Pro" || UIDevice.current.systemVersion != "18.1" {
            assertionFailure(
                """
-               Tests must be run using iOS 18.1 on an iPhone 15 Pro simulator. Snapshot tests depend on using the correct device.
+               Tests must be run using iOS 18.1 on an iPhone 16 Pro simulator. Snapshot tests depend on using the correct device.
                """
            )
        }

--- a/GlobalTestHelpers/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers/Support/BitwardenTestCase.swift
@@ -10,12 +10,12 @@ open class BitwardenTestCase: XCTestCase {
     @MainActor
     override open class func setUp() {
         if UIDevice.current.name != "iPhone 16 Pro" || UIDevice.current.systemVersion != "18.1" {
-           assertionFailure(
+            assertionFailure(
                """
                Tests must be run using iOS 18.1 on an iPhone 16 Pro simulator. Snapshot tests depend on using the correct device.
                """
-           )
-       }
+            )
+        }
 
         // Apply default appearances for snapshot tests.
         UI.applyDefaultAppearances()

--- a/GlobalTestHelpers/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers/Support/BitwardenTestCase.swift
@@ -11,9 +11,10 @@ open class BitwardenTestCase: XCTestCase {
     override open class func setUp() {
         if UIDevice.current.name != "iPhone 16 Pro" || UIDevice.current.systemVersion != "18.1" {
             assertionFailure(
-               """
-               Tests must be run using iOS 18.1 on an iPhone 16 Pro simulator. Snapshot tests depend on using the correct device.
-               """
+                """
+                Tests must be run using iOS 18.1 on an iPhone 16 Pro simulator.
+                Snapshot tests depend on using the correct device.
+                """
             )
         }
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 
 ### Run the App
 
-1. Open the project in Xcode 15.4+.
+1. Open the project in Xcode 16.1+.
 2. Run the app in the Simulator with the `Bitwarden` target.
 
 ### Running Tests

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 
 ### Running Tests
 
-The test target requires running in an iPhone 15 Pro simulator running iOS 18.1. It is, however, worth noting that our snapshot tests almost entirely work off of enforced iPhone 12/13/14 dimensions, with a 3x scale; however a few use the dimensions of the chosen simulator, and thus require an iPhone 15 Pro.
+The test target requires running in an iPhone 16 Pro simulator running iOS 18.1. While our snapshot tests work off of enforced device dimensions, small differences can still arise between devices and iOS versions, and this makes sure our snapshots are as consistent as we can make them in testing.
 
 1. In Xcode's toolbar, select the project and a connected device or simulator.
    - The `Generic iOS Device` used for builds will not work for testing.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-11213

## 📔 Objective

Because the [macos-15 runner](https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md) doesn't have an iPhone 15 Pro as an option, we need to update to an iPhone 16 Pro.

As well, in [the previous PR](https://github.com/bitwarden/ios/pull/1070), I missed that `CI-main.yml` was also manually setting the Xcode version, and that has also been updated.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
