### PR TITLE
PM-15388: Remove plus button from navigation bars on screens which have a FAB

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
@@ -5,19 +5,6 @@ import SwiftUI
 extension View {
     // MARK: Buttons
 
-    /// Returns a toolbar button configured for adding an item.
-    ///
-    /// - Parameters:
-    ///   - hidden: Whether to hide the toolbar item.
-    ///   - action: The action to perform when the button is tapped.
-    /// - Returns: A `Button` configured for adding an item.
-    ///
-    func addToolbarButton(hidden: Bool = false, action: @escaping () -> Void) -> some View {
-        toolbarButton(asset: Asset.Images.plus24, label: Localizations.add, action: action)
-            .hidden(hidden)
-            .accessibilityIdentifier("AddItemButton")
-    }
-
     /// Returns a toolbar button configured for cancelling an operation in a view.
     ///
     /// - Parameter action: The action to perform when the button is tapped.
@@ -132,19 +119,6 @@ extension View {
     }
 
     // MARK: Toolbar Items
-
-    /// A `ToolbarItem` for views with an add button.
-    ///
-    /// - Parameters:
-    ///   - hidden: Whether to hide the toolbar item.
-    ///   - action: The action to perform when the add button is tapped.
-    /// - Returns: A `ToolbarItem` with an add button.
-    ///
-    func addToolbarItem(hidden: Bool = false, _ action: @escaping () -> Void) -> some ToolbarContent {
-        ToolbarItem(placement: .topBarTrailing) {
-            addToolbarButton(hidden: hidden, action: action)
-        }
-    }
 
     /// A `ToolbarItem` for views with a cancel text button.
     ///

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersView.swift
@@ -23,11 +23,6 @@ struct FoldersView: View {
             }
         }
         .navigationBar(title: Localizations.folders, titleDisplayMode: .inline)
-        .toolbar {
-            addToolbarItem {
-                store.send(.add)
-            }
-        }
         .overlay(alignment: .bottomTrailing) {
             addItemFloatingActionButton {
                 store.send(.add)

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/FoldersViewTests.swift
@@ -29,15 +29,7 @@ class FoldersViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// Tapping the add button dispatches the `.add` action.
-    @MainActor
-    func test_addButton_tap() throws {
-        let button = try subject.inspect().find(button: Localizations.add)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .add)
-    }
-
-    /// Tapping the new folder floating acrtion button dispatches the `.add` action.`
+    /// Tapping the new folder floating action button dispatches the `.add` action.`
     @MainActor
     func test_addItemFloatingActionButton_tap() throws {
         let fab = try subject.inspect().find(viewWithAccessibilityIdentifier: "AddItemFloatingActionButton")

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -239,10 +239,6 @@ struct SendListView: View {
                         .frame(minHeight: 44)
                     }
                 }
-
-                addToolbarItem {
-                    store.send(.addItemPressed)
-                }
             }
             .toast(
                 store.binding(

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListViewTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListViewTests.swift
@@ -29,14 +29,6 @@ class SendListViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// Tapping the add an item button dispatches the `.addItemPressed` action.
-    @MainActor
-    func test_addItemButton_tap() throws {
-        let button = try subject.inspect().find(button: Localizations.add)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed)
-    }
-
     /// Tapping the add item floating acrtion button dispatches the `.addItemPressed` action.`
     @MainActor
     func test_additemFloatingActionButton_tap() throws {

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListAction.swift
@@ -6,7 +6,7 @@ import BitwardenSdk
 ///
 enum VaultAutofillListAction: Equatable {
     /// The add button was tapped.
-    case addTapped(fromToolbar: Bool)
+    case addTapped(fromFAB: Bool)
 
     /// The cancel button was tapped.
     case cancelTapped

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -108,7 +108,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
             username: fido2CredentialNewView.userName
         )
 
-        subject.receive(.addTapped(fromToolbar: true))
+        subject.receive(.addTapped(fromFAB: true))
 
         XCTAssertEqual(
             coordinator.routes.last,
@@ -130,7 +130,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
         fido2UserInterfaceHelper.checkUserResult = .success(CheckUserResult(userPresent: true, userVerified: true))
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         waitFor(fido2UserInterfaceHelper.pickedCredentialForCreationMocker.called)
 
@@ -162,7 +162,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
         fido2UserInterfaceHelper.checkUserResult = .success(CheckUserResult(userPresent: true, userVerified: false))
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         waitFor(fido2UserInterfaceHelper.pickedCredentialForCreationMocker.called)
 
@@ -194,7 +194,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
         fido2UserInterfaceHelper.checkUserResult = .failure(BitwardenTestError.example)
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         waitFor(!errorReporter.errors.isEmpty)
 
@@ -216,7 +216,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
         fido2UserInterfaceHelper.checkUserResult = .failure(UserVerificationError.cancelled)
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         waitFor(fido2UserInterfaceHelper.checkUserCalled)
 
@@ -231,7 +231,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         let fido2CredentialNewView = Fido2CredentialNewView.fixture(userName: "username", rpName: "rpName")
         fido2UserInterfaceHelper.fido2CredentialNewView = fido2CredentialNewView
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         waitFor(!coordinator.alertShown.isEmpty)
 
@@ -253,7 +253,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
             requireVerification: .required
         )
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         waitFor(!coordinator.alertShown.isEmpty)
 

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -147,11 +147,11 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
 
     override func receive(_ action: VaultAutofillListAction) {
         switch action {
-        case let .addTapped(fromToolbar):
+        case let .addTapped(fromFAB):
             state.profileSwitcherState.setIsVisible(false)
 
             guard #available(iOSApplicationExtension 17.0, *),
-                  !fromToolbar,
+                  !fromFAB,
                   let autofillAppExtensionDelegate,
                   autofillAppExtensionDelegate.isCreatingFido2Credential else {
                 coordinator.navigate(

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
@@ -282,7 +282,7 @@ class VaultAutofillListProcessorTests: BitwardenTestCase { // swiftlint:disable:
     /// `receive(_:)` with `.addTapped` navigates to the add item view.
     @MainActor
     func test_receive_addTapped() {
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         XCTAssertEqual(
             coordinator.routes.last,
@@ -295,7 +295,7 @@ class VaultAutofillListProcessorTests: BitwardenTestCase { // swiftlint:disable:
     func test_receive_addTapped_hidesProfileSwitcher() {
         subject.state.profileSwitcherState.isVisible = true
 
-        subject.receive(.addTapped(fromToolbar: false))
+        subject.receive(.addTapped(fromFAB: false))
 
         XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
     }
@@ -303,7 +303,7 @@ class VaultAutofillListProcessorTests: BitwardenTestCase { // swiftlint:disable:
     /// `receive(_:)` with `.addTapped` navigates to the add item view when adding from toolbar.
     @MainActor
     func test_receive_addTapped_fromToolbar() {
-        subject.receive(.addTapped(fromToolbar: true))
+        subject.receive(.addTapped(fromFAB: true))
 
         XCTAssertEqual(
             coordinator.routes.last,
@@ -316,7 +316,7 @@ class VaultAutofillListProcessorTests: BitwardenTestCase { // swiftlint:disable:
     func test_receive_addTapped_hidesProfileSwitcher_fromToolbar() {
         subject.state.profileSwitcherState.isVisible = true
 
-        subject.receive(.addTapped(fromToolbar: true))
+        subject.receive(.addTapped(fromFAB: true))
 
         XCTAssertFalse(subject.state.profileSwitcherState.isVisible)
     }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -45,10 +45,6 @@ struct VaultAutofillListView: View {
                     )
                 )
             }
-
-            addToolbarItem(hidden: !store.state.showAddItemButton) {
-                store.send(.addTapped(fromToolbar: true))
-            }
         }
     }
 
@@ -213,7 +209,7 @@ private struct VaultAutofillListSearchableView: View {
                             EmptyView()
                         } else {
                             Button {
-                                store.send(.addTapped(fromToolbar: false))
+                                store.send(.addTapped(fromFAB: false))
                             } label: {
                                 Label {
                                     Text(store.state.emptyViewButtonText)
@@ -233,7 +229,7 @@ private struct VaultAutofillListSearchableView: View {
             }
             .overlay(alignment: .bottomTrailing) {
                 addItemFloatingActionButton {
-                    store.send(.addTapped(fromToolbar: false))
+                    store.send(.addTapped(fromFAB: true))
                 }
             }
             .hidden(isSearching)

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListViewTests.swift
@@ -32,20 +32,12 @@ class VaultAutofillListViewTests: BitwardenTestCase { // swiftlint:disable:this 
 
     // MARK: Tests
 
-    /// Tapping the add an item button dispatches the `.addTapped` action.
-    @MainActor
-    func test_addItemButton_tap() throws {
-        let button = try subject.inspect().find(button: Localizations.add)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addTapped(fromToolbar: true))
-    }
-
-    /// Tapping the add item floating acrtion button dispatches the `.addItemPressed` action.`
+    /// Tapping the add item floating action button dispatches the `.addItemPressed` action.`
     @MainActor
     func test_addItemFloatingActionButton_tap() throws {
         let fab = try subject.inspect().find(viewWithAccessibilityIdentifier: "AddItemFloatingActionButton")
         try fab.button().tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addTapped(fromToolbar: false))
+        XCTAssertEqual(processor.dispatchedActions.last, .addTapped(fromFAB: true))
     }
 
     /// Tapping the add an item button dispatches the `.addTapped` action.
@@ -56,7 +48,7 @@ class VaultAutofillListViewTests: BitwardenTestCase { // swiftlint:disable:this 
         processor.state.emptyViewButtonText = Localizations.savePasskeyAsNewLogin
         let button = try subject.inspect().find(button: Localizations.savePasskeyAsNewLogin)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addTapped(fromToolbar: false))
+        XCTAssertEqual(processor.dispatchedActions.last, .addTapped(fromFAB: false))
     }
 
     /// Tapping the cancel button dispatches the `.cancelTapped` action.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -33,12 +33,6 @@ struct VaultGroupView: View {
             .navigationTitle(store.state.group.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
             .background(Asset.Colors.backgroundPrimary.swiftUIColor.ignoresSafeArea())
-            .toolbar {
-                // Using this state here temporarily until we remove the toolbar button.
-                addToolbarItem(hidden: !store.state.showAddItemFloatingActionButton) {
-                    store.send(.addItemPressed)
-                }
-            }
             .task {
                 await store.perform(.appeared)
             }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupViewTests.swift
@@ -56,15 +56,6 @@ class VaultGroupViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed)
     }
 
-    /// Tapping the add an item toolbar button dispatches the `.addItemPressed` action.
-    @MainActor
-    func test_addAnItemToolbarButton_tap() throws {
-        processor.state.loadingState = .data([])
-        let button = try subject.inspect().find(button: Localizations.add)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed)
-    }
-
     /// Tapping a vault item dispatches the `.itemPressed` action.
     @MainActor
     func test_vaultItem_tap() throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
@@ -45,10 +45,6 @@ struct VaultItemSelectionView: View {
                     )
                 )
             }
-
-            addToolbarItem {
-                store.send(.addTapped)
-            }
         }
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionViewTests.swift
@@ -33,15 +33,7 @@ class VaultItemSelectionViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// Tapping the add an item button dispatches the `.addTapped` action.
-    @MainActor
-    func test_addItemButton_tap() throws {
-        let button = try subject.inspect().find(button: Localizations.add)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addTapped)
-    }
-
-    /// Tapping the add item floating acrtion button dispatches the `.addTapped` action.`
+    /// Tapping the add item floating action button dispatches the `.addTapped` action.`
     @MainActor
     func test_addFloatingActionButton_tap() throws {
         let fab = try subject.inspect().find(viewWithAccessibilityIdentifier: "AddItemFloatingActionButton")

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -326,9 +326,6 @@ struct VaultListView: View {
                     )
                 )
             }
-            addToolbarItem {
-                store.send(.addItemPressed)
-            }
         }
         .task {
             await store.perform(.refreshAccountProfiles)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListViewTests.swift
@@ -50,15 +50,6 @@ class VaultListViewTests: BitwardenTestCase { // swiftlint:disable:this type_bod
 
     // MARK: Tests
 
-    /// Tapping the add item button dispatches the `.addItemPressed` action.
-    @MainActor
-    func test_addItemButton_tap() throws {
-        processor.state.loadingState = .data([])
-        let button = try subject.inspect().find(button: Localizations.add)
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed)
-    }
-
     /// Tapping the add the new login button dispatches the `.addItemPressed` action.
     @MainActor
     func test_newLoginButton_tap() throws {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-15388](https://bitwarden.atlassian.net/browse/PM-15388)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the plus button from the navigation bar on screens where the FAB was previously added.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
| --- | --- |
| <img width="568" alt="Screenshot 2024-12-05 at 10 32 38 AM" src="https://github.com/user-attachments/assets/b5124aff-f2cb-4cea-8340-7bf5b1935493"> | <img width="568" alt="Screenshot 2024-12-05 at 10 32 08 AM" src="https://github.com/user-attachments/assets/99b93076-2dc8-495e-9e6a-78fca27af210"> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-15388]: https://bitwarden.atlassian.net/browse/PM-15388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ