### PR TITLE
PM-15435: Use TOTP manual entry in extension when camera isn't supported

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -707,7 +707,9 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     /// Kicks off the TOTP setup flow.
     ///
     private func setupTotp() async {
-        guard services.cameraService.deviceSupportsCamera() else {
+        guard services.cameraService.deviceSupportsCamera(),
+              appExtensionDelegate?.isInAppExtension != true // Extensions don't allow camera access.
+        else {
             coordinator.navigate(to: .setupTotpManual, context: self)
             return
         }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -1381,6 +1381,16 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .setupTotpManual)
     }
 
+    /// `perform(_:)` with `.setupTotpPressed` when in the app extension navigates to the
+    /// `.setupTotpManual` route.
+    @MainActor
+    func test_perform_setupTotpPressed_extension() async {
+        appExtensionDelegate.isInAppExtension = true
+        await subject.perform(.setupTotpPressed)
+
+        XCTAssertEqual(coordinator.routes.last, .setupTotpManual)
+    }
+
     /// `receive(_:)` with `authKeyVisibilityTapped` updates the value in the state.
     @MainActor
     func test_receive_authKeyVisibilityTapped() {

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinator.swift
@@ -48,6 +48,9 @@ final class AuthenticatorKeyCaptureCoordinator: Coordinator, HasStackNavigator {
 
     // MARK: Private Properties
 
+    /// A delegate used to communicate with the app extension.
+    private weak var appExtensionDelegate: AppExtensionDelegate?
+
     /// A delegate that responds to events in this coordinator.
     private weak var delegate: AuthenticatorKeyCaptureDelegate?
 
@@ -64,15 +67,18 @@ final class AuthenticatorKeyCaptureCoordinator: Coordinator, HasStackNavigator {
     /// Creates a new `AuthenticatorKeyCaptureCoordinator`.
     ///
     /// - Parameters:
+    ///   - appExtensionDelegate: A delegate used to communicate with the app extension.
     ///   - delegate: An optional delegate that responds to events in this coordinator.
     ///   - services: The services used by this coordinator.
     ///   - stackNavigator: The stack navigator that is managed by this coordinator.
     ///
     init(
+        appExtensionDelegate: AppExtensionDelegate?,
         delegate: AuthenticatorKeyCaptureDelegate?,
         services: Services,
         stackNavigator: StackNavigator
     ) {
+        self.appExtensionDelegate = appExtensionDelegate
         self.delegate = delegate
         self.services = services
         self.stackNavigator = stackNavigator
@@ -168,11 +174,13 @@ final class AuthenticatorKeyCaptureCoordinator: Coordinator, HasStackNavigator {
     /// Shows the totp manual setup screen.
     ///
     private func showManualTotp() {
+        let deviceSupportsCamera = services.cameraService.deviceSupportsCamera() &&
+            appExtensionDelegate?.isInAppExtension != true  // Extensions don't allow camera access.
         let processor = ManualEntryProcessor(
             coordinator: asAnyCoordinator(),
             services: services,
             state: DefaultEntryState(
-                deviceSupportsCamera: services.cameraService.deviceSupportsCamera()
+                deviceSupportsCamera: deviceSupportsCamera
             )
         )
         let view = ManualEntryView(

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
@@ -201,6 +201,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     private func showCamera(delegate: AuthenticatorKeyCaptureDelegate) async {
         let navigationController = UINavigationController()
         let coordinator = AuthenticatorKeyCaptureCoordinator(
+            appExtensionDelegate: appExtensionDelegate,
             delegate: delegate,
             services: services,
             stackNavigator: navigationController
@@ -339,6 +340,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     private func showManualTotp(delegate: AuthenticatorKeyCaptureDelegate) {
         let navigationController = UINavigationController()
         let coordinator = AuthenticatorKeyCaptureCoordinator(
+            appExtensionDelegate: appExtensionDelegate,
             delegate: delegate,
             services: services,
             stackNavigator: navigationController


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-15435](https://bitwarden.atlassian.net/browse/PM-15435)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The camera isn't supported in iOS extensions. Previously, if the Set up TOTP button was tapped on the add vault item screen in the autofill extension, the camera feed would show as all black. This adds a check to redirect the user to the manual TOTP entry view instead of using the camera when in the extension.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/dab53c1f-79de-4571-bc8a-787089589c62

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
