### PR TITLE
[PM-17194] Split test.yml job 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,7 +144,7 @@ jobs:
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
         continue-on-error: true
         with:
-          plugin: xcode
+          plugins: xcode
           files: test-reports
           fail_ci_if_error: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,9 +107,7 @@ jobs:
             -configuration Debug \
             -destination "platform=iOS Simulator,name=${{ env.SIMULATOR_NAME || env.DEFAULT_SIMULATOR_NAME }},OS=${{ env.SIMULATOR_VERSION || env.DEFAULT_SIMULATOR_VERSION }}" \
             -resultBundlePath ${{ env.RESULT_BUNDLE_PATH }} \
-            -derivedDataPath build/DerivedData \
-            -test-timeouts-enabled yes \
-            -maximum-test-execution-time-allowance 1
+            -derivedDataPath build/DerivedData
 
       - name: Convert coverage to Cobertura
         run: |
@@ -124,7 +122,6 @@ jobs:
           name: test-reports
           path: |
             ${{ env.COVERAGE_PATH }}
-            ${{ env.RESULT_BUNDLE_PATH }}
   report:
     name: Process Test Reports
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -144,8 +144,7 @@ jobs:
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
         continue-on-error: true
         with:
-          plugins: xcode
-          files: test-reports
+          files: coverage.xml
           fail_ci_if_error: true
 
       - name: Comment PR if tests failed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,8 +124,9 @@ jobs:
         if: always()
         with:
           name: test-reports
-          path: ${{ env.COVERAGE_PATH }}
-
+          path: |
+            ${{ env.COVERAGE_PATH }}
+            ${{ env.RESULT_BUNDLE_PATH }}
   report:
     name: Process Test Reports
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,8 @@ jobs:
             -destination "platform=iOS Simulator,name=${{ env.SIMULATOR_NAME || env.DEFAULT_SIMULATOR_NAME }},OS=${{ env.SIMULATOR_VERSION || env.DEFAULT_SIMULATOR_VERSION }}" \
             -resultBundlePath ${{ env.RESULT_BUNDLE_PATH }} \
             -derivedDataPath build/DerivedData \
+            -test-timeouts-enabled yes \
+            -maximum-test-execution-time-allowance 1 \
             | xcbeautify --renderer github-actions
 
       - name: Convert coverage to Cobertura

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,6 +134,12 @@ jobs:
     if: success()
 
     steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/codecov.yml
+          sparse-checkout-cone-mode: false
+
       - name: Download test artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ env:
   SIMULATOR_NAME: ${{ inputs.simulator-name }}
   SIMULATOR_VERSION: ${{ inputs.simulator-version }}
   XCODE_VERSION: ${{ inputs.xcode-version }}
+  _GITHUB_ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
 
 jobs:
   test:
@@ -47,8 +48,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-      issues: write
-      pull-requests: write
 
     steps:
       - name: Log inputs to job summary
@@ -118,8 +117,48 @@ jobs:
             xcresultparser --output-format cobertura \
             "$RESULT_BUNDLE_PATH" >"$COVERAGE_PATH"
 
+      - name: Upload test reports
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        if: always()
+        with:
+          name: test-reports
+          path: ${{ env.COVERAGE_PATH }}
+
+  report:
+    name: Process Test Reports
+    needs: test
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: write
+      pull-requests: write
+    if: success()
+
+    steps:
+      - name: Download test artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: test-reports
+
       - name: Upload to codecov.io
+        id: upload-to-codecov
         uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # v5.1.2
+        continue-on-error: true
         with:
           plugin: xcode
-          files: ${{ env.COVERAGE_PATH }}
+          files: test-reports
+          fail_ci_if_error: true
+
+      - name: Comment PR if tests failed
+        if: steps.upload-to-codecov.outcome == 'failure'
+        env:
+            PR_NUMBER: ${{ github.event.number }}
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            RUN_ACTOR: ${{ github.triggering_actor }}
+        run: |
+          echo "> [!WARNING]" >> $GITHUB_STEP_SUMMARY
+          echo "> Uploading code coverage report failed. Please check the \"Upload to codecov.io\" step of \"Process Test Reports\" job for more details." >> $GITHUB_STEP_SUMMARY
+
+          if [ ! -z "$PR_NUMBER" ]; then
+            message=$'> [!WARNING]\n> @'$RUN_ACTOR' Uploading code coverage report failed. Please check the "Upload to codecov.io" step of [Process Test Reports job]('$_GITHUB_ACTION_RUN_URL') for more details.'
+            gh pr comment --repo $GITHUB_REPOSITORY $PR_NUMBER --body "$message"
+          fi

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
@@ -7,6 +7,7 @@ class CipherTypeTests: BitwardenTestCase {
 
     /// `getter:allowedFieldTypes` return the correct `FielldType` array for the given cipher type..
     func test_allowedFieldTypes() {
+        sleep(120)
         XCTAssertEqual(CipherType.login.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
         XCTAssertEqual(CipherType.card.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
         XCTAssertEqual(CipherType.identity.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
@@ -16,6 +17,7 @@ class CipherTypeTests: BitwardenTestCase {
 
     /// `localizedName` returns the correct values.
     func test_localizedName() {
+        sleep(120)
         XCTAssertEqual(CipherType.card.localizedName, Localizations.typeCard)
         XCTAssertEqual(CipherType.identity.localizedName, Localizations.typeIdentity)
         XCTAssertEqual(CipherType.login.localizedName, Localizations.typeLogin)
@@ -37,6 +39,7 @@ class CipherTypeTests: BitwardenTestCase {
 
     /// `canCreateCases` return the correct cipher types that the user can use to create ciphers.
     func test_canCreateCases() {
+        sleep(120)
         XCTAssertEqual(CipherType.canCreateCases, [.login, .card, .identity, .secureNote])
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
@@ -7,7 +7,6 @@ class CipherTypeTests: BitwardenTestCase {
 
     /// `getter:allowedFieldTypes` return the correct `FielldType` array for the given cipher type..
     func test_allowedFieldTypes() {
-        sleep(120)
         XCTAssertEqual(CipherType.login.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
         XCTAssertEqual(CipherType.card.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
         XCTAssertEqual(CipherType.identity.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
@@ -17,7 +16,6 @@ class CipherTypeTests: BitwardenTestCase {
 
     /// `localizedName` returns the correct values.
     func test_localizedName() {
-        sleep(120)
         XCTAssertEqual(CipherType.card.localizedName, Localizations.typeCard)
         XCTAssertEqual(CipherType.identity.localizedName, Localizations.typeIdentity)
         XCTAssertEqual(CipherType.login.localizedName, Localizations.typeLogin)
@@ -39,7 +37,6 @@ class CipherTypeTests: BitwardenTestCase {
 
     /// `canCreateCases` return the correct cipher types that the user can use to create ciphers.
     func test_canCreateCases() {
-        sleep(120)
         XCTAssertEqual(CipherType.canCreateCases, [.login, .card, .identity, .secureNote])
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-17194

## 📔 Objective

1. Splits test.yml in test and report jobs to reduce the permissions available during the build process. 
2. Adds a comment to the PR when code coverage report upload fails. [Example](https://github.com/bitwarden/android/pull/4538#issuecomment-2580778503)
3. While at it, fixes the codecov plugin input by removing it. In V5 it would need to be `plugins` but, given that we're taking care of building first we don't seem to need that plugin.

> [!IMPORTANT]
> About 3., while testing the initial changes I noticed that when the codecov action fails, it's a silent error by design and won't fail the workflow job. This is the case if the coverage report can't be found for instance. Discussing it with @SaintPatrck we agreed that uploading code coverage reports shouldn't block a PR so it should continue to not fail workflow jobs, but we needed to raise visibility of errors when that happens. The quickest win was adding a comment to the PR tagging the user that triggered the action run. 

## 📸 Screenshots

<img width="916" alt="image" src="https://github.com/user-attachments/assets/4613f275-6b2a-436c-af0f-73d7babc44ba" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
