### PR TITLE
PM-14620: Remove unused accessSecretsManager property to fix JSON decoding errors

### DIFF
--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
@@ -47,6 +47,13 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
     /// The service to get server-specified configuration.
     private let configService: ConfigService
 
+    /// A task that sets up syncing for a user.
+    ///
+    /// Using an actor-protected `Task` ensures that multiple threads don't attempt
+    /// to setup sync at the same time. `enableSyncForUserId(_)` `await`s
+    /// the result of this task before adding the next sync setup to the end of it.
+    private var enableSyncTask: Task<Void, Never>?
+
     /// The service used by the application to report non-fatal errors.
     private let errorReporter: ErrorReporter
 
@@ -246,19 +253,34 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
     /// - Parameter userId: The userId of the user whose sync status is being determined.
     ///
     private func determineSyncForUserId(_ userId: String) async throws {
-        guard try await stateService.getSyncToAuthenticator(userId: userId) else {
+        if try await stateService.getSyncToAuthenticator(userId: userId) {
+            enableSyncForUserId(userId)
+        } else {
             cipherPublisherTasks[userId]?.cancel()
             cipherPublisherTasks.removeValue(forKey: userId)
             try await keychainRepository.deleteAuthenticatorVaultKey(userId: userId)
             try await authBridgeItemService.deleteAllForUserId(userId)
             try await deleteKeyIfSyncingIsOff()
-            return
         }
+    }
 
-        if !vaultTimeoutService.isLocked(userId: userId) {
-            try await createAuthenticatorKeyIfNeeded()
-            try await createAuthenticatorVaultKeyIfNeeded(userId: userId)
-            subscribeToCipherUpdates(userId: userId)
+    /// Enable sync for the provided userId.
+    ///
+    /// - Parameter userId: The userId of the user whose sync is being enabled.
+    ///
+    private func enableSyncForUserId(_ userId: String) {
+        guard !vaultTimeoutService.isLocked(userId: userId) else { return }
+
+        enableSyncTask = Task { [enableSyncTask] in
+            _ = await enableSyncTask?.result
+
+            do {
+                try await createAuthenticatorKeyIfNeeded()
+                try await createAuthenticatorVaultKeyIfNeeded(userId: userId)
+                subscribeToCipherUpdates(userId: userId)
+            } catch {
+                errorReporter.log(error: error)
+            }
         }
     }
 

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -21,6 +21,11 @@ protocol AppSettingsStore: AnyObject {
     /// The app's theme.
     var appTheme: String? { get set }
 
+    /// The last published active user ID by `activeAccountIdPublisher` in the current process.
+    /// If this is different than the active user ID in the `State`, the active user was likely
+    /// switched in an extension and the main app should update accordingly.
+    var cachedActiveUserId: String? { get }
+
     /// Whether to disable the website icons.
     var disableWebIcons: Bool { get set }
 
@@ -816,6 +821,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     var appTheme: String? {
         get { fetch(for: .appTheme) }
         set { store(newValue, for: .appTheme) }
+    }
+
+    var cachedActiveUserId: String? {
+        activeAccountIdSubject.value
     }
 
     var disableWebIcons: Bool {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -213,6 +213,26 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNil(userDefaults.string(forKey: "bwPreferencesStorage:theme"))
     }
 
+    /// `cachedActiveUserId` returns `nil` if there isn't a cached active user.
+    func test_cachedActiveUserId_isInitiallyNil() {
+        XCTAssertNil(subject.cachedActiveUserId)
+    }
+
+    /// `cachedActiveUserId` returns the user ID of the last active user ID in the current process.
+    func test_cachedActiveUserId_withValue() {
+        subject.state = State(accounts: ["1": .fixture()], activeUserId: "1")
+        XCTAssertEqual(subject.cachedActiveUserId, "1")
+
+        subject.state = State(
+            accounts: [
+                "1": .fixture(profile: .fixture(userId: "1")),
+                "2": .fixture(profile: .fixture(userId: "2")),
+            ],
+            activeUserId: "2"
+        )
+        XCTAssertEqual(subject.cachedActiveUserId, "2")
+    }
+
     /// `clearClipboardValue(userId:)` returns `.never` if there isn't a previously stored value.
     func test_clearClipboardValue_isInitiallyNever() {
         XCTAssertEqual(subject.clearClipboardValue(userId: "0"), .never)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -13,6 +13,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var appLocale: String?
     var appRehydrationState = [String: AppRehydrationState]()
     var appTheme: String?
+    var cachedActiveUserId: String?
     var disableWebIcons = false
     var introCarouselShown = false
     var lastUserShouldConnectToWatch = false

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockConfigService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockConfigService.swift
@@ -11,8 +11,11 @@ class MockConfigService: ConfigService {
     var configSubject = CurrentValueSubject<BitwardenShared.MetaServerConfig?, Never>(nil)
     var debugFeatureFlags = [DebugMenuFeatureFlag]()
     var featureFlagsBool = [FeatureFlag: Bool]()
+    var featureFlagsBoolPreAuth = [FeatureFlag: Bool]()
     var featureFlagsInt = [FeatureFlag: Int]()
+    var featureFlagsIntPreAuth = [FeatureFlag: Int]()
     var featureFlagsString = [FeatureFlag: String]()
+    var featureFlagsStringPreAuth = [FeatureFlag: String]()
     var getDebugFeatureFlagsCalled = false
     var refreshDebugFeatureFlagsCalled = false
     var toggleDebugFeatureFlagCalled = false
@@ -31,11 +34,13 @@ class MockConfigService: ConfigService {
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Bool, forceRefresh: Bool, isPreAuth: Bool) async -> Bool {
-        featureFlagsBool[flag] ?? defaultValue
+        let value = isPreAuth ? featureFlagsBoolPreAuth[flag] : featureFlagsBool[flag]
+        return value ?? defaultValue
     }
 
     func getFeatureFlag(_ flag: FeatureFlag, defaultValue: Int, forceRefresh: Bool, isPreAuth: Bool) async -> Int {
-        featureFlagsInt[flag] ?? defaultValue
+        let value = isPreAuth ? featureFlagsIntPreAuth[flag] : featureFlagsInt[flag]
+        return value ?? defaultValue
     }
 
     func getFeatureFlag(
@@ -44,7 +49,8 @@ class MockConfigService: ConfigService {
         forceRefresh: Bool,
         isPreAuth: Bool
     ) async -> String? {
-        featureFlagsString[flag] ?? defaultValue
+        let value = isPreAuth ? featureFlagsStringPreAuth[flag] : featureFlagsString[flag]
+        return value ?? defaultValue
     }
 
     func getDebugFeatureFlags() async -> [DebugMenuFeatureFlag] {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -29,6 +29,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var connectToWatchSubject = CurrentValueSubject<(String?, Bool), Never>((nil, false))
     var timeProvider = MockTimeProvider(.currentTime)
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
+    var didAccountSwitchInExtensionResult: Result<Bool, Error> = .success(false)
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
     var doesActiveAccountHavePremiumResult: Result<Bool, Error> = .success(true)
@@ -110,6 +111,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         accounts?.removeAll(where: { account in
             account == activeAccount
         })
+    }
+
+    func didAccountSwitchInExtension() async throws -> Bool {
+        try didAccountSwitchInExtensionResult.get()
     }
 
     func doesActiveAccountHavePremium() async throws -> Bool {

--- a/BitwardenShared/Core/Vault/Models/Response/Fixtures/ProfileOrganizationResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/Fixtures/ProfileOrganizationResponseModel+Fixtures.swift
@@ -4,7 +4,6 @@ import Foundation
 
 extension ProfileOrganizationResponseModel {
     static func fixture(
-        accessSecretsManager: Bool = false,
         enabled: Bool = true,
         familySponsorshipAvailable: Bool = false,
         familySponsorshipFriendlyName: String? = nil,
@@ -49,7 +48,6 @@ extension ProfileOrganizationResponseModel {
         usersGetPremium: Bool = false
     ) -> ProfileOrganizationResponseModel {
         self.init(
-            accessSecretsManager: accessSecretsManager,
             enabled: enabled,
             familySponsorshipAvailable: familySponsorshipAvailable,
             familySponsorshipFriendlyName: familySponsorshipFriendlyName,

--- a/BitwardenShared/Core/Vault/Models/Response/ProfileOrganizationResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/ProfileOrganizationResponseModel.swift
@@ -5,9 +5,6 @@ import Foundation
 struct ProfileOrganizationResponseModel: Codable, Equatable {
     // MARK: Properties
 
-    /// Whether the user can access secrets manager.
-    let accessSecretsManager: Bool
-
     /// Whether the profile organization is enabled.
     let enabled: Bool
 

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -174,7 +174,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselShown() async {
         authRepository.activeAccount = .fixture()
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
 
         let route = await subject.handleAndRoute(.didCompleteAuth)
 
@@ -187,7 +187,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselShown_vaultUnlockSetup() async {
         authRepository.activeAccount = .fixture()
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
         stateService.activeAccount = .fixture()
         stateService.accountSetupVaultUnlock["1"] = .incomplete
 
@@ -907,7 +907,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// the carousel flow is enabled.
     @MainActor
     func test_handleAndRoute_didStart_carouselFlow() async {
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
 
         let route = await subject.handleAndRoute(.didStart)
 
@@ -953,7 +953,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     func test_handleAndRoute_didStart_carouselFlow_existingAccountNeverLock() async {
         let account = Account.fixture()
         authRepository.activeAccount = .fixture()
-        configService.featureFlagsBool[.nativeCarouselFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
         vaultTimeoutService.vaultTimeout[account.profile.userId] = .never
 
         let route = await subject.handleAndRoute(.didStart)

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -193,7 +193,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     /// `perform(.appeared)` with feature flag for .nativeCreateAccountFlow set to true
     @MainActor
     func test_perform_appeared_loadFeatureFlag_true() async {
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = true
         subject.state.nativeCreateAccountFeatureFlag = false
 
         await subject.perform(.appeared)

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessorTests.swift
@@ -47,7 +47,7 @@ class IntroCarouselProcessorTests: BitwardenTestCase {
     /// verification is enabled.
     @MainActor
     func test_perform_createAccount_emailVerificationEnabled() async {
-        configService.featureFlagsBool[.emailVerification] = true
+        configService.featureFlagsBoolPreAuth[.emailVerification] = true
         await subject.perform(.createAccount)
         XCTAssertEqual(coordinator.routes.last, .startRegistration)
     }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -118,7 +118,8 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
     private func loadFeatureFlag() async {
         state.emailVerificationFeatureFlag = await services.configService.getFeatureFlag(
             FeatureFlag.emailVerification,
-            defaultValue: false
+            defaultValue: false,
+            isPreAuth: true
         )
     }
 

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -140,39 +140,42 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `perform(.appeared)` with feature flag for .emailVerification set to true
     @MainActor
     func test_perform_appeared_loadsFeatureFlag_true() async {
-        configService.featureFlagsBool[.emailVerification] = true
+        configService.featureFlagsBoolPreAuth[.emailVerification] = true
         subject.state.emailVerificationFeatureFlag = false
 
         let task = Task {
             await subject.perform(.appeared)
         }
         await task.value
+        XCTAssertEqual(configService.configMocker.invokedParam?.isPreAuth, true)
         XCTAssertTrue(subject.state.emailVerificationFeatureFlag)
     }
 
     /// `perform(.appeared)` with feature flag for .emailVerification set to false
     @MainActor
     func test_perform_appeared_loadsFeatureFlag_false() async {
-        configService.featureFlagsBool[.emailVerification] = false
+        configService.featureFlagsBoolPreAuth[.emailVerification] = false
         subject.state.emailVerificationFeatureFlag = true
 
         let task = Task {
             await subject.perform(.appeared)
         }
         await task.value
+        XCTAssertEqual(configService.configMocker.invokedParam?.isPreAuth, true)
         XCTAssertFalse(subject.state.emailVerificationFeatureFlag)
     }
 
     /// `perform(.appeared)` with feature flag defaulting to false
     @MainActor
     func test_perform_appeared_loadsFeatureFlag_nil() async {
-        configService.featureFlagsBool[.emailVerification] = nil
+        configService.featureFlagsBoolPreAuth[.emailVerification] = nil
         subject.state.emailVerificationFeatureFlag = true
 
         let task = Task {
             await subject.perform(.appeared)
         }
         await task.value
+        XCTAssertEqual(configService.configMocker.invokedParam?.isPreAuth, true)
         XCTAssertFalse(subject.state.emailVerificationFeatureFlag)
     }
 

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -538,11 +538,11 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
     func test_perform_appeared_loadFeatureFlags() async {
         XCTAssertFalse(subject.state.isCreateAccountFeatureFlagEnabled)
 
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = true
         await subject.perform(.appeared)
         XCTAssertTrue(subject.state.isCreateAccountFeatureFlagEnabled)
 
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = false
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = false
         await subject.perform(.appeared)
         XCTAssertFalse(subject.state.isCreateAccountFeatureFlagEnabled)
     }

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -81,6 +81,16 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             await handleAuthEvent(.didTimeout(userId: userId))
         case let .setAuthCompletionRoute(route):
             authCompletionRoute = route
+        case let .switchAccounts(userId, isAutomatic):
+            await handleAuthEvent(
+                .action(
+                    .switchAccount(
+                        isAutomatic: isAutomatic,
+                        userId: userId,
+                        authCompletionRoute: nil
+                    )
+                )
+            )
         }
     }
 

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -229,6 +229,23 @@ class AppCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(module.authCoordinator.routes, [.landing])
     }
 
+    /// `handleEvent(_:)` with `.switchAccounts` has the router handle switching accounts.
+    @MainActor
+    func test_handleEvent_switchAccounts() async {
+        await subject.handleEvent(.switchAccounts(userId: "1", isAutomatic: false))
+        XCTAssertEqual(
+            router.events,
+            [.action(.switchAccount(isAutomatic: false, userId: "1", authCompletionRoute: nil))]
+        )
+        router.events.removeAll()
+
+        await subject.handleEvent(.switchAccounts(userId: "2", isAutomatic: true))
+        XCTAssertEqual(
+            router.events,
+            [.action(.switchAccount(isAutomatic: true, userId: "2", authCompletionRoute: nil))]
+        )
+    }
+
     /// `navigate(to:)` with `.onboarding` starts the auth coordinator and navigates to the proper auth route.
     @MainActor
     func test_navigateTo_auth() throws {

--- a/BitwardenShared/UI/Platform/Application/AppRoute.swift
+++ b/BitwardenShared/UI/Platform/Application/AppRoute.swift
@@ -42,4 +42,7 @@ public enum AppEvent: Equatable {
 
     /// Allows setting a route that should be navigated to after the user's vault is unlocked.
     case setAuthCompletionRoute(AppRoute)
+
+    /// Switches to the specified account.
+    case switchAccounts(userId: String, isAutomatic: Bool)
 }

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationProcessorTests.swift
@@ -46,7 +46,7 @@ class ExtensionActivationProcessorTests: BitwardenTestCase {
     /// `perform(.appeared)` with feature flag for .nativeCreateAccountFlow set to true
     @MainActor
     func test_perform_appeared_loadFeatureFlag_true() async {
-        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        configService.featureFlagsBoolPreAuth[.nativeCreateAccountFlow] = true
         subject.state.isNativeCreateAccountFeatureFlagEnabled = false
 
         await subject.perform(.appeared)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14620](https://bitwarden.atlassian.net/browse/PM-14620)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a JSON decoding error in Crashlytics because `accessSecretsManager` is missing. I'm guessing this is caused by an older self-hosted instance? But since we don't use this property, I don't see any reason to keep it around.

<img width="1143" alt="Screenshot 2024-11-07 at 3 40 22 PM" src="https://github.com/user-attachments/assets/d2b6e86c-179e-4cbd-b9e9-26e6963d26a1">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14620]: https://bitwarden.atlassian.net/browse/PM-14620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ