### PR TITLE
[PM-15360] Consider Credential Exchange export policies.

### DIFF
--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessorTests.swift
@@ -13,6 +13,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     var delegate: MockExportCXFProcessorDelegate!
     var errorReporter: MockErrorReporter!
     var exportCXFCiphersRepository: MockExportCXFCiphersRepository!
+    var policyService: MockPolicyService!
     var stackNavigator: MockStackNavigator!
     var stateService: MockStateService!
     var subject: ExportCXFProcessor!
@@ -28,6 +29,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         delegate = MockExportCXFProcessorDelegate()
         errorReporter = MockErrorReporter()
         exportCXFCiphersRepository = MockExportCXFCiphersRepository()
+        policyService = MockPolicyService()
         stackNavigator = MockStackNavigator()
         stateService = MockStateService()
         vaultRepository = MockVaultRepository()
@@ -38,6 +40,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
                 configService: configService,
                 errorReporter: errorReporter,
                 exportCXFCiphersRepository: exportCXFCiphersRepository,
+                policyService: policyService,
                 stateService: stateService,
                 vaultRepository: vaultRepository
             ),
@@ -53,6 +56,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         delegate = nil
         errorReporter = nil
         exportCXFCiphersRepository = nil
+        policyService = nil
         stackNavigator = nil
         stateService = nil
         subject = nil
@@ -67,6 +71,22 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         exportCXFCiphersRepository.getCipherCountToExportCXFResult = .success(100)
         await subject.perform(.appeared)
         XCTAssertEqual(subject.state.totalItemsToExport, 100)
+    }
+
+    /// `perform(_:)` appeared doesn't load the initial data when `.disablePersonalVaultExport`
+    /// applies to user changing the status to failure.
+    @MainActor
+    func test_perform_appearedDisablePersonalVaultExportPolicy() async throws {
+        policyService.policyAppliesToUserResult[.disablePersonalVaultExport] = true
+
+        await subject.perform(.appeared)
+
+        guard case let .failure(message) = subject.state.status else {
+            XCTFail("Status should be failure")
+            return
+        }
+        XCTAssertEqual(message, Localizations.disablePersonalVaultExportPolicyInEffect)
+        XCTAssertFalse(subject.state.showMainButton)
     }
 
     /// `perform(_:)` appeared loads the initial data but there are zero items
@@ -131,6 +151,23 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         try await confirmCancelAlert.tapAction(title: Localizations.no)
 
         XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+
+    /// `perform(_:)` with `.cancel` when not showing main button navigates to dismiss.
+    @MainActor
+    func test_perform_cancelMainButtonNotShown() async throws {
+        subject.state.showMainButton = false
+        let task = Task {
+            await subject.perform(.cancel)
+        }
+        defer { task.cancel() }
+
+        try await waitForAsync { [weak self] in
+            guard let self else { return true }
+            return !coordinator.routes.isEmpty
+        }
+
+        XCTAssertEqual(.dismiss, coordinator.routes.last)
     }
 
     /// `perform(_:)` with `.mainButtonTapped` in `.start` status prepares export.

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXFCoordinator.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXFCoordinator.swift
@@ -10,6 +10,7 @@ class ExportCXFCoordinator: Coordinator, HasStackNavigator {
     typealias Services = HasConfigService
         & HasErrorReporter
         & HasExportCXFCiphersRepository
+        & HasPolicyService
         & HasStateService
         & HasVaultRepository
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-15360](https://bitwarden.atlassian.net/browse/PM-15360)

## 📔 Objective

Fail CXP export if disable personal vault export policy is enabled.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
