### PR TITLE
BITAU-204 Fix Concurrency Issues in Sync Service/Tests

### DIFF
--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
@@ -47,6 +47,13 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
     /// The service to get server-specified configuration.
     private let configService: ConfigService
 
+    /// A task that sets up syncing for a user.
+    ///
+    /// Using an actor-protected `Task` ensures that multiple threads don't attempt
+    /// to setup sync at the same time. `enableSyncForUserId(_)` `await`s
+    /// the result of this task before adding the next sync setup to the end of it.
+    private var enableSyncTask: Task<Void, Never>?
+
     /// The service used by the application to report non-fatal errors.
     private let errorReporter: ErrorReporter
 
@@ -246,23 +253,35 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
     /// - Parameter userId: The userId of the user whose sync status is being determined.
     ///
     private func determineSyncForUserId(_ userId: String) async throws {
-        guard try await stateService.getSyncToAuthenticator(userId: userId) else {
+        if try await stateService.getSyncToAuthenticator(userId: userId) {
+            enableSyncForUserId(userId)
+        } else {
             cipherPublisherTasks[userId]?.cancel()
             cipherPublisherTasks.removeValue(forKey: userId)
             try await keychainRepository.deleteAuthenticatorVaultKey(userId: userId)
             try await authBridgeItemService.deleteAllForUserId(userId)
             try await deleteKeyIfSyncingIsOff()
-            return
         }
+    }
 
+    /// Enable sync for the provided userId.
+    ///
+    /// - Parameter userId: The userId of the user whose sync is being enabled.
+    ///
+    private func enableSyncForUserId(_ userId: String) {
         guard !vaultTimeoutService.isLocked(userId: userId) else { return }
 
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { try await self.createAuthenticatorKeyIfNeeded() }
-            group.addTask { try await self.createAuthenticatorVaultKeyIfNeeded(userId: userId) }
-            try await group.waitForAll()
+        enableSyncTask = Task { [enableSyncTask] in
+            _ = await enableSyncTask?.result
+
+            do {
+                try await createAuthenticatorKeyIfNeeded()
+                try await createAuthenticatorVaultKeyIfNeeded(userId: userId)
+                subscribeToCipherUpdates(userId: userId)
+            } catch {
+                errorReporter.log(error: error)
+            }
         }
-        subscribeToCipherUpdates(userId: userId)
     }
 
     /// Create a task for the given userId to listen for Cipher updates and sync to the Authenticator store.

--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
@@ -464,7 +464,9 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
         // Unsubscribe from sync, wait for items to be deleted
         stateService.syncToAuthenticatorByUserId["1"] = false
         stateService.syncToAuthenticatorSubject.send(("1", false))
-        waitFor((authBridgeItemService.storedItems["1"]?.isEmpty) ?? false)
+        try await waitForAsync {
+            (self.authBridgeItemService.storedItems["1"]?.isEmpty) ?? false
+        }
 
         // Sending additional updates should not appear in Store
         cipherDataStore.cipherSubjectByUserId["1"]?.send([

--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
@@ -51,6 +51,7 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
     override func tearDown() {
         super.tearDown()
 
+        subject = nil
         authBridgeItemService = nil
         authRepository = nil
         cipherDataStore = nil
@@ -60,7 +61,6 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
         keychainRepository = nil
         sharedKeychainRepository = nil
         stateService = nil
-        subject = nil
         vaultTimeoutService = nil
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-204](https://livefront.atlassian.net/browse/BITAU-204)

## 📔 Objective

This PR attempts to address the threading issue that's been causing problems in unit tests. Specifically, it adds a Task property to manage enabling sync. Previously, there were issues where multiple threads could enter the key methods, both threads find there is no key, and both threads attempt to add the key. The property is guaranteed to be thread-safe by virtue of the sync service being an actor. In addition, `enableSyncForUserId(_)` is **not** `async`, meaning that the actor will only allow one thread in at a time. This essentially creates a serial, synchronous queue for sync enabling.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
