### PR TITLE
[PM-14800] Fix importCxf so it doesn't break build in non-debug builds.

### DIFF
--- a/BitwardenShared/Core/Tools/Services/Temp/ClientExportersProtocol+Extensions.swift
+++ b/BitwardenShared/Core/Tools/Services/Temp/ClientExportersProtocol+Extensions.swift
@@ -27,7 +27,7 @@ extension ClientExporters: ClientExportersServiceTemp {
     }
 
     func importCxf(payload: String) throws -> [BitwardenSdk.Cipher] {
-        [.fixture(), .fixture()]
+        []
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-14800

## 📔 Objective

Fix CI build on release because it was using `fixture` from DEBUG builds which was breaking.
Changed the fixtures array to be empty; it will be updated in a future PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
