### PR TITLE
PM-14852: made name field optional for start registration request

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/StartRegistrationRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/StartRegistrationRequestModel.swift
@@ -12,7 +12,7 @@ struct StartRegistrationRequestModel: Equatable {
     let email: String
 
     /// The user name.
-    let name: String
+    let name: String?
 
     /// If the user wants to receive marketing emails.
     let receiveMarketingEmails: Bool

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -142,7 +142,7 @@ class StartRegistrationProcessor: StateProcessor<
 
         do {
             let email = state.emailText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            let name = state.nameText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let name = state.nameText.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
             guard !email.isEmpty else {
                 throw StartRegistrationError.emailEmpty
             }

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -267,6 +267,26 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
     }
 
+    /// `perform(_:)` with `.startRegistration` should not send name field in request body if the name is empty.
+    @MainActor
+    func test_perform_startRegistration_emptyName() async throws {
+        subject.state = .fixture(nameText: "")
+
+        client.result = .httpSuccess(testData: .startRegistrationSuccess)
+
+        await subject.perform(.startRegistration)
+
+        let requestBody = try XCTUnwrap(client.requests.first?.body)
+        let requestBodyStr = try XCTUnwrap(String(data: requestBody, encoding: .utf8))
+        XCTAssertFalse(
+            requestBodyStr.contains("name"),
+            "Request body should not contain 'name' field when it is empty."
+        )
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertNil(coordinator.alertShown.last)
+        XCTAssertFalse(coordinator.loadingOverlaysShown.isEmpty)
+    }
+
     /// `perform(_:)` with `.startRegistration` presents an alert when the email is in an invalid format.
     @MainActor
     func test_perform_startRegistration_invalidEmailFormat() async {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-14852](https://bitwarden.atlassian.net/browse/PM-14852)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Made ```name ``` optional for ```StartRegistrationRequestModel.swift``` and Updated the processor to convert empty ```name``` string to ```nil```.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
