### PR TITLE
[PM-12991] Don't show delete on edit screen if user can't delete

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -261,7 +261,9 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             let ownershipOptions = try await services.vaultRepository
                 .fetchCipherOwnershipOptions(includePersonal: !isPersonalOwnershipDisabled)
 
-            state.collections = try await services.vaultRepository.fetchCollections(includeReadOnly: false)
+            // We need read-only collections so that we can include them in the state
+            // to correctly calculate if the item can be deleted
+            state.collections = try await services.vaultRepository.fetchCollections(includeReadOnly: true)
             // Filter out any collection IDs that aren't included in the fetched collections.
             state.collectionIds = state.collectionIds.filter { collectionId in
                 state.collections.contains(where: { $0.id == collectionId })

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -117,9 +117,10 @@ struct CipherItemState: Equatable {
     }
 
     /// The list of collections that can be selected from for the current owner.
+    /// These are collections that the user can add items to, so they are non-read-only collections.
     var collectionsForOwner: [CollectionView] {
         guard let owner, !owner.isPersonal else { return [] }
-        return collections.filter { $0.organizationId == owner.organizationId }
+        return collections.filter { $0.organizationId == owner.organizationId && !$0.readOnly }
     }
 
     /// The folder this item should be added to.

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -114,4 +114,21 @@ class CipherItemStateTests: BitwardenTestCase {
         ]
         XCTAssertTrue(state.canBeDeleted)
     }
+
+    /// `collectionsForOwner` contains collections that are not read-only
+    func test_collectionsForOwner() throws {
+        let cipher = CipherView.loginFixture(
+            collectionIds: ["1", "2", "3"],
+            login: .fixture(),
+            organizationId: "Org1"
+        )
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        state.ownershipOptions = [.organization(id: "Org1", name: "Organization 1")]
+        state.collections = [
+            CollectionView.fixture(id: "1", organizationId: "Org1", manage: true, readOnly: false),
+            CollectionView.fixture(id: "2", organizationId: "Org1", manage: false, readOnly: false),
+            CollectionView.fixture(id: "3", organizationId: "Org1", manage: false, readOnly: true),
+        ]
+        XCTAssertEqual(state.collectionsForOwner.map(\.id), ["1", "2"])
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-15419

## 📔 Objective

This is a defect on https://github.com/bitwarden/ios/pull/1130

There was an issue where we were showing the Delete button on the Edit Item screen even when a user didn't have Manage permissions for the collection that item was in. This was because when finding relevant collections, we were explicitly only getting ones that weren't readonly—which meant that when computing whether or not the user could delete the item, it would look like the item wasn't in any collections, which means it can be deleted. This updates the logic for getting those collections to include readonly collections.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
