### PR TITLE
[PM-11598] fix: GitHub Release v2

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -91,37 +91,39 @@ jobs:
           rm -rf tmp
 
       - name: Create GitHub Release
-        id: create_gh_release
+        id: create_release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Create release with generated notes
-          gh release create "v${{ steps.version_info.outputs.version_name }}" \
+          url=$(gh release create "v${{ steps.version_info.outputs.version_name }}" \
             --title "${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }})" \
             --target ${{ steps.get_release_branch.outputs.release_branch }} \
             --generate-notes \
             --notes-start-tag "${{ steps.get_last_tag.outputs.last_release_tag }}" \
             --prerelease=${{ inputs.prerelease }} \
             --draft=${{ inputs.draft }} \
-            $ARTIFACTS_PATH/*
+            $ARTIFACTS_PATH/*)
+          # Extract release tag from URL
+          release_tag=$(echo "$url" | sed 's/.*\/tag\///')
+          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+          echo "release_url=$url" >> $GITHUB_OUTPUT
 
       - name: Update Release Description
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ID: ${{ steps.create_release.outputs.id }}
-          RELEASE_URL: ${{ steps.create_release.outputs.url }}
+          RELEASE_ID: ${{ steps.create_release.outputs.release_tag }}
+          RELEASE_URL: ${{ steps.create_release.outputs.release_url }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
         run: |
           # Get current release body
-          current_body=$(gh api /repos/${{ github.repository }}/releases/$RELEASE_ID --jq .body)
-
+          current_body=$(gh release view ${{ steps.create_release.outputs.release_tag }} --json body --jq .body)
           # Append build source to the end
           updated_body="${current_body}
           **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$ARTIFACT_RUN_ID"
 
           # Update release
-          gh api --method PATCH /repos/${{ github.repository }}/releases/$RELEASE_ID \
-            -f body="$updated_body"
+          gh release edit ${{ steps.create_release.outputs.release_tag }} --notes "$updated_body"
 
           echo "# :rocket: Release ready at:" >> $GITHUB_STEP_SUMMARY
           echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -107,23 +107,21 @@ jobs:
           # Extract release tag from URL
           release_tag=$(echo "$url" | sed 's/.*\/tag\///')
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
-          echo "release_url=$url" >> $GITHUB_OUTPUT
 
       - name: Update Release Description
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_ID: ${{ steps.create_release.outputs.release_tag }}
-          RELEASE_URL: ${{ steps.create_release.outputs.release_url }}
+          RELEASE_TAG: ${{ steps.create_release.outputs.release_tag }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
         run: |
           # Get current release body
-          current_body=$(gh release view ${{ steps.create_release.outputs.release_tag }} --json body --jq .body)
+          current_body=$(gh release view $RELEASE_TAG --json body --jq .body)
           # Append build source to the end
           updated_body="${current_body}
           **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$ARTIFACT_RUN_ID"
 
           # Update release
-          gh release edit ${{ steps.create_release.outputs.release_tag }} --notes "$updated_body"
+          new_url=$(gh release edit $RELEASE_TAG --notes "$updated_body")
 
           echo "# :rocket: Release ready at:" >> $GITHUB_STEP_SUMMARY
-          echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY
+          echo "$new_url" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -78,6 +78,11 @@ jobs:
           esac
 
           echo "release_branch=$release_branch" >> $GITHUB_OUTPUT
+      - name: Get last release tag
+        id: get_last_tag
+        run: |
+          last_release_tag=$(git tag -l --sort=-authordate | head -n 1)
+          echo "last_release_tag=$last_release_tag" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
         env:
@@ -96,6 +101,49 @@ jobs:
           echo "version_name=$version_name" >> $GITHUB_OUTPUT
           rm -rf tmp
 
+      # - name: Create Release Notes
+      #   id: release_notes
+      #   env:
+      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: |
+      #     if [ -n "${{ steps.get_last_tag.outputs.last_release_tag }}" ]; then
+      #       # Generate release notes from last tag to HEAD
+      #       gh api \
+      #         --method POST \
+      #         -H "Accept: application/vnd.github+json" \
+      #         /repos/${{ github.repository }}/releases/generate-notes \
+      #         -f tag_name="v${{ steps.version_info.outputs.version_name }}" \
+      #         -f target_commitish="${{ steps.get_release_branch.outputs.release_branch }}" \
+      #         -f previous_tag_name="${{ steps.get_last_tag.outputs.last_release_tag }}" \
+      #         -q .body > release_notes.txt
+      #     else
+      #       # If no previous tag exists, just add a basic note
+      #       echo "Initial release" > release_notes.txt
+      #     fi
+
+      - name: Create GitHub Release
+        id: create_gh_release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create release with generated notes
+          gh release create "v${{ steps.version_info.outputs.version_name }}" \
+            --title "${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }})" \
+            --target ${{ steps.get_release_branch.outputs.release_branch }} \
+            --generate-notes \
+            --notes-start-tag "${{ steps.get_last_tag.outputs.last_release_tag }}" \
+            --prerelease=${{ inputs.prerelease }} \
+            --draft=${{ inputs.draft }} \
+            "$ARTIFACTS_PATH"/*.*
+
+            #--latest=${{ inputs.make-latest }} \
+
+          # # Upload all artifacts
+          # for file in $ARTIFACTS_PATH/*; do
+          #   if [ -f "$file" ]; then
+          #     gh release upload "v${{ steps.version_info.outputs.version_name }}" "$file"
+          #   fi
+          done
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -109,19 +109,35 @@ jobs:
           echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
 
       - name: Update Release Description
+        id: update_release_description
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_TAG: ${{ steps.create_release.outputs.release_tag }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
         run: |
-          # Get current release body
+          # Add builds source to the end of the release description
           current_body=$(gh release view $RELEASE_TAG --json body --jq .body)
-          # Append build source to the end
           updated_body="${current_body}
           **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$ARTIFACT_RUN_ID"
-
-          # Update release
           new_url=$(gh release edit $RELEASE_TAG --notes "$updated_body")
 
+          # draft release links change after editing
+          echo "release_url=$new_url" >> $GITHUB_OUTPUT
+
+      - name: Add Release Summary
+        env:
+          RELEASE_TAG: ${{ steps.create_release.outputs.release_tag }}
+          RELEASE_BRANCH: ${{ steps.get_release_branch.outputs.release_branch }}
+          LAST_RELEASE_TAG: ${{ steps.get_last_tag.outputs.last_release_tag }}
+          RELEASE_URL: ${{ steps.update_release_description.outputs.release_url }}
+        run: |
           echo "# :fish_cake: Release ready at:" >> $GITHUB_STEP_SUMMARY
-          echo "$new_url" >> $GITHUB_STEP_SUMMARY
+          echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Confirm that the defined GitHub Release options are correct:"  >> $GITHUB_STEP_SUMMARY
+          echo " * New tag name: $RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
+          echo " * Target branch: $RELEASE_BRANCH" >> $GITHUB_STEP_SUMMARY
+          echo " * Previous tag set in the description \"Full Changelog\" link: $LAST_RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
+          echo " * Description has automated release notes and they match the commits in the release branch" >> $GITHUB_STEP_SUMMARY
+          echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
+          echo "> Commits directly pushed to branches without a Pull Request won't appear in the automated release notes." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -85,12 +85,23 @@ jobs:
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
         run: ./Scripts/download-artifacts.sh $ARTIFACTS_PATH $ARTIFACT_RUN_ID
 
+      - name: Parse version info
+        id: version_info
+        run: |
+          unzip -o "$ARTIFACTS_PATH/version-info.zip" -d "tmp"
+          filepath="tmp/version-info/version_info.json"
+          version_name=$(jq -r '.version_name' "$filepath")
+          version_number=$(jq -r '.version_number' "$filepath")
+          echo "version_number=$version_number" >> $GITHUB_OUTPUT
+          echo "version_name=$version_name" >> $GITHUB_OUTPUT
+          rm -rf tmp
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
         with:
-          tag_name: "v${{ inputs.version-name }}"
-          name: "${{ inputs.version-name }} (${{ inputs.version-number }})"
+          tag_name: "v${{ steps.version_info.outputs.version_name }}"
+          name: "${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }})"
           prerelease: ${{ inputs.prerelease }}
           draft: ${{ inputs.draft }}
           make_latest: ${{ inputs.make-latest }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -3,14 +3,6 @@ name: Create GitHub Release
 on:
   workflow_dispatch:
     inputs:
-      version-name:
-        description: 'Version Name - E.g. "2024.11.1"'
-        required: true
-        type: string
-      version-number:
-        description: 'Version Number - E.g. "123456"'
-        required: true
-        type: string
       artifact-run-id:
         description: 'GitHub Action Run ID containing artifacts'
         required: true
@@ -23,9 +15,6 @@ on:
         description: 'Mark as pre-release'
         type: boolean
         default: true
-      make-latest:
-        description: 'Set as the latest release'
-        type: boolean
       branch-protection-type:
         description: 'Branch protection type'
         type: choice
@@ -101,26 +90,6 @@ jobs:
           echo "version_name=$version_name" >> $GITHUB_OUTPUT
           rm -rf tmp
 
-      # - name: Create Release Notes
-      #   id: release_notes
-      #   env:
-      #     GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: |
-      #     if [ -n "${{ steps.get_last_tag.outputs.last_release_tag }}" ]; then
-      #       # Generate release notes from last tag to HEAD
-      #       gh api \
-      #         --method POST \
-      #         -H "Accept: application/vnd.github+json" \
-      #         /repos/${{ github.repository }}/releases/generate-notes \
-      #         -f tag_name="v${{ steps.version_info.outputs.version_name }}" \
-      #         -f target_commitish="${{ steps.get_release_branch.outputs.release_branch }}" \
-      #         -f previous_tag_name="${{ steps.get_last_tag.outputs.last_release_tag }}" \
-      #         -q .body > release_notes.txt
-      #     else
-      #       # If no previous tag exists, just add a basic note
-      #       echo "Initial release" > release_notes.txt
-      #     fi
-
       - name: Create GitHub Release
         id: create_gh_release
         env:
@@ -134,16 +103,8 @@ jobs:
             --notes-start-tag "${{ steps.get_last_tag.outputs.last_release_tag }}" \
             --prerelease=${{ inputs.prerelease }} \
             --draft=${{ inputs.draft }} \
-            "$ARTIFACTS_PATH"/*.*
+            $ARTIFACTS_PATH/*
 
-            #--latest=${{ inputs.make-latest }} \
-
-          # # Upload all artifacts
-          # for file in $ARTIFACTS_PATH/*; do
-          #   if [ -f "$file" ]; then
-          #     gh release upload "v${{ steps.version_info.outputs.version_name }}" "$file"
-          #   fi
-          done
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -70,8 +70,8 @@ jobs:
       - name: Get last release tag
         id: get_last_tag
         run: |
-          last_release_tag=$(git tag -l --sort=-authordate | head -n 1)
-          echo "last_release_tag=$last_release_tag" >> $GITHUB_OUTPUT
+          last_release_id=$(git tag -l --sort=-authordate | head -n 1)
+          echo "last_release_id=$last_release_id" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
         env:
@@ -100,44 +100,45 @@ jobs:
             --title "${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }})" \
             --target ${{ steps.get_release_branch.outputs.release_branch }} \
             --generate-notes \
-            --notes-start-tag "${{ steps.get_last_tag.outputs.last_release_tag }}" \
+            --notes-start-tag "${{ steps.get_last_tag.outputs.last_release_id }}" \
             --prerelease=${{ inputs.prerelease }} \
             --draft=${{ inputs.draft }} \
             $ARTIFACTS_PATH/*)
           # Extract release tag from URL
-          release_tag=$(echo "$url" | sed 's/.*\/tag\///')
-          echo "release_tag=$release_tag" >> $GITHUB_OUTPUT
+          release_id=$(echo "$url" | sed 's/.*\/tag\///')
+          echo "release_id=$release_id" >> $GITHUB_OUTPUT
 
       - name: Update Release Description
         id: update_release_description
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ steps.create_release.outputs.release_tag }}
+          RELEASE_ID: ${{ steps.create_release.outputs.release_id }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
         run: |
           # Add builds source to the end of the release description
-          current_body=$(gh release view $RELEASE_TAG --json body --jq .body)
+          current_body=$(gh release view $RELEASE_ID --json body --jq .body)
           updated_body="${current_body}
           **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$ARTIFACT_RUN_ID"
-          new_url=$(gh release edit $RELEASE_TAG --notes "$updated_body")
+          new_url=$(gh release edit $RELEASE_ID --notes "$updated_body")
 
           # draft release links change after editing
           echo "release_url=$new_url" >> $GITHUB_OUTPUT
 
       - name: Add Release Summary
         env:
-          RELEASE_TAG: ${{ steps.create_release.outputs.release_tag }}
+          RELEASE_ID: ${{ steps.create_release.outputs.release_id }}
+          RELEASE_TAG: "v${{ steps.version_info.outputs.version_name }}"
           RELEASE_BRANCH: ${{ steps.get_release_branch.outputs.release_branch }}
-          LAST_RELEASE_TAG: ${{ steps.get_last_tag.outputs.last_release_tag }}
+          LAST_RELEASE_TAG: ${{ steps.get_last_tag.outputs.last_release_id }}
           RELEASE_URL: ${{ steps.update_release_description.outputs.release_url }}
         run: |
           echo "# :fish_cake: Release ready at:" >> $GITHUB_STEP_SUMMARY
           echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Confirm that the defined GitHub Release options are correct:"  >> $GITHUB_STEP_SUMMARY
-          echo " * New tag name: $RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
-          echo " * Target branch: $RELEASE_BRANCH" >> $GITHUB_STEP_SUMMARY
-          echo " * Previous tag set in the description \"Full Changelog\" link: $LAST_RELEASE_TAG" >> $GITHUB_STEP_SUMMARY
-          echo " * Description has automated release notes and they match the commits in the release branch" >> $GITHUB_STEP_SUMMARY
+          echo ":clipboard: Confirm that the defined GitHub Release options are correct:"  >> $GITHUB_STEP_SUMMARY
+          echo " * :bookmark: New tag name: `$RELEASE_TAG`" >> $GITHUB_STEP_SUMMARY
+          echo " * :palm_tree: Target branch: `$RELEASE_BRANCH`" >> $GITHUB_STEP_SUMMARY
+          echo " * :ocean: Previous tag set in the description \"Full Changelog\" link: `$LAST_RELEASE_TAG`" >> $GITHUB_STEP_SUMMARY
+          echo " * :white_check_mark: Description has automated release notes and they match the commits in the release branch" >> $GITHUB_STEP_SUMMARY
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> Commits directly pushed to branches without a Pull Request won't appear in the automated release notes." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -105,20 +105,6 @@ jobs:
             --draft=${{ inputs.draft }} \
             $ARTIFACTS_PATH/*
 
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@e7a8f85e1c67a31e6ed99a94b41bd0b71bbee6b8 # v2.0.9
-        with:
-          tag_name: "v${{ steps.version_info.outputs.version_name }}"
-          name: "${{ steps.version_info.outputs.version_name }} (${{ steps.version_info.outputs.version_number }})"
-          prerelease: ${{ inputs.prerelease }}
-          draft: ${{ inputs.draft }}
-          make_latest: ${{ inputs.make-latest }}
-          target_commitish: ${{ steps.get_release_branch.outputs.release_branch }}
-          generate_release_notes: true
-          files: |
-            artifacts/**/*
-
       - name: Update Release Description
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -83,14 +83,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
-        run: |
-          gh run download $ARTIFACT_RUN_ID -D $ARTIFACTS_PATH
-          file_count=$(find $ARTIFACTS_PATH -type f | wc -l)
-          echo "Downloaded $file_count file(s)."
-          if [ "$file_count" -gt 0 ]; then
-            echo "Downloaded files:"
-            find $ARTIFACTS_PATH -type f
-          fi
+        run: ./Scripts/download-artifacts.sh $ARTIFACTS_PATH $ARTIFACT_RUN_ID
 
       - name: Create Release
         id: create_release

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -123,5 +123,5 @@ jobs:
           # Update release
           new_url=$(gh release edit $RELEASE_TAG --notes "$updated_body")
 
-          echo "# :rocket: Release ready at:" >> $GITHUB_STEP_SUMMARY
+          echo "# :fish_cake: Release ready at:" >> $GITHUB_STEP_SUMMARY
           echo "$new_url" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -136,9 +136,9 @@ jobs:
           echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo ":clipboard: Confirm that the defined GitHub Release options are correct:"  >> $GITHUB_STEP_SUMMARY
-          echo " * :bookmark: New tag name: `$RELEASE_TAG`" >> $GITHUB_STEP_SUMMARY
-          echo " * :palm_tree: Target branch: `$RELEASE_BRANCH`" >> $GITHUB_STEP_SUMMARY
-          echo " * :ocean: Previous tag set in the description \"Full Changelog\" link: `$LAST_RELEASE_TAG`" >> $GITHUB_STEP_SUMMARY
+          echo " * :bookmark: New tag name: \`$RELEASE_TAG\`" >> $GITHUB_STEP_SUMMARY
+          echo " * :palm_tree: Target branch: \`$RELEASE_BRANCH\`" >> $GITHUB_STEP_SUMMARY
+          echo " * :ocean: Previous tag set in the description \"Full Changelog\" link: \`$LAST_RELEASE_TAG\`" >> $GITHUB_STEP_SUMMARY
           echo " * :white_check_mark: Description has automated release notes and they match the commits in the release branch" >> $GITHUB_STEP_SUMMARY
           echo "> [!NOTE]" >> $GITHUB_STEP_SUMMARY
           echo "> Commits directly pushed to branches without a Pull Request won't appear in the automated release notes." >> $GITHUB_STEP_SUMMARY

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -53,7 +53,7 @@ for dir in */; do
     dirname=${dir%/}
     basename=$(basename "$dirname")
     echo $dirname $basename
-    zip -r "${basename}.zip" "$dirname"
+    zip -r -q "${basename}.zip" "$dirname"
     rm -rf "$dirname"
 done
 

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -53,7 +53,7 @@ for dir in */; do
     dirname=${dir%/}
     basename=$(basename "$dirname")
     zip -r -q "${basename}.zip" "$dirname"
+    echo "    🍣 Zipped $dirname"
     rm -rf "$dirname"
 done
-
-
+echo "🍱 Finished zipping!"

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Download Artifacts Script
+#
+# This script downloads build artifacts from a GitHub Actions run and processes them
+# for the GitHub Release upload. It requires:
+#   - GitHub CLI (gh) to be installed and authenticated
+#   - Two arguments:
+#     1. Target path where artifacts should be downloaded
+#     2. GitHub Actions run ID to download artifacts from
+#
+# Example usage:
+#   ./download-artifacts.sh 2024.10.2 1234567890
+#
+# The script will:
+# 1. Create the target directory if it doesn't exist
+# 2. Download all artifacts from the specified GitHub Actions run
+# 3. Process the artifacts by zipping them with the same name as the folder
+
+
+# Check if required arguments are provided
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <path> <github_run_id>"
+    exit 1
+fi
+
+# Store arguments
+TARGET_PATH="$1"
+GITHUB_RUN_ID="$2"
+
+# Create target directory if it doesn't exist
+mkdir -p "$TARGET_PATH"
+
+# Change to target directory
+cd "$TARGET_PATH" || exit 1
+
+# Download artifacts using GitHub CLI
+echo "Downloading artifacts from GitHub run $GITHUB_RUN_ID..."
+#gh run download "$GITHUB_RUN_ID"
+
+# Process downloaded artifacts
+for dir in */; do
+if [ -d "$dir" ]; then
+    # Remove trailing slash from directory name
+    dirname=${dir%/}
+    # Get just the folder name without the path
+    basename=$(basename "$dirname")
+    echo $dirname $basename
+    # Create zip file with same name as directory
+    zip -r "${basename}.zip" "$dirname"
+    # Remove the original directory
+    rm -rf "$dirname"
+fi
+done
+
+

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -48,11 +48,9 @@ for dir in */; do
     if [ ! -d "$dir" ]; then
         continue
     fi
-    echo $dir
     # Remove trailing slash from directory name
     dirname=${dir%/}
     basename=$(basename "$dirname")
-    echo $dirname $basename
     zip -r -q "${basename}.zip" "$dirname"
     rm -rf "$dirname"
 done

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -17,39 +17,44 @@
 # 3. Process the artifacts by zipping them with the same name as the folder
 
 
-# Check if required arguments are provided
 if [ $# -ne 2 ]; then
     echo "Usage: $0 <path> <github_run_id>"
     exit 1
 fi
 
-# Store arguments
 TARGET_PATH="$1"
 GITHUB_RUN_ID="$2"
 
-# Create target directory if it doesn't exist
 mkdir -p "$TARGET_PATH"
 
-# Change to target directory
 cd "$TARGET_PATH" || exit 1
 
-# Download artifacts using GitHub CLI
 echo "Downloading artifacts from GitHub run $GITHUB_RUN_ID..."
-#gh run download "$GITHUB_RUN_ID"
+gh run download "$GITHUB_RUN_ID"
+
+# Output downloaded files
+file_count=$(find . -type f | wc -l)
+if [ "$file_count" -eq 0 ]; then
+    echo "No files downloaded, processing skipped."
+    exit 0
+fi
+
+echo "Downloaded $file_count file(s)."
+echo "Downloaded files:"
+find . -type f
 
 # Process downloaded artifacts
 for dir in */; do
-if [ -d "$dir" ]; then
+    if [ ! -d "$dir" ]; then
+        continue
+    fi
+    echo $dir
     # Remove trailing slash from directory name
     dirname=${dir%/}
-    # Get just the folder name without the path
     basename=$(basename "$dirname")
     echo $dirname $basename
-    # Create zip file with same name as directory
     zip -r "${basename}.zip" "$dirname"
-    # Remove the original directory
     rm -rf "$dirname"
-fi
 done
 
 

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -29,21 +29,22 @@ mkdir -p "$TARGET_PATH"
 
 cd "$TARGET_PATH" || exit 1
 
-echo "Downloading artifacts from GitHub run $GITHUB_RUN_ID..."
+echo "🏃‍♂️💨 Downloading artifacts from GitHub run $GITHUB_RUN_ID..."
 gh run download "$GITHUB_RUN_ID"
 
 # Output downloaded files
 file_count=$(find . -type f | wc -l)
 if [ "$file_count" -eq 0 ]; then
-    echo "No files downloaded, processing skipped."
+    echo "👀 No files downloaded, processing skipped."
     exit 0
 fi
 
-echo "Downloaded $file_count file(s)."
+echo "🎉 Downloaded $file_count file(s)."
 echo "Downloaded files:"
 find . -type f
 
 # Process downloaded artifacts
+echo "📦 Zipping artifacts"
 for dir in */; do
     if [ ! -d "$dir" ]; then
         continue

--- a/Scripts/download-artifacts.sh
+++ b/Scripts/download-artifacts.sh
@@ -53,7 +53,7 @@ for dir in */; do
     dirname=${dir%/}
     basename=$(basename "$dirname")
     zip -r -q "${basename}.zip" "$dirname"
-    echo "    🍣 Zipped $dirname"
+    echo "    🍣 Created $basename.zip"
     rm -rf "$dirname"
 done
 echo "🍱 Finished zipping!"


### PR DESCRIPTION
## 🎟️ Tracking

PM-11598

## 📔 Objective

Started as a fix for iOS artifacts upload, ended up as bigger revamp of the GitHub Release creation workflow. Improvements:

1. Gets Version info from run artifacts
2. Replaced third-party action with GH CLI
3. Automated notes now handle tags in unconnected branches (ie, release branches with cherry picks 🍒 ⛏️ )
4. Run artifacts are now zipped and properly uploaded
5. 🍥 Logs  

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
