### PR TITLE
[PM-16211] chore(ci): Fix hotfix branch creation workflow by retrieving the last tag across all branches

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -10,10 +10,6 @@ on:
         options:
           - RC
           - Hotfix
-      rc_prefix_date:
-        description: 'RC - Prefix with date. E.g. 2024.11-rc1'
-        type: boolean
-        default: true
 
 jobs:
   create-release-branch:
@@ -23,14 +19,14 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
 
       - name: Create RC Branch
         if: inputs.release_type == 'RC'
         env:
-          RC_PREFIX_DATE: ${{ inputs.rc_prefix_date }}
+          RC_PREFIX_DATE: "true" # replace with input if needed
         run: |
           if [ "$RC_PREFIX_DATE" = "true" ]; then
             current_date=$(date +'%Y.%m')
@@ -46,12 +42,17 @@ jobs:
       - name: Create Hotfix Branch
         if: inputs.release_type == 'Hotfix'
         run: |
-          latest_tag=$(git describe --tags --abbrev=0)
+          latest_tag=$(git tag -l --sort=-creatordate | head -n 1)
           if [ -z "$latest_tag" ]; then
             echo "::error::No tags found in the repository"
             exit 1
           fi
           branch_name="release/hotfix-${latest_tag}"
+          echo "🌿 branch name: $branch_name"
+          if git show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
+            echo "# :fire: :warning: Hotfix branch already exists: ${branch_name}" >> $GITHUB_STEP_SUMMARY
+            exit 0
+          fi
           git switch -c $branch_name $latest_tag
           git push origin $branch_name
           echo "# :fire: Hotfix branch: ${branch_name}" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 🎟️ Tracking

PM-16211

## 📔 Objective

The previous method to retrieve the last release git tag only worked when all tags are in the main branch. We'll now get the last tag across all branches.

While at it removed the rc prefix input which won't be used in this repo.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
