### PR TITLE
PM-13319: Fix unable to JIT into domain claimed organization

### DIFF
--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -136,7 +136,6 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
         coordinator.showLoadingOverlay(title: Localizations.loading)
         defer {
             coordinator.hideLoadingOverlay()
-            state.identifierText = services.stateService.rememberedOrgIdentifier ?? ""
         }
 
         // Get the single sign on details for the user.
@@ -149,6 +148,8 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
                 await handleLoginTapped()
             }
         } catch {
+            // Default back to the last used org identifier if the API doesn't return one.
+            state.identifierText = services.stateService.rememberedOrgIdentifier ?? ""
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -140,13 +140,17 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
 
         // Get the single sign on details for the user.
         do {
-            if let organizationIdentifier = try await services.authRepository.getSingleSignOnOrganizationIdentifier(
-                email: state.email
-            ) {
-                state.identifierText = organizationIdentifier
-                coordinator.hideLoadingOverlay()
-                await handleLoginTapped()
+            guard let organizationIdentifier = try await services.authRepository
+                .getSingleSignOnOrganizationIdentifier(email: state.email)
+            else {
+                // Default back to the last used org identifier if the API doesn't return one.
+                state.identifierText = services.stateService.rememberedOrgIdentifier ?? ""
+                return
             }
+
+            state.identifierText = organizationIdentifier
+            coordinator.hideLoadingOverlay()
+            await handleLoginTapped()
         } catch {
             // Default back to the last used org identifier if the API doesn't return one.
             state.identifierText = services.stateService.rememberedOrgIdentifier ?? ""

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-class SingleSignOnProcessorTests: BitwardenTestCase {
+class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var authRepository: MockAuthRepository!
@@ -57,6 +57,21 @@ class SingleSignOnProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_loadSingleSignOnDetails_error() async throws {
         authRepository.getSSOOrganizationIdentifierByResult = .failure(BitwardenTestError.example)
+
+        await subject.perform(.loadSingleSignOnDetails)
+
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loading))
+        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+
+        XCTAssertEqual(subject.state.identifierText, "")
+    }
+
+    /// `perform(_:)` with `.loadSingleSignOnDetails` records an error if getting the org id throws
+    /// and loads the last used organization identifier.
+    @MainActor
+    func test_perform_loadSingleSignOnDetails_errorRememberedOrgId() async throws {
+        authRepository.getSSOOrganizationIdentifierByResult = .failure(BitwardenTestError.example)
         stateService.rememberedOrgIdentifier = "BestOrganization"
 
         await subject.perform(.loadSingleSignOnDetails)
@@ -102,6 +117,26 @@ class SingleSignOnProcessorTests: BitwardenTestCase {
             .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example)
         )
         XCTAssertEqual(subject.state.identifierText, "")
+    }
+
+    /// `perform(_:)` with `.loadSingleSignOnDetails` doesn't start the login process
+    /// if the organization identifier is `nil`, but populates the organization identifier with the
+    /// last used identifier.
+    @MainActor
+    func test_perform_loadSingleSignOnDetails_orgIdNilRememberedOrgId() async throws {
+        authRepository.getSSOOrganizationIdentifierByResult = .success(nil)
+        stateService.rememberedOrgIdentifier = "BestOrganization"
+
+        await subject.perform(.loadSingleSignOnDetails)
+
+        XCTAssertEqual(coordinator.loadingOverlaysShown.first, LoadingOverlayState(title: Localizations.loading))
+        XCTAssertNotEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
+        XCTAssertNotEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
+        XCTAssertNotEqual(
+            coordinator.routes.last,
+            .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example)
+        )
+        XCTAssertEqual(subject.state.identifierText, "BestOrganization")
     }
 
     /// `perform(_:)` with `.loadSingleSignOnDetails` loads the SSO organization identifier even if


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-13319](https://bitwarden.atlassian.net/browse/PM-13319)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When using SSO and a claimed domain, the organization's identifier was being overwritten by the saved organization identifier. That led to downstream errors when the identifier was later used after SSO authentication. This fixes that to only use the saved organization identifier if the API doesn't return an organization identifier.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-13319]: https://bitwarden.atlassian.net/browse/PM-13319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ