### PR TITLE
PM-11494: fixed session timeout not being respected when switch account

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -438,7 +438,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.activeAccount = beeAccount
         stateService.timeoutAction = [anneAccount.profile.userId: .lock]
         vaultTimeoutService.shouldSessionTimeout[anneAccount.profile.userId] = true
-        await subject.checkSessionTimeout()
+        await subject.checkSessionTimeouts(handleActiveUser: nil)
         XCTAssertTrue(vaultTimeoutService.isLocked(userId: anneAccount.profile.userId))
     }
 
@@ -448,19 +448,58 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.activeAccount = beeAccount
         stateService.timeoutAction = [anneAccount.profile.userId: .logout]
         vaultTimeoutService.shouldSessionTimeout[anneAccount.profile.userId] = true
-        await subject.checkSessionTimeout()
+        await subject.checkSessionTimeouts(handleActiveUser: nil)
         XCTAssertTrue(vaultTimeoutService.removedIds.contains(anneAccount.profile.userId))
         XCTAssertTrue(stateService.accountsLoggedOut.contains(anneAccount.profile.userId))
     }
 
-    /// `checkSessionTimeout()` takes no action to an active  account when the session timeout.
+    /// `checkSessionTimeout()` takes no action to an active  account when the session timeout if the `handleActiveUser`
+    /// closure is nil.
     func test_checkSessionTimeout_activeAccount() async {
         stateService.accounts = [anneAccount, beeAccount]
         stateService.activeAccount = beeAccount
         stateService.timeoutAction = [beeAccount.profile.userId: .lock]
         vaultTimeoutService.shouldSessionTimeout[beeAccount.profile.userId] = true
-        await subject.checkSessionTimeout()
+        await subject.checkSessionTimeouts(handleActiveUser: nil)
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: anneAccount.profile.userId))
+    }
+
+    /// `checkSessionTimeout()` calls `handleActiveUser` closure when the active account is timed out.
+    /// closure is nil.
+    func test_checkSessionTimeout_timedOut_activeAccount_handleActiveUser() async {
+        stateService.accounts = [anneAccount, beeAccount]
+        stateService.activeAccount = beeAccount
+        stateService.timeoutAction = [beeAccount.profile.userId: .lock]
+        vaultTimeoutService.shouldSessionTimeout[beeAccount.profile.userId] = true
+        await subject.checkSessionTimeouts { [beeAccount] userId in
+            XCTAssertEqual(userId, beeAccount.profile.userId)
+        }
+    }
+
+    /// `checkSessionTimeout()` takes no action to an active account is not timed out.
+    func test_checkSessionTimeout_activeAccount_handleActiveUser() async {
+        stateService.accounts = [anneAccount, beeAccount]
+        stateService.activeAccount = beeAccount
+        stateService.timeoutAction = [beeAccount.profile.userId: .lock]
+        vaultTimeoutService.shouldSessionTimeout[beeAccount.profile.userId] = false
+        await subject.checkSessionTimeouts { userId in
+            XCTFail(
+                "shouldn't be calling `handleActiveUser` closure if the active account is not timed out"
+            )
+        }
+    }
+
+    /// `checkSessionTimeout(handleActiveUser:)` logs an error if one occurs when checking timeouts.
+    func test_checkSessionTimeout_error() async {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.accounts = [account]
+        vaultTimeoutService.shouldSessionTimeoutError = BitwardenTestError.example
+
+        await subject.checkSessionTimeouts(handleActiveUser: nil)
+
+        waitFor(!errorReporter.errors.isEmpty)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
     /// `getProfilesState()` throws an error when the accounts are nil.

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -11,6 +11,7 @@ class MockAuthRepository: AuthRepository {
     var canBeLockedResult: [String: Bool] = [:]
     var canVerifyMasterPasswordResult: Result<Bool, Error> = .success(true)
     var canVerifyMasterPasswordForUserResult: Result<[String: Bool], Error> = .success([:])
+    var checkSessionTimeoutCalled = false
     var clearPinsCalled = false
     var createNewSsoUserRememberDevice: Bool = false
     var createNewSsoUserOrgIdentifier: String = ""
@@ -125,6 +126,10 @@ class MockAuthRepository: AuthRepository {
         } else {
             try canVerifyMasterPasswordResult.get()
         }
+    }
+
+    func checkSessionTimeout() async {
+        checkSessionTimeoutCalled = true
     }
 
     func clearPins() async throws {

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -28,6 +28,7 @@ class MockAuthRepository: AuthRepository {
     var altAccounts = [Account]()
     var getAccountError: Error?
     var getSSOOrganizationIdentifierByResult: Result<String?, Error> = .success(nil)
+    var handleActiveUserClosure: ((String) async -> Void)?
     var hasManuallyLocked = false
     var hasMasterPasswordResult = Result<Bool, Error>.success(true)
     var isLockedResult: Result<Bool, Error> = .success(true)
@@ -128,8 +129,9 @@ class MockAuthRepository: AuthRepository {
         }
     }
 
-    func checkSessionTimeout() async {
+    func checkSessionTimeouts(handleActiveUser: ((String) async -> Void)?) async {
         checkSessionTimeoutCalled = true
+        handleActiveUserClosure = handleActiveUser
     }
 
     func clearPins() async throws {

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -1247,6 +1247,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         let active = Account.fixture()
         authRepository.activeAccount = active
         authRepository.isLockedResult = .success(false)
+        vaultTimeoutService.lastActiveTime = [:]
         let route = await subject.handleAndRoute(
             .action(
                 .switchAccount(isAutomatic: true, userId: active.profile.userId)
@@ -1254,6 +1255,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
         XCTAssertEqual(route, .complete)
         XCTAssertEqual(authRepository.setActiveAccountId, active.profile.userId)
+        XCTAssertNil(vaultTimeoutService.lastActiveTime[active.profile.userId])
     }
 
     /// `handleAndRoute(_ :)` redirects `.switchAccount()` to `.vaultUnlock` when switching to a
@@ -1265,6 +1267,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         authRepository.altAccounts = [inactive]
         authRepository.isLockedResult = .success(true)
         stateService.isAuthenticated["2"] = true
+        vaultTimeoutService.lastActiveTime = [:]
         let route = await subject.handleAndRoute(
             .action(
                 .switchAccount(isAutomatic: true, userId: inactive.profile.userId)
@@ -1280,6 +1283,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
             )
         )
         XCTAssertEqual(authRepository.setActiveAccountId, inactive.profile.userId)
+        XCTAssertNotNil(vaultTimeoutService.lastActiveTime[active.profile.userId])
     }
 
     /// `handleAndRoute(_ :)` redirects `.switchAccount()` to `.landingSoftLoggedOut` when that

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -323,6 +323,14 @@ extension AuthRouter {
     ///
     func switchAccountRedirect(isAutomatic: Bool, userId: String) async -> AuthRoute {
         do {
+            // Set the last active time for the current account before switching.
+            if let currentActiveAccount = try? await services.authRepository.getAccount(),
+               currentActiveAccount.profile.userId != userId {
+                try await services.vaultTimeoutService.setLastActiveTime(
+                    userId: currentActiveAccount.profile.userId
+                )
+            }
+
             let activeAccount = try await services.authRepository.setActiveAccount(userId: userId)
             // Setup the unlock route for the active account.
             let event = AuthEvent.accountBecameActive(

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
@@ -105,7 +105,7 @@ extension ProfileSwitcherHandler {
             showAddAccount()
         case let .requestedProfileSwitcher(isVisible):
             if isVisible {
-                await profileServices.authRepository.checkSessionTimeout()
+                await profileServices.authRepository.checkSessionTimeouts(handleActiveUser: nil)
                 await refreshProfileState()
             }
             profileSwitcherState.isVisible = isVisible

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherHandler.swift
@@ -105,6 +105,7 @@ extension ProfileSwitcherHandler {
             showAddAccount()
         case let .requestedProfileSwitcher(isVisible):
             if isVisible {
+                await profileServices.authRepository.checkSessionTimeout()
                 await refreshProfileState()
             }
             profileSwitcherState.isVisible = isVisible

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -83,7 +83,11 @@ public class AppProcessor {
             for await _ in services.notificationCenterService.willEnterForegroundPublisher() {
                 startEventTimer()
                 await checkIfExtensionSwitchedAccounts()
-                await checkAccountsForTimeout()
+                await services.authRepository.checkSessionTimeouts { [weak self] activeUserId in
+                    // Allow the AuthCoordinator to handle the timeout for the active user
+                    // so any necessary routing can occur.
+                    await self?.coordinator?.handleEvent(.didTimeout(userId: activeUserId))
+                }
                 await handleNeverTimeOutAccountBecameActive()
                 await completeAutofillAccountSetupIfEnabled()
                 #if DEBUG
@@ -341,38 +345,6 @@ public class AppProcessor {
 
 extension AppProcessor {
     // MARK: Private Methods
-
-    /// Checks if any accounts have timed out.
-    ///
-    private func checkAccountsForTimeout() async {
-        do {
-            let accounts = try await services.stateService.getAccounts()
-            let activeUserId = try await services.stateService.getActiveAccountId()
-            for account in accounts {
-                let userId = account.profile.userId
-                let shouldTimeout = try await services.vaultTimeoutService.hasPassedSessionTimeout(userId: userId)
-                if shouldTimeout {
-                    if userId == activeUserId {
-                        // Allow the AuthCoordinator to handle the timeout for the active user
-                        // so any necessary routing can occur.
-                        await coordinator?.handleEvent(.didTimeout(userId: activeUserId))
-                    } else {
-                        let timeoutAction = try? await services.authRepository.sessionTimeoutAction(userId: userId)
-                        switch timeoutAction {
-                        case .lock:
-                            await services.vaultTimeoutService.lockVault(userId: userId)
-                        case .logout, .none:
-                            try await services.authRepository.logout(userId: userId, userInitiated: false)
-                        }
-                    }
-                }
-            }
-        } catch StateServiceError.noAccounts, StateServiceError.noActiveAccount {
-            // No-op: nothing to do if there's no accounts or an active account.
-        } catch {
-            services.errorReporter.log(error: error)
-        }
-    }
 
     /// Handles unlocking the vault for a manually locked account that uses never lock
     /// and was previously unlocked in an extension.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -529,6 +529,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         // Ensure that the profile switcher state is updated
         waitFor(subject.state.profileSwitcherState == authRepository.profileSwitcherState)
         XCTAssertTrue(subject.state.profileSwitcherState.isVisible)
+        XCTAssertTrue(authRepository.checkSessionTimeoutCalled)
     }
 
     /// `perform(.profileSwitcher(.rowAppeared))` should not update the state for add Account


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-11494](https://bitwarden.atlassian.net/browse/PM-11494)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This update addresses the issue where session timeouts are not recorded when a user switches accounts.
- The ```lastActiveTime``` is now recorded whenever a user switches to a different account.
- A session timeout verification is performed before displaying the profile switcher.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11494]: https://bitwarden.atlassian.net/browse/PM-11494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ