### PR TITLE
PM-9089: Update two factor auth screen to parse server error

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModel.swift
@@ -12,7 +12,7 @@ struct ResponseValidationErrorModel: Codable, Equatable {
     let error: String
 
     /// A string that provides a description of the error.
-    let errorDescription: String
+    let errorDescription: String?
 
     /// An `ErrorModel` object that provides more details about the error.
     let errorModel: ErrorModel

--- a/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/ResponseValidationErrorModelTests.swift
@@ -23,4 +23,32 @@ class ResponseValidationErrorModelTests: BitwardenTestCase {
         let subject = try ResponseValidationErrorModel.decoder.decode(ResponseValidationErrorModel.self, from: json)
         XCTAssertEqual(subject.errorModel.message, "Username or password is incorrect. Try again.")
     }
+
+    /// Tests the successful decoding of a JSON response with no error description.
+    func test_decode_success_missingErrorDescription() throws {
+        let json = """
+        {
+          "error": "invalid_grant",
+          "ErrorModel": {
+            "Message": "Two-step token is invalid. Try again.",
+            "Object": "error"
+          }
+        }
+        """
+        let subject = try ResponseValidationErrorModel.decoder.decode(
+            ResponseValidationErrorModel.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+        XCTAssertEqual(
+            subject,
+            ResponseValidationErrorModel(
+                error: "invalid_grant",
+                errorDescription: nil,
+                errorModel: ErrorModel(
+                    message: "Two-step token is invalid. Try again.",
+                    object: "error"
+                )
+            )
+        )
+    }
 }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -177,15 +177,8 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
             try await tryToUnlockVault(unlockMethod)
         } catch let error as InputValidationError {
             coordinator.showAlert(Alert.inputValidationAlert(error: error))
-        } catch let error as IdentityTokenRequestError {
-            if case let .captchaRequired(hCaptchaSiteCode) = error {
-                launchCaptchaFlow(with: hCaptchaSiteCode)
-            } else {
-                coordinator.showAlert(.defaultAlert(
-                    title: Localizations.anErrorHasOccurred,
-                    message: Localizations.invalidVerificationCode
-                ))
-            }
+        } catch let IdentityTokenRequestError.captchaRequired(hCaptchaSiteCode) {
+            launchCaptchaFlow(with: hCaptchaSiteCode)
         } catch let authError as AuthError {
             if authError == .requireSetPassword,
                let orgId = state.orgIdentifier {
@@ -199,10 +192,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
                 coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             }
         } catch {
-            coordinator.showAlert(.defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: Localizations.invalidVerificationCode
-            ))
+            coordinator.showAlert(.networkResponseError(error))
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -394,10 +394,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.verifying)])
         XCTAssertEqual(authService.loginWithTwoFactorCodeCode, "Test")
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(
-            title: Localizations.anErrorHasOccurred,
-            message: Localizations.invalidVerificationCode
-        ))
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -486,15 +483,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.continueTapped)
 
         XCTAssertFalse(authRepository.unlockVaultWithKeyConnectorKeyCalled)
-        XCTAssertEqual(
-            coordinator.alertShown,
-            [
-                .defaultAlert(
-                    title: Localizations.anErrorHasOccurred,
-                    message: Localizations.invalidVerificationCode
-                ),
-            ]
-        )
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(TwoFactorAuthError.missingOrgIdentifier))
         XCTAssertEqual(coordinator.routes, [])
         XCTAssertEqual(errorReporter.errors as? [TwoFactorAuthError], [.missingOrgIdentifier])
     }
@@ -502,18 +491,14 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
     /// `perform(_:)` with `.continueTapped` handles a two-factor error correctly.
     @MainActor
     func test_perform_continueTapped_twoFactorError() async {
+        let error = IdentityTokenRequestError.twoFactorRequired(.init(), nil, nil)
         subject.state.verificationCode = "Test"
-        authService.loginWithTwoFactorCodeResult = .failure(
-            IdentityTokenRequestError.twoFactorRequired(.init(), nil, nil)
-        )
+        authService.loginWithTwoFactorCodeResult = .failure(error)
 
         await subject.perform(.continueTapped)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(
-            title: Localizations.anErrorHasOccurred,
-            message: Localizations.invalidVerificationCode
-        ))
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(error))
     }
 
     /// `perform(_:)` with `.listenForNFC` starts listening for NFC tags and attempts login if one is read.
@@ -559,10 +544,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.receivedDuoToken("DuoToken"))
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(
-            title: Localizations.anErrorHasOccurred,
-            message: Localizations.invalidVerificationCode
-        ))
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
     }
 
     /// `perform(_:)` with `.receivedDuoToken` handles a two-factor error correctly.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-9089](https://bitwarden.atlassian.net/browse/PM-9089)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When logging in with a master password and 2FA code when SSO is required, the app was incorrectly showing an error stating that the verification code was incorrect instead of that SSO is required. This fixes that so the error from the server is parsed and used to display the error alert.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="568" alt="Screenshot 2024-11-01 at 2 41 38 PM" src="https://github.com/user-attachments/assets/97aef714-53e3-4e83-abbc-f45b33f724a8">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-9089]: https://bitwarden.atlassian.net/browse/PM-9089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ