### PR TITLE
Fix how CI main invokes simulator build

### DIFF
--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -129,7 +129,8 @@ jobs:
     needs: resolve-values
     uses: bitwarden/ios/.github/workflows/build.yml@main
     with:
-      build-variant: Simulator
+      build-variant: Production
+      build-mode: Simulator
       build-version: ${{ needs.resolve-values.outputs.version_name }}
       build-number: ${{ needs.resolve-values.outputs.version_number }}
       xcode-version: ${{ needs.resolve-values.outputs.xcode_version }}


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-9375

## 📔 Objective

When building the [previous PR for this](https://github.com/bitwarden/ios/pull/1151), changes were made over time to how `CI - main` would invoke the Simulator build, but we missed the split of variant and mode into two properties. This fixes that invocation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
