### PR TITLE
[PM-16183] Temporarily remove xcbeautify to troubleshoot hanging test runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -102,15 +102,13 @@ jobs:
 
       - name: Build and test
         run: |
-          set -o pipefail && \
             xcrun xcodebuild test \
             -project Bitwarden.xcodeproj \
             -scheme Bitwarden \
             -configuration Debug \
             -destination "platform=iOS Simulator,name=${{ env.SIMULATOR_NAME || env.DEFAULT_SIMULATOR_NAME }},OS=${{ env.SIMULATOR_VERSION || env.DEFAULT_SIMULATOR_VERSION }}" \
             -resultBundlePath ${{ env.RESULT_BUNDLE_PATH }} \
-            -derivedDataPath build/DerivedData \
-            | xcbeautify --renderer github-actions
+            -derivedDataPath build/DerivedData
 
       - name: Convert coverage to Cobertura
         run: |


### PR DESCRIPTION
## 🎟️ Tracking

PM-16183

## 📔 Objective

Some test runs are hanging until the runner reaches the timeout limit (e.g. https://github.com/bitwarden/ios/actions/runs/12776029096/). While troubleshooting it I noticed logs weren't correctly ordered, which is due to our testing suit running concurrently and us missing `NSUnbufferedIO=YES`, per xcbeautify docs ([ref](https://github.com/cpisciotta/xcbeautify?tab=readme-ov-file#usage).

While setting that flag would help, for the time being we're temporarily removing xcbeautify until we figure what's causing tests to hang.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
