### PR TITLE
[PM-15416] Change pull-to-refresh to not force a sync

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -46,7 +46,7 @@ public protocol SendRepository: AnyObject {
     ///
     /// - Parameter isManualRefresh: Whether the sync is being performed as a manual refresh.
     ///
-    func fetchSync(isManualRefresh: Bool) async throws
+    func fetchSync(forceSync: Bool) async throws
 
     /// Performs an API request to remove the password on the provided send.
     ///
@@ -216,10 +216,10 @@ class DefaultSendRepository: SendRepository {
 
     // MARK: API Methods
 
-    func fetchSync(isManualRefresh: Bool) async throws {
+    func fetchSync(forceSync: Bool) async throws {
         let allowSyncOnRefresh = try await stateService.getAllowSyncOnRefresh()
-        if !isManualRefresh || allowSyncOnRefresh {
-            try await syncService.fetchSync(forceSync: isManualRefresh)
+        if !forceSync || allowSyncOnRefresh {
+            try await syncService.fetchSync(forceSync: forceSync)
         }
     }
 

--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -44,7 +44,7 @@ public protocol SendRepository: AnyObject {
     /// Performs an API request to sync the user's send data. The publishers in the repository can
     /// be used to subscribe to the send data, which are updated as a result of the request.
     ///
-    /// - Parameter isManualRefresh: Whether the sync is being performed as a manual refresh.
+    /// - Parameter forceSync: Whether the sync should be forced.
     ///
     func fetchSync(forceSync: Bool) async throws
 

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -169,7 +169,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.allowSyncOnRefresh = ["1": true]
         syncService.fetchSyncResult = .success(())
 
-        try await subject.fetchSync(isManualRefresh: true)
+        try await subject.fetchSync(forceSync: true)
 
         XCTAssertTrue(syncService.didFetchSync)
     }
@@ -180,7 +180,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.allowSyncOnRefresh = [:]
         syncService.fetchSyncResult = .success(())
 
-        try await subject.fetchSync(isManualRefresh: true)
+        try await subject.fetchSync(forceSync: true)
 
         XCTAssertFalse(syncService.didFetchSync)
     }
@@ -191,7 +191,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.allowSyncOnRefresh = ["1": true]
         syncService.fetchSyncResult = .failure(BitwardenTestError.example)
         await assertAsyncThrows {
-            try await subject.fetchSync(isManualRefresh: true)
+            try await subject.fetchSync(forceSync: true)
         }
         XCTAssertTrue(syncService.didFetchSync)
     }

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -163,7 +163,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertFalse(isVerified)
     }
 
-    /// `fetchSync(isManualRefresh:)` while manual refresh is allowed does perform a sync.
+    /// `fetchSync(forceSync:)` while manual refresh is allowed does perform a sync.
     func test_fetchSync_manualRefreshAllowed_success() async throws {
         await stateService.addAccount(.fixture())
         stateService.allowSyncOnRefresh = ["1": true]
@@ -174,7 +174,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertTrue(syncService.didFetchSync)
     }
 
-    /// `fetchSync(isManualRefresh:)` while manual refresh is not allowed does not perform a sync.
+    /// `fetchSync(forceSync:)` while manual refresh is not allowed does not perform a sync.
     func test_fetchSync_manualRefreshNotAllowed_success() async throws {
         await stateService.addAccount(.fixture())
         stateService.allowSyncOnRefresh = [:]
@@ -185,7 +185,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertFalse(syncService.didFetchSync)
     }
 
-    /// `fetchSync(isManualRefresh:)` and a failure performs a sync and throws the error.
+    /// `fetchSync(forceSync:)` and a failure performs a sync and throws the error.
     func test_fetchSync_failure() async throws {
         await stateService.addAccount(.fixture())
         stateService.allowSyncOnRefresh = ["1": true]

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -14,7 +14,7 @@ class MockSendRepository: SendRepository {
     var doesActiveAccountHaveVerifiedEmailResult: Result<Bool, Error> = .success(true)
 
     var fetchSyncCalled = false
-    var fetchSyncIsManualRefresh: Bool?
+    var fetchSyncForceSync: Bool?
     var fetchSyncResult: Result<Void, Error> = .success(())
 
     var searchSendSearchText: String?
@@ -81,9 +81,9 @@ class MockSendRepository: SendRepository {
         try doesActiveAccountHaveVerifiedEmailResult.get()
     }
 
-    func fetchSync(isManualRefresh: Bool) async throws {
+    func fetchSync(forceSync: Bool) async throws {
         fetchSyncCalled = true
-        fetchSyncIsManualRefresh = isManualRefresh
+        fetchSyncForceSync = forceSync
         try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -44,7 +44,7 @@ class MockVaultRepository: VaultRepository {
     var fetchFoldersResult: Result<[FolderView], Error> = .success([])
 
     var fetchSyncCalled = false
-    var fetchSyncIsManualRefresh: Bool?
+    var fetchSyncForceSync: Bool?
     var fetchSyncResult: Result<[VaultListSection]?, Error> = .success([])
 
     var getActiveAccountIdResult: Result<String, StateServiceError> = .failure(.noActiveAccount)
@@ -183,11 +183,11 @@ class MockVaultRepository: VaultRepository {
     }
 
     func fetchSync(
-        isManualRefresh: Bool,
+        forceSync: Bool,
         filter _: VaultFilterType
     ) async throws -> [VaultListSection]? {
         fetchSyncCalled = true
-        fetchSyncIsManualRefresh = isManualRefresh
+        fetchSyncForceSync = forceSync
         return try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -44,6 +44,7 @@ class MockVaultRepository: VaultRepository {
     var fetchFoldersResult: Result<[FolderView], Error> = .success([])
 
     var fetchSyncCalled = false
+    var fetchSyncManualRefresh: Bool?
     var fetchSyncResult: Result<[VaultListSection]?, Error> = .success([])
 
     var getActiveAccountIdResult: Result<String, StateServiceError> = .failure(.noActiveAccount)
@@ -182,10 +183,11 @@ class MockVaultRepository: VaultRepository {
     }
 
     func fetchSync(
-        isManualRefresh _: Bool,
+        isManualRefresh: Bool,
         filter _: VaultFilterType
     ) async throws -> [VaultListSection]? {
         fetchSyncCalled = true
+        fetchSyncManualRefresh = isManualRefresh
         return try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -44,7 +44,7 @@ class MockVaultRepository: VaultRepository {
     var fetchFoldersResult: Result<[FolderView], Error> = .success([])
 
     var fetchSyncCalled = false
-    var fetchSyncManualRefresh: Bool?
+    var fetchSyncIsManualRefresh: Bool?
     var fetchSyncResult: Result<[VaultListSection]?, Error> = .success([])
 
     var getActiveAccountIdResult: Result<String, StateServiceError> = .failure(.noActiveAccount)
@@ -187,7 +187,7 @@ class MockVaultRepository: VaultRepository {
         filter _: VaultFilterType
     ) async throws -> [VaultListSection]? {
         fetchSyncCalled = true
-        fetchSyncManualRefresh = isManualRefresh
+        fetchSyncIsManualRefresh = isManualRefresh
         return try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -17,7 +17,7 @@ public protocol VaultRepository: AnyObject {
     /// - Returns: If a sync is performed without error, this returns `[VaultListSection]` to display.
     ///
     @discardableResult
-    func fetchSync(isManualRefresh: Bool, filter: VaultFilterType) async throws -> [VaultListSection]?
+    func fetchSync(forceSync: Bool, filter: VaultFilterType) async throws -> [VaultListSection]?
 
     // MARK: Data Methods
 
@@ -928,10 +928,10 @@ extension DefaultVaultRepository: VaultRepository {
     // MARK: API Methods
 
     @discardableResult
-    func fetchSync(isManualRefresh: Bool, filter: VaultFilterType) async throws -> [VaultListSection]? {
+    func fetchSync(forceSync: Bool, filter: VaultFilterType) async throws -> [VaultListSection]? {
         let allowSyncOnRefresh = try await stateService.getAllowSyncOnRefresh()
-        guard !isManualRefresh || allowSyncOnRefresh else { return nil }
-        try await syncService.fetchSync(forceSync: isManualRefresh)
+        guard !forceSync || allowSyncOnRefresh else { return nil }
+        try await syncService.fetchSync(forceSync: forceSync)
         let ciphers = try await cipherService.fetchAllCiphers()
         let collections = try await collectionService.fetchAllCollections(includeReadOnly: true)
         let folders = try await folderService.fetchAllFolders()

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -813,7 +813,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         // If it's not a manual refresh, it should sync.
         let automaticSections = try await subject.fetchSync(
-            isManualRefresh: false,
+            forceSync: false,
             filter: .allVaults
         )
         XCTAssertTrue(syncService.didFetchSync)
@@ -824,7 +824,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         syncService.didFetchSync = false
         stateService.allowSyncOnRefresh["1"] = true
         let manualSections = try await subject.fetchSync(
-            isManualRefresh: true,
+            forceSync: true,
             filter: .myVault
         )
         XCTAssertTrue(syncService.didFetchSync)
@@ -834,7 +834,10 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         // it should not sync.
         syncService.didFetchSync = false
         stateService.allowSyncOnRefresh["1"] = false
-        let nilSections = try await subject.fetchSync(isManualRefresh: true, filter: .allVaults)
+        let nilSections = try await subject.fetchSync(
+            forceSync: true,
+            filter: .allVaults
+        )
         XCTAssertFalse(syncService.didFetchSync)
         XCTAssertNil(nilSections)
     }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -807,7 +807,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(clientService.mockVault.clientFolders.decryptedFolders, folders)
     }
 
-    /// `fetchSync(isManualRefresh:)` only syncs when expected.
+    /// `fetchSync(forceSync:)` only syncs when expected.
     func test_fetchSync() async throws {
         stateService.activeAccount = .fixture()
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -114,7 +114,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     ///
     private func refresh() async {
         do {
-            try await services.sendRepository.fetchSync(isManualRefresh: true)
+            try await services.sendRepository.fetchSync(isManualRefresh: false)
         } catch {
             let alert = Alert.networkResponseError(error) { [weak self] in
                 await self?.refresh()

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -114,7 +114,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     ///
     private func refresh() async {
         do {
-            try await services.sendRepository.fetchSync(isManualRefresh: false)
+            try await services.sendRepository.fetchSync(forceSync: false)
         } catch {
             let alert = Alert.networkResponseError(error) { [weak self] in
                 await self?.refresh()

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -66,7 +66,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await subject.perform(.refresh)
 
         XCTAssertTrue(sendRepository.fetchSyncCalled)
-        XCTAssertEqual(sendRepository.fetchSyncIsManualRefresh, false)
+        XCTAssertEqual(sendRepository.fetchSyncForceSync, false)
     }
 
     /// `perform(_:)` with `search(_:)` and an empty search query returns early.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -61,7 +61,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(subject.state.isSendDisabled)
     }
 
-    /// `perform(_:)` with `refresh` calls the refresh method.
+    /// `perform(_:)` with `refresh` requests a fetch sync update, but does not force a sync.
     func test_perform_refresh() async {
         await subject.perform(.refresh)
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -66,6 +66,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await subject.perform(.refresh)
 
         XCTAssertTrue(sendRepository.fetchSyncCalled)
+        XCTAssertEqual(sendRepository.fetchSyncIsManualRefresh, false)
     }
 
     /// `perform(_:)` with `search(_:)` and an empty search query returns early.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -203,7 +203,7 @@ final class VaultGroupProcessor: StateProcessor<
     ///
     private func refreshVaultGroup() async {
         do {
-            try await services.vaultRepository.fetchSync(isManualRefresh: true, filter: state.vaultFilterType)
+            try await services.vaultRepository.fetchSync(forceSync: true, filter: state.vaultFilterType)
         } catch {
             coordinator.showAlert(.networkResponseError(error))
             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -86,7 +86,7 @@ final class VaultListProcessor: StateProcessor<
         case .refreshAccountProfiles:
             await refreshProfileState()
         case .refreshVault:
-            await refreshVault(isManualRefresh: true)
+            await refreshVault(isManualRefresh: false)
         case let .search(text):
             state.searchResults = await searchVault(for: text)
         case .streamAccountSetupProgress:

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -65,7 +65,7 @@ final class VaultListProcessor: StateProcessor<
     override func perform(_ effect: VaultListEffect) async {
         switch effect {
         case .appeared:
-            await refreshVault(isManualRefresh: false)
+            await refreshVault()
             await handleNotifications()
             await checkPendingLoginRequests()
             await checkPersonalOwnershipPolicy()
@@ -86,7 +86,7 @@ final class VaultListProcessor: StateProcessor<
         case .refreshAccountProfiles:
             await refreshProfileState()
         case .refreshVault:
-            await refreshVault(isManualRefresh: false)
+            await refreshVault()
         case let .search(text):
             state.searchResults = await searchVault(for: text)
         case .streamAccountSetupProgress:
@@ -195,12 +195,10 @@ extension VaultListProcessor {
 
     /// Refreshes the vault's contents.
     ///
-    /// - Parameter isManualRefresh: Whether the sync is being performed as a manual refresh.
-    ///
-    private func refreshVault(isManualRefresh: Bool) async {
+    private func refreshVault() async {
         do {
             guard let sections = try await services.vaultRepository.fetchSync(
-                forceSync: isManualRefresh,
+                forceSync: false,
                 filter: state.vaultFilterType
             ) else { return }
             state.loadingState = .data(sections)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -200,7 +200,7 @@ extension VaultListProcessor {
     private func refreshVault(isManualRefresh: Bool) async {
         do {
             guard let sections = try await services.vaultRepository.fetchSync(
-                isManualRefresh: isManualRefresh,
+                forceSync: isManualRefresh,
                 filter: state.vaultFilterType
             ) else { return }
             state.loadingState = .data(sections)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -427,7 +427,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
-        XCTAssertEqual(vaultRepository.fetchSyncIsManualRefresh, false)
+        XCTAssertEqual(vaultRepository.fetchSyncForceSync, false)
     }
 
     /// `perform(_:)` with `.refreshed` records an error if applicable.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -421,12 +421,13 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.url, url)
     }
 
-    /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository.
+    /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository, but does not force a sync.
     @MainActor
     func test_perform_refresh() async {
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
+        XCTAssertEqual(vaultRepository.fetchSyncManualRefresh, false)
     }
 
     /// `perform(_:)` with `.refreshed` records an error if applicable.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -421,13 +421,13 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.url, url)
     }
 
-    /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository, but does not force a sync.
+    /// `perform(_:)` with `.refreshed` requests a fetch sync update, but does not force a sync.
     @MainActor
     func test_perform_refresh() async {
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
-        XCTAssertEqual(vaultRepository.fetchSyncManualRefresh, false)
+        XCTAssertEqual(vaultRepository.fetchSyncIsManualRefresh, false)
     }
 
     /// `perform(_:)` with `.refreshed` records an error if applicable.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15416

## 📔 Objective

This changes the behavior of pull-to-refresh to respect time gates and other business logic around when we should actually do a refresh. It does not change the behavior of other places we trigger a manual refresh.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
