### PR TITLE
[BITAU-194] Fix issue with unit tests failing occasionally; Add tests for NotifcationCenterService

### DIFF
--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
@@ -62,6 +62,12 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
     /// The service used by the application to manage account state.
     private let stateService: StateService
 
+    /// A Task to hold the subscription that waits for sync to be turned on/off.
+    private var syncSubscriber: Task<Void, Never>?
+
+    /// A Task to hold the subscription that waits for the vault to be locked/unlocked..
+    private var vaultSubscriber: Task<Void, Never>?
+
     /// The service used by the application to manage vault access.
     private let vaultTimeoutService: VaultTimeoutService
 
@@ -107,6 +113,11 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
         super.init()
     }
 
+    deinit {
+        syncSubscriber?.cancel()
+        vaultSubscriber?.cancel()
+    }
+
     // MARK: Public Methods
 
     public func getTemporaryTotpItem() async -> AuthenticatorBridgeItemDataView? {
@@ -130,7 +141,7 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
             return
         }
 
-        Task {
+        syncSubscriber = Task {
             for await (userId, _) in await self.stateService.syncToAuthenticatorPublisher().values {
                 guard let userId else { continue }
 
@@ -141,7 +152,7 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
                 }
             }
         }
-        Task {
+        vaultSubscriber = Task {
             for await vaultStatus in await self.vaultTimeoutService.vaultLockStatusPublisher().values {
                 guard let vaultStatus else { continue }
 

--- a/BitwardenShared/Core/Platform/Services/NotificationCenterService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationCenterService.swift
@@ -20,8 +20,25 @@ protocol NotificationCenterService: AnyObject {
 /// A default implementation of the `NotificationCenterService` which accesses the app's notification center.
 ///
 class DefaultNotificationCenterService: NotificationCenterService {
+    // MARK: Properties
+
+    /// The NotificationCenter to use in subscribing to notifications.
+    let notificationCenter: NotificationCenter
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultNotificationCenterService`.
+    ///
+    /// - Parameter notificationCenter: The NotificationCenter to use in subscribing to notifications.
+    ///
+    init(notificationCenter: NotificationCenter = NotificationCenter.default) {
+        self.notificationCenter = notificationCenter
+    }
+
+    // MARK: Methods
+
     func didEnterBackgroundPublisher() -> AsyncPublisher<AnyPublisher<Void, Never>> {
-        NotificationCenter.default
+        notificationCenter
             .publisher(for: UIApplication.didEnterBackgroundNotification)
             .map { _ in }
             .eraseToAnyPublisher()
@@ -29,7 +46,7 @@ class DefaultNotificationCenterService: NotificationCenterService {
     }
 
     func willEnterForegroundPublisher() -> AsyncPublisher<AnyPublisher<Void, Never>> {
-        NotificationCenter.default
+        notificationCenter
             .publisher(for: UIApplication.willEnterForegroundNotification)
             .map { _ in }
             .eraseToAnyPublisher()

--- a/BitwardenShared/Core/Platform/Services/NotificationCenterServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationCenterServiceTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+
+@testable import BitwardenShared
+
+final class NotificationCenterServiceTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var notificationCenter: NotificationCenter!
+    var subject: DefaultNotificationCenterService!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        notificationCenter = NotificationCenter()
+        subject = DefaultNotificationCenterService(notificationCenter: notificationCenter)
+    }
+
+    override func tearDown() {
+        notificationCenter = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `didEnterBackgroundPublisher` publishes a notification when the app enters the background.
+    func testDidEnterBackgroundPublisher() async throws {
+        var iterator = subject.didEnterBackgroundPublisher().makeAsyncIterator()
+        Task {
+            notificationCenter.post(
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil
+            )
+        }
+        let result: Void? = await iterator.next()
+
+        XCTAssertNotNil(result)
+    }
+
+    /// `willEnterForegroundPublisher` publishes a notification when the app will enter the foreground.
+    func testWillEnterForegroundPublisher() async throws {
+        var iterator = subject.willEnterForegroundPublisher().makeAsyncIterator()
+        Task {
+            notificationCenter.post(
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
+        }
+        let result: Void? = await iterator.next()
+
+        XCTAssertNotNil(result)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-194](https://livefront.atlassian.net/browse/BITAU-194)

## 📔 Objective

This PR addresses two problems:
1. BITAU-194: We were seeing occasional `NSInvalidArgumentException` that were caused by the `AuthenticatorSyncService` trying to write to the Keychain when it had moved out of memory. I've added specific tasks that we then cancel in the `AuthenticatorSyncService.deinit()`. This avoids the service continuing to listen for events past the end of the test that spawned it.
2. Katherine had asked me to bring my tests for NotificationCenterService from [Authenticator PR #178](https://github.com/bitwarden/authenticator-ios/pull/178) to the PM app. We previously didn't have tests in the PM app for this.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
