### PR TITLE
PM-16239: Fix tap area of SecondaryButtonStyle

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Appearance/Styles/SecondaryButtonStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Styles/SecondaryButtonStyle.swift
@@ -48,6 +48,7 @@ struct SecondaryButtonStyle: ButtonStyle {
                 Capsule()
                     .strokeBorder(borderColor, lineWidth: 1.5)
             }
+            .contentShape(Capsule())
             .clipShape(Capsule())
             .opacity(configuration.isPressed ? 0.5 : 1)
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-16239](https://bitwarden.atlassian.net/browse/PM-16239)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an issue where the secondary button style wasn't receiving tap events when tapping on the transparent background area of the button.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16239]: https://bitwarden.atlassian.net/browse/PM-16239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ