### PR TITLE
[PM-11598] chore: Add version overrides to GitHub Release workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -89,17 +89,29 @@ jobs:
         run: ./Scripts/download-artifacts.sh $ARTIFACTS_PATH $ARTIFACT_RUN_ID
 
       - name: Parse version info
+        env:
+          _VERSION_NAME: ${{ inputs.version-name }}
+          _VERSION_NUMBER: ${{ inputs.version-number }}
         id: version_info
         run: |
           if [ ! -f ARTIFACTS_PATH/version_info.zip ]; then
             echo "::warning::version-version.zip not found. Confirm why the build workflow skipped uploading it."
-            if [[ -z "$version_name" || -z "$version_number" ]]; then
-              echo "::error::version-info.json not found and version-name/version-number are empty. Cannot proceed with release."
-              exit 1
+
+            version_name="$_VERSION_NAME"
+            version_number="$_VERSION_NUMBER"
+            if [[ -z "$_VERSION_NAME" ]]; then
+              echo "::warning::version name override input is empty. Using default value."
+              version_name="0.0.0"
+            fi
+
+            if [[ -z "$_VERSION_NUMBER" ]]; then
+              echo "::warning::version number override input is empty. Using default value."
+              version_number="0"
             fi
 
             echo "version_number=$version_number" >> $GITHUB_OUTPUT
             echo "version_name=$version_name" >> $GITHUB_OUTPUT
+            echo "Version: $version_name ($version_number)"
             exit 0
           fi
 

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -7,6 +7,14 @@ on:
         description: 'GitHub Action Run ID containing artifacts'
         required: true
         type: string
+      version-name:
+        description: 'Version Name Override - E.g. "2024.11.1"'
+        required: true
+        type: string
+      version-number:
+        description: 'Version Number Override - E.g. "123456"'
+        required: true
+        type: string
       draft:
         description: 'Create as draft release'
         type: boolean
@@ -83,6 +91,19 @@ jobs:
       - name: Parse version info
         id: version_info
         run: |
+          if [ ! -f ARTIFACTS_PATH/version_info.zip ]; then
+            echo "::warning::version-version.zip not found. Confirm why the build workflow skipped uploading it."
+            if [[ -z "$version_name" || -z "$version_number" ]]; then
+              echo "::error::version-info.json not found and version-name/version-number are empty. Cannot proceed with release."
+              exit 1
+            fi
+
+            echo "version_number=$version_number" >> $GITHUB_OUTPUT
+            echo "version_name=$version_name" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # version-info.zip was found, extracting info
           unzip -o "$ARTIFACTS_PATH/version-info.zip" -d "tmp"
           filepath="tmp/version-info/version_info.json"
           version_name=$(jq -r '.version_name' "$filepath")

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -165,10 +165,19 @@ jobs:
           RELEASE_BRANCH: ${{ steps.get_release_branch.outputs.release_branch }}
           LAST_RELEASE_TAG: ${{ steps.get_last_tag.outputs.last_release_id }}
           RELEASE_URL: ${{ steps.update_release_description.outputs.release_url }}
+          VERSION_NAME: ${{ steps.version_info.outputs.version_name }}
+          VERSION_NUMBER: ${{ steps.version_info.outputs.version_number }}
         run: |
           echo "# :fish_cake: Release ready at:" >> $GITHUB_STEP_SUMMARY
           echo "$RELEASE_URL" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [[ "$VERSION_NAME" == "0.0.0" || "$VERSION_NUMBER" == "0" ]]; then
+            echo "> [!CAUTION]" >> $GITHUB_STEP_SUMMARY
+            echo "> Version name or number wasn't previously found and a default value was used. You'll need to manually update the release Title, Tag and Description, specifically, the "Full Changelog" link." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
           echo ":clipboard: Confirm that the defined GitHub Release options are correct:"  >> $GITHUB_STEP_SUMMARY
           echo " * :bookmark: New tag name: \`$RELEASE_TAG\`" >> $GITHUB_STEP_SUMMARY
           echo " * :palm_tree: Target branch: \`$RELEASE_BRANCH\`" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11598](https://bitwarden.atlassian.net/browse/PM-11598)

## 📔 Objective

Adds version input overrides to GitHub Release workflows, enabling 🛹 stake holders to continue the release process when the build workflow doesn't provide the version-info file. If nothing is provided we'll fallback to 0.0.0 (0).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11598]: https://bitwarden.atlassian.net/browse/PM-11598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ