### PR TITLE
PM-14167: fixed a crash when user try to delete hidden custom fields

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCustomFields/AddEditCustomFieldsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCustomFields/AddEditCustomFieldsView.swift
@@ -34,7 +34,7 @@ struct AddEditCustomFieldsView: View {
                         passwordVisibilityAccessibilityId: "HiddenCustomFieldShowValueButton",
                         canViewPassword: true,
                         isPasswordVisible: store.binding(
-                            get: \.customFields[index].isPasswordVisible,
+                            get: { _ in field.isPasswordVisible },
                             send: { flag in
                                 AddEditCustomFieldsAction.togglePasswordVisibilityChanged(flag, index)
                             }
@@ -46,7 +46,7 @@ struct AddEditCustomFieldsView: View {
                 case .boolean:
                     HStack(spacing: 16) {
                         Toggle(field.name ?? "", isOn: store.binding(
-                            get: \.customFields[index].booleanValue,
+                            get: { _ in field.booleanValue },
                             send: { flag in
                                 AddEditCustomFieldsAction.booleanFieldChanged(flag, index)
                             }
@@ -63,7 +63,7 @@ struct AddEditCustomFieldsView: View {
                             Picker(selection:
                                 store.binding(
                                     get: { state in
-                                        if let idType = state.customFields[index].linkedIdType ??
+                                        if let idType = field.linkedIdType ??
                                             LinkedIdType.getLinkedIdType(for: state.cipherType).first {
                                             return idType
                                         } else {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This will fix a crash when user tries to delete a ```hidden``` custom field from the vault item, the crash only happens on physical device, not reproducible on simulator.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
