### PR TITLE
[PM-15996] [BEEEP] PoC Implement Autofill vault filter for favorites/folders.

### DIFF
--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
@@ -35,6 +35,8 @@ protocol SettingsRepository: AnyObject {
     /// Get the current value of the allow sync on refresh value.
     func getAllowSyncOnRefresh() async throws -> Bool
 
+    func getAutofillFilter() async throws -> AutofillFilter
+
     /// Get the current value of the connect to watch setting.
     func getConnectToWatch() async throws -> Bool
 
@@ -61,6 +63,8 @@ protocol SettingsRepository: AnyObject {
     /// - Parameter allowSyncOnRefresh: Whether the vault should sync on refreshing.
     ///
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws
+
+    func updateAutofillFilter(_ filter: AutofillFilter) async throws
 
     /// Update the cached value of the connect to watch setting.
     ///
@@ -179,6 +183,14 @@ extension DefaultSettingsRepository: SettingsRepository {
         try await stateService.getAllowSyncOnRefresh()
     }
 
+    func getAutofillFilter() async throws -> AutofillFilter {
+        let filter = try await stateService.getAutofillFilter()
+        guard let filter else {
+            return AutofillFilter(idType: .none)
+        }
+        return filter
+    }
+
     func getConnectToWatch() async throws -> Bool {
         try await stateService.getConnectToWatch()
     }
@@ -201,6 +213,14 @@ extension DefaultSettingsRepository: SettingsRepository {
 
     func updateAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
         try await stateService.setAllowSyncOnRefresh(allowSyncOnRefresh)
+    }
+
+    func updateAutofillFilter(_ filter: AutofillFilter) async throws {
+        guard filter.idType != .none else {
+            try await stateService.setAutofillFilter(nil)
+            return
+        }
+        try await stateService.setAutofillFilter(filter)
     }
 
     func updateConnectToWatch(_ connectToWatch: Bool) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -129,6 +129,8 @@ protocol StateService: AnyObject {
     /// - Returns: The app theme.
     ///
     func getAppTheme() async -> AppTheme
+    
+    func getAutofillFilter(userId: String?) async throws -> AutofillFilter?
 
     /// Get the active user's Biometric Authentication Preference.
     ///
@@ -442,6 +444,8 @@ protocol StateService: AnyObject {
     /// - Parameter appTheme: The new app theme.
     ///
     func setAppTheme(_ appTheme: AppTheme) async
+    
+    func setAutofillFilter(_ filter: AutofillFilter?, userId: String?) async throws
 
     /// Sets the user's Biometric Authentication Preference.
     ///
@@ -822,6 +826,10 @@ extension StateService {
     func getAppRehydrationState() async throws -> AppRehydrationState? {
         try await getAppRehydrationState(userId: nil)
     }
+    
+    func getAutofillFilter() async throws -> AutofillFilter? {
+        try await getAutofillFilter(userId: nil)
+    }
 
     /// Gets the clear clipboard value for the active account.
     ///
@@ -1049,6 +1057,10 @@ extension StateService {
     ///
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool) async throws {
         try await setAllowSyncOnRefresh(allowSyncOnRefresh, userId: nil)
+    }
+    
+    func setAutofillFilter(_ filter: AutofillFilter?) async throws {
+        try await setAutofillFilter(filter, userId: nil)
     }
 
     /// Sets the clear clipboard value for the active account.
@@ -1425,6 +1437,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         AppTheme(appSettingsStore.appTheme)
     }
 
+    func getAutofillFilter(userId: String?) async throws -> AutofillFilter? {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.autofillFilter(userId: userId)
+    }
+
     func getClearClipboardValue(userId: String?) async throws -> ClearClipboardValue {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.clearClipboardValue(userId: userId)
@@ -1686,6 +1703,11 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
     func setAppTheme(_ appTheme: AppTheme) async {
         appSettingsStore.appTheme = appTheme.value
         appThemeSubject.send(appTheme)
+    }
+    
+    func setAutofillFilter(_ filter: AutofillFilter?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setAutofillFilter(filter, userId: userId)
     }
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -93,6 +93,8 @@ protocol AppSettingsStore: AnyObject {
     /// - Parameter userId: The user ID associated with this state.
     /// - Returns: The rehydration state.
     func appRehydrationState(userId: String) -> AppRehydrationState?
+    
+    func autofillFilter(userId: String) -> AutofillFilter?
 
     /// Gets the time after which the clipboard should be cleared.
     ///
@@ -283,6 +285,8 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the sync on refresh setting.
     ///
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool?, userId: String)
+    
+    func setAutofillFilter(_ filter: AutofillFilter?, userId: String)
 
     /// Sets the user's Biometric Authentication Preference.
     ///
@@ -677,6 +681,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case accountSetupVaultUnlock(userId: String)
         case addSitePromptShown
         case allowSyncOnRefresh(userId: String)
+        case autofillFilter(userId: String)
         case appId
         case appLocale
         case appRehydrationState(userId: String)
@@ -734,6 +739,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "addSitePromptShown"
             case let .allowSyncOnRefresh(userId):
                 key = "syncOnRefresh_\(userId)"
+            case let .autofillFilter(userId):
+                key = "autofillFilter_\(userId)"
             case .appId:
                 key = "appId"
             case .appLocale:
@@ -924,6 +931,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
     func appRehydrationState(userId: String) -> AppRehydrationState? {
         fetch(for: .appRehydrationState(userId: userId))
     }
+    
+    func autofillFilter(userId: String) -> AutofillFilter? {
+        fetch(for: .autofillFilter(userId: userId))
+    }
 
     func clearClipboardValue(userId: String) -> ClearClipboardValue {
         if let rawValue: Int = fetch(for: .clearClipboardValue(userId: userId)),
@@ -1025,6 +1036,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setAllowSyncOnRefresh(_ allowSyncOnRefresh: Bool?, userId: String) {
         store(allowSyncOnRefresh, for: .allowSyncOnRefresh(userId: userId))
+    }
+    
+    func setAutofillFilter(_ filter: AutofillFilter?, userId: String) {
+        store(filter, for: .autofillFilter(userId: userId))
     }
 
     func setAppRehydrationState(_ state: AppRehydrationState?, userId: String) {

--- a/BitwardenShared/Core/Platform/Utilities/AutofillFilter.swift
+++ b/BitwardenShared/Core/Platform/Utilities/AutofillFilter.swift
@@ -1,0 +1,28 @@
+import BitwardenSdk
+
+struct AutofillFilter: Menuable, Codable {
+    var idType: AutofillFilterType
+    var folderName: String?
+
+    var localizedName: String {
+        switch idType {
+        case .none:
+            "None"
+        case .favorites:
+            Localizations.favorites
+        case .folder:
+            folderName ?? "Unknown"
+        }
+    }
+
+    init(idType: AutofillFilterType, folderName: String? = nil) {
+        self.idType = idType
+        self.folderName = folderName
+    }
+}
+
+enum AutofillFilterType: Equatable, Hashable, Codable {
+    case none
+    case favorites
+    case folder(Uuid)
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
@@ -5,6 +5,9 @@
 enum AutoFillAction: Equatable {
     /// The app extension button was tapped.
     case appExtensionTapped
+    
+    /// The autofill filter was changed.
+    case autofillFilterChanged(AutofillFilter)
 
     /// The default URI match type was changed.
     case defaultUriMatchTypeChanged(UriMatchType)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
@@ -5,6 +5,13 @@
 struct AutoFillState {
     // MARK: Properties
 
+    var autofillFilter: AutofillFilter = AutofillFilter(idType: .none)
+
+    var autofillFilterOptions: [AutofillFilter] = [
+        AutofillFilter(idType: .none),
+        AutofillFilter(idType: .favorites)
+    ]
+
     /// The state of the badges in the settings tab.
     var badgeState: SettingsBadgeState?
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -90,6 +90,21 @@ struct AutoFillView: View {
                     .styleGuide(.subheadline)
                     .foregroundColor(Color(asset: Asset.Colors.textSecondary))
             }
+
+            VStack(spacing: 2) {
+                SettingsMenuField(
+                    title: "Autofill vault filter",
+                    options: store.state.autofillFilterOptions,
+                    hasDivider: false,
+                    selection: store.binding(
+                        get: \.autofillFilter,
+                        send: AutoFillAction.autofillFilterChanged
+                    )
+                )
+                .cornerRadius(10)
+                .padding(.bottom, 8)
+                .accessibilityIdentifier("AutofillFilterChooser")
+            }
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15996](https://bitwarden.atlassian.net/browse/PM-15996)

## 📔 Objective

Add an additional setting to set a filter for the Autofill extension. So one can let the Autofill extension work with the whole vault, only favorite items or items belonging only to a specific folder. This is to decrease the likelihood of a crash because of memory pressure on the extension.

## 📸 Screenshots

To be added.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
