### PR TITLE
[PM-16776] Add back button to the set up two-factor screen

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -363,7 +363,10 @@ final class VaultCoordinator: Coordinator, HasStackNavigator {
     ///   - emailAddress: The email address of the user.
     private func showTwoFactorNotice(allowDelay: Bool, emailAddress: String) {
         let navigationController = UINavigationController()
-        navigationController.navigationBar.isHidden = true
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        navigationController.navigationBar.scrollEdgeAppearance = appearance
+
         let coordinator = module.makeTwoFactorNoticeCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-16776

## 📔 Objective

This adds a Back button to the second screen of the Two-Factor Notice, where the user can set up their two-factor authentication. This is accomplished by making the navigation bar not be hidden, and instead be transparent.

## 📸 Screenshots

![Simulator Screenshot - iPhone 16 Pro - 2025-01-07 at 12 48 20](https://github.com/user-attachments/assets/7fa09e59-eca5-4550-869d-c8bb02406214)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
