### PR TITLE
PM-16551: Prevent debug menu from being opened on itself

### DIFF
--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -33,6 +33,9 @@ class AppCoordinator: Coordinator, HasRootNavigator {
     /// The coordinator currently being displayed.
     private var childCoordinator: AnyObject?
 
+    /// Whether the debug menu is currently being shown.
+    private(set) var isShowingDebugMenu = false
+
     // MARK: Properties
 
     /// The module to use for creating child coordinators.
@@ -308,12 +311,14 @@ class AppCoordinator: Coordinator, HasRootNavigator {
     /// Presents the navigation controller and triggers haptic feedback upon completion.
     ///
     private func showDebugMenu() {
+        guard !isShowingDebugMenu else { return }
+
         let feedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
         feedbackGenerator.prepare()
         let stackNavigator = UINavigationController()
         stackNavigator.navigationBar.prefersLargeTitles = true
         stackNavigator.modalPresentationStyle = .fullScreen
-        let debugMenuCoordinator = module.makeDebugMenuCoordinator(stackNavigator: stackNavigator)
+        let debugMenuCoordinator = module.makeDebugMenuCoordinator(delegate: self, stackNavigator: stackNavigator)
         debugMenuCoordinator.start()
 
         rootNavigator?.rootViewController?.topmostViewController().present(
@@ -321,6 +326,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             animated: true,
             completion: { feedbackGenerator.impactOccurred() }
         )
+        isShowingDebugMenu = true
     }
 }
 
@@ -359,6 +365,14 @@ extension AppCoordinator: AuthCoordinatorDelegate {
                 self.authCompletionRoute = nil
             }
         }
+    }
+}
+
+// MARK: - DebugMenuCoordinatorDelegate
+
+extension AppCoordinator: DebugMenuCoordinatorDelegate {
+    func didDismissDebugMenu() {
+        isShowingDebugMenu = false
     }
 }
 

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -308,6 +308,33 @@ class AppCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.navigate(to: .debugMenu)
 
         waitFor(module.debugMenuCoordinator.isStarted)
+        XCTAssertTrue(subject.isShowingDebugMenu)
+        XCTAssertTrue(module.debugMenuCoordinatorDelegate === subject)
+    }
+
+    /// `navigate(to:)` with `.debugMenu` doesn't navigate to the debug menu if it is already showing.
+    @MainActor
+    func test_navigateTo_debugMenu_alreadyShowing() throws {
+        subject.navigate(to: .debugMenu)
+
+        XCTAssertTrue(subject.isShowingDebugMenu)
+        XCTAssertTrue(module.debugMenuCoordinatorDelegate === subject)
+
+        let originalDebugMenuCoordinator = module.debugMenuCoordinator
+        let newDebugMenuCoordinator = MockCoordinator<DebugMenuRoute, Void>()
+        module.debugMenuCoordinator = newDebugMenuCoordinator
+
+        // Since the original debug menu is still showing, navigating to it again shouldn't start
+        // the new coordinator.
+        subject.navigate(to: .debugMenu)
+        XCTAssertFalse(newDebugMenuCoordinator.isStarted)
+
+        // Once the original is dismissed, navigating to the debug menu should start the new coordinator.
+        module.debugMenuCoordinatorDelegate?.didDismissDebugMenu()
+        XCTAssertFalse(subject.isShowingDebugMenu)
+
+        subject.navigate(to: .debugMenu)
+        XCTAssertTrue(newDebugMenuCoordinator.isStarted)
     }
 
     /// `navigate(to:)` with `.extensionSetup(.extensionActivation))` starts the extension setup

--- a/BitwardenShared/UI/Platform/Application/AppModuleTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppModuleTests.swift
@@ -57,6 +57,7 @@ class AppModuleTests: BitwardenTestCase {
     func test_makeDebugMenuCoordinator() {
         let navigationController = UINavigationController()
         let coordinator = subject.makeDebugMenuCoordinator(
+            delegate: MockDebugMenuCoordinatorDelegate(),
             stackNavigator: navigationController
         )
         coordinator.start()

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuCoordinator.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuCoordinator.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+/// An object that is notified when the debug menu is dismissed.
+///
+protocol DebugMenuCoordinatorDelegate: AnyObject {
+    /// The debug menu has been dismissed.
+    ///
+    func didDismissDebugMenu()
+}
+
 /// A coordinator that manages navigation for the debug menu.
 ///
 final class DebugMenuCoordinator: Coordinator, HasStackNavigator {
@@ -10,6 +18,9 @@ final class DebugMenuCoordinator: Coordinator, HasStackNavigator {
         & HasErrorReporter
 
     // MARK: Private Properties
+
+    /// The delegate for this coordinator, which is notified when the debug menu is dismissed.
+    private weak var delegate: DebugMenuCoordinatorDelegate?
 
     /// The services used by this coordinator.
     private let services: Services
@@ -24,13 +35,16 @@ final class DebugMenuCoordinator: Coordinator, HasStackNavigator {
     /// Creates a new `DebugMenuCoordinator`.
     ///
     /// - Parameters:
+    ///   - delegate: The delegate for this coordinator, which is notified when the debug menu is dismissed.
     ///   - services: The services used by this coordinator.
     ///   - stackNavigator: The stack navigator that is managed by this coordinator.
     ///
     init(
+        delegate: DebugMenuCoordinatorDelegate,
         services: Services,
         stackNavigator: StackNavigator
     ) {
+        self.delegate = delegate
         self.services = services
         self.stackNavigator = stackNavigator
     }
@@ -43,7 +57,9 @@ final class DebugMenuCoordinator: Coordinator, HasStackNavigator {
     ) {
         switch route {
         case .dismiss:
-            stackNavigator?.dismiss()
+            stackNavigator?.dismiss {
+                self.delegate?.didDismissDebugMenu()
+            }
         }
     }
 

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuCoordinatorTests.swift
@@ -8,6 +8,7 @@ class DebugMenuCoordinatorTests: BitwardenTestCase {
 
     var appSettingsStore: MockAppSettingsStore!
     var configService: MockConfigService!
+    var delegate: MockDebugMenuCoordinatorDelegate!
     var stackNavigator: MockStackNavigator!
     var subject: DebugMenuCoordinator!
 
@@ -18,9 +19,11 @@ class DebugMenuCoordinatorTests: BitwardenTestCase {
 
         appSettingsStore = MockAppSettingsStore()
         configService = MockConfigService()
+        delegate = MockDebugMenuCoordinatorDelegate()
         stackNavigator = MockStackNavigator()
 
         subject = DebugMenuCoordinator(
+            delegate: delegate,
             services: ServiceContainer.withMocks(
                 appSettingsStore: appSettingsStore,
                 configService: configService
@@ -34,6 +37,7 @@ class DebugMenuCoordinatorTests: BitwardenTestCase {
 
         appSettingsStore = nil
         configService = nil
+        delegate = nil
         stackNavigator = nil
         subject = nil
     }
@@ -46,7 +50,8 @@ class DebugMenuCoordinatorTests: BitwardenTestCase {
         subject.navigate(to: .dismiss)
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .dismissed)
+        XCTAssertEqual(action.type, .dismissedWithCompletionHandler)
+        XCTAssertTrue(delegate.didDismissDebugMenuCalled)
     }
 
     /// `start()` correctly shows the `DebugMenuView`.
@@ -55,5 +60,13 @@ class DebugMenuCoordinatorTests: BitwardenTestCase {
         subject.start()
 
         XCTAssertTrue(stackNavigator.actions.last?.view is DebugMenuView)
+    }
+}
+
+class MockDebugMenuCoordinatorDelegate: DebugMenuCoordinatorDelegate {
+    var didDismissDebugMenuCalled = false
+
+    func didDismissDebugMenu() {
+        didDismissDebugMenuCalled = true
     }
 }

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuModule.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuModule.swift
@@ -8,19 +8,23 @@ protocol DebugMenuModule {
     /// Initializes a coordinator for navigating between `DebugMenuRoute`s.
     ///
     /// - Parameters:
+    ///   - delegate: The delegate for the debug menu coordinator.
     ///   - stackNavigator: The stack navigator that will be used to navigate between routes.
     /// - Returns: A coordinator that can navigate to `DebugMenuRoute`s.
     ///
     func makeDebugMenuCoordinator(
+        delegate: DebugMenuCoordinatorDelegate,
         stackNavigator: StackNavigator
     ) -> AnyCoordinator<DebugMenuRoute, Void>
 }
 
 extension DefaultAppModule: DebugMenuModule {
     func makeDebugMenuCoordinator(
+        delegate: DebugMenuCoordinatorDelegate,
         stackNavigator: StackNavigator
     ) -> AnyCoordinator<DebugMenuRoute, Void> {
         DebugMenuCoordinator(
+            delegate: delegate,
             services: services,
             stackNavigator: stackNavigator
         )

--- a/GlobalTestHelpers/MockAppModule.swift
+++ b/GlobalTestHelpers/MockAppModule.swift
@@ -25,6 +25,7 @@ class MockAppModule:
     var authCoordinator = MockCoordinator<AuthRoute, AuthEvent>()
     var authRouter = MockRouter<AuthEvent, AuthRoute>(routeForEvent: { _ in .landing })
     var debugMenuCoordinator = MockCoordinator<DebugMenuRoute, Void>()
+    var debugMenuCoordinatorDelegate: DebugMenuCoordinatorDelegate?
     var extensionSetupCoordinator = MockCoordinator<ExtensionSetupRoute, Void>()
     var fileSelectionDelegate: FileSelectionDelegate?
     var fileSelectionCoordinator = MockCoordinator<FileSelectionRoute, Void>()
@@ -66,9 +67,11 @@ class MockAppModule:
     }
 
     func makeDebugMenuCoordinator(
+        delegate: DebugMenuCoordinatorDelegate,
         stackNavigator: StackNavigator
     ) -> AnyCoordinator<DebugMenuRoute, Void> {
-        debugMenuCoordinator.asAnyCoordinator()
+        debugMenuCoordinatorDelegate = delegate
+        return debugMenuCoordinator.asAnyCoordinator()
     }
 
     func makeExtensionSetupCoordinator(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-16551](https://bitwarden.atlassian.net/browse/PM-16551)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Prevents the debug menu from being presented again if it's already showing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
