### PR TITLE
PM-14632: Revert to legacy create account flow if updated environment doesn't support email verification

### DIFF
--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessor.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessor.swift
@@ -70,4 +70,10 @@ extension IntroCarouselProcessor: StartRegistrationDelegate {
     func didChangeRegion() async {
         // No-op: the carousel doesn't show the region so there's nothing to do here.
     }
+
+    func switchToLegacyCreateAccountFlow() {
+        coordinator.navigate(to: .dismissWithAction(DismissAction {
+            self.coordinator.navigate(to: .createAccount)
+        }))
+    }
 }

--- a/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/IntroCarousel/IntroCarouselProcessorTests.swift
@@ -71,4 +71,19 @@ class IntroCarouselProcessorTests: BitwardenTestCase {
         subject.receive(.logIn)
         XCTAssertEqual(coordinator.routes.last, .landing)
     }
+
+    /// `switchToLegacyCreateAccountFlow()` dismisses the currently presented view and navigates to
+    /// create account.
+    @MainActor
+    func test_switchToLegacyCreateAccountFlow() throws {
+        subject.switchToLegacyCreateAccountFlow()
+
+        let dismissRoute = try XCTUnwrap(coordinator.routes.last)
+        guard case let .dismissWithAction(action) = dismissRoute else {
+            return XCTFail("Expected route `.dismissWithAction` not found.")
+        }
+        action?.action()
+
+        XCTAssertEqual(coordinator.routes, [.dismissWithAction(action), .createAccount])
+    }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -219,6 +219,12 @@ extension LandingProcessor: StartRegistrationDelegate {
     func didChangeRegion() async {
         await regionHelper.loadRegion()
     }
+
+    func switchToLegacyCreateAccountFlow() {
+        coordinator.navigate(to: .dismissWithAction(DismissAction {
+            self.coordinator.navigate(to: .createAccount)
+        }))
+    }
 }
 
 // MARK: - RegionDelegate

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -875,4 +875,19 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         subject.receive(.toastShown(nil))
         XCTAssertNil(subject.state.toast)
     }
+
+    /// `switchToLegacyCreateAccountFlow()` dismisses the currently presented view and navigates to
+    /// create account.
+    @MainActor
+    func test_switchToLegacyCreateAccountFlow() throws {
+        subject.switchToLegacyCreateAccountFlow()
+
+        let dismissRoute = try XCTUnwrap(coordinator.routes.last)
+        guard case let .dismissWithAction(action) = dismissRoute else {
+            return XCTFail("Expected route `.dismissWithAction` not found.")
+        }
+        action?.action()
+
+        XCTAssertEqual(coordinator.routes, [.dismissWithAction(action), .createAccount])
+    }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationAction.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationAction.swift
@@ -3,11 +3,14 @@
 /// Actions that can be processed by a `StartRegistrationProcessor`.
 ///
 enum StartRegistrationAction: Equatable {
-    /// The `StartRegistrationView` was dismissed.
-    case dismiss
-
     /// The user edited the email text field.
     case emailTextChanged(String)
+
+    /// The start registration appeared on screen.
+    case disappeared
+
+    /// The `StartRegistrationView` was dismissed.
+    case dismiss
 
     /// The user edited the name text field.
     case nameTextChanged(String)

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -74,6 +74,9 @@ class StartRegistrationProcessor: StateProcessor<
         stateService: services.stateService
     )
 
+    /// Whether the start registration view is visible in the view hierarchy.
+    private var viewIsVisible = false
+
     // MARK: Initialization
 
     /// Creates a new `StartRegistrationProcessor`.
@@ -100,6 +103,7 @@ class StartRegistrationProcessor: StateProcessor<
     override func perform(_ effect: StartRegistrationEffect) async {
         switch effect {
         case .appeared:
+            viewIsVisible = true
             await regionHelper.loadRegion()
             state.isReceiveMarketingToggleOn = state.region == .unitedStates
             await loadFeatureFlags()
@@ -117,6 +121,8 @@ class StartRegistrationProcessor: StateProcessor<
         switch action {
         case let .emailTextChanged(text):
             state.emailText = text
+        case .disappeared:
+            viewIsVisible = false
         case .dismiss:
             coordinator.navigate(to: .dismiss)
         case let .nameTextChanged(text):
@@ -240,7 +246,7 @@ extension StartRegistrationProcessor: RegionDelegate {
             defaultValue: false,
             forceRefresh: true,
             isPreAuth: true
-        ) {
+        ), viewIsVisible {
             // If email verification isn't enabled in the selected environment, switch to the
             // legacy create account flow.
             delegate?.switchToLegacyCreateAccountFlow()

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -15,9 +15,9 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
     var clientAuth: MockClientAuth!
     var configService: MockConfigService!
     var coordinator: MockCoordinator<AuthRoute, AuthEvent>!
+    var delegate: MockStartRegistrationDelegate!
     var errorReporter: MockErrorReporter!
     var subject: StartRegistrationProcessor!
-    var delegate: MockStartRegistrationDelegate!
     var stateService: MockStateService!
     var environmentService: MockEnvironmentService!
 
@@ -31,6 +31,7 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         clientAuth = MockClientAuth()
         configService = MockConfigService()
         coordinator = MockCoordinator<AuthRoute, AuthEvent>()
+        delegate = MockStartRegistrationDelegate()
         environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         stateService = MockStateService()
@@ -629,12 +630,39 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(environmentService.setPreAuthEnvironmentUrlsData, .defaultEU)
         XCTAssertFalse(subject.state.isReceiveMarketingToggleOn)
     }
+
+    /// `setRegion(_:_:)` doesn't notify the delegate to switch to the legacy create account flow
+    /// if the selected region supports email verification.
+    @MainActor
+    func test_setRegion_emailVerificationEnabled() async {
+        configService.featureFlagsBoolPreAuth[.emailVerification] = true
+
+        await subject.setRegion(.unitedStates, .defaultUS)
+
+        XCTAssertFalse(delegate.switchToLegacyCreateAccountFlowCalled)
+    }
+
+    /// `setRegion(_:_:)` notifies the delegate to switch to the legacy create account flow if the
+    /// selected region doesn't support email verification.
+    @MainActor
+    func test_setRegion_emailVerificationDisabled() async {
+        configService.featureFlagsBoolPreAuth[.emailVerification] = false
+
+        await subject.setRegion(.unitedStates, .defaultUS)
+
+        XCTAssertTrue(delegate.switchToLegacyCreateAccountFlowCalled)
+    }
 }
 
 class MockStartRegistrationDelegate: StartRegistrationDelegate {
     var didChangeRegionCalled: Bool = false
+    var switchToLegacyCreateAccountFlowCalled = false
 
     func didChangeRegion() async {
         didChangeRegionCalled = true
+    }
+
+    func switchToLegacyCreateAccountFlow() {
+        switchToLegacyCreateAccountFlowCalled = true
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -646,11 +646,26 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
     /// selected region doesn't support email verification.
     @MainActor
     func test_setRegion_emailVerificationDisabled() async {
-        configService.featureFlagsBoolPreAuth[.emailVerification] = false
+        await subject.perform(.appeared)
 
+        configService.featureFlagsBoolPreAuth[.emailVerification] = false
         await subject.setRegion(.unitedStates, .defaultUS)
 
         XCTAssertTrue(delegate.switchToLegacyCreateAccountFlowCalled)
+    }
+
+    /// `setRegion(_:_:)` doesn't notify the delete if the selected region doesn't support email
+    /// verification but the view is no longer visible.
+    @MainActor
+    func test_setRegion_emailVerificationDisabled_viewNotVisible() async {
+        configService.featureFlagsBoolPreAuth[.emailVerification] = true
+        await subject.perform(.appeared)
+        subject.receive(.disappeared)
+
+        configService.featureFlagsBoolPreAuth[.emailVerification] = false
+        await subject.setRegion(.unitedStates, .defaultUS)
+
+        XCTAssertFalse(delegate.switchToLegacyCreateAccountFlowCalled)
     }
 }
 

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationView.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationView.swift
@@ -21,6 +21,9 @@ struct StartRegistrationView: View {
                 title: Localizations.createAccount,
                 titleDisplayMode: .inline
             )
+            .onDisappear {
+                store.send(.disappeared)
+            }
             .task {
                 await store.perform(.appeared)
             }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14632](https://bitwarden.atlassian.net/browse/PM-14632)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

From the create account screen in the email verification flow, if you change the environment to an environment that doesn't support email verification, attempting to create an account will fail because the environment doesn't have the updated endpoints. This changes that to switch back to the legacy create account flow.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/6c60b706-082d-4c58-aade-a95e0d532f7e


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-14632]: https://bitwarden.atlassian.net/browse/PM-14632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ