### PR TITLE
[BITAU-179] Refactor Vault Selection to Include Standard and SteamURI TOTP Types

### DIFF
--- a/BitwardenShared/Core/Vault/Services/TOTP/TOTPKey.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TOTPKey.swift
@@ -1,6 +1,6 @@
 /// Represents different types of TOTP keys.
 ///
-enum TOTPKey: Equatable, Sendable {
+enum TOTPKey: Equatable, Hashable, Sendable {
     /// An OTP Auth URI
     case otpAuthUri(OTPAuthModel)
 

--- a/BitwardenShared/Core/Vault/Services/TOTP/TOTPKeyModel.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TOTPKeyModel.swift
@@ -1,6 +1,6 @@
 /// A model representing  a TOTP authentication key.
 ///
-public struct TOTPKeyModel: Equatable, Sendable {
+public struct TOTPKeyModel: Equatable, Hashable, Sendable {
     // MARK: Properties
 
     /// The hash algorithm used for the TOTP code.

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -407,14 +407,14 @@ extension AppProcessor {
             return AppRoute.tab(.settings(.accountSecurity))
         case BitwardenDeepLinkConstants.authenticatorNewItem:
             guard let item = await services.authenticatorSyncService?.getTemporaryTotpItem(),
-                  let totpKey = item.totpKey,
-                  let otpAuthModel = OTPAuthModel(otpAuthKey: totpKey) else {
+                  let totpKey = item.totpKey else {
                 coordinator?.showAlert(.defaultAlert(title: Localizations.somethingWentWrong,
                                                      message: Localizations.unableToMoveTheSelectedItemPleaseTryAgain))
                 return nil
             }
 
-            return AppRoute.tab(.vault(.vaultItemSelection(otpAuthModel)))
+            let totpKeyModel = TOTPKeyModel(authenticatorKey: totpKey)
+            return AppRoute.tab(.vault(.vaultItemSelection(totpKeyModel)))
         default:
             return nil
         }
@@ -428,12 +428,13 @@ extension AppProcessor {
     private func getOtpAuthUrlRoute(url: URL) async -> AppRoute? {
         guard let scheme = url.scheme, scheme.isOtpAuthScheme else { return nil }
 
-        guard let otpAuthModel = OTPAuthModel(otpAuthKey: url.absoluteString) else {
+        let totpKeyModel = TOTPKeyModel(authenticatorKey: url.absoluteString)
+        guard case .otpAuthUri = totpKeyModel.totpKey else {
             coordinator?.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             return nil
         }
 
-        return AppRoute.tab(.vault(.vaultItemSelection(otpAuthModel)))
+        return AppRoute.tab(.vault(.vaultItemSelection(totpKeyModel)))
     }
 
     /// Starts timer to send organization events regularly

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -518,7 +518,6 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
     @MainActor
     func test_openUrl_bitwardenAuthenticatorNewItem_invalidItem() async throws {
         let account = Account.fixture()
-        let otpKey: String = .otpAuthUriKeyNoSecret
         stateService.activeAccount = .fixture()
         vaultTimeoutService.isClientLocked[account.profile.userId] = false
         authenticatorSyncService.tempItem = AuthenticatorBridgeItemDataView(
@@ -527,7 +526,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
             favorite: false,
             id: "",
             name: "",
-            totpKey: otpKey,
+            totpKey: nil,
             username: nil
         )
 
@@ -584,7 +583,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_openUrl_bitwardenAuthenticatorNewItem_success() async throws {
         let account = Account.fixture()
         let otpKey: String = .otpAuthUriKeyComplete
-        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        let model = TOTPKeyModel(authenticatorKey: otpKey)
         stateService.activeAccount = .fixture()
         vaultTimeoutService.isClientLocked[account.profile.userId] = false
         authenticatorSyncService.tempItem = AuthenticatorBridgeItemDataView(
@@ -629,7 +628,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.openUrl(XCTUnwrap(URL(string: otpKey)))
 
-        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        let model = TOTPKeyModel(authenticatorKey: otpKey)
         XCTAssertEqual(coordinator.events, [.setAuthCompletionRoute(.tab(.vault(.vaultItemSelection(model))))])
     }
 
@@ -643,7 +642,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.openUrl(XCTUnwrap(URL(string: otpKey)))
 
-        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        let model = TOTPKeyModel(authenticatorKey: otpKey)
         XCTAssertEqual(coordinator.routes.last, .tab(.vault(.vaultItemSelection(model))))
     }
 
@@ -660,7 +659,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.openUrl(XCTUnwrap(URL(string: otpKey)))
 
-        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        let model = TOTPKeyModel(authenticatorKey: otpKey)
         XCTAssertEqual(coordinator.events, [.setAuthCompletionRoute(.tab(.vault(.vaultItemSelection(model))))])
     }
 
@@ -677,7 +676,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.openUrl(XCTUnwrap(URL(string: otpKey)))
 
-        let model = try XCTUnwrap(OTPAuthModel(otpAuthKey: otpKey))
+        let model = TOTPKeyModel(authenticatorKey: otpKey)
         XCTAssertEqual(coordinator.events, [.setAuthCompletionRoute(.tab(.vault(.vaultItemSelection(model))))])
     }
 

--- a/BitwardenShared/UI/Vault/PreviewContent/String+TOTPFixtures.swift
+++ b/BitwardenShared/UI/Vault/PreviewContent/String+TOTPFixtures.swift
@@ -14,8 +14,8 @@ extension String {
     static let steamUriKey = "steam://\(steamUriKeyIdentifier)"
 }
 
-extension OTPAuthModel {
-    static let fixtureExample = OTPAuthModel(otpAuthKey: .otpAuthUriKeyComplete)!
-    static let fixtureMinimum = OTPAuthModel(otpAuthKey: .otpAuthUriKeyMinimum)!
+extension TOTPKeyModel {
+    static let fixtureExample = TOTPKeyModel(authenticatorKey: .otpAuthUriKeyComplete)
+    static let fixtureMinimum = TOTPKeyModel(authenticatorKey: .otpAuthUriKeyMinimum)
 }
 #endif

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -191,8 +191,8 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
             showList()
         case let .loginRequest(loginRequest):
             delegate?.presentLoginRequest(loginRequest)
-        case let .vaultItemSelection(otpAuthModel):
-            showVaultItemSelection(otpAuthModel: otpAuthModel)
+        case let .vaultItemSelection(totpKeyModel):
+            showVaultItemSelection(totpKeyModel: totpKeyModel)
         case let .viewItem(id):
             showVaultItem(route: .viewItem(id: id), delegate: context as? CipherItemOperationDelegate)
         case let .switchAccount(userId: userId):
@@ -309,9 +309,9 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
 
     /// Shows the vault item selection screen.
     ///
-    /// - Parameter otpAuthModel: The parsed OTP data to search for matching ciphers.
+    /// - Parameter totpKeyModel: The parsed TOTP data to search for matching ciphers.
     ///
-    func showVaultItemSelection(otpAuthModel: OTPAuthModel) {
+    func showVaultItemSelection(totpKeyModel: TOTPKeyModel) {
         let userVerificationHelper = DefaultUserVerificationHelper(
             authRepository: services.authRepository,
             errorReporter: services.errorReporter,
@@ -324,7 +324,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
             services: services,
             state: VaultItemSelectionState(
                 iconBaseURL: services.environmentService.iconsURL,
-                otpAuthModel: otpAuthModel
+                totpKeyModel: totpKeyModel
             ),
             userVerificationHelper: userVerificationHelper,
             vaultItemMoreOptionsHelper: DefaultVaultItemMoreOptionsHelper(

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -267,8 +267,7 @@ class VaultCoordinatorTests: BitwardenTestCase {
     /// `.navigate(to:)` with `.vaultItemSelection` presents the vault item selection screen.
     @MainActor
     func test_navigateTo_vaultItemSelection() throws {
-        let otpAuthModel = try XCTUnwrap(OTPAuthModel(otpAuthKey: .otpAuthUriKeyComplete))
-        subject.navigate(to: .vaultItemSelection(otpAuthModel))
+        subject.navigate(to: .vaultItemSelection(.fixtureExample))
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -96,7 +96,7 @@ class VaultItemSelectionProcessor: StateProcessor<
                     group: .login,
                     newCipherOptions: NewCipherOptions(
                         name: state.ciphersMatchingName,
-                        totpKey: state.otpAuthModel.uri
+                        totpKey: state.totpKeyModel.rawAuthenticatorKey
                     )
                 ),
                 context: self
@@ -206,7 +206,7 @@ class VaultItemSelectionProcessor: StateProcessor<
                 }
             }
 
-            let updatedCipherView = cipherView.update(login: login.update(totp: state.otpAuthModel.uri))
+            let updatedCipherView = cipherView.update(login: login.update(totp: state.totpKeyModel.rawAuthenticatorKey))
             coordinator.navigate(to: .editItem(updatedCipherView), context: self)
         } catch UserVerificationError.cancelled {
             // No-op: don't log or alert for cancellation errors.
@@ -287,7 +287,7 @@ extension VaultItemSelectionProcessor: ProfileSwitcherHandler {
     }
 
     var switchAccountAuthCompletionRoute: AppRoute? {
-        .tab(.vault(.vaultItemSelection(state.otpAuthModel)))
+        .tab(.vault(.vaultItemSelection(state.totpKeyModel)))
     }
 
     var toast: Toast? {

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -43,7 +43,7 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
             ),
             state: VaultItemSelectionState(
                 iconBaseURL: nil,
-                otpAuthModel: OTPAuthModel(otpAuthKey: .otpAuthUriKeyComplete)!
+                totpKeyModel: .fixtureExample
             ),
             userVerificationHelper: userVerificationHelper,
             vaultItemMoreOptionsHelper: vaultItemMoreOptionsHelper

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionState.swift
@@ -11,9 +11,6 @@ struct VaultItemSelectionState: Equatable {
     /// The base url used to fetch icons.
     let iconBaseURL: URL?
 
-    /// The parsed OTP key used to find matching ciphers to add the key to.
-    let otpAuthModel: OTPAuthModel
-
     /// The user's current account profile state and alternative accounts.
     var profileSwitcherState: ProfileSwitcherState = .empty(shouldAlwaysHideAddAccount: true)
 
@@ -32,6 +29,9 @@ struct VaultItemSelectionState: Equatable {
     /// A toast message to show in the view.
     var toast: Toast?
 
+    /// The parsed TOTP Key used to find matching ciphers to add the key to.
+    var totpKeyModel: TOTPKeyModel
+
     /// The url to open in the device's web browser.
     var url: URL?
 
@@ -42,6 +42,11 @@ struct VaultItemSelectionState: Equatable {
 
     /// The search term used to find ciphers that match the OTP key.
     var ciphersMatchingName: String? {
-        otpAuthModel.issuer ?? otpAuthModel.accountName
+        switch totpKeyModel.totpKey {
+        case let .otpAuthUri(otpAuthModel):
+            return otpAuthModel.issuer ?? otpAuthModel.accountName
+        case .standard, .steamUri:
+            return nil
+        }
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionStateTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionStateTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class VaultItemSelectionStateTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `ciphersMatchingName` returns the issuer from an OTPAuth key.
+    func test_ciphersMatchingName_issuer() {
+        let subject = VaultItemSelectionState(iconBaseURL: nil, totpKeyModel: .fixtureExample)
+        XCTAssertEqual(subject.ciphersMatchingName, "Example")
+    }
+
+    /// `ciphersMatchingName` returns `nil` when an OTPAuth key has no issuer or account name.
+    func test_ciphersMatchingName_minimum() {
+        let subject = VaultItemSelectionState(iconBaseURL: nil, totpKeyModel: .fixtureMinimum)
+        XCTAssertNil(subject.ciphersMatchingName)
+    }
+
+    /// `ciphersMatchingName` returns `nil` when the `totpKeyModel` is based on a standard code type.
+    func test_ciphersMatchingName_standard() {
+        let subject = VaultItemSelectionState(iconBaseURL: nil,
+                                              totpKeyModel: TOTPKeyModel(authenticatorKey: .standardTotpKey))
+        XCTAssertNil(subject.ciphersMatchingName)
+    }
+
+    /// `ciphersMatchingName` returns `nil` when the `totpKeyModel` is based on a SteamURI code type.
+    func test_ciphersMatchingName_steamURI() {
+        let subject = VaultItemSelectionState(iconBaseURL: nil,
+                                              totpKeyModel: TOTPKeyModel(authenticatorKey: .steamUriKey))
+        XCTAssertNil(subject.ciphersMatchingName)
+    }
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
@@ -253,7 +253,7 @@ private struct VaultItemSelectionSearchableView: View {
 #Preview("Empty") {
     NavigationView {
         VaultItemSelectionView(store: Store(processor: StateProcessor(
-            state: VaultItemSelectionState(iconBaseURL: nil, otpAuthModel: .fixtureExample)
+            state: VaultItemSelectionState(iconBaseURL: nil, totpKeyModel: .fixtureExample)
         )))
     }
 }
@@ -265,9 +265,9 @@ private struct VaultItemSelectionSearchableView: View {
                 processor: StateProcessor(
                     state: VaultItemSelectionState(
                         iconBaseURL: nil,
-                        otpAuthModel: .fixtureExample,
                         searchResults: [.init(id: "1", itemType: .cipher(.fixture()))],
-                        searchText: "Search"
+                        searchText: "Search",
+                        totpKeyModel: .fixtureExample
                     )
                 )
             )
@@ -326,7 +326,7 @@ private struct VaultItemSelectionSearchableView: View {
                 processor: StateProcessor(
                     state: VaultItemSelectionState(
                         iconBaseURL: nil,
-                        otpAuthModel: .fixtureExample,
+                        totpKeyModel: .fixtureExample,
                         vaultListSections: [
                             VaultListSection(
                                 id: Localizations.matchingItems,

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionViewTests.swift
@@ -17,7 +17,7 @@ class VaultItemSelectionViewTests: BitwardenTestCase {
 
         processor = MockProcessor(state: VaultItemSelectionState(
             iconBaseURL: nil,
-            otpAuthModel: .fixtureExample
+            totpKeyModel: .fixtureExample
         ))
         let store = Store(processor: processor)
 
@@ -84,7 +84,7 @@ class VaultItemSelectionViewTests: BitwardenTestCase {
     func test_snapshot_cipherSelection_emptyNoAccountOrIssuer() {
         processor = MockProcessor(state: VaultItemSelectionState(
             iconBaseURL: nil,
-            otpAuthModel: .fixtureMinimum
+            totpKeyModel: .fixtureMinimum
         ))
         subject = VaultItemSelectionView(store: Store(processor: processor))
 

--- a/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
@@ -61,7 +61,7 @@ public enum VaultRoute: Equatable, Hashable {
     case switchAccount(userId: String)
 
     /// A route to the vault item selection screen.
-    case vaultItemSelection(OTPAuthModel)
+    case vaultItemSelection(TOTPKeyModel)
 
     /// A route to the view item screen.
     ///


### PR DESCRIPTION
## 🎟️ Tracking

[BITAU-179](https://livefront.atlassian.net/browse/BITAU-179)

## 📔 Objective

This PR refactors the Vault selection to handle `TOTPKeyModel` instead of `OTPAuthModel`. Previously, the vault selection was only used for incoming otpauth URLs from the camera's QR code scanning. This meant that it was built using `OTPAuthModel` to hold all of the TOTP details. When building the Authenticator sync feature, we wanted to allow users to move any of their codes from Authenticator to the PM app. But some of those codes could be Steam URI codes or standard codes, which wouldn't have parsed when handed to `OTPAuthModel`.

By refactoring the route, processor, state, etc to use `TOTPKeyModel` we allow for handling of any codes that could be sent from the Authenticator app.

### Testing notes
In testing this, I discovered that the way the Authenticator stores manually entered codes means that even Base32/Standard codes would have been represented using `otpauth://` style reference. So these codes probably worked before this refactor. However, it would still be necessary to support SteamURI codes. You can test this with the example: `steam://JBSWY3DPEHPK3PXP`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
