### PR TITLE
PM-14172: Remove alert controller tint

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/Alert.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/Alert.swift
@@ -104,7 +104,6 @@ public class Alert {
         alertTextFields.forEach { alertTextField in
             alert.addTextField { textField in
                 textField.placeholder = alertTextField.placeholder
-                textField.tintColor = Asset.Colors.tintPrimary.color
                 textField.keyboardType = alertTextField.keyboardType
                 textField.isSecureTextEntry = alertTextField.isSecureTextEntry
                 textField.autocapitalizationType = alertTextField.autocapitalizationType
@@ -131,7 +130,6 @@ public class Alert {
                 alert.preferredAction = action
             }
         }
-        alert.view.tintColor = Asset.Colors.tintPrimary.color
 
         return alert
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-14172](https://bitwarden.atlassian.net/browse/PM-14172)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the custom tint color applied to alerts so that they use the system blue.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <img width="568" alt="Screenshot 2024-12-04 at 3 13 18 PM" src="https://github.com/user-attachments/assets/679f00ba-7945-437a-8da4-e4ec84c7581c"> | <img width="568" alt="Screenshot 2024-12-04 at 3 14 13 PM" src="https://github.com/user-attachments/assets/93328bb5-ced9-4751-9a37-8c521acea910"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
