### PR TITLE
[PM-14579] Fix maintaining vault locked on timeout Never.

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -918,7 +918,11 @@ extension DefaultAuthRepository: AuthRepository {
         let isLocked = await (try? isLocked(userId: account.profile.userId)) ?? true
         let isAuthenticated = await (try? stateService.isAuthenticated(userId: account.profile.userId)) == true
         let hasNeverLock = await (try? stateService.getVaultTimeout(userId: account.profile.userId)) == .never
-        let displayAsUnlocked = !isLocked || hasNeverLock
+        let isManuallyLocked = await (try? stateService.getManuallyLockedAccount(
+            userId: account.profile.userId
+        )) == true
+        let unlockedOnNeverLock = hasNeverLock && !isManuallyLocked
+        let displayAsUnlocked = !isLocked || unlockedOnNeverLock
 
         let color = if let avatarColor = account.profile.avatarColor {
             Color(hex: avatarColor)

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1035,6 +1035,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             try await subject.unlockVaultWithNeverlockKey()
         }
         XCTAssertFalse(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `test_unlockVaultWithDeviceKey` attempts to unlock the vault using the device key from the keychain.
@@ -1061,6 +1062,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             try await subject.unlockVaultWithDeviceKey()
         }
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `test_unlockVaultWithDeviceKey` attempts to unlock the vault using the device key from the keychain.
@@ -1092,6 +1094,21 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_lockVault() async {
         await subject.lockVault(userId: "10")
         XCTAssertTrue(vaultTimeoutService.isLocked(userId: "10"))
+    }
+
+    /// `lockVault(userId:)` manually locks the vault for the specified user id.
+    func test_lockVault_manuallyLocking() async {
+        await subject.lockVault(userId: "10", isManuallyLocking: true)
+        XCTAssertTrue(vaultTimeoutService.isLocked(userId: "10"))
+        XCTAssertEqual(stateService.manuallyLockedAccounts["10"], true)
+    }
+
+    /// `lockVault(userId:)` logs error when manually locks the vault for the specified user id.
+    func test_lockVault_throwsManuallyLocking() async {
+        stateService.activeAccount = nil
+        await subject.lockVault(userId: nil, isManuallyLocking: true)
+        XCTAssertTrue(stateService.manuallyLockedAccounts.isEmpty)
+        XCTAssertEqual(errorReporter.errors.last as? StateServiceError, .noActiveAccount)
     }
 
     /// `passwordStrength(email:password)` returns the calculated password strength.
@@ -1307,6 +1324,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "ENCRYPTED_USER_KEY")
         XCTAssertEqual(stateService.masterPasswordHashes["1"], "hashed")
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithAuthenticatorVaultKey` throws when it encounters an error trying to unlock
@@ -1344,6 +1362,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         clientService.mockCrypto.initializeUserCryptoResult = .success(())
         try await subject.unlockVaultWithAuthenticatorVaultKey(userId: active.profile.userId)
         XCTAssertFalse(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithBiometrics()` throws an error if the vault is unable to be unlocked.
@@ -1443,6 +1462,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "ENCRYPTED_USER_KEY")
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithKeyConnectorKey()` unlocks the user's vault with their key connector key.
@@ -1475,6 +1495,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         )
         XCTAssertFalse(keyConnectorService.convertNewUserToKeyConnectorCalled)
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithKeyConnectorKey()` converts a new user to use key connector and unlocks the
@@ -1652,6 +1673,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             )
         )
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN.
@@ -1681,6 +1703,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithPIN(_:)` throws an error if there's no pin.

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -22,6 +22,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var activeAccount: Account?
     var altAccounts = [Account]()
     var getAccountError: Error?
+    var hasManuallyLocked = false
     var hasMasterPasswordResult = Result<Bool, Error>.success(true)
     var isLockedResult: Result<Bool, Error> = .success(true)
     var isPinUnlockAvailableResult: Result<Bool, Error> = .success(false)
@@ -185,8 +186,9 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
         return passwordStrengthResult
     }
 
-    func lockVault(userId: String?) async {
+    func lockVault(userId: String?, isManuallyLocking: Bool) async {
         lockVaultUserId = userId
+        hasManuallyLocked = isManuallyLocking
     }
 
     func logout(userId: String?, userInitiated: Bool) async throws {

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -260,8 +260,11 @@ class DefaultAutofillCredentialService {
     private func tryUnlockVaultWithoutUserInteraction(delegate: AutofillCredentialServiceDelegate) async throws {
         let userId = try await stateService.getActiveAccountId()
         let isLocked = vaultTimeoutService.isLocked(userId: userId)
+        let isManuallyLocked = await (try? stateService.getManuallyLockedAccount(userId: userId)) == true
         let vaultTimeout = try? await vaultTimeoutService.sessionTimeoutValue(userId: nil)
-        guard vaultTimeout == .never, isLocked else { return }
+        guard vaultTimeout == .never, isLocked, !isManuallyLocked else {
+            return
+        }
         try await delegate.unlockVaultWithNeverlockKey()
     }
 }

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -186,6 +186,30 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         XCTAssertNil(pasteboardService.copiedString)
     }
 
+    /// `provideCredential(for:)` doesn't unlock the user's vault if they use never lock
+    /// but it has been manually locked.
+    func test_provideCredential_neverLockManuallyLocked() async throws {
+        autofillCredentialServiceDelegate.unlockVaultWithNaverlockHandler = { [weak self] in
+            self?.vaultTimeoutService.isClientLocked["1"] = false
+        }
+        cipherService.fetchCipherResult = .success(
+            .fixture(login: .fixture(password: "password123", username: "user@bitwarden.com"))
+        )
+        stateService.activeAccount = .fixture()
+        stateService.manuallyLockedAccounts["1"] = true
+        vaultTimeoutService.isClientLocked["1"] = true
+        vaultTimeoutService.vaultTimeout["1"] = .never
+
+        await assertAsyncThrows(error: ASExtensionError(.userInteractionRequired)) {
+            _ = try await subject.provideCredential(
+                for: "1",
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                repromptPasswordValidated: false
+            )
+        }
+        XCTAssertFalse(autofillCredentialServiceDelegate.unlockVaultWithNeverlockKeyCalled)
+    }
+
     /// `provideCredential(for:)` throws an error if reprompt is required.
     func test_provideCredential_repromptRequired() async throws {
         stateService.activeAccount = .fixture()
@@ -420,6 +444,31 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         XCTAssertEqual(result.clientDataHash, passkeyRequest.clientDataHash)
         XCTAssertEqual(result.authenticatorData, expectedAssertionResult.authenticatorData)
         XCTAssertEqual(result.credentialID, expectedAssertionResult.credentialId)
+    }
+
+    /// `provideFido2Credential(for:autofillCredentialServiceDelegate:fido2UserVerificationMediatorDelegate:)`
+    /// throws when unlocking with never key but is manually locked.
+    @available(iOS 17.0, *)
+    func test_provideFido2Credential_throwsWithUnlockingNeverKeyAndManuallyLocked() async throws {
+        autofillCredentialServiceDelegate.unlockVaultWithNaverlockHandler = { [weak self] in
+            self?.vaultTimeoutService.isClientLocked["1"] = false
+        }
+        stateService.activeAccount = .fixture()
+        stateService.manuallyLockedAccounts["1"] = true
+        vaultTimeoutService.isClientLocked["1"] = true
+        vaultTimeoutService.vaultTimeout["1"] = .never
+
+        let passkeyIdentity = ASPasskeyCredentialIdentity.fixture()
+        let passkeyRequest = ASPasskeyCredentialRequest.fixture(credentialIdentity: passkeyIdentity)
+
+        await assertAsyncThrows(error: Fido2Error.userInteractionRequired) {
+            _ = try await subject.provideFido2Credential(
+                for: passkeyRequest,
+                autofillCredentialServiceDelegate: autofillCredentialServiceDelegate,
+                fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate
+            )
+        }
+        XCTAssertFalse(autofillCredentialServiceDelegate.unlockVaultWithNeverlockKeyCalled)
     }
 
     /// `provideFido2Credential(for:autofillCredentialServiceDelegate:fido2UserVerificationMediatorDelegate:)`

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -217,11 +217,6 @@ protocol StateService: AnyObject {
     ///
     func getLoginRequest() async -> LoginRequestNotification?
 
-    /// Gets whether the account belonging to the user Id has been manually locked.
-    /// - Parameter userId: The user ID associated with the account.
-    /// - Returns: `true` if manually locked, `false` otherwise.
-    func getManuallyLockedAccount(userId: String?) async throws -> Bool
-
     /// Gets the master password hash for a user ID.
     ///
     /// - Parameter userId: The user ID associated with the master password hash.
@@ -513,13 +508,6 @@ protocol StateService: AnyObject {
     /// - Parameter loginRequest: The pending login request data.
     ///
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async
-
-    /// Sets whether the account belonging to the user Id has been manually locked.
-    /// - Parameters
-    ///   - isLocked: Whether the account has been locked manually.
-    ///   - userId: The user ID associated with the account.
-    /// - Returns: `true` if manually locked, `false` otherwise.
-    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws
 
     /// Sets the master password hash for a user ID.
     ///
@@ -1451,11 +1439,6 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appSettingsStore.loginRequest
     }
 
-    func getManuallyLockedAccount(userId: String?) async throws -> Bool {
-        let userId = try userId ?? getActiveAccountUserId()
-        return appSettingsStore.manuallyLockedAccount(userId: userId)
-    }
-
     func getMasterPasswordHash(userId: String?) async throws -> String? {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.masterPasswordHash(userId: userId)
@@ -1709,11 +1692,6 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
 
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async {
         appSettingsStore.loginRequest = loginRequest
-    }
-
-    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws {
-        let userId = try userId ?? getActiveAccountUserId()
-        appSettingsStore.setManuallyLockedAccount(isLocked, userId: userId)
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -217,6 +217,11 @@ protocol StateService: AnyObject {
     ///
     func getLoginRequest() async -> LoginRequestNotification?
 
+    /// Gets whether the account belonging to the user Id has been manually locked.
+    /// - Parameter userId: The user ID associated with the account.
+    /// - Returns: `true` if manually locked, `false` otherwise.
+    func getManuallyLockedAccount(userId: String?) async throws -> Bool
+
     /// Gets the master password hash for a user ID.
     ///
     /// - Parameter userId: The user ID associated with the master password hash.
@@ -508,6 +513,13 @@ protocol StateService: AnyObject {
     /// - Parameter loginRequest: The pending login request data.
     ///
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async
+
+    /// Sets whether the account belonging to the user Id has been manually locked.
+    /// - Parameters
+    ///   - isLocked: Whether the account has been locked manually.
+    ///   - userId: The user ID associated with the account.
+    /// - Returns: `true` if manually locked, `false` otherwise.
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws
 
     /// Sets the master password hash for a user ID.
     ///
@@ -1439,6 +1451,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         appSettingsStore.loginRequest
     }
 
+    func getManuallyLockedAccount(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.manuallyLockedAccount(userId: userId)
+    }
+
     func getMasterPasswordHash(userId: String?) async throws -> String? {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.masterPasswordHash(userId: userId)
@@ -1692,6 +1709,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
 
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async {
         appSettingsStore.loginRequest = loginRequest
+    }
+
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setManuallyLockedAccount(isLocked, userId: userId)
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -686,6 +686,25 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(value, loginRequest)
     }
 
+    /// `getManuallyLockedAccount(userId:)` returns whether the account has been manually locked.
+    func test_getManuallyLockedAccount() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        let noManuallyLockedAccount = try await subject.getManuallyLockedAccount(userId: "1")
+        XCTAssertFalse(noManuallyLockedAccount)
+
+        appSettingsStore.manuallyLockedAccounts["1"] = true
+        let manuallyLockedAccount = try await subject.getManuallyLockedAccount(userId: "1")
+        XCTAssertTrue(manuallyLockedAccount)
+    }
+
+    /// `getManuallyLockedAccount(userId:)` throws because no active account.
+    func test_getManuallyLockedAccount_throws() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.getManuallyLockedAccount(userId: nil)
+        }
+    }
+
     /// `getMasterPasswordHash()` returns the user's master password hash.
     func test_getMasterPasswordHash() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
@@ -1663,6 +1682,27 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let loginRequest = LoginRequestNotification(id: "1", userId: "10")
         await subject.setLoginRequest(loginRequest)
         XCTAssertEqual(appSettingsStore.loginRequest, loginRequest)
+    }
+
+    /// `setManuallyLockedAccount(_:userId:)` sets if the account has been manually locked for a user.
+    func test_setManuallyLockedAccount() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        try await subject.setManuallyLockedAccount(true, userId: nil)
+        XCTAssertEqual(appSettingsStore.manuallyLockedAccounts, ["1": true])
+
+        try await subject.setManuallyLockedAccount(false, userId: "1")
+        XCTAssertEqual(appSettingsStore.manuallyLockedAccounts, ["1": false])
+
+        try await subject.setManuallyLockedAccount(true, userId: "1")
+        XCTAssertEqual(appSettingsStore.manuallyLockedAccounts, ["1": true])
+    }
+
+    /// `setManuallyLockedAccount(_:userId:)` throws when setting if the account has been manually locked for a user.
+    func test_setManuallyLockedAccount_throws() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            try await subject.setManuallyLockedAccount(true, userId: nil)
+        }
     }
 
     /// `setMasterPasswordHash(_:)` sets the master password hash for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -178,11 +178,6 @@ protocol AppSettingsStore: AnyObject {
     ///
     func lastSyncTime(userId: String) -> Date?
 
-    /// Gets whether the account belonging to the user Id has been manually locked.
-    /// - Parameter userId: The user ID associated with the account.
-    /// - Returns: `true` if manually locked, `false` otherwise.
-    func manuallyLockedAccount(userId: String) -> Bool
-
     /// Gets the master password hash for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the master password hash.
@@ -367,12 +362,6 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the last sync time.
     ///
     func setLastSyncTime(_ date: Date?, userId: String)
-
-    /// Sets whether the account belonging to the user Id has been manually locked.
-    /// - Parameters
-    ///   - isLocked: Whether the account has been locked manually.
-    ///   - userId: The user ID associated with the account.
-    func setManuallyLockedAccount(_ isLocked: Bool, userId: String)
 
     /// Sets the master password hash for a user ID.
     ///
@@ -689,7 +678,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case lastSync(userId: String)
         case lastUserShouldConnectToWatch
         case loginRequest
-        case manuallyLockedAccount(userId: String)
         case masterPasswordHash(userId: String)
         case migrationVersion
         case notificationsLastRegistrationDate(userId: String)
@@ -765,8 +753,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "lastUserShouldConnectToWatch"
             case .loginRequest:
                 key = "passwordlessLoginNotificationKey"
-            case let .manuallyLockedAccount(userId):
-                key = "manuallyLockedAccount_\(userId)"
             case let .masterPasswordHash(userId):
                 key = "keyHash_\(userId)"
             case .migrationVersion:
@@ -957,10 +943,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .lastSync(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
 
-    func manuallyLockedAccount(userId: String) -> Bool {
-        fetch(for: .manuallyLockedAccount(userId: userId))
-    }
-
     func masterPasswordHash(userId: String) -> String? {
         fetch(for: .masterPasswordHash(userId: userId))
     }
@@ -1053,10 +1035,6 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setLastSyncTime(_ date: Date?, userId: String) {
         store(date?.timeIntervalSince1970, for: .lastSync(userId: userId))
-    }
-
-    func setManuallyLockedAccount(_ isLocked: Bool, userId: String) {
-        store(isLocked, for: .manuallyLockedAccount(userId: userId))
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -178,6 +178,11 @@ protocol AppSettingsStore: AnyObject {
     ///
     func lastSyncTime(userId: String) -> Date?
 
+    /// Gets whether the account belonging to the user Id has been manually locked.
+    /// - Parameter userId: The user ID associated with the account.
+    /// - Returns: `true` if manually locked, `false` otherwise.
+    func manuallyLockedAccount(userId: String) -> Bool
+
     /// Gets the master password hash for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the master password hash.
@@ -362,6 +367,12 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the last sync time.
     ///
     func setLastSyncTime(_ date: Date?, userId: String)
+
+    /// Sets whether the account belonging to the user Id has been manually locked.
+    /// - Parameters
+    ///   - isLocked: Whether the account has been locked manually.
+    ///   - userId: The user ID associated with the account.
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String)
 
     /// Sets the master password hash for a user ID.
     ///
@@ -678,6 +689,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case lastSync(userId: String)
         case lastUserShouldConnectToWatch
         case loginRequest
+        case manuallyLockedAccount(userId: String)
         case masterPasswordHash(userId: String)
         case migrationVersion
         case notificationsLastRegistrationDate(userId: String)
@@ -753,6 +765,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "lastUserShouldConnectToWatch"
             case .loginRequest:
                 key = "passwordlessLoginNotificationKey"
+            case let .manuallyLockedAccount(userId):
+                key = "manuallyLockedAccount_\(userId)"
             case let .masterPasswordHash(userId):
                 key = "keyHash_\(userId)"
             case .migrationVersion:
@@ -943,6 +957,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .lastSync(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
 
+    func manuallyLockedAccount(userId: String) -> Bool {
+        fetch(for: .manuallyLockedAccount(userId: userId))
+    }
+
     func masterPasswordHash(userId: String) -> String? {
         fetch(for: .masterPasswordHash(userId: userId))
     }
@@ -1035,6 +1053,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setLastSyncTime(_ date: Date?, userId: String) {
         store(date?.timeIntervalSince1970, for: .lastSync(userId: userId))
+    }
+
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String) {
+        store(isLocked, for: .manuallyLockedAccount(userId: userId))
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -529,6 +529,30 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
+    /// `manuallyLockedAccount(userId:)` returns `false` if there isn't a previously stored value.
+    func test_manuallyLockedAccount_isInitiallyFalse() {
+        XCTAssertFalse(subject.manuallyLockedAccount(userId: "-1"))
+    }
+
+    /// `manuallyLockedAccount(userId:)` can be used to get whether the account has been manually locked.
+    func test_manuallyLockedAccount_withValue() {
+        subject.setManuallyLockedAccount(false, userId: "1")
+        subject.setManuallyLockedAccount(true, userId: "2")
+
+        XCTAssertFalse(subject.manuallyLockedAccount(userId: "1"))
+        XCTAssertTrue(subject.manuallyLockedAccount(userId: "2"))
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:manuallyLockedAccount_1"))
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:manuallyLockedAccount_2"))
+
+        subject.setManuallyLockedAccount(true, userId: "1")
+        subject.setManuallyLockedAccount(false, userId: "2")
+
+        XCTAssertTrue(subject.manuallyLockedAccount(userId: "1"))
+        XCTAssertFalse(subject.manuallyLockedAccount(userId: "2"))
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:manuallyLockedAccount_1"))
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:manuallyLockedAccount_2"))
+    }
+
     /// `migrationVersion` returns `0` if there isn't a previously stored value.
     func test_migrationVersion_isInitiallyZero() {
         XCTAssertEqual(subject.migrationVersion, 0)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -36,7 +36,6 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var featureFlags = [String: Bool]()
     var lastActiveTime = [String: Date]()
     var lastSyncTimeByUserId = [String: Date]()
-    var manuallyLockedAccounts = [String: Bool]()
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
@@ -122,10 +121,6 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func lastSyncTime(userId: String) -> Date? {
         lastSyncTimeByUserId[userId]
-    }
-
-    func manuallyLockedAccount(userId: String) -> Bool {
-        manuallyLockedAccounts[userId] ?? false
     }
 
     func masterPasswordHash(userId: String) -> String? {
@@ -231,10 +226,6 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setLastSyncTime(_ date: Date?, userId: String) {
         lastSyncTimeByUserId[userId] = date
-    }
-
-    func setManuallyLockedAccount(_ isLocked: Bool, userId: String) {
-        manuallyLockedAccounts[userId] = isLocked
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -36,6 +36,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var featureFlags = [String: Bool]()
     var lastActiveTime = [String: Date]()
     var lastSyncTimeByUserId = [String: Date]()
+    var manuallyLockedAccounts = [String: Bool]()
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
@@ -121,6 +122,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func lastSyncTime(userId: String) -> Date? {
         lastSyncTimeByUserId[userId]
+    }
+
+    func manuallyLockedAccount(userId: String) -> Bool {
+        manuallyLockedAccounts[userId] ?? false
     }
 
     func masterPasswordHash(userId: String) -> String? {
@@ -226,6 +231,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setLastSyncTime(_ date: Date?, userId: String) {
         lastSyncTimeByUserId[userId] = date
+    }
+
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String) {
+        manuallyLockedAccounts[userId] = isLocked
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -52,6 +52,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastSyncTimeByUserId = [String: Date]()
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lastUserShouldConnectToWatch = false
+    var manuallyLockedAccounts = [String: Bool]()
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var notificationsLastRegistrationError: Error?
@@ -257,6 +258,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func getLoginRequest() async -> LoginRequestNotification? {
         loginRequest
+    }
+
+    func getManuallyLockedAccount(userId: String?) async throws -> Bool {
+        let userId = try unwrapUserId(userId)
+        return manuallyLockedAccounts[userId] ?? false
     }
 
     func getMasterPasswordHash(userId: String?) async throws -> String? {
@@ -499,6 +505,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async {
         self.loginRequest = loginRequest
+    }
+
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        manuallyLockedAccounts[userId] = isLocked
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -29,6 +29,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var connectToWatchSubject = CurrentValueSubject<(String?, Bool), Never>((nil, false))
     var timeProvider = MockTimeProvider(.currentTime)
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
+    var didAccountSwitchInExtensionResult = false
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
     var doesActiveAccountHavePremiumResult: Result<Bool, Error> = .success(true)
@@ -51,6 +52,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastSyncTimeByUserId = [String: Date]()
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lastUserShouldConnectToWatch = false
+    var manuallyLockedAccounts = [String: Bool]()
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var notificationsLastRegistrationError: Error?
@@ -110,6 +112,10 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         accounts?.removeAll(where: { account in
             account == activeAccount
         })
+    }
+
+    func didAccountSwitchInExtension() async throws -> Bool {
+        didAccountSwitchInExtensionResult
     }
 
     func doesActiveAccountHavePremium() async throws -> Bool {
@@ -252,6 +258,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func getLoginRequest() async -> LoginRequestNotification? {
         loginRequest
+    }
+
+    func getManuallyLockedAccount(userId: String?) async throws -> Bool {
+        let userId = try unwrapUserId(userId)
+        return manuallyLockedAccounts[userId] ?? false
     }
 
     func getMasterPasswordHash(userId: String?) async throws -> String? {
@@ -494,6 +505,11 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async {
         self.loginRequest = loginRequest
+    }
+
+    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        manuallyLockedAccounts[userId] = isLocked
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -52,7 +52,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var lastSyncTimeByUserId = [String: Date]()
     var lastSyncTimeSubject = CurrentValueSubject<Date?, Never>(nil)
     var lastUserShouldConnectToWatch = false
-    var manuallyLockedAccounts = [String: Bool]()
     var masterPasswordHashes = [String: String]()
     var notificationsLastRegistrationDates = [String: Date]()
     var notificationsLastRegistrationError: Error?
@@ -258,11 +257,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func getLoginRequest() async -> LoginRequestNotification? {
         loginRequest
-    }
-
-    func getManuallyLockedAccount(userId: String?) async throws -> Bool {
-        let userId = try unwrapUserId(userId)
-        return manuallyLockedAccounts[userId] ?? false
     }
 
     func getMasterPasswordHash(userId: String?) async throws -> String? {
@@ -505,11 +499,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
 
     func setLoginRequest(_ loginRequest: LoginRequestNotification?) async {
         self.loginRequest = loginRequest
-    }
-
-    func setManuallyLockedAccount(_ isLocked: Bool, userId: String?) async throws {
-        let userId = try unwrapUserId(userId)
-        manuallyLockedAccounts[userId] = isLocked
     }
 
     func setMasterPasswordHash(_ hash: String?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -29,7 +29,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var connectToWatchSubject = CurrentValueSubject<(String?, Bool), Never>((nil, false))
     var timeProvider = MockTimeProvider(.currentTime)
     var defaultUriMatchTypeByUserId = [String: UriMatchType]()
-    var didAccountSwitchInExtensionResult = false
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
     var doesActiveAccountHavePremiumResult: Result<Bool, Error> = .success(true)
@@ -112,10 +111,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         accounts?.removeAll(where: { account in
             account == activeAccount
         })
-    }
-
-    func didAccountSwitchInExtension() async throws -> Bool {
-        didAccountSwitchInExtensionResult
     }
 
     func doesActiveAccountHavePremium() async throws -> Bool {

--- a/BitwardenShared/UI/Auth/AuthAction.swift
+++ b/BitwardenShared/UI/Auth/AuthAction.swift
@@ -5,9 +5,11 @@
 public enum AuthAction: Equatable {
     /// When the app should lock an account.
     ///
-    /// - Parameter userId: The user Id of the account.
+    /// - Parameters:
+    ///   - userId: The user Id of the selected account. Defaults to the active user id if nil.
+    ///   - isManuallyLocking: Whether the user is manually locking the account.
     ///
-    case lockVault(userId: String?)
+    case lockVault(userId: String?, isManuallyLocking: Bool = false)
 
     /// When the app should logout an account vault.
     ///

--- a/BitwardenShared/UI/Auth/AuthRouter.swift
+++ b/BitwardenShared/UI/Auth/AuthRouter.swift
@@ -106,8 +106,8 @@ final class AuthRouter: NSObject, Router {
     ///
     private func handleAuthAction(_ action: AuthAction) async -> AuthRoute {
         switch action {
-        case let .lockVault(userId):
-            return await lockVaultRedirect(userId: userId)
+        case let .lockVault(userId, isManuallyLocking):
+            return await lockVaultRedirect(userId: userId, isManuallyLocking: isManuallyLocking)
         case let .logout(userId, userInitiated):
             return await logoutRedirect(userId: userId, userInitiated: userInitiated)
         case let .switchAccount(isAutomatic, userId, _):

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -88,7 +88,6 @@ extension Alert {
     ///
     static func accountOptions(
         _ item: ProfileSwitcherItem,
-        hasNeverLock: Bool = false,
         lockAction: @escaping () async -> Void,
         logoutAction: @escaping () async -> Void
     ) -> Alert {
@@ -101,8 +100,7 @@ extension Alert {
                 handler: { _, _ in await logoutAction() }
             ),
         ]
-        if item.isUnlocked,
-           !hasNeverLock {
+        if item.isUnlocked {
             alertActions.insert(
                 AlertAction(
                     title: Localizations.lock,

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -549,7 +549,7 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         // Verify the results.
         XCTAssertEqual(
             coordinator.events.last,
-            .action(.lockVault(userId: otherProfile.userId))
+            .action(.lockVault(userId: otherProfile.userId, isManuallyLocking: true))
         )
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.accountLockedSuccessfully))
     }

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
@@ -168,7 +168,7 @@ private extension ProfileSwitcherHandler {
         do {
             // Lock the vault of the selected account.
             let activeAccountId = try await profileServices.authRepository.getUserId()
-            await handleAuthEvent(.action(.lockVault(userId: account.userId)))
+            await handleAuthEvent(.action(.lockVault(userId: account.userId, isManuallyLocking: true)))
 
             // No navigation is necessary, since the user is already on the unlock
             // vault view, but if it was the non-active account, display a success toast

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
@@ -144,12 +144,9 @@ private extension ProfileSwitcherHandler {
     ///
     func didLongPressProfileSwitcherItem(_ account: ProfileSwitcherItem) async {
         profileSwitcherState.isVisible = false
-        let sessionTimeout = try? await profileServices.authRepository.sessionTimeoutValue(userId: account.userId)
-        let hasNeverLock = sessionTimeout == .never
         showAlert(
             .accountOptions(
                 account,
-                hasNeverLock: hasNeverLock,
                 lockAction: {
                     await self.lock(account)
                 },

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
@@ -839,7 +839,15 @@ class VaultUnlockProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         await lockAction.handler?(lockAction, [])
 
         // Verify the results.
-        XCTAssertEqual(coordinator.events.last, .action(.lockVault(userId: otherProfile.userId)))
+        XCTAssertEqual(
+            coordinator.events.last,
+            .action(
+                .lockVault(
+                    userId: otherProfile.userId,
+                    isManuallyLocking: true
+                )
+            )
+        )
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.accountLockedSuccessfully))
     }
 

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -392,11 +392,11 @@ extension AppCoordinator: SettingsCoordinatorDelegate {
         }
     }
 
-    func lockVault(userId: String?) {
+    func lockVault(userId: String?, isManuallyLocking: Bool) {
         Task {
             await handleAuthEvent(
                 .action(
-                    .lockVault(userId: userId)
+                    .lockVault(userId: userId, isManuallyLocking: isManuallyLocking)
                 )
             )
         }

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -155,14 +155,31 @@ class AppCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_didLockVault() {
         let account: Account = .fixtureAccountLogin()
 
-        subject.lockVault(userId: account.profile.userId)
+        subject.lockVault(userId: account.profile.userId, isManuallyLocking: false)
 
         waitFor(module.authCoordinator.isStarted)
         waitFor(!router.events.isEmpty)
         XCTAssertEqual(
             router.events,
             [
-                .action(.lockVault(userId: account.profile.userId)),
+                .action(.lockVault(userId: account.profile.userId, isManuallyLocking: false)),
+            ]
+        )
+    }
+
+    /// `lockVault(_:)` passes the lock event to the router with manual locking.
+    @MainActor
+    func test_didLockVault_onManualLocking() {
+        let account: Account = .fixtureAccountLogin()
+
+        subject.lockVault(userId: account.profile.userId, isManuallyLocking: true)
+
+        waitFor(module.authCoordinator.isStarted)
+        waitFor(!router.events.isEmpty)
+        XCTAssertEqual(
+            router.events,
+            [
+                .action(.lockVault(userId: account.profile.userId, isManuallyLocking: true)),
             ]
         )
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -70,9 +70,7 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
         case .lockVault:
             await coordinator.handleEvent(
                 .authAction(
-                    .lockVault(
-                        userId: nil
-                    )
+                    .lockVault(userId: nil, isManuallyLocking: true)
                 )
             )
         case .streamSettingsBadge:

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -312,7 +312,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         await subject.perform(.lockVault)
 
         XCTAssertEqual(authRepository.lockVaultUserId, nil)
-        XCTAssertEqual(coordinator.events.last, .authAction(.lockVault(userId: nil)))
+        XCTAssertEqual(coordinator.events.last, .authAction(.lockVault(userId: nil, isManuallyLocking: true)))
     }
 
     /// `perform(_:)` with `.streamSettingsBadge` updates the state's badge state whenever it changes.

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -18,10 +18,11 @@ public protocol SettingsCoordinatorDelegate: AnyObject {
     func didDeleteAccount()
 
     /// Called when the user has requested an account vault be locked.
+    /// - Parameters:
+    ///   - userId: The user Id of the selected account. Defaults to the active user id if nil.
+    ///   - isManuallyLocking: Whether the user is manually locking the account.
     ///
-    /// - Parameter userId: The id of the user to lock.
-    ///
-    func lockVault(userId: String?)
+    func lockVault(userId: String?, isManuallyLocking: Bool)
 
     /// Called when the user has requested an account be logged out.
     ///
@@ -117,8 +118,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         switch event {
         case let .authAction(action):
             switch action {
-            case let .lockVault(userId):
-                delegate?.lockVault(userId: userId)
+            case let .lockVault(userId, isManuallyLocking):
+                delegate?.lockVault(userId: userId, isManuallyLocking: isManuallyLocking)
             case let .logout(userId, userInitiated):
                 delegate?.logout(userId: userId, userInitiated: userInitiated)
             case let .switchAccount(isAutomatic, userId, _):

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -194,6 +194,17 @@ class SettingsCoordinatorTests: BitwardenTestCase {
         await subject.handleEvent(.authAction(.lockVault(userId: "")))
 
         XCTAssertTrue(delegate.didLockVaultCalled)
+        XCTAssertFalse(delegate.hasManuallyLockedVault)
+    }
+
+    /// `navigate(to:)` with `.lockVault` calls the delegate to handle locking vault
+    /// on manually locked.
+    @MainActor
+    func test_navigateTo_lockVaultManually() async throws {
+        await subject.handleEvent(.authAction(.lockVault(userId: "", isManuallyLocking: true)))
+
+        XCTAssertTrue(delegate.didLockVaultCalled)
+        XCTAssertTrue(delegate.hasManuallyLockedVault)
     }
 
     /// `navigate(to:)` with `.loginRequest` pushes the login request view onto the stack navigator.
@@ -359,6 +370,7 @@ class MockSettingsCoordinatorDelegate: SettingsCoordinatorDelegate {
     var didDeleteAccountCalled = false
     var didLockVaultCalled = false
     var didLogoutCalled = false
+    var hasManuallyLockedVault = false
     var lockedId: String?
     var loggedOutId: String?
     var switchAccountCalled = false
@@ -374,9 +386,10 @@ class MockSettingsCoordinatorDelegate: SettingsCoordinatorDelegate {
         didDeleteAccountCalled = true
     }
 
-    func lockVault(userId: String?) {
+    func lockVault(userId: String?, isManuallyLocking: Bool) {
         lockedId = userId
         didLockVaultCalled = true
+        hasManuallyLockedVault = isManuallyLocking
     }
 
     func logout(userId: String?, userInitiated: Bool) {
@@ -390,4 +403,4 @@ class MockSettingsCoordinatorDelegate: SettingsCoordinatorDelegate {
         wasSwitchAutomatic = isAutomatic
         switchUserId = userId
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -9,9 +9,11 @@ import SwiftUI
 public protocol VaultCoordinatorDelegate: AnyObject {
     /// Called when the user locks their vault.
     ///
-    /// - Parameter userId: The id of the account to lock.
+    /// - Parameters:
+    ///   - userId: The user Id of the selected account. Defaults to the active user id if nil.
+    ///   - isManuallyLocking: Whether the user is manually locking the account.
     ///
-    func lockVault(userId: String?)
+    func lockVault(userId: String?, isManuallyLocking: Bool)
 
     /// Called when the user has been logged out.
     ///
@@ -130,8 +132,8 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
         switch event {
         case let .logout(userId, userInitiated):
             delegate?.logout(userId: userId, userInitiated: userInitiated)
-        case let .lockVault(userId):
-            delegate?.lockVault(userId: userId)
+        case let .lockVault(userId, isManuallyLocking):
+            delegate?.lockVault(userId: userId, isManuallyLocking: isManuallyLocking)
         case let .switchAccount(isAutomatic, userId, authCompletionRoute):
             delegate?.switchAccount(
                 userId: userId,

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -209,6 +209,18 @@ class VaultCoordinatorTests: BitwardenTestCase {
         }
         waitFor(delegate.lockVaultId == "123")
         task.cancel()
+        XCTAssertFalse(delegate.hasManuallyLocked)
+    }
+
+    /// `navigate(to:)` with `.lockVault` calls the delegate to handle locking the vault manually.
+    @MainActor
+    func test_navigateTo_lockVaultManually() throws {
+        let task = Task {
+            await subject.handleEvent(.lockVault(userId: "123", isManuallyLocking: true))
+        }
+        waitFor(delegate.lockVaultId == "123")
+        task.cancel()
+        XCTAssertTrue(delegate.hasManuallyLocked)
     }
 
     /// `navigate(to:)` with `.loginRequest` calls the delegate method.
@@ -303,6 +315,7 @@ class VaultCoordinatorTests: BitwardenTestCase {
 class MockVaultCoordinatorDelegate: VaultCoordinatorDelegate {
     var addAccountTapped = false
     var accountTapped = [String]()
+    var hasManuallyLocked = false
     var lockVaultId: String?
     var logoutTapped = false
     var logoutUserId: String?
@@ -313,8 +326,9 @@ class MockVaultCoordinatorDelegate: VaultCoordinatorDelegate {
     var switchedAccounts = false
     var userInitiated: Bool?
 
-    func lockVault(userId: String?) {
+    func lockVault(userId: String?, isManuallyLocking: Bool) {
         lockVaultId = userId
+        hasManuallyLocked = isManuallyLocking
     }
 
     func logout(userId: String?, userInitiated: Bool) {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -864,7 +864,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await lockAction.handler?(lockAction, [])
 
         // Verify the results.
-        XCTAssertEqual(coordinator.events.last, .lockVault(userId: activeProfile.userId))
+        XCTAssertEqual(coordinator.events.last, .lockVault(userId: activeProfile.userId, isManuallyLocking: true))
     }
 
     /// `receive(_:)` with `.profileSwitcher(.accountLongPressed)` shows the alert and allows the user to
@@ -894,7 +894,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await lockAction.handler?(lockAction, [])
 
         // Verify the results.
-        XCTAssertEqual(coordinator.events.last, .lockVault(userId: otherProfile.userId))
+        XCTAssertEqual(coordinator.events.last, .lockVault(userId: otherProfile.userId, isManuallyLocking: true))
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.accountLockedSuccessfully))
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-14579](https://bitwarden.atlassian.net/browse/PM-14579)

## 📔 Objective

Fix issue where when session timeout is Never and the user manually locked the vault, the vault was being automatically unlocked when closing and opening back the app again.
So the behavior now is that if the user manually locks the vault then it remains locked no matter the session timeout.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14579]: https://bitwarden.atlassian.net/browse/PM-14579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ