### PR TITLE
[BEEEP] Fix intermittently failing tests

### DIFF
--- a/BitwardenShared/UI/Vault/Utilities/HasTOTPCodesSections.swift
+++ b/BitwardenShared/UI/Vault/Utilities/HasTOTPCodesSections.swift
@@ -1,4 +1,5 @@
 /// A protocol to work with processors that have TOTP sections.
+@MainActor
 protocol HasTOTPCodesSections {
     /// The repository used by the application to manage vault data for the UI layer.
     var vaultRepository: VaultRepository { get }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -1,4 +1,4 @@
-@preconcurrency import AuthenticationServices
+import AuthenticationServices
 @preconcurrency import BitwardenSdk
 
 // MARK: - VaultAutofillListProcessor

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -1,4 +1,4 @@
-import AuthenticationServices
+@preconcurrency import AuthenticationServices
 @preconcurrency import BitwardenSdk
 
 // MARK: - VaultAutofillListProcessor


### PR DESCRIPTION
## 📔 Objective

The tests `VaultAutofillListProcessorTotpTests.test_refreshTOTPCodes_searchItems()` and `VaultAutofillListProcessorTotpTests.test_refreshTOTPCodes_searchItemsEmpty()` have had race conditions causing intermittent failures, particularly on CI.

The ultimate issue is that `VaultAutofillListProcessor.refreshTOTPCodes(searchItems:)` calls out to `HasTOTPCodesSections.refreshTOTPCodes(for:in:using:)`, which is a nonisolating function, to get a new value of `state.ciphersForSearch`. However, the tests—which are `@MainActor`—rely on waiting for a call being made inside that nonisolating function. Sometimes the test would pick up that change before execution would go back to the `.refreshTOTPCodes(searchItems:)` to get assigned to the variable, so the test was checking the variable's value before the assignment was done and execution completed.

With `SWIFT_STRICT_CONCURRENCY = complete;` set in a configuration file, however, the call in `VautAutofillListProcessor` gives a warning on line 312 (the call to `refreshTOTPCodes(for:in:using:)`):

> Sending main actor-isolated value of type '(any TOTPExpirationManager)?' with later accesses to nonisolated context risks causing data races; this is an error in the Swift 6 language mode

So, marking the protocol as `@MainActor` means that it runs on the main actor, and avoids switching execution contexts (since the `VaultAutofillListProcessor` is `@MainActor` because it inherits ultimately from `Processor`). This seems reasonable since it's meant to be a protocol extension to abstract out common execution behavior between multiple processors.

There are a number of other concurrency warnings in `VaultAutofillListProcessor` and `HasTOTPCodesSections` still—and this change just moves the execution context switch to `vaultRepository.refreshTOTPCodes`, since the `VaultRepository` is currently nonisolated. We'll probably want to work at clearing those up eventually.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
