### PR TITLE
[PM-15119] Fix SSH Key item cloning issue

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -85,7 +85,6 @@ enum FeatureFlag: String, CaseIterable, Codable {
              .importLoginsFlow,
              .nativeCarouselFlow,
              .nativeCreateAccountFlow,
-             .sshKeyVaultItem,
              .testLocalFeatureFlag,
              .testLocalInitialBoolFlag,
              .testLocalInitialIntFlag,
@@ -93,6 +92,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
             false
         case .emailVerification,
              .refactorSsoDetailsEndpoint,
+             .sshKeyVaultItem,
              .testRemoteFeatureFlag,
              .testRemoteInitialBoolFlag,
              .testRemoteInitialIntFlag,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -16,6 +16,7 @@ final class FeatureFlagTests: BitwardenTestCase {
     func test_isRemotelyConfigured() {
         XCTAssertTrue(FeatureFlag.emailVerification.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.refactorSsoDetailsEndpoint.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.sshKeyVaultItem.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialBoolFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialIntFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialStringFlag.isRemotelyConfigured)
@@ -25,7 +26,6 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertFalse(FeatureFlag.importLoginsFlow.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.nativeCarouselFlow.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.nativeCreateAccountFlow.isRemotelyConfigured)
-        XCTAssertFalse(FeatureFlag.sshKeyVaultItem.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.testLocalFeatureFlag.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.testLocalInitialBoolFlag.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.testLocalInitialIntFlag.isRemotelyConfigured)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditSSHKeyItem/SSHKeyItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditSSHKeyItem/SSHKeyItemState.swift
@@ -19,4 +19,13 @@ struct SSHKeyItemState: Equatable, Sendable {
 
     /// The fingerprint of the SSH key.
     var keyFingerprint: String = ""
+
+    /// Gets the `SshKeyView` from this state.
+    var sshKeyView: SshKeyView {
+        SshKeyView(
+            privateKey: privateKey,
+            publicKey: publicKey,
+            fingerprint: keyFingerprint
+        )
+    }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -366,7 +366,7 @@ extension CipherItemState {
             identity: type == .identity ? identityState.identityView : nil,
             card: type == .card ? cardItemState.cardView : nil,
             secureNote: type == .secureNote ? .init(type: .generic) : nil,
-            sshKey: nil, // SSH keys cannot be created in mobile yet.
+            sshKey: type == .sshKey ? sshKeyState.sshKeyView : nil,
             favorite: isFavoriteOn,
             reprompt: isMasterPasswordRePromptOn ? .password : .none,
             organizationUseTotp: false,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15119](https://bitwarden.atlassian.net/browse/PM-15119)

## 📔 Objective

Fix SSH key item should be able to be cloned.
Additionally, enabled `ssh-key-vault-item ` feature flag to be remotely configured.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15119]: https://bitwarden.atlassian.net/browse/PM-15119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ