### PR TITLE
PM-10913: Fix pre-approved users are forced to request admin approval

### DIFF
--- a/BitwardenShared/Core/Auth/Services/KeychainRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepository.swift
@@ -381,7 +381,8 @@ extension DefaultKeychainRepository {
             .biometrics(userId: userId),
             // Exclude `deviceKey` since it is used to log back into an account.
             .neverLock(userId: userId),
-            .pendingAdminLoginRequest(userId: userId),
+            // Exclude `pendingAdminLoginRequest` since if a TDE user is logged out before the request
+            // is approved, the next login for the user will succeed with the pending request.
             .refreshToken(userId: userId),
         ]
         for keychainItem in keychainItems {

--- a/BitwardenShared/Core/Auth/Services/KeychainRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepositoryTests.swift
@@ -104,7 +104,6 @@ final class KeychainRepositoryTests: BitwardenTestCase { // swiftlint:disable:th
             subject.keychainQueryValues(for: .authenticatorVaultKey(userId: "1")),
             subject.keychainQueryValues(for: .biometrics(userId: "1")),
             subject.keychainQueryValues(for: .neverLock(userId: "1")),
-            subject.keychainQueryValues(for: .pendingAdminLoginRequest(userId: "1")),
             subject.keychainQueryValues(for: .refreshToken(userId: "1")),
         ]
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10913](https://bitwarden.atlassian.net/browse/PM-10913)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an issue where a TDE user who is requesting admin approval closes the app before approval is granted. This ends up logging the user out and when they launch the app again and do SSO, they land back on the approval screen even if approval was previously granted. The pending login request was being deleted when the user was logged out. This removes it from being deleted when logging out.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/e90f98b4-b4b4-4285-b958-83b11fec292e



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-10913]: https://bitwarden.atlassian.net/browse/PM-10913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ