### PR TITLE
PM-14962: Don't add organization keys to SDK after sync if vault is locked

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -451,6 +451,12 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             tokenService: tokenService
         )
 
+        let vaultTimeoutService = DefaultVaultTimeoutService(
+            clientService: clientService,
+            stateService: stateService,
+            timeProvider: timeProvider
+        )
+
         let syncService = DefaultSyncService(
             accountAPIService: apiService,
             cipherService: cipherService,
@@ -464,7 +470,8 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             settingsService: settingsService,
             stateService: stateService,
             syncAPIService: apiService,
-            timeProvider: timeProvider
+            timeProvider: timeProvider,
+            vaultTimeoutService: vaultTimeoutService
         )
 
         let trustDeviceService = DefaultTrustDeviceService(
@@ -476,11 +483,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         )
 
         let twoStepLoginService = DefaultTwoStepLoginService(environmentService: environmentService)
-        let vaultTimeoutService = DefaultVaultTimeoutService(
-            clientService: clientService,
-            stateService: stateService,
-            timeProvider: timeProvider
-        )
+
 
         let pasteboardService = DefaultPasteboardService(
             errorReporter: errorReporter,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14962](https://bitwarden.atlassian.net/browse/PM-14962)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If a push notification triggers a background sync while the vault is locked, we should wait on adding the organization’s keys to the SDK until the user unlocks their vault. Currently it happens as part of sync which causes an error to be thrown by the SDK.

This fixes a Crashlytics error where an SDK error is logged: `BitwardenSdk.BitwardenError: The client vault is locked and needs to be unlocked before use.`

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14962]: https://bitwarden.atlassian.net/browse/PM-14962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ