### PR TITLE
[PM-8216] Add Change Email and Set Up Two-Factor URLs

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlData.swift
@@ -61,9 +61,14 @@ struct EnvironmentUrlData: Codable, Equatable, Hashable {
 extension EnvironmentUrlData {
     // MARK: Properties
 
+    /// The URL for the user to change their email.
+    var changeEmailURL: URL? {
+        subpageURL(additionalPath: "settings/account")
+    }
+
     /// The base url for importing items.
     var importItemsURL: URL? {
-        subpageUrl(additionalPath: "tools/import")
+        subpageURL(additionalPath: "tools/import")
     }
 
     /// Whether all of the environment URLs are not set.
@@ -78,8 +83,8 @@ extension EnvironmentUrlData {
     }
 
     /// The URL for the recovery code help page.
-    var recoveryCodeUrl: URL? {
-        subpageUrl(additionalPath: "recover-2fa")
+    var recoveryCodeURL: URL? {
+        subpageURL(additionalPath: "recover-2fa")
     }
 
     /// Gets the region depending on the base url.
@@ -99,12 +104,17 @@ extension EnvironmentUrlData {
         guard region != .unitedStates else {
             return URL(string: "https://send.bitwarden.com/#")!
         }
-        return subpageUrl(additionalPath: "send")
+        return subpageURL(additionalPath: "send")
     }
 
     /// The base url for the settings screen.
     var settingsURL: URL? {
-        subpageUrl(additionalPath: "settings")
+        subpageURL(additionalPath: "settings")
+    }
+
+    /// The URL to set up two-factor login.
+    var setUpTwoFactorURL: URL? {
+        subpageURL(additionalPath: "settings/security/two-factor")
     }
 
     /// The host of URL to the user's web vault.
@@ -119,7 +129,7 @@ extension EnvironmentUrlData {
     ///
     /// - Parameters:
     ///   - additionalPath: The additional path string to append to the vault's base URL
-    private func subpageUrl(additionalPath: String) -> URL? {
+    private func subpageURL(additionalPath: String) -> URL? {
         // Foundation's URL appending methods percent encode the path component that is passed into the method,
         // which includes the `#` symbol. Since the `#` character is a critical portion of these urls, we use String
         // concatenation to get around this limitation.

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlDataTests.swift
@@ -5,6 +5,27 @@ import XCTest
 class EnvironmentUrlDataTests: XCTestCase {
     // MARK: Tests
 
+    /// `changeEmailURL` returns the change email URL for the base URL.
+    func test_changeEmailURL_baseURL() {
+        let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
+        XCTAssertEqual(subject.changeEmailURL?.absoluteString, "https://vault.example.com/#/settings/account")
+    }
+
+    /// `changeEmailURL` returns the default change email base URL.
+    func test_changeEmailURL_noURLs() {
+        let subject = EnvironmentUrlData(base: nil, webVault: nil)
+        XCTAssertNil(subject.changeEmailURL?.absoluteString)
+    }
+
+    /// `changeEmailURL` returns the change email URL for the web vault URL.
+    func test_changeEmailURL_webVaultURL() {
+        let subject = EnvironmentUrlData(
+            base: URL(string: "https://vault.example.com"),
+            webVault: URL(string: "https://web.vault.example.com")
+        )
+        XCTAssertEqual(subject.changeEmailURL?.absoluteString, "https://web.vault.example.com/#/settings/account")
+    }
+
     /// `defaultUS` returns the properly configured `EnvironmentUrlData`
     /// with the deafult Urls for united states region.
     func test_defaultUS() {
@@ -39,19 +60,19 @@ class EnvironmentUrlDataTests: XCTestCase {
         )
     }
 
-    /// `importItemsURL` returns the import items url for the base url.
+    /// `importItemsURL` returns the import items URL for the base URL.
     func test_importItemsURL_baseURL() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
         XCTAssertEqual(subject.importItemsURL?.absoluteString, "https://vault.example.com/#/tools/import")
     }
 
-    /// `importItemsURL` returns the default import items base url.
+    /// `importItemsURL` returns the default import items base URL.
     func test_importItemsURL_noURLs() {
         let subject = EnvironmentUrlData(base: nil, webVault: nil)
         XCTAssertNil(subject.importItemsURL?.absoluteString)
     }
 
-    /// `importItemsURL` returns the import items url for the web vault url.
+    /// `importItemsURL` returns the import items URL for the web vault URL.
     func test_importItemsURL_webVaultURL() {
         let subject = EnvironmentUrlData(
             base: URL(string: "https://vault.example.com"),
@@ -76,49 +97,70 @@ class EnvironmentUrlDataTests: XCTestCase {
         XCTAssertFalse(EnvironmentUrlData(webVault: .example).isEmpty)
     }
 
-    /// `region` returns `.unitedStates` if base url is the same as the default for US.
+    /// `recoveryCodeURL` returns the recovery code URL for the base URL.
+    func test_recoveryCodeURL_baseURL() {
+        let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
+        XCTAssertEqual(subject.recoveryCodeURL?.absoluteString, "https://vault.example.com/#/recover-2fa")
+    }
+
+    /// `recoveryCodeURL` returns the default settings base URL.
+    func test_recoveryCodeURL_noURLs() {
+        let subject = EnvironmentUrlData(base: nil, webVault: nil)
+        XCTAssertNil(subject.recoveryCodeURL?.absoluteString)
+    }
+
+    /// `recoveryCodeURL` returns the settings URL for the web vault URL.
+    func test_recoveryCodeURL_webVaultURL() {
+        let subject = EnvironmentUrlData(
+            base: URL(string: "https://vault.example.com"),
+            webVault: URL(string: "https://web.vault.example.com")
+        )
+        XCTAssertEqual(subject.recoveryCodeURL?.absoluteString, "https://web.vault.example.com/#/recover-2fa")
+    }
+
+    /// `region` returns `.unitedStates` if base URL is the same as the default for US.
     func test_region_unitedStates() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.com")!)
         XCTAssertTrue(subject.region == .unitedStates)
     }
 
-    /// `region` returns `.europe` if base url is the same as the default for EU.
+    /// `region` returns `.europe` if base URL is the same as the default for EU.
     func test_region_europe() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.bitwarden.eu")!)
         XCTAssertTrue(subject.region == .europe)
     }
 
-    /// `region` returns `.selfHosted` if base url is neither the default for US nor for EU.
+    /// `region` returns `.selfHosted` if base URL is neither the default for US nor for EU.
     func test_region_selfHost() {
         let subject = EnvironmentUrlData(base: URL(string: "https://example.com")!)
         XCTAssertTrue(subject.region == .selfHosted)
     }
 
-    /// `sendShareURL` returns the send url for the united states region.
+    /// `sendShareURL` returns the send URL for the united states region.
     func test_sendShareURL_unitedStates() {
         let subject = EnvironmentUrlData.defaultUS
         XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://send.bitwarden.com/#")
     }
 
-    /// `sendShareURL` returns the send url for the europe region.
+    /// `sendShareURL` returns the send URL for the europe region.
     func test_sendShareURL_europe() {
         let subject = EnvironmentUrlData.defaultEU
         XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://vault.bitwarden.eu/#/send")
     }
 
-    /// `sendShareURL` returns the send url for the base url.
+    /// `sendShareURL` returns the send URL for the base URL.
     func test_sendShareURL_baseURL() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
         XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://vault.example.com/#/send")
     }
 
-    /// `sendShareURL` returns the default send base url.
+    /// `sendShareURL` returns the default send base URL.
     func test_sendShareURL_noURLs() {
         let subject = EnvironmentUrlData(base: nil, webVault: nil)
         XCTAssertNil(subject.sendShareURL?.absoluteString)
     }
 
-    /// `sendShareURL` returns the send url for the web vault url.
+    /// `sendShareURL` returns the send URL for the web vault URL.
     func test_sendShareURL_webVaultURL() {
         let subject = EnvironmentUrlData(
             base: URL(string: "https://vault.example.com"),
@@ -127,25 +169,46 @@ class EnvironmentUrlDataTests: XCTestCase {
         XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://web.vault.example.com/#/send")
     }
 
-    /// `settingsURL` returns the settings url for the base url.
+    /// `settingsURL` returns the settings URL for the base URL.
     func test_settingsURL_baseURL() {
         let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
         XCTAssertEqual(subject.settingsURL?.absoluteString, "https://vault.example.com/#/settings")
     }
 
-    /// `settingsURL` returns the default settings base url.
+    /// `settingsURL` returns the default settings base URL.
     func test_settingsURL_noURLs() {
         let subject = EnvironmentUrlData(base: nil, webVault: nil)
         XCTAssertNil(subject.settingsURL?.absoluteString)
     }
 
-    /// `settingsURL` returns the settings url for the web vault url.
+    /// `settingsURL` returns the settings URL for the web vault URL.
     func test_settingsURL_webVaultURL() {
         let subject = EnvironmentUrlData(
             base: URL(string: "https://vault.example.com"),
             webVault: URL(string: "https://web.vault.example.com")
         )
         XCTAssertEqual(subject.settingsURL?.absoluteString, "https://web.vault.example.com/#/settings")
+    }
+
+    /// `setUpTwoFactorURL` returns the change email URL for the base URL.
+    func test_setUpTwoFactorURL_baseURL() {
+        let subject = EnvironmentUrlData(base: URL(string: "https://vault.example.com"))
+        XCTAssertEqual(subject.setUpTwoFactorURL?.absoluteString, "https://vault.example.com/#/settings/security/two-factor")
+    }
+
+    /// `setUpTwoFactorURL` returns the default change email base URL.
+    func test_setUpTwoFactorURL_noURLs() {
+        let subject = EnvironmentUrlData(base: nil, webVault: nil)
+        XCTAssertNil(subject.setUpTwoFactorURL?.absoluteString)
+    }
+
+    /// `setUpTwoFactorURL` returns the change email URL for the web vault URL.
+    func test_setUpTwoFactorURL_webVaultURL() {
+        let subject = EnvironmentUrlData(
+            base: URL(string: "https://vault.example.com"),
+            webVault: URL(string: "https://web.vault.example.com")
+        )
+        XCTAssertEqual(subject.setUpTwoFactorURL?.absoluteString, "https://web.vault.example.com/#/settings/security/two-factor")
     }
 
     /// `webVaultHost` returns the host for the base URL if no web vault URL is set.

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrls.swift
@@ -11,6 +11,9 @@ struct EnvironmentUrls: Equatable {
     /// The base URL.
     let baseURL: URL
 
+    /// The URL for changing email address.
+    let changeEmailURL: URL
+
     /// The URL for the events API.
     let eventsURL: URL
 
@@ -31,6 +34,9 @@ struct EnvironmentUrls: Equatable {
 
     /// The URL for vault settings.
     let settingsURL: URL
+
+    /// The URL for setting up two-factor login.
+    let setUpTwoFactorURL: URL
 
     /// The URL for the web vault.
     let webVaultURL: URL
@@ -65,10 +71,12 @@ extension EnvironmentUrls {
             webVaultURL = environmentUrlData.webVault ?? URL(string: "https://vault.bitwarden.com")!
         }
         importItemsURL = environmentUrlData.importItemsURL ?? URL(string: "https://vault.bitwarden.com/#/tools/import")!
-        recoveryCodeURL = environmentUrlData.recoveryCodeUrl ?? URL(
+        recoveryCodeURL = environmentUrlData.recoveryCodeURL ?? URL(
             string: "https://vault.bitwarden.com/#/recover-2fa"
         )!
         sendShareURL = environmentUrlData.sendShareURL ?? URL(string: "https://send.bitwarden.com/#")!
         settingsURL = environmentUrlData.settingsURL ?? webVaultURL
+        changeEmailURL = environmentUrlData.changeEmailURL ?? settingsURL
+        setUpTwoFactorURL = environmentUrlData.setUpTwoFactorURL ?? settingsURL
     }
 }

--- a/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/EnvironmentUrlsTests.swift
@@ -15,6 +15,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://api.bitwarden.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden.com/#/settings/account")!,
                 eventsURL: URL(string: "https://events.bitwarden.com")!,
                 iconsURL: URL(string: "https://icons.bitwarden.net")!,
                 identityURL: URL(string: "https://identity.bitwarden.com")!,
@@ -22,6 +23,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://send.bitwarden.com/#")!,
                 settingsURL: URL(string: "https://vault.bitwarden.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://vault.bitwarden.com")!
             )
         )
@@ -37,6 +39,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://api.bitwarden.eu")!,
                 baseURL: URL(string: "https://vault.bitwarden.eu")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden.eu/#/settings/account")!,
                 eventsURL: URL(string: "https://events.bitwarden.eu")!,
                 iconsURL: URL(string: "https://icons.bitwarden.eu")!,
                 identityURL: URL(string: "https://identity.bitwarden.eu")!,
@@ -44,6 +47,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.eu/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://vault.bitwarden.eu/#/send")!,
                 settingsURL: URL(string: "https://vault.bitwarden.eu/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden.eu/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://vault.bitwarden.eu")!
             )
         )
@@ -60,6 +64,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://example.com/api")!,
                 baseURL: URL(string: "https://example.com")!,
+                changeEmailURL: URL(string: "https://example.com/#/settings/account")!,
                 eventsURL: URL(string: "https://example.com/events")!,
                 iconsURL: URL(string: "https://example.com/icons")!,
                 identityURL: URL(string: "https://example.com/identity")!,
@@ -67,6 +72,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://example.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://example.com/#/send")!,
                 settingsURL: URL(string: "https://example.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://example.com/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://example.com")!
             )
         )
@@ -82,6 +88,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://api.bitwarden.eu")!,
                 baseURL: URL(string: "https://vault.bitwarden.eu")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden.eu/#/settings/account")!,
                 eventsURL: URL(string: "https://events.bitwarden.eu")!,
                 iconsURL: URL(string: "https://icons.bitwarden.eu")!,
                 identityURL: URL(string: "https://identity.bitwarden.eu")!,
@@ -89,6 +96,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.eu/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://vault.bitwarden.eu/#/send")!,
                 settingsURL: URL(string: "https://vault.bitwarden.eu/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden.eu/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://vault.bitwarden.eu")!
             )
         )
@@ -104,6 +112,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://api.bitwarden.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden.com/#/settings/account")!,
                 eventsURL: URL(string: "https://events.bitwarden.com")!,
                 iconsURL: URL(string: "https://icons.bitwarden.net")!,
                 identityURL: URL(string: "https://identity.bitwarden.com")!,
@@ -111,6 +120,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://send.bitwarden.com/#")!,
                 settingsURL: URL(string: "https://vault.bitwarden.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://vault.bitwarden.com")!
             )
         )
@@ -126,6 +136,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://example.com/api")!,
                 baseURL: URL(string: "https://example.com/")!,
+                changeEmailURL: URL(string: "https://example.com/#/settings/account")!,
                 eventsURL: URL(string: "https://example.com/events")!,
                 iconsURL: URL(string: "https://example.com/icons")!,
                 identityURL: URL(string: "https://example.com/identity")!,
@@ -133,6 +144,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://example.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://example.com/#/send")!,
                 settingsURL: URL(string: "https://example.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://example.com/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://example.com/")!
             )
         )
@@ -154,6 +166,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://api.example.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
+                changeEmailURL: URL(string: "https://example.com/#/settings/account")!,
                 eventsURL: URL(string: "https://events.example.com")!,
                 iconsURL: URL(string: "https://icons.example.com")!,
                 identityURL: URL(string: "https://identity.example.com")!,
@@ -161,6 +174,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://example.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://example.com/#/send")!,
                 settingsURL: URL(string: "https://example.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://example.com/#/settings/security/two-factor")!,
                 webVaultURL: URL(string: "https://example.com")!
             )
         )
@@ -174,6 +188,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
             EnvironmentUrls(
                 apiURL: URL(string: "https://api.bitwarden.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden.com")!,
                 eventsURL: URL(string: "https://events.bitwarden.com")!,
                 iconsURL: URL(string: "https://icons.bitwarden.net")!,
                 identityURL: URL(string: "https://identity.bitwarden.com")!,
@@ -181,6 +196,7 @@ class EnvironmentUrlsTests: BitwardenTestCase {
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://send.bitwarden.com/#")!,
                 settingsURL: URL(string: "https://vault.bitwarden.com")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden.com")!,
                 webVaultURL: URL(string: "https://vault.bitwarden.com")!
             )
         )

--- a/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
@@ -12,6 +12,9 @@ protocol EnvironmentService {
     /// The environment's base URL.
     var baseURL: URL { get }
 
+    /// The URL for changing email address.
+    var changeEmailURL: URL { get }
+
     /// The URL for the events API.
     var eventsURL: URL { get }
 
@@ -35,6 +38,9 @@ protocol EnvironmentService {
 
     /// The URL for vault settings.
     var settingsURL: URL { get }
+
+    /// The URL for setting up two-factor login.
+    var setUpTwoFactorURL: URL { get }
 
     /// The URL for the web vault.
     var webVaultURL: URL { get }
@@ -152,6 +158,10 @@ extension DefaultEnvironmentService {
         environmentUrls.baseURL
     }
 
+    var changeEmailURL: URL {
+        environmentUrls.changeEmailURL
+    }
+
     var eventsURL: URL {
         environmentUrls.eventsURL
     }
@@ -188,6 +198,10 @@ extension DefaultEnvironmentService {
 
     var settingsURL: URL {
         environmentUrls.settingsURL
+    }
+
+    var setUpTwoFactorURL: URL {
+        environmentUrls.setUpTwoFactorURL
     }
 
     var webVaultURL: URL {

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -41,13 +41,18 @@ class EnvironmentServiceTests: XCTestCase {
     /// The default US URLs are returned if the URLs haven't been loaded.
     func test_defaultUrls() {
         XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .unitedStates)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
     }
 
@@ -61,13 +66,17 @@ class EnvironmentServiceTests: XCTestCase {
         await subject.loadURLsForActiveAccount()
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://example.com/api"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://example.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://example.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://example.com/events"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://example.com/icons"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://example.com/identity"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://example.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://example.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .selfHosted)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://example.com/#/send"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://example.com/#/settings"))
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://example.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://example.com"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, urls)
 
@@ -85,13 +94,18 @@ class EnvironmentServiceTests: XCTestCase {
         await subject.loadURLsForActiveAccount()
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.eu"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.eu"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.eu/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.eu"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.eu"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.eu"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.eu/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.eu/#/recover-2fa"))
         XCTAssertEqual(subject.region, .europe)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.bitwarden.eu/#/send"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.eu/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.eu/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.eu"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, urls)
 
@@ -110,13 +124,18 @@ class EnvironmentServiceTests: XCTestCase {
 
         let urls = try EnvironmentUrlData(base: XCTUnwrap(URL(string: "https://vault.example.com")))
         XCTAssertEqual(subject.apiURL, URL(string: "https://vault.example.com/api"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.example.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.example.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://vault.example.com/events"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://vault.example.com/icons"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://vault.example.com/identity"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.example.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.example.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .selfHosted)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.example.com/#/send"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.example.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.example.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.example.com"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, urls)
     }
@@ -135,13 +154,18 @@ class EnvironmentServiceTests: XCTestCase {
         await subject.loadURLsForActiveAccount()
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .unitedStates)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
 
         let urls = try EnvironmentUrlData(base: XCTUnwrap(URL(string: "https://vault.example.com")))
@@ -154,13 +178,18 @@ class EnvironmentServiceTests: XCTestCase {
         await subject.loadURLsForActiveAccount()
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .unitedStates)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, .defaultUS)
 
@@ -177,13 +206,18 @@ class EnvironmentServiceTests: XCTestCase {
         await subject.loadURLsForActiveAccount()
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://example.com/api"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://example.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://example.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://example.com/events"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://example.com/icons"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://example.com/identity"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://example.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://example.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .selfHosted)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://example.com/#/send"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://example.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://example.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://example.com"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, urls)
 
@@ -198,13 +232,18 @@ class EnvironmentServiceTests: XCTestCase {
         await subject.setPreAuthURLs(urls: urls)
 
         XCTAssertEqual(subject.apiURL, URL(string: "https://example.com/api"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://example.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://example.com/#/settings/account"))
         XCTAssertEqual(subject.eventsURL, URL(string: "https://example.com/events"))
         XCTAssertEqual(subject.iconsURL, URL(string: "https://example.com/icons"))
         XCTAssertEqual(subject.identityURL, URL(string: "https://example.com/identity"))
         XCTAssertEqual(subject.importItemsURL, URL(string: "https://example.com/#/tools/import"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://example.com/#/recover-2fa"))
         XCTAssertEqual(subject.region, .selfHosted)
         XCTAssertEqual(subject.sendShareURL, URL(string: "https://example.com/#/send"))
         XCTAssertEqual(subject.settingsURL, URL(string: "https://example.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://example.com/#/settings/security/two-factor"))
         XCTAssertEqual(subject.webVaultURL, URL(string: "https://example.com"))
         XCTAssertEqual(stateService.preAuthEnvironmentUrls, urls)
         XCTAssertEqual(errorReporter.region?.region, "Self-Hosted")

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockEnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockEnvironmentService.swift
@@ -9,6 +9,7 @@ class MockEnvironmentService: EnvironmentService {
 
     var apiURL = URL(string: "https://example.com/api")!
     var baseURL = URL(string: "https://example.com")!
+    var changeEmailURL = URL(string: "https://example.com/#/settings/account")!
     var eventsURL = URL(string: "https://example.com/events")!
     var iconsURL = URL(string: "https://example.com/icons")!
     var identityURL = URL(string: "https://example.com/identity")!
@@ -17,6 +18,7 @@ class MockEnvironmentService: EnvironmentService {
     var region = RegionType.selfHosted
     var sendShareURL = URL(string: "https://example.com/#/send")!
     var settingsURL = URL(string: "https://example.com/#/settings")!
+    var setUpTwoFactorURL = URL(string: "https://example.com/#/settings/security/two-factor")!
     var webVaultURL = URL(string: "https://example.com")!
 
     func loadURLsForActiveAccount() async {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8216

## 📔 Objective

This adds additional URLs to the Environment Service, Environment URLs, and Environment URL Data objects for 1) changing email (which is currently just the account screen) and 2) setting up two-factor authentication. These will be used by new screens in the future.

This also adds new tests to backfill some gaps in our test coverage.

This also does a bit of minor refactoring to unify casing structure inside each of these classes to follow the [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/), which suggests that "URL" should be capitalized inside of properties and function names. Ideally we would also change `EnvironmentUrls` and `EnvironmentUrlData` to `EnvironmentURLs` and `EnvironmentURLData` for this as well, but I wasn't sure if that was too big a change for this PR. If sentiment is towards ripping that bandaid off now, I can do that additionally.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
