### PR TITLE
PM-14501 - Sometimes tapping the Verify Email link will not load the Master Password bottom sheet correctly

### DIFF
--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -292,7 +292,6 @@ class AppCoordinator: Coordinator, HasRootNavigator {
         stackNavigator.modalPresentationStyle = .fullScreen
         let debugMenuCoordinator = module.makeDebugMenuCoordinator(stackNavigator: stackNavigator)
         debugMenuCoordinator.start()
-        childCoordinator = debugMenuCoordinator
 
         rootNavigator?.rootViewController?.topmostViewController().present(
             stackNavigator,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14501](https://bitwarden.atlassian.net/browse/PM-14501)

## 📔 Objective

- This PR addresses an issue where setting DebugMenuCoordinator as a child coordinator within AuthCoordinator caused a navigation error during the email verification flow. Specifically, attempting to present CompleteRegistrationView resulted in the error:
`Attempt to present <UINavigationController: 0x1069ea200> on <UINavigationController: 0x10d010000> (from <UINavigationController: 0x10d010000>) whose view is not in the window hierarchy.`
- The solution was to avoid setting `DebugMenuCoordinator` as a child coordinator, as it didn’t require being a part of the AuthCoordinator's child coordinators. This fix ensures that the email verification flow functions correctly without interference from the debug menu.
## 📸 Screenshots

##Before

https://github.com/user-attachments/assets/8d709430-a160-4f67-bdef-9de42a577b01

##After

https://github.com/user-attachments/assets/2517da56-1b6e-446e-859d-e3ec63fa5b37
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14501]: https://bitwarden.atlassian.net/browse/PM-14501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ