### PR TITLE
PM-14502: Fix account creation email verification feature flag loading

### DIFF
--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockConfigService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockConfigService.swift
@@ -11,8 +11,11 @@ class MockConfigService: ConfigService {
     var configSubject = CurrentValueSubject<BitwardenShared.MetaServerConfig?, Never>(nil)
     var debugFeatureFlags = [DebugMenuFeatureFlag]()
     var featureFlagsBool = [FeatureFlag: Bool]()
+    var featureFlagsBoolPreAuth = [FeatureFlag: Bool]()
     var featureFlagsInt = [FeatureFlag: Int]()
+    var featureFlagsIntPreAuth = [FeatureFlag: Int]()
     var featureFlagsString = [FeatureFlag: String]()
+    var featureFlagsStringPreAuth = [FeatureFlag: String]()
     var getDebugFeatureFlagsCalled = false
     var refreshDebugFeatureFlagsCalled = false
     var toggleDebugFeatureFlagCalled = false
@@ -31,11 +34,13 @@ class MockConfigService: ConfigService {
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Bool, forceRefresh: Bool, isPreAuth: Bool) async -> Bool {
-        featureFlagsBool[flag] ?? defaultValue
+        let value = isPreAuth ? featureFlagsBoolPreAuth[flag] : featureFlagsBool[flag]
+        return value ?? defaultValue
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Int, forceRefresh: Bool, isPreAuth: Bool) async -> Int {
-        featureFlagsInt[flag] ?? defaultValue
+        let value = isPreAuth ? featureFlagsInt[flag] : featureFlagsInt[flag]
+        return value ?? defaultValue
     }
 
     func getFeatureFlag(
@@ -44,7 +49,8 @@ class MockConfigService: ConfigService {
         forceRefresh: Bool,
         isPreAuth: Bool
     ) async -> String? {
-        featureFlagsString[flag] ?? defaultValue
+        let value = isPreAuth ? featureFlagsString[flag] : featureFlagsString[flag]
+        return value ?? defaultValue
     }
 
     func getDebugFeatureFlags() async -> [DebugMenuFeatureFlag] {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockConfigService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockConfigService.swift
@@ -39,7 +39,7 @@ class MockConfigService: ConfigService {
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Int, forceRefresh: Bool, isPreAuth: Bool) async -> Int {
-        let value = isPreAuth ? featureFlagsInt[flag] : featureFlagsInt[flag]
+        let value = isPreAuth ? featureFlagsIntPreAuth[flag] : featureFlagsInt[flag]
         return value ?? defaultValue
     }
 
@@ -49,7 +49,7 @@ class MockConfigService: ConfigService {
         forceRefresh: Bool,
         isPreAuth: Bool
     ) async -> String? {
-        let value = isPreAuth ? featureFlagsString[flag] : featureFlagsString[flag]
+        let value = isPreAuth ? featureFlagsStringPreAuth[flag] : featureFlagsString[flag]
         return value ?? defaultValue
     }
 

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -174,7 +174,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselShown() async {
         authRepository.activeAccount = .fixture()
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
 
         let route = await subject.handleAndRoute(.didCompleteAuth)
 
@@ -187,7 +187,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselShown_vaultUnlockSetup() async {
         authRepository.activeAccount = .fixture()
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
         stateService.activeAccount = .fixture()
         stateService.accountSetupVaultUnlock["1"] = .incomplete
 
@@ -907,7 +907,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// the carousel flow is enabled.
     @MainActor
     func test_handleAndRoute_didStart_carouselFlow() async {
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
 
         let route = await subject.handleAndRoute(.didStart)
 
@@ -953,7 +953,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     func test_handleAndRoute_didStart_carouselFlow_existingAccountNeverLock() async {
         let account = Account.fixture()
         authRepository.activeAccount = .fixture()
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
         vaultTimeoutService.vaultTimeout[account.profile.userId] = .never
 
         let route = await subject.handleAndRoute(.didStart)

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -193,7 +193,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     /// `perform(.appeared)` with feature flag for .nativeCreateAccountFlow set to true
     @MainActor
     func test_perform_appeared_loadFeatureFlag_true() async {
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = true
         subject.state.nativeCreateAccountFeatureFlag = false
 
         await subject.perform(.appeared)

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessorTests.swift
@@ -47,7 +47,7 @@ class IntroCarouselProcessorTests: BitwardenTestCase {
     /// verification is enabled.
     @MainActor
     func test_perform_createAccount_emailVerificationEnabled() async {
-        configService.featureFlagsBool[.emailVerification] = true
+        configService.featureFlagsBoolPreAuth[.emailVerification] = true
         await subject.perform(.createAccount)
         XCTAssertEqual(coordinator.routes.last, .startRegistration)
     }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -118,7 +118,8 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
     private func loadFeatureFlag() async {
         state.emailVerificationFeatureFlag = await services.configService.getFeatureFlag(
             FeatureFlag.emailVerification,
-            defaultValue: false
+            defaultValue: false,
+            isPreAuth: true
         )
     }
 

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -140,39 +140,42 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `perform(.appeared)` with feature flag for .emailVerification set to true
     @MainActor
     func test_perform_appeared_loadsFeatureFlag_true() async {
-        configService.featureFlagsBool[.emailVerification] = true
+        configService.featureFlagsBoolPreAuth[.emailVerification] = true
         subject.state.emailVerificationFeatureFlag = false
 
         let task = Task {
             await subject.perform(.appeared)
         }
         await task.value
+        XCTAssertEqual(configService.configMocker.invokedParam?.isPreAuth, true)
         XCTAssertTrue(subject.state.emailVerificationFeatureFlag)
     }
 
     /// `perform(.appeared)` with feature flag for .emailVerification set to false
     @MainActor
     func test_perform_appeared_loadsFeatureFlag_false() async {
-        configService.featureFlagsBool[.emailVerification] = false
+        configService.featureFlagsBoolPreAuth[.emailVerification] = false
         subject.state.emailVerificationFeatureFlag = true
 
         let task = Task {
             await subject.perform(.appeared)
         }
         await task.value
+        XCTAssertEqual(configService.configMocker.invokedParam?.isPreAuth, true)
         XCTAssertFalse(subject.state.emailVerificationFeatureFlag)
     }
 
     /// `perform(.appeared)` with feature flag defaulting to false
     @MainActor
     func test_perform_appeared_loadsFeatureFlag_nil() async {
-        configService.featureFlagsBool[.emailVerification] = nil
+        configService.featureFlagsBoolPreAuth[.emailVerification] = nil
         subject.state.emailVerificationFeatureFlag = true
 
         let task = Task {
             await subject.perform(.appeared)
         }
         await task.value
+        XCTAssertEqual(configService.configMocker.invokedParam?.isPreAuth, true)
         XCTAssertFalse(subject.state.emailVerificationFeatureFlag)
     }
 

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -538,11 +538,11 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
     func test_perform_appeared_loadFeatureFlags() async {
         XCTAssertFalse(subject.state.isCreateAccountFeatureFlagEnabled)
 
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = true
         await subject.perform(.appeared)
         XCTAssertTrue(subject.state.isCreateAccountFeatureFlagEnabled)
 
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = false
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = false
         await subject.perform(.appeared)
         XCTAssertFalse(subject.state.isCreateAccountFeatureFlagEnabled)
     }

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationProcessorTests.swift
@@ -46,7 +46,7 @@ class ExtensionActivationProcessorTests: BitwardenTestCase {
     /// `perform(.appeared)` with feature flag for .nativeCreateAccountFlow set to true
     @MainActor
     func test_perform_appeared_loadFeatureFlag_true() async {
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = true
         subject.state.isNativeCreateAccountFeatureFlagEnabled = false
 
         await subject.perform(.appeared)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14502](https://bitwarden.atlassian.net/browse/PM-14502)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes the email verification feature flag not loading for account creation. When the landing processor was fetching the feature flags, it was missing the `isPreAuth: true` argument.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/4f6eb01a-3de7-4d5d-bcd7-e8a308d27f6a



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14502]: https://bitwarden.atlassian.net/browse/PM-14502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ