### PR TITLE
Fix CoreData test warnings

### DIFF
--- a/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/DataStore.swift
@@ -19,6 +19,17 @@ enum StoreType {
 /// A data store that manages persisting data across app launches in Core Data.
 ///
 class DataStore {
+    // MARK: Type Properties
+
+    /// The managed object model representing the entities in the database schema. CoreData throws
+    /// warnings if this is instantiated multiple times (e.g. in tests), which is fixed by making
+    /// it static.
+    private static let managedObjectModel: NSManagedObjectModel = {
+        let modelURL = Bundle(for: DataStore.self).url(forResource: "Bitwarden", withExtension: "momd")!
+        let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL)!
+        return managedObjectModel
+    }()
+
     // MARK: Properties
 
     /// A managed object context which executes on a background queue.
@@ -45,9 +56,7 @@ class DataStore {
     init(errorReporter: ErrorReporter, storeType: StoreType = .persisted) {
         self.errorReporter = errorReporter
 
-        let modelURL = Bundle(for: type(of: self)).url(forResource: "Bitwarden", withExtension: "momd")!
-        let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL)!
-        persistentContainer = NSPersistentContainer(name: "Bitwarden", managedObjectModel: managedObjectModel)
+        persistentContainer = NSPersistentContainer(name: "Bitwarden", managedObjectModel: Self.managedObjectModel)
         let storeDescription: NSPersistentStoreDescription
         switch storeType {
         case .memory:


### PR DESCRIPTION
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes the following CoreData test warnings:

```
⚠️  CoreData: Multiple NSEntityDescriptions claim the NSManagedObject subclass 'BitwardenShared.CipherData' so +entity is unable to disambiguate.
CoreData: warning: 'CipherData' from NSManagedObjectModel claims 'BitwardenShared.CipherData'.
```
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
