### PR TITLE
[PM-17135] Update test.yml target and set job timeout limit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - "main"
       - "rc"
       - "hotfix-rc"
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
     inputs:
@@ -41,14 +41,9 @@ env:
   XCODE_VERSION: ${{ inputs.xcode-version }}
 
 jobs:
-  check-run:
-    name: Check PR run
-    uses: bitwarden/gh-actions/.github/workflows/check-run.yml@main
-
   test:
     name: Test
     runs-on: macos-15-xlarge
-    needs: check-run
     permissions:
       contents: read
       issues: write
@@ -66,8 +61,6 @@ jobs:
 
       - name: Check out repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{  github.event.pull_request.head.sha }}
 
       - name: Read default Xcode version and simulator configuration
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,7 @@ jobs:
   test:
     name: Test
     runs-on: macos-15-xlarge
+    timeout-minutes: 30
     permissions:
       contents: read
       issues: write


### PR DESCRIPTION
## 🎟️ Tracking

PM-17135

## 📔 Objective

Updates test.yml pull request target and sets a job limit timeout, as a stopgap while we figure what's causing some runs to hang. E.g. https://github.com/bitwarden/ios/actions/runs/12776029096/

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
