### PR TITLE
Fix various warnings

### DIFF
--- a/Bitwarden/Application/UIApplication+Application.swift
+++ b/Bitwarden/Application/UIApplication+Application.swift
@@ -1,7 +1,7 @@
 import BitwardenShared
 import UIKit
 
-extension UIApplication: Application {
+extension UIApplication: @retroactive Application {
     public func startBackgroundTask(withName: String?, expirationHandler: (() -> Void)?) -> UIBackgroundTaskIdentifier {
         // Because the annotations for `UIApplication.beginBackgroundTask(::)` changed
         // between Xcode 15.4 and Xcode 16 and also between Swift 5 and Swift 6,

--- a/BitwardenShared/Core/Autofill/Extensions/BitwardenSdk+Autofill.swift
+++ b/BitwardenShared/Core/Autofill/Extensions/BitwardenSdk+Autofill.swift
@@ -54,7 +54,7 @@ extension GetAssertionRequest {
 
 // MARK: - MakeCredentialRequest
 
-extension BitwardenSdk.MakeCredentialRequest: CustomDebugStringConvertible {
+extension BitwardenSdk.MakeCredentialRequest: @retroactive CustomDebugStringConvertible {
     public var debugDescription: String {
         let rpName = rp.name ?? "nil"
         let excludeList = excludeList?.description ?? "nil"
@@ -78,7 +78,7 @@ extension BitwardenSdk.MakeCredentialRequest: CustomDebugStringConvertible {
 
 // MARK: - MakeCredentialResult
 
-extension BitwardenSdk.MakeCredentialResult: CustomDebugStringConvertible {
+extension BitwardenSdk.MakeCredentialResult: @retroactive CustomDebugStringConvertible {
     public var debugDescription: String {
         [
             "AuthenticatorData: \(authenticatorData.asHexString())",

--- a/BitwardenShared/Core/Platform/Extensions/BitwardenSdk+Platform.swift
+++ b/BitwardenShared/Core/Platform/Extensions/BitwardenSdk+Platform.swift
@@ -3,7 +3,7 @@
 import BitwardenSdk
 import Foundation
 
-extension BitwardenSdk.BitwardenError: CustomNSError {
+extension BitwardenSdk.BitwardenError: @retroactive CustomNSError {
     /// The user-info dictionary.
     public var errorUserInfo: [String: Any] {
         guard case let .E(message) = self else {

--- a/BitwardenShared/Core/Platform/Services/API/Extensions/JSONRequestBody+Bitwarden.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Extensions/JSONRequestBody+Bitwarden.swift
@@ -9,7 +9,7 @@ public extension JSONRequestBody {
 // MARK: - Array + RequestBody
 
 /// Conforms `Array` to `RequestBody`.
-extension Array: RequestBody, JSONRequestBody where Element: Codable {
+extension Array: @retroactive RequestBody, @retroactive JSONRequestBody where Element: Codable {
     public var additionalHeaders: [String: String] {
         ["Content-Type": "application/json"]
     }

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -40,7 +40,7 @@ extension AttachmentResponseModel {
     }
 }
 
-extension AttachmentView: Identifiable {}
+extension AttachmentView: @retroactive Identifiable {}
 
 extension CipherCardModel {
     init(card: BitwardenSdk.Card) {
@@ -330,9 +330,9 @@ extension BitwardenSdk.Cipher {
     }
 }
 
-extension BitwardenSdk.CipherListView: Identifiable {}
+extension BitwardenSdk.CipherListView: @retroactive Identifiable {}
 
-extension BitwardenSdk.CipherView: Identifiable {
+extension BitwardenSdk.CipherView: @retroactive Identifiable {
     /// Initializes a new `CipherView` based on a `Fido2CredentialNewView`
     /// - Parameters:
     ///   - fido2CredentialNewView: The `Fido2CredentialNewView` for the Fido2 creation flow
@@ -407,7 +407,7 @@ extension BitwardenSdk.CipherRepromptType {
     }
 }
 
-extension BitwardenSdk.Fido2Credential: Identifiable, @unchecked Sendable {
+extension BitwardenSdk.Fido2Credential: @retroactive Identifiable, @unchecked @retroactive Sendable {
     public var id: String { credentialId }
 
     init(cipherLoginFido2Credential model: CipherLoginFido2Credential) {
@@ -429,9 +429,9 @@ extension BitwardenSdk.Fido2Credential: Identifiable, @unchecked Sendable {
     }
 }
 
-extension BitwardenSdk.Fido2CredentialView: @unchecked Sendable {}
+extension BitwardenSdk.Fido2CredentialView: @unchecked @retroactive Sendable {}
 
-extension BitwardenSdk.Fido2CredentialAutofillView: @unchecked Sendable {}
+extension BitwardenSdk.Fido2CredentialAutofillView: @unchecked @retroactive Sendable {}
 
 extension BitwardenSdk.Field {
     init(cipherFieldModel model: CipherFieldModel) {
@@ -610,7 +610,7 @@ extension BitwardenSdk.Collection {
     }
 }
 
-extension BitwardenSdk.CollectionView: @unchecked Sendable, TreeNodeModel {}
+extension BitwardenSdk.CollectionView: @unchecked @retroactive Sendable, TreeNodeModel {}
 
 // MARK: - Folders (BitwardenSdk)
 
@@ -637,7 +637,7 @@ extension BitwardenSdk.Folder {
     }
 }
 
-extension BitwardenSdk.FolderView: Menuable, @unchecked Sendable, TreeNodeModel {
+extension BitwardenSdk.FolderView: Menuable, @unchecked @retroactive Sendable, TreeNodeModel {
     static var defaultValueLocalizedName: String {
         Localizations.folderNone
     }

--- a/BitwardenShared/UI/Auth/Utilities/TestHelpers/MockVaultUnlockSetupHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/TestHelpers/MockVaultUnlockSetupHelper.swift
@@ -7,12 +7,18 @@ class MockVaultUnlockSetupHelper: VaultUnlockSetupHelper {
     var setPinUnlockCalled = false
     var setPinUnlockResult: Bool?
 
-    func setBiometricUnlock(enabled: Bool, showAlert: @escaping (Alert) -> Void) async -> BiometricsUnlockStatus? {
+    func setBiometricUnlock(
+        enabled: Bool,
+        showAlert: @escaping @MainActor (Alert) -> Void
+    ) async -> BiometricsUnlockStatus? {
         setBiometricUnlockCalled = true
         return setBiometricUnlockStatus
     }
 
-    func setPinUnlock(enabled: Bool, showAlert: @escaping (Alert) -> Void) async -> Bool {
+    func setPinUnlock(
+        enabled: Bool,
+        showAlert: @escaping @MainActor (Alert) -> Void
+    ) async -> Bool {
         setPinUnlockCalled = true
         return setPinUnlockResult ?? !enabled
     }

--- a/BitwardenShared/UI/Auth/Utilities/VaultUnlockSetupHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/VaultUnlockSetupHelper.swift
@@ -11,7 +11,10 @@ protocol VaultUnlockSetupHelper: AnyObject {
     ///     vault unlock.
     /// - Returns: The biometric unlock status after vault unlock has been updated.
     ///
-    func setBiometricUnlock(enabled: Bool, showAlert: @escaping (Alert) -> Void) async -> BiometricsUnlockStatus?
+    func setBiometricUnlock(
+        enabled: Bool,
+        showAlert: @escaping @MainActor (Alert) -> Void
+    ) async -> BiometricsUnlockStatus?
 
     /// Enables or disables pin vault unlock.
     ///
@@ -20,7 +23,10 @@ protocol VaultUnlockSetupHelper: AnyObject {
     ///   - showAlert: A closure used to handle showing an alert if needed while toggling pin vault unlock.
     /// - Returns: Whether pin unlock is enabled after vault unlock has been updated.
     ///
-    func setPinUnlock(enabled: Bool, showAlert: @escaping (Alert) -> Void) async -> Bool
+    func setPinUnlock(
+        enabled: Bool,
+        showAlert: @escaping @MainActor (Alert) -> Void
+    ) async -> Bool
 }
 
 // MARK: - VaultUnlockSetupHelperError
@@ -104,7 +110,10 @@ class DefaultVaultUnlockSetupHelper {
 // MARK: - DefaultVaultUnlockSetupHelper+VaultUnlockSetupHelper
 
 extension DefaultVaultUnlockSetupHelper: VaultUnlockSetupHelper {
-    func setBiometricUnlock(enabled: Bool, showAlert: @escaping (Alert) -> Void) async -> BiometricsUnlockStatus? {
+    func setBiometricUnlock(
+        enabled: Bool,
+        showAlert: @escaping @MainActor (Alert) -> Void
+    ) async -> BiometricsUnlockStatus? {
         do {
             try await services.authRepository.allowBioMetricUnlock(enabled)
             return try await services.biometricsRepository.getBiometricUnlockStatus()
@@ -118,7 +127,10 @@ extension DefaultVaultUnlockSetupHelper: VaultUnlockSetupHelper {
         }
     }
 
-    func setPinUnlock(enabled: Bool, showAlert: @escaping (Alert) -> Void) async -> Bool {
+    func setPinUnlock(
+        enabled: Bool,
+        showAlert: @escaping @MainActor (Alert) -> Void
+    ) async -> Bool {
         do {
             guard enabled else {
                 try await services.authRepository.clearPins()

--- a/BitwardenShared/UI/Platform/Application/TestHelpers/Extensions/DispatchTimeInterval.swift
+++ b/BitwardenShared/UI/Platform/Application/TestHelpers/Extensions/DispatchTimeInterval.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension DispatchTimeInterval: Comparable {
+extension DispatchTimeInterval: @retroactive Comparable {
     /// The total number of nanoseconds in this duration.
     var totalNanoseconds: Int64 {
         switch self {

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListView.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryList/PasswordHistoryListView.swift
@@ -127,7 +127,7 @@ struct PasswordHistoryListView: View {
 
 // MARK: - PasswordHistoryView
 
-extension PasswordHistoryView: Identifiable {
+extension PasswordHistoryView: @retroactive Identifiable {
     public var id: UUID {
         UUID()
     }


### PR DESCRIPTION
## 📔 Objective

Now that we're on Xcode 16.1, there are a number of new warnings that have cropped up in the project. As well, Xcode 16.1 gives us more ability to deal with some other warnings that have been hanging around a while. This attempts to fix some of these warnings, which should prepare us better for Swift 6 eventually.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
