### PR TITLE
PM-12051: Fix sync error after delete and switch accounts

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -520,8 +520,10 @@ extension DefaultAuthRepository: AuthRepository {
             )
         )
 
+        // Get the user's ID before it's removed from `StateService`.
+        let userId = try await stateService.getActiveAccountId()
         try await stateService.deleteAccount()
-        await vaultTimeoutService.remove(userId: nil)
+        await vaultTimeoutService.remove(userId: userId)
     }
 
     func existingAccountUserId(email: String) async -> String? {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -250,8 +250,10 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let accounts = try await stateService.getAccounts()
 
         XCTAssertEqual(accounts.count, 1)
+        XCTAssertEqual(accounts, [beeAccount])
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertEqual(client.requests[0].url, URL(string: "https://example.com/api/accounts"))
+        XCTAssertEqual(vaultTimeoutService.removedIds, [anneAccount.profile.userId])
     }
 
     /// `existingAccountUserId(email:)` returns the user ID of the existing account with the same

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -352,28 +352,24 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `handleAndRoute(_ :)` redirects`.didDeleteAccount` to another account
     ///     when there are more accounts.
     @MainActor
-    func test_handleAndRoute_didDeleteAccount_alternateAccount() {
-        let alt = Account.fixtureAccountLogin()
-        stateService.accounts = [alt]
-        stateService.isAuthenticated[alt.profile.userId] = true
-        authRepository.altAccounts = [alt]
-        var route: AuthRoute?
-        let task = Task {
-            route = await subject.handleAndRoute(.didDeleteAccount)
-        }
-        waitFor(authRepository.setActiveAccountId != nil)
-        stateService.activeAccount = alt
-        waitFor(route != nil)
-        task.cancel()
+    func test_handleAndRoute_didDeleteAccount_alternateAccount() async {
+        let activeAccount = Account.fixture()
+        stateService.activeAccount = activeAccount
+        stateService.isAuthenticated[activeAccount.profile.userId] = true
+        authRepository.altAccounts = [activeAccount]
+
+        let route = await subject.handleAndRoute(.didDeleteAccount)
+
         XCTAssertEqual(
             route,
             .vaultUnlock(
-                alt,
+                activeAccount,
                 animated: false,
                 attemptAutomaticBiometricUnlock: true,
                 didSwitchAccountAutomatically: true
             )
         )
+        XCTAssertEqual(authRepository.activeAccount, activeAccount)
     }
 
     /// `handleAndRoute(_ :)` redirects`.didDeleteAccount` to `.landing`

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -377,21 +377,19 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     func test_handleAndRoute_didDeleteAccount_noAccounts() async {
         let route = await subject.handleAndRoute(.didDeleteAccount)
         XCTAssertEqual(route, .landing)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
     }
 
     /// `handleAndRoute(_ :)` redirects`.didDeleteAccount` to `.landing`
     ///     when an error occurs setting a new active account.
     func test_handleAndRoute_didDeleteAccount_setActiveFail() async {
         let alt = Account.fixtureAccountLogin()
-        stateService.accounts = [
-            alt,
-        ]
+        stateService.accounts = [alt]
+        stateService.activeAccount = alt
         authRepository.setActiveAccountError = BitwardenTestError.example
         let route = await subject.handleAndRoute(.didDeleteAccount)
-        XCTAssertEqual(
-            route,
-            .landing
-        )
+        XCTAssertEqual(route, .landing)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
     /// `handleAndRoute(_ :)` delivers the locked active user to `.vaultUnlock`

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -76,6 +76,8 @@ extension AuthRouter {
             )
             // Handle any vault unlock redirects for this active account.
             return await handleAndRoute(event)
+        } catch StateServiceError.noActiveAccount {
+            return .landing
         } catch {
             services.errorReporter.log(error: error)
             return .landing

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -61,23 +61,25 @@ extension AuthRouter {
     /// - Returns: A redirect to either `.landing` or `prepareAndRedirect(.vaultUnlock)`.
     ///
     func deleteAccountRedirect() async -> AuthRoute {
-        // Ensure that the active account id is nil, otherwise, handle a failed account deletion by directing
-        // The user to the unlock flow.
-        let oldActiveId = try? await services.stateService.getActiveAccountId()
-        // Try to set the next available account.
-        guard let activeAccount = try? await configureActiveAccount(shouldSwitchAutomatically: true) else {
-            // If no other accounts are available, go to landing.
+        do {
+            // After an account is deleted, the next account is already active in `StateService`.
+            // Make it active in the repository and switch to it.
+            let userId = try await services.stateService.getActiveAccountId()
+            let activeAccount = try await services.authRepository.setActiveAccount(userId: userId)
+
+            // Setup the unlock route for the newly active account.
+            let event = AuthEvent.accountBecameActive(
+                activeAccount,
+                animated: false,
+                attemptAutomaticBiometricUnlock: true,
+                didSwitchAccountAutomatically: true
+            )
+            // Handle any vault unlock redirects for this active account.
+            return await handleAndRoute(event)
+        } catch {
+            services.errorReporter.log(error: error)
             return .landing
         }
-        // Setup the unlock route for the newly active account.
-        let event = AuthEvent.accountBecameActive(
-            activeAccount,
-            animated: false,
-            attemptAutomaticBiometricUnlock: true,
-            didSwitchAccountAutomatically: oldActiveId != activeAccount.profile.userId
-        )
-        // Handle any vault unlock redirects for this active account.
-        return await handleAndRoute(event)
     }
 
     /// Handles the `.didLogout()`route and redirects the user to the correct screen


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-12051](https://bitwarden.atlassian.net/browse/PM-12051)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Related to https://github.com/bitwarden/ios/pull/1100.

Fixes an issue with automatic account switching when deleting an account if the account that will be switched to after the deletion is in a separate environments.

- Account A logged into environment X
- Account B logged into environment Y
- If account A is deleted, the app will automatically switches to account B. When this occurred, the environment service wasn't loading the URLs for account B/environment Y. This caused any future networking requests to fail for account B in the current session.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-12051]: https://bitwarden.atlassian.net/browse/PM-12051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ