### PR TITLE
[PM-8216] Add ignore-environment-check flag to make dev/QA of the two-factor notice easier

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -29,6 +29,11 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// An SDK flag that enables individual cipher encryption.
     case enableCipherKeyEncryption
 
+    /// A flag to ignore the environment check for the two-factor authentication
+    /// notice. If this is on, then it will display even on self-hosted servers,
+    /// which means it's easier to dev/QA the feature.
+    case ignoreEnvironmentCheck = "ignore-environment-check"
+
     /// A feature flag for the import logins flow for new accounts.
     case importLoginsFlow = "import-logins-flow"
 
@@ -107,6 +112,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
         switch self {
         case .enableCipherKeyEncryption,
              .enableDebugAppReviewPrompt,
+             .ignoreEnvironmentCheck,
              .importLoginsFlow,
              .nativeCarouselFlow,
              .nativeCreateAccountFlow,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -32,7 +32,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// A flag to ignore the environment check for the two-factor authentication
     /// notice. If this is on, then it will display even on self-hosted servers,
     /// which means it's easier to dev/QA the feature.
-    case ignoreEnvironmentCheck = "ignore-environment-check"
+    case ignore2FANoticeEnvironmentCheck = "ignore-2fa-notice-environment-check"
 
     /// A feature flag for the import logins flow for new accounts.
     case importLoginsFlow = "import-logins-flow"
@@ -112,7 +112,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
         switch self {
         case .enableCipherKeyEncryption,
              .enableDebugAppReviewPrompt,
-             .ignoreEnvironmentCheck,
+             .ignore2FANoticeEnvironmentCheck,
              .importLoginsFlow,
              .nativeCarouselFlow,
              .nativeCreateAccountFlow,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -33,7 +33,7 @@ final class FeatureFlagTests: BitwardenTestCase {
 
         XCTAssertFalse(FeatureFlag.enableDebugAppReviewPrompt.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.enableCipherKeyEncryption.isRemotelyConfigured)
-        XCTAssertFalse(FeatureFlag.ignoreEnvironmentCheck.isRemotelyConfigured)
+        XCTAssertFalse(FeatureFlag.ignore2FANoticeEnvironmentCheck.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.importLoginsFlow.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.nativeCarouselFlow.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.nativeCreateAccountFlow.isRemotelyConfigured)

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -33,6 +33,7 @@ final class FeatureFlagTests: BitwardenTestCase {
 
         XCTAssertFalse(FeatureFlag.enableDebugAppReviewPrompt.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.enableCipherKeyEncryption.isRemotelyConfigured)
+        XCTAssertFalse(FeatureFlag.ignoreEnvironmentCheck.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.importLoginsFlow.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.nativeCarouselFlow.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.nativeCreateAccountFlow.isRemotelyConfigured)

--- a/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelper.swift
+++ b/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelper.swift
@@ -83,7 +83,7 @@ class DefaultTwoFactorNoticeHelper: TwoFactorNoticeHelper {
             defaultValue: false
         )
         let ignoreEnvironmentCheck = await services.configService.getFeatureFlag(
-            .ignoreEnvironmentCheck,
+            .ignore2FANoticeEnvironmentCheck,
             defaultValue: false
         )
         guard temporary || permanent else { return }

--- a/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelper.swift
+++ b/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelper.swift
@@ -82,9 +82,13 @@ class DefaultTwoFactorNoticeHelper: TwoFactorNoticeHelper {
             .newDeviceVerificationPermanentDismiss,
             defaultValue: false
         )
+        let ignoreEnvironmentCheck = await services.configService.getFeatureFlag(
+            .ignoreEnvironmentCheck,
+            defaultValue: false
+        )
         guard temporary || permanent else { return }
         do {
-            guard services.environmentService.region != .selfHosted else {
+            guard services.environmentService.region != .selfHosted || ignoreEnvironmentCheck else {
                 return
             }
 

--- a/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelperTests.swift
+++ b/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelperTests.swift
@@ -168,6 +168,19 @@ class TwoFactorNoticeHelperTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes, [])
     }
 
+    /// `.maybeShowTwoFactorNotice()` will show the notice
+    /// if the user is self-hosted
+    /// and the "ignore environment check" feature flag is true
+    @MainActor
+    func test_maybeShow_server_selfHosted_ignoreEnvironmentCheck() async {
+        environmentService.region = .selfHosted
+        configService.featureFlagsBool[.ignoreEnvironmentCheck] = true
+
+        await subject.maybeShowTwoFactorNotice()
+
+        XCTAssertEqual(coordinator.routes, [.twoFactorNotice(allowDelay: false, emailAddress: "user@bitwarden.com")])
+    }
+
     /// `.maybeShowTwoFactorNotice()` will not show the notice
     /// if the user is SSO-only
     ///

--- a/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelperTests.swift
+++ b/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeHelperTests.swift
@@ -174,7 +174,7 @@ class TwoFactorNoticeHelperTests: BitwardenTestCase {
     @MainActor
     func test_maybeShow_server_selfHosted_ignoreEnvironmentCheck() async {
         environmentService.region = .selfHosted
-        configService.featureFlagsBool[.ignoreEnvironmentCheck] = true
+        configService.featureFlagsBool[.ignore2FANoticeEnvironmentCheck] = true
 
         await subject.maybeShowTwoFactorNotice()
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-8216 but see discussion also at: https://bitwarden.atlassian.net/browse/PM-8217?focusedCommentId=80853

## 📔 Objective

This adds a local feature flag, `ignore-environment-check`, [matching Android's name](https://github.com/bitwarden/android/blob/main/app/src/main/java/com/x8bit/bitwarden/data/platform/manager/model/FlagKey.kt#L168). When this flag is `true`, then the Two-Factor notice will not take into account the user's region when determining if the notice should be displayed, which will make it easier to develop or test this screen, because it can now work against our non-prod environments.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
