### PR TITLE
PM-14620: Remove unused accessSecretsManager property to fix JSON decoding errors (backport of #1116)

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Response/Fixtures/ProfileOrganizationResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/Fixtures/ProfileOrganizationResponseModel+Fixtures.swift
@@ -4,7 +4,6 @@ import Foundation
 
 extension ProfileOrganizationResponseModel {
     static func fixture(
-        accessSecretsManager: Bool = false,
         enabled: Bool = true,
         familySponsorshipAvailable: Bool = false,
         familySponsorshipFriendlyName: String? = nil,
@@ -49,7 +48,6 @@ extension ProfileOrganizationResponseModel {
         usersGetPremium: Bool = false
     ) -> ProfileOrganizationResponseModel {
         self.init(
-            accessSecretsManager: accessSecretsManager,
             enabled: enabled,
             familySponsorshipAvailable: familySponsorshipAvailable,
             familySponsorshipFriendlyName: familySponsorshipFriendlyName,

--- a/BitwardenShared/Core/Vault/Models/Response/ProfileOrganizationResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/ProfileOrganizationResponseModel.swift
@@ -5,9 +5,6 @@ import Foundation
 struct ProfileOrganizationResponseModel: Codable, Equatable {
     // MARK: Properties
 
-    /// Whether the user can access secrets manager.
-    let accessSecretsManager: Bool
-
     /// Whether the profile organization is enabled.
     let enabled: Bool
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14620](https://bitwarden.atlassian.net/browse/PM-14620)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Backport https://github.com/bitwarden/ios/pull/1116 to main.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14620]: https://bitwarden.atlassian.net/browse/PM-14620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ