### PR TITLE
[PM-16212] Fix: bootstrap version mismatch fails when multiple xcodes are installed

### DIFF
--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -20,7 +20,8 @@ if [ ! -f "$xcode_version_file" ]; then
 fi
 
 required_version=$(cat "$xcode_version_file")
-current_version=$(system_profiler SPDeveloperToolsDataType | grep "Xcode:" | awk '{print $2}')
+xcode_line=$(xcodebuild -version 2>/dev/null || system_profiler SPDeveloperToolsDataType | grep "Xcode:")
+current_version=$(echo "$xcode_line" | head -n 1 | awk '{print $2}')
 if [ -z "$current_version" ]; then
     echo "❌ Could not determine current Xcode version. Is Xcode installed?"
     exit 1


### PR DESCRIPTION
## 🎟️ Tracking

PM-16212

## 📔 Objective

Improves bootstrap.sh version mismatch check to handle multiple xcodes installed. The actual fix is `head -n 1` but while at it, we're now checking `xcodebuild -version` first and falling back to `system_profiler SPDeveloperToolsDataType` if it fails. This will happen on fresh installs, before xcode-select is configured. 

This check was introduced in https://github.com/bitwarden/ios/pull/1221

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
