### PR TITLE
[PM-11598] Add workflows for creating GitHub Releases and release branches

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,128 @@
+name: Create GitHub Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-name:
+        description: 'Version Name - E.g. "2024.11.1"'
+        required: true
+        type: string
+      version-number:
+        description: 'Version Number - E.g. "123456"'
+        required: true
+        type: string
+      artifact-run-id:
+        description: 'GitHub Action Run ID containing artifacts'
+        required: true
+        type: string
+      draft:
+        description: 'Create as draft release'
+        type: boolean
+        default: true
+      prerelease:
+        description: 'Mark as pre-release'
+        type: boolean
+        default: true
+      make-latest:
+        description: 'Set as the latest release'
+        type: boolean
+      branch-protection-type:
+        description: 'Branch protection type'
+        type: choice
+        options:
+          - Branch Name
+          - GitHub API
+        default: Branch Name
+env:
+    ARTIFACTS_PATH: artifacts
+jobs:
+  create-release:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Get branch from workflow run
+        id: get_release_branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+          BRANCH_PROTECTION_TYPE: ${{ inputs.branch-protection-type }}
+        run: |
+          release_branch=$(gh run view $ARTIFACT_RUN_ID --json headBranch -q .headBranch)
+
+          case "$BRANCH_PROTECTION_TYPE" in
+            "Branch Name")
+              if [[ "$release_branch" != "main" && ! "$release_branch" =~ ^release/ ]]; then
+                echo "::error::Branch '$release_branch' is not 'main' or a release branch starting with 'release/'. Releases must be created from protected branches."
+                exit 1
+              fi
+              ;;
+            "GitHub API")
+              #NOTE requires token with "administration:read" scope
+              if ! gh api "repos/${{ github.repository }}/branches/$release_branch/protection" | grep -q "required_status_checks"; then
+                echo "::error::Branch '$release_branch' is not protected. Releases must be created from protected branches. If that's not correct, confirm if the github token user has the 'administration:read' scope."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unsupported branch protection type: $BRANCH_PROTECTION_TYPE"
+              exit 1
+              ;;
+          esac
+
+          echo "release_branch=$release_branch" >> $GITHUB_OUTPUT
+
+      - name: Download artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+        run: |
+          gh run download $ARTIFACT_RUN_ID -D $ARTIFACTS_PATH
+          file_count=$(find $ARTIFACTS_PATH -type f | wc -l)
+          echo "Downloaded $file_count file(s)."
+          if [ "$file_count" -gt 0 ]; then
+            echo "Downloaded files:"
+            find $ARTIFACTS_PATH -type f
+          fi
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
+        with:
+          tag_name: "v${{ inputs.version-name }}"
+          name: "${{ inputs.version-name }} (${{ inputs.version-number }})"
+          prerelease: ${{ inputs.prerelease }}
+          draft: ${{ inputs.draft }}
+          make_latest: ${{ inputs.make-latest }}
+          target_commitish: ${{ steps.get_release_branch.outputs.release_branch }}
+          generate_release_notes: true
+          files: |
+            artifacts/**/*
+
+      - name: Update Release Description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ steps.create_release.outputs.id }}
+          RELEASE_URL: ${{ steps.create_release.outputs.url }}
+          ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+        run: |
+          # Get current release body
+          current_body=$(gh api /repos/${{ github.repository }}/releases/$RELEASE_ID --jq .body)
+
+          # Append build source to the end
+          updated_body="${current_body}
+          **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$ARTIFACT_RUN_ID"
+
+          # Update release
+          gh api --method PATCH /repos/${{ github.repository }}/releases/$RELEASE_ID \
+            -f body="$updated_body"
+
+          echo "# :rocket: Release ready at:" >> $GITHUB_STEP_SUMMARY
+          echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,56 @@
+name: Cut Release Branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Release Type'
+        required: true
+        type: choice
+        options:
+          - RC
+          - Hotfix
+      rc_prefix_date:
+        description: 'RC - Prefix with date. E.g. 2024.11-rc1'
+        type: boolean
+        default: true
+
+jobs:
+  create-release-branch:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
+
+      - name: Create RC Branch
+        if: inputs.release_type == 'RC'
+        env:
+          RC_PREFIX_DATE: ${{ inputs.rc_prefix_date }}
+        run: |
+          if [ "$RC_PREFIX_DATE" = "true" ]; then
+            current_date=$(date +'%Y.%m')
+            branch_name="release/${current_date}-rc${{ github.run_number }}"
+          else
+            branch_name="release/rc${{ github.run_number }}"
+          fi
+          git switch main
+          git switch -c $branch_name
+          git push origin $branch_name
+          echo "# :cherry_blossom: RC branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Create Hotfix Branch
+        if: inputs.release_type == 'Hotfix'
+        run: |
+          latest_tag=$(git describe --tags --abbrev=0)
+          if [ -z "$latest_tag" ]; then
+            echo "::error::No tags found in the repository"
+            exit 1
+          fi
+          branch_name="release/hotfix-${latest_tag}"
+          git switch -c $branch_name $latest_tag
+          git push origin $branch_name
+          echo "# :fire: Hotfix branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11598](https://bitwarden.atlassian.net/browse/PM-11598)

## 📔 Objective

Adds workflows for creating GitHub Releases and release branches. These have been tested in https://github.com/bitwarden/android first.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11598]: https://bitwarden.atlassian.net/browse/PM-11598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ