### PR TITLE
PM-11974: Fix login with device notification for inactive account not switching to that account

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Domain/PushNotificationData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/PushNotificationData.swift
@@ -103,6 +103,6 @@ struct LoginRequestPushNotification: Codable, Equatable {
     /// How long until the request times out.
     let timeoutInMinutes: Int
 
-    /// The email of the account sending the login request.
-    let userEmail: String
+    /// The user id that sent the login request.
+    let userId: String
 }

--- a/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
@@ -371,6 +371,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` tells
     /// the delegate to show the switch account alert if it's a login request for a non-active account.
+    @MainActor
     func test_messageReceived_loginRequest_differentAccount() async throws {
         // Set up the mock data.
         stateService.setIsAuthenticated()
@@ -379,7 +380,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         authService.getPendingLoginRequestResult = .success([.fixture()])
         let loginRequestNotification = LoginRequestNotification(id: "requestId", userId: "differentUser")
         let notificationData = try JSONEncoder().encode(loginRequestNotification)
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "data": [
                 "type": NotificationType.authRequest.rawValue,
                 "payload": String(data: notificationData, encoding: .utf8) ?? "",
@@ -392,12 +393,12 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         // Confirm the results.
         XCTAssertEqual(stateService.loginRequest, loginRequestNotification)
         XCTAssertEqual(delegate.switchAccountsAccount, .fixture(profile: .fixture(userId: "differentUser")))
-        XCTAssertEqual(delegate.switchAccountsLoginRequest, .fixture())
         XCTAssertEqual(delegate.switchAccountsShowAlert, true)
     }
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` tells
     /// the delegate to show the login request if it's a login request for the active account.
+    @MainActor
     func test_messageReceived_loginRequest_sameAccount() async throws {
         // Set up the mock data.
         stateService.setIsAuthenticated()
@@ -406,7 +407,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         authService.getPendingLoginRequestResult = .success([.fixture()])
         let loginRequestNotification = LoginRequestNotification(id: "requestId", userId: "1")
         let notificationData = try JSONEncoder().encode(loginRequestNotification)
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "data": [
                 "type": NotificationType.authRequest.rawValue,
                 "payload": String(data: notificationData, encoding: .utf8) ?? "",
@@ -423,6 +424,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles logout requests and will not route
     /// to the landing screen if the logged-out account was not the currently active account.
+    @MainActor
     func test_messageReceived_logout_nonActiveUser() async throws {
         // Set up the mock data.
         stateService.setIsAuthenticated()
@@ -430,7 +432,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         let nonActiveAccount: Account = .fixture(profile: .fixture(userId: "b245a33f"))
         stateService.accounts = [activeAccount, nonActiveAccount]
 
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "data": [
                 "type": NotificationType.logOut.rawValue,
                 "payload": "{\"UserId\":\"\(nonActiveAccount.profile.userId)\"}",
@@ -445,6 +447,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles logout requests and will route
     /// to the landing screen if the logged-out account was the currently active account.
+    @MainActor
     func test_messageReceived_logout_activeUser() async throws {
         // Set up the mock data.
         stateService.setIsAuthenticated()
@@ -452,7 +455,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         let nonActiveAccount: Account = .fixture(profile: .fixture(userId: "b245a33f"))
         stateService.accounts = [activeAccount, nonActiveAccount]
 
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "data": [
                 "type": NotificationType.logOut.rawValue,
                 "payload": "{\"UserId\":\"\(activeAccount.profile.userId)\"}",
@@ -466,15 +469,16 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     }
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles notifications being dismissed.
+    @MainActor
     func test_messageReceived_notificationDismissed() async throws {
         // Set up the mock data.
         stateService.loginRequest = LoginRequestNotification(id: "1", userId: "2")
         let loginRequest = LoginRequestPushNotification(
             timeoutInMinutes: 15,
-            userEmail: "test@email.com"
+            userId: "2"
         )
         let testData = try JSONEncoder().encode(loginRequest)
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "notificationData": String(data: testData, encoding: .utf8) ?? "",
         ]
 
@@ -486,6 +490,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     }
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles notifications being tapped.
+    @MainActor
     func test_messageReceived_notificationTapped() async throws {
         // Set up the mock data.
         stateService.accounts = [.fixture()]
@@ -494,10 +499,10 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         authService.getPendingLoginRequestResult = .success([.fixture(id: "requestId")])
         let loginRequest = LoginRequestPushNotification(
             timeoutInMinutes: 15,
-            userEmail: Account.fixture().profile.email
+            userId: Account.fixture().profile.userId
         )
         let testData = try JSONEncoder().encode(loginRequest)
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "notificationData": String(data: testData, encoding: .utf8) ?? "",
         ]
 
@@ -506,23 +511,19 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         // Confirm the results.
         XCTAssertEqual(delegate.switchAccountsAccount, .fixture())
-        XCTAssertEqual(delegate.switchAccountsLoginRequest, .fixture(id: "requestId"))
         XCTAssertEqual(delegate.switchAccountsShowAlert, false)
     }
 
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles errors.
+    @MainActor
     func test_messageReceived_notificationTapped_error() async throws {
         // Set up the mock data.
-        stateService.accounts = [.fixture()]
-        stateService.activeAccount = .fixtureAccountLogin()
-        stateService.loginRequest = LoginRequestNotification(id: "requestId", userId: "1")
-        authService.getPendingLoginRequestResult = .failure(BitwardenTestError.example)
         let loginRequest = LoginRequestPushNotification(
             timeoutInMinutes: 15,
-            userEmail: Account.fixture().profile.email
+            userId: Account.fixture().profile.userId
         )
         let testData = try JSONEncoder().encode(loginRequest)
-        let message: [AnyHashable: Any] = [
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
             "notificationData": String(data: testData, encoding: .utf8) ?? "",
         ]
 
@@ -530,7 +531,7 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: true)
 
         // Confirm the results.
-        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors.last as? StateServiceError, .noAccounts)
     }
 }
 
@@ -542,7 +543,6 @@ class MockNotificationServiceDelegate: NotificationServiceDelegate {
     var showLoginRequestRequest: LoginRequest?
 
     var switchAccountsAccount: Account?
-    var switchAccountsLoginRequest: LoginRequest?
     var switchAccountsShowAlert: Bool?
 
     func routeToLanding() async {
@@ -553,9 +553,8 @@ class MockNotificationServiceDelegate: NotificationServiceDelegate {
         showLoginRequestRequest = loginRequest
     }
 
-    func switchAccounts(to account: Account, for loginRequest: LoginRequest, showAlert: Bool) {
+    func switchAccountsForLoginRequest(to account: Account, showAlert: Bool) {
         switchAccountsAccount = account
-        switchAccountsLoginRequest = loginRequest
         switchAccountsShowAlert = showAlert
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -520,33 +520,29 @@ extension AppProcessor: NotificationServiceDelegate {
     ///
     /// - Parameters:
     ///   - account: The account associated with the login request.
-    ///   - loginRequest: The login request to show.
     ///   - showAlert: Whether to show the alert or simply switch the account.
     ///
-    func switchAccounts(to account: Account, for loginRequest: LoginRequest, showAlert: Bool) {
-        DispatchQueue.main.async {
-            if showAlert {
-                self.coordinator?.showAlert(.confirmation(
-                    title: Localizations.logInRequested,
-                    message: Localizations.loginAttemptFromXDoYouWantToSwitchToThisAccount(account.profile.email)
-                ) {
-                    self.switchAccounts(to: account.profile.userId, for: loginRequest)
-                })
-            } else {
-                self.switchAccounts(to: account.profile.userId, for: loginRequest)
-            }
+    func switchAccountsForLoginRequest(to account: Account, showAlert: Bool) async {
+        if showAlert {
+            coordinator?.showAlert(.confirmation(
+                title: Localizations.logInRequested,
+                message: Localizations.loginAttemptFromXDoYouWantToSwitchToThisAccount(account.profile.email)
+            ) {
+                await self.switchAccountsForLoginRequest(to: account.profile.userId)
+            })
+        } else {
+            await switchAccountsForLoginRequest(to: account.profile.userId)
         }
     }
 
-    /// Switch to the specified account and show the login request.
+    /// Switch to the specified account so they can see the login request.
     ///
-    /// - Parameters:
-    ///   - userId: The userId of the account to switch to.
-    ///   - loginRequest: The login request to show.
+    /// - Parameter userId: The user ID of the account to switch to.
     ///
-    private func switchAccounts(to userId: String, for loginRequest: LoginRequest) {
-        (coordinator as? VaultCoordinatorDelegate)?.didTapAccount(userId: userId)
-        coordinator?.navigate(to: .loginRequest(loginRequest))
+    private func switchAccountsForLoginRequest(to userId: String) async {
+        // Switch to the account, the login request will be shown when their vault loads (either
+        // immediately or after vault unlock).
+        await coordinator?.handleEvent(.switchAccounts(userId: userId, isAutomatic: false))
     }
 }
 

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -1055,6 +1055,39 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(stateService.accountSetupAutofill, ["1": .complete])
     }
 
+    /// `switchAccountsForLoginRequest(to:showAlert:)` has the coordinator switch to the specified
+    /// account without showing a confirmation alert.
+    @MainActor
+    func test_switchAccountsForLoginRequest() async {
+        await subject.switchAccountsForLoginRequest(to: .fixture(), showAlert: false)
+
+        XCTAssertEqual(coordinator.events, [.switchAccounts(userId: "1", isAutomatic: false)])
+    }
+
+    /// `switchAccountsForLoginRequest(to:showAlert:)` shows an alert to confirm the user wants to
+    /// switch to the specified account and then has the coordinator switch accounts.
+    @MainActor
+    func test_switchAccountsForLoginRequest_showAlert() async throws {
+        let account = Account.fixture()
+        await subject.switchAccountsForLoginRequest(to: account, showAlert: true)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(
+            alert,
+            .confirmation(
+                title: Localizations.logInRequested,
+                message: Localizations.loginAttemptFromXDoYouWantToSwitchToThisAccount(account.profile.email),
+                confirmationHandler: {}
+            )
+        )
+
+        try await alert.tapAction(title: Localizations.cancel)
+        XCTAssertTrue(coordinator.events.isEmpty)
+
+        try await alert.tapAction(title: Localizations.yes)
+        XCTAssertEqual(coordinator.events, [.switchAccounts(userId: account.profile.userId, isAutomatic: false)])
+    }
+
     /// `unlockVaultWithNeverlockKey()` unlocks it calling the auth repository.
     func test_unlockVaultWithNeverlockKey() async throws {
         try await subject.unlockVaultWithNeverlockKey()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-11974](https://bitwarden.atlassian.net/browse/PM-11974)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes receiving a login with device notification for an inactive account. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/055fa648-68e7-4dd3-84b6-0e422a843c73



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
