### PR TITLE
[PM-16686] Update copyrights to be dynamic

### DIFF
--- a/Bitwarden/Application/Support/Settings.bundle/Acknowledgements/SwiftLint.plist
+++ b/Bitwarden/Application/Support/Settings.bundle/Acknowledgements/SwiftLint.plist
@@ -8,7 +8,7 @@
 			<key>FooterText</key>
 			<string>The MIT License (MIT)
 
-Copyright (c) 2020 Realm Inc.
+Copyright (c) 2025 Realm Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/BitwardenShared/UI/Platform/Application/Extensions/String.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/String.swift
@@ -22,6 +22,9 @@ enum URLDecodingError: Error, Equatable {
 extension String {
     // MARK: Type Properties
 
+    /// En-dashes are used to represent number ranges. https://en.wikipedia.org/wiki/Dash#En_dash
+    static let enDash = "\u{2013}"
+
     /// Double paragraph breaks to show the next line of text separated by a blank line.
     static let newLine = "\n\n"
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
@@ -158,7 +158,7 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             pasteboardService.copiedString,
             """
-            © Bitwarden Inc. 2015-2024
+            © Bitwarden Inc. 2015-2025
 
             Version: 2024.6.0 (1)
             📱 iPhone14,2 🍏 iOS 16.4 📦 Production
@@ -181,7 +181,7 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             pasteboardService.copiedString,
             """
-            © Bitwarden Inc. 2015-2024
+            © Bitwarden Inc. 2015-2025
 
             Version: 2024.6.0 (1)
             📱 iPhone14,2 🍏 iOS 16.4 📦 Production
@@ -207,7 +207,7 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             pasteboardService.copiedString,
             """
-            © Bitwarden Inc. 2015-2024
+            © Bitwarden Inc. 2015-2025
 
             Version: 2024.6.0 (1)
             📱 iPhone14,2 🍏 iOS 16.4 📦 Production

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
@@ -158,7 +158,7 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             pasteboardService.copiedString,
             """
-            © Bitwarden Inc. 2015-2025
+            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
 
             Version: 2024.6.0 (1)
             📱 iPhone14,2 🍏 iOS 16.4 📦 Production
@@ -181,7 +181,7 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             pasteboardService.copiedString,
             """
-            © Bitwarden Inc. 2015-2025
+            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
 
             Version: 2024.6.0 (1)
             📱 iPhone14,2 🍏 iOS 16.4 📦 Production
@@ -207,7 +207,7 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             pasteboardService.copiedString,
             """
-            © Bitwarden Inc. 2015-2025
+            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
 
             Version: 2024.6.0 (1)
             📱 iPhone14,2 🍏 iOS 16.4 📦 Production

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutState.swift
@@ -9,7 +9,7 @@ struct AboutState {
     var appReviewUrl: URL?
 
     /// The copyright text.
-    var copyrightText = "© Bitwarden Inc. 2015-\(Calendar.current.component(.year, from: Date.now))"
+    var copyrightText = "© Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))"
 
     /// Whether the submit crash logs toggle is on.
     var isSubmitCrashLogsToggleOn: Bool = false


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16686

## 📔 Objective

Some tests were failing because of hardcoded copyright strings set to 2024. This updates them to be dynamic. Along with this is an update to copyright in the acknowledgements bundle, along with updating to use an en-dash in the year range.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
