### PR TITLE
PM-14573: Add ToolbarButtonStyle to update a toolbar button's disabled state color

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/ImageStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/ImageStyle.swift
@@ -93,7 +93,7 @@ extension Image {
     func imageStyle(_ style: ImageStyle) -> some View {
         resizable()
             .frame(width: style.width, height: style.height, scaleWithFont: style.scaleWithFont)
-            .foregroundStyle(style.color)
+            .tint(style.color)
     }
 }
 
@@ -111,6 +111,6 @@ extension View {
     ///
     func imageStyle(_ style: ImageStyle) -> some View {
         frame(width: style.width, height: style.height, scaleWithFont: style.scaleWithFont)
-            .foregroundStyle(style.color)
+            .tint(style.color)
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Appearance/Styles/ToolbarButtonStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Styles/ToolbarButtonStyle.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+// MARK: - ToolbarButtonStyle
+
+/// The style for all toolbar buttons in this application.
+///
+struct ToolbarButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled: Bool
+
+    /// The color of the foreground elements in this button, including text and template
+    /// images.
+    var foregroundColor: Color {
+        isEnabled
+            ? Asset.Colors.buttonOutlinedForeground.swiftUIColor
+            : Asset.Colors.buttonFilledDisabledForeground.swiftUIColor
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundColor(foregroundColor)
+            .styleGuide(.body)
+            .contentShape(Rectangle())
+            .opacity(configuration.isPressed ? 0.5 : 1)
+    }
+}
+
+// MARK: ButtonStyle
+
+extension ButtonStyle where Self == ToolbarButtonStyle {
+    /// The style for all toolbar buttons in this application.
+    ///
+    static var toolbar: ToolbarButtonStyle {
+        ToolbarButtonStyle()
+    }
+}
+
+// MARK: Previews
+
+#if DEBUG
+#Preview {
+    VStack {
+        Button("Hello World!") {}
+
+        Button("Hello World!") {}
+            .disabled(true)
+    }
+    .buttonStyle(.toolbar)
+    .padding()
+}
+#endif

--- a/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
@@ -71,6 +71,7 @@ extension View {
             Image(asset: asset, label: Text(label))
                 .imageStyle(.toolbarIcon)
         }
+        .buttonStyle(.toolbar)
         // Ideally we would set both `minHeight` and `minWidth` to 44. Setting `minWidth` causes
         // padding to be applied equally on both sides of the image. This results in extra padding
         // along the margin though.
@@ -86,8 +87,7 @@ extension View {
     ///
     func toolbarButton(_ label: String, action: @escaping () -> Void) -> some View {
         Button(label, action: action)
-            .foregroundColor(Asset.Colors.textInteraction.swiftUIColor)
-            .styleGuide(.body)
+            .buttonStyle(.toolbar)
             // Ideally we would set both `minHeight` and `minWidth` to 44. Setting `minWidth` causes
             // padding to be applied equally on both sides of the image. This results in extra padding
             // along the margin though.
@@ -103,8 +103,7 @@ extension View {
     ///
     func toolbarButton(_ label: String, action: @escaping () async -> Void) -> some View {
         AsyncButton(label, action: action)
-            .foregroundColor(Asset.Colors.textInteraction.swiftUIColor)
-            .styleGuide(.body)
+            .buttonStyle(.toolbar)
             // Ideally we would set both `minHeight` and `minWidth` to 44. Setting `minWidth` causes
             // padding to be applied equally on both sides of the image. This results in extra padding
             // along the margin though.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14573](https://bitwarden.atlassian.net/browse/PM-14573)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the color of disabled toolbar buttons. This fixes an issue where the save button when sends are disabled looks like the enabled button.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <img width="568" alt="Screenshot 2024-11-15 at 10 17 41 AM" src="https://github.com/user-attachments/assets/d03e6de6-0112-42d1-a658-6424192dd1d4"> | <img width="568" alt="Screenshot 2024-11-15 at 10 16 15 AM" src="https://github.com/user-attachments/assets/c425bd5e-f6e4-4217-ba52-c24b4be8a03d"> |

Dark mode:
<img width="568" alt="Screenshot 2024-11-15 at 10 19 56 AM" src="https://github.com/user-attachments/assets/84ad00be-d14e-4859-8aee-de0cad324833">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14573]: https://bitwarden.atlassian.net/browse/PM-14573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ