### PR TITLE
[PM-16555] Remove Xcode 16.2 compiler checks (>= 6.0.3)

### DIFF
--- a/Bitwarden/Application/SceneDelegate.swift
+++ b/Bitwarden/Application/SceneDelegate.swift
@@ -73,14 +73,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 appProcessor.handleAppLinks(incomingURL: incomingURL)
             }
 
-            #if compiler(>=6.0.3)
-
             if #available(iOS 18.2, *),
                let userActivity = connectionOptions.userActivities.first {
                 await checkAndHandleCredentialExchangeActivity(appProcessor: appProcessor, userActivity: userActivity)
             }
-
-            #endif
         }
     }
 
@@ -97,15 +93,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             appProcessor.handleAppLinks(incomingURL: incomingURL)
         }
 
-        #if compiler(>=6.0.3)
-
         if #available(iOS 18.2, *) {
             Task {
                 await checkAndHandleCredentialExchangeActivity(appProcessor: appProcessor, userActivity: userActivity)
             }
         }
-
-        #endif
     }
 
     func scene(_ scene: UIScene, openURLContexts urlContexts: Set<UIOpenURLContext>) {
@@ -182,8 +174,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 // MARK: - SceneDelegate 18.2
 
-#if compiler(>=6.0.3)
-
 @available(iOS 18.2, *)
 extension SceneDelegate {
     /// Checks  whether there is an `ASCredentialExchangeActivity` in the `userActivity` and handles it.
@@ -202,5 +192,3 @@ extension SceneDelegate {
         await appProcessor.handleImportCredentials(credentialImportToken: token)
     }
 }
-
-#endif

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
@@ -10,26 +10,22 @@ protocol ExportCXFCiphersRepository {
     /// - Returns: An array of `CXFCredentialsResult` that has the summary of the ciphers to export by type.
     func buildCiphersToExportSummary(from ciphers: [Cipher]) -> [CXFCredentialsResult]
 
-    #if compiler(>=6.0.3)
     /// Export the credentials using the Credential Exchange flow.
     ///
     /// - Parameter data: Data to export.
     @available(iOS 18.2, *)
     func exportCredentials(data: ASImportableAccount, presentationAnchor: () -> ASPresentationAnchor) async throws
-    #endif
 
     /// Gets all ciphers to export in Credential Exchange flow.
     ///
     /// - Returns: Ciphers to export.
     func getAllCiphersToExportCXF() async throws -> [Cipher]
 
-    #if compiler(>=6.0.3)
     /// Exports the vault creating the `ASImportableAccount` to be used in Credential Exchange Protocol.
     ///
     /// - Returns: An `ASImportableAccount`
     @available(iOS 18.2, *)
     func getExportVaultDataForCXF() async throws -> ASImportableAccount
-    #endif
 }
 
 class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
@@ -90,22 +86,16 @@ class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
         return cxfCredentialsResultBuilder.build(from: ciphers).filter { !$0.isEmpty }
     }
 
-    #if compiler(>=6.0.3)
-
     @available(iOS 18.2, *)
     func exportCredentials(data: ASImportableAccount, presentationAnchor: () -> ASPresentationAnchor) async throws {
         try await credentialManagerFactory.createExportManager(presentationAnchor: presentationAnchor())
             .exportCredentials(ASExportedCredentialData(accounts: [data]))
     }
 
-    #endif
-
     func getAllCiphersToExportCXF() async throws -> [Cipher] {
         try await cipherService.fetchAllCiphers()
             .filter { $0.deletedDate == nil }
     }
-
-    #if compiler(>=6.0.3)
 
     @available(iOS 18.2, *)
     func getExportVaultDataForCXF() async throws -> ASImportableAccount {
@@ -120,6 +110,4 @@ class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
         let serializedCXF = try await clientService.exporters().exportCxf(account: sdkAccount, ciphers: ciphers)
         return try JSONDecoder.cxfDecoder.decode(ASImportableAccount.self, from: Data(serializedCXF.utf8))
     }
-
-    #endif
 }

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
@@ -71,8 +71,6 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
         XCTAssertTrue(subject.buildCiphersToExportSummary(from: []).isEmpty)
     }
 
-    #if compiler(>=6.0.3)
-
     /// `exportCredentials(data:presentationAnchor:)` exports the credential data.
     @MainActor
     func test_exportCredentials() async throws {
@@ -102,8 +100,6 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
         }
     }
 
-    #endif
-
     /// `getAllCiphersToExportCXF()` fetches all ciphers filtering the deleted ones out.
     func test_getAllCiphersToExportCXF() async throws {
         cipherService.fetchAllCiphersResult = .success([
@@ -126,8 +122,6 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
             _ = try await subject.getAllCiphersToExportCXF()
         }
     }
-
-    #if compiler(>=6.0.3)
 
     /// `getExportVaultDataForCXF()` gets the vault data prepared for export on CXF.
     @MainActor
@@ -241,6 +235,4 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
             _ = try await subject.getExportVaultDataForCXF()
         }
     }
-
-    #endif
 }

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepository.swift
@@ -74,8 +74,6 @@ extension DefaultImportCiphersRepository: ImportCiphersRepository {
         credentialImportToken: UUID,
         onProgress: @MainActor (Double) -> Void
     ) async throws -> [CXFCredentialsResult] {
-        #if compiler(>=6.0.3)
-
         let credentialData = try await credentialManagerFactory.createImportManager().importCredentials(
             token: credentialImportToken
         )
@@ -110,9 +108,6 @@ extension DefaultImportCiphersRepository: ImportCiphersRepository {
         await onProgress(1.0)
 
         return importedCredentialsCount.filter { !$0.isEmpty }
-        #else
-        return []
-        #endif
     }
 }
 

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
@@ -1,4 +1,3 @@
-#if compiler(>=6.0.3)
 import AuthenticationServices
 import XCTest
 
@@ -253,4 +252,3 @@ class ImportCiphersRepositoryTests: BitwardenTestCase {
         return credentialDataJsonString
     }
 }
-#endif

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockExportCXFCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockExportCXFCiphersRepository.swift
@@ -5,20 +5,14 @@ import BitwardenSdk
 
 class MockExportCXFCiphersRepository: ExportCXFCiphersRepository {
     var buildCiphersToExportSummaryResult: [CXFCredentialsResult] = []
-    #if compiler(>=6.0.3)
     var exportCredentialsData: ImportableAccountProxy?
     var exportCredentialsError: Error?
-    #endif
     var getAllCiphersToExportCXFResult: Result<[Cipher], Error> = .failure(BitwardenTestError.example)
-    #if compiler(>=6.0.3)
     var getExportVaultDataForCXFResult: Result<ImportableAccountProxy, Error> = .failure(BitwardenTestError.example)
-    #endif
 
     func buildCiphersToExportSummary(from ciphers: [Cipher]) -> [CXFCredentialsResult] {
         buildCiphersToExportSummaryResult
     }
-
-    #if compiler(>=6.0.3)
 
     @available(iOS 18.2, *)
     func exportCredentials(data: ASImportableAccount, presentationAnchor: () -> ASPresentationAnchor) async throws {
@@ -28,13 +22,9 @@ class MockExportCXFCiphersRepository: ExportCXFCiphersRepository {
         }
     }
 
-    #endif
-
     func getAllCiphersToExportCXF() async throws -> [Cipher] {
         try getAllCiphersToExportCXFResult.get()
     }
-
-    #if compiler(>=6.0.3)
 
     @available(iOS 18.2, *)
     func getExportVaultDataForCXF() async throws -> ASImportableAccount {
@@ -43,16 +33,12 @@ class MockExportCXFCiphersRepository: ExportCXFCiphersRepository {
         }
         return result
     }
-
-    #endif
 }
 
 protocol ImportableAccountProxy {}
 
-#if compiler(>=6.0.3)
 @available(iOS 18.2, *)
 extension ASImportableAccount: ImportableAccountProxy {}
-#endif
 
 enum MockExportCXFCiphersRepositoryError: Error {
     case unableToCastToASImportableAccount

--- a/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactory.swift
+++ b/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactory.swift
@@ -44,28 +44,8 @@ protocol CredentialImportManager: AnyObject {
 // This section is needed for compiling the project on Xcode version < 16.2
 // and to ease unit testing.
 
-#if compiler(>=6.0.3)
-
 @available(iOS 18.2, *)
 extension ASCredentialExportManager: CredentialExportManager {}
 
 @available(iOS 18.2, *)
 extension ASCredentialImportManager: CredentialImportManager {}
-
-#else
-
-class ASCredentialImportManager: CredentialImportManager {
-    func importCredentials(token: UUID) async throws -> ASExportedCredentialData {
-        ASExportedCredentialData()
-    }
-}
-
-class ASCredentialExportManager: CredentialExportManager {
-    init(presentationAnchor: ASPresentationAnchor) {}
-
-    func exportCredentials(_ credentialData: ASExportedCredentialData) async throws {}
-}
-
-struct ASExportedCredentialData {}
-
-#endif

--- a/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactoryTests.swift
+++ b/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactoryTests.swift
@@ -1,6 +1,4 @@
-#if compiler(>=6.0.3)
 import AuthenticationServices
-#endif
 import XCTest
 
 @testable import BitwardenShared

--- a/BitwardenShared/Core/Tools/Utilities/TestHelpers/MockCredentialManagerFactory.swift
+++ b/BitwardenShared/Core/Tools/Utilities/TestHelpers/MockCredentialManagerFactory.swift
@@ -1,4 +1,3 @@
-#if compiler(>=6.0.3)
 import AuthenticationServices
 import BitwardenSdk
 
@@ -65,4 +64,3 @@ class MockCredentialImportManager: CredentialImportManager {
         )
     }
 }
-#endif

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableAccount+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableAccount+Extensions.swift
@@ -1,5 +1,3 @@
-#if compiler(>=6.0.3)
-
 import AuthenticationServices
 
 @available(iOS 18.2, *)
@@ -121,5 +119,3 @@ private extension String {
         append("\(indentation)\(other)")
     }
 }
-
-#endif

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableItem+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableItem+Extensions.swift
@@ -1,4 +1,3 @@
-#if compiler(>=6.0.3)
 import AuthenticationServices
 
 @available(iOS 18.2, *)
@@ -26,4 +25,3 @@ extension ASImportableItem {
         )
     }
 }
-#endif

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessor.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessor.swift
@@ -99,8 +99,6 @@ class ExportCXFProcessor: StateProcessor<ExportCXFState, ExportCXFAction, Export
 
     /// Starts the export process.
     private func startExport() async {
-        #if compiler(>=6.0.3)
-
         guard #available(iOS 18.2, *) else {
             coordinator.showAlert(
                 .defaultAlert(
@@ -137,8 +135,6 @@ class ExportCXFProcessor: StateProcessor<ExportCXFState, ExportCXFAction, Export
             state.status = .failure(message: Localizations.thereHasBeenAnIssueExportingItems)
             services.errorReporter.log(error: error)
         }
-
-        #endif
     }
 
     /// Shows the alert confirming the user wants to export items later.

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessorTests.swift
@@ -194,8 +194,6 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         try await preparesExportZeroItemsFromStatusTest(status: .failure(message: "failure"), fromAppeared: true)
     }
 
-    #if compiler(>=6.0.3)
-
     /// `perform(_:)` with `.mainButtonTapped` in `.prepared` status starts export.
     @MainActor
     func test_perform_mainButtonTappedPreparedStartsExport() async throws {
@@ -328,18 +326,6 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
             Localizations.youMayNeedToEnableDevicePasscodeOrBiometrics
         )
     }
-
-    #else
-
-    /// `perform(_:)` with `.mainButtonTapped` in `.prepared` status does nothing.
-    @MainActor
-    func test_perform_mainButtonTappedPreparedNothing() async throws {
-        subject.state.status = .prepared(itemsToExport: [])
-        await subject.perform(.mainButtonTapped)
-        throw XCTSkip("This feature is available on iOS 18.2 or later compiling with Xcode 16.2 or later")
-    }
-
-    #endif
 
     // MARK: Private
 

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessor.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessor.swift
@@ -77,8 +77,6 @@ class ImportCXFProcessor: StateProcessor<ImportCXFState, Void, ImportCXFEffect> 
 
     /// Starts the import process.
     private func startImport() async {
-        #if compiler(>=6.0.3)
-
         guard #available(iOS 18.2, *), let credentialImportToken = state.credentialImportToken else {
             coordinator.showAlert(
                 .defaultAlert(
@@ -109,8 +107,6 @@ class ImportCXFProcessor: StateProcessor<ImportCXFState, Void, ImportCXFEffect> 
             state.status = .failure(message: Localizations.thereWasAnIssueImportingAllOfYourPasswordsNoDataWasDeleted)
             services.errorReporter.log(error: error)
         }
-
-        #endif
     }
 
     /// Shows the alert confirming the user wants to import logins later.

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessorTests.swift
@@ -199,10 +199,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.mainButtonTapped` with `.start` status but no data found.
     @MainActor
     func test_perform_mainButtonTappedStartNoDataFound() async throws {
-        guard try checkCompiler() else {
-            return
-        }
-
         subject.state.status = .start
         subject.state.credentialImportToken = UUID(uuidString: "e8f3b381-aac2-4379-87fe-14fac61079ec")
 
@@ -227,10 +223,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.mainButtonTapped` with `.start` status but data encoding failed.
     @MainActor
     func test_perform_mainButtonTappedStartDataEncodingFailed() async throws {
-        guard try checkCompiler() else {
-            return
-        }
-
         subject.state.status = .start
         subject.state.credentialImportToken = UUID(uuidString: "e8f3b381-aac2-4379-87fe-14fac61079ec")
 
@@ -255,10 +247,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.mainButtonTapped` with `.start` status but throws error.
     @MainActor
     func test_perform_mainButtonTappedStartThrowing() async throws {
-        guard try checkCompiler() else {
-            return
-        }
-
         subject.state.status = .start
         subject.state.credentialImportToken = UUID(uuidString: "e8f3b381-aac2-4379-87fe-14fac61079ec")
 
@@ -286,10 +274,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     /// Performs `.perform(.mainButtonTapped)` to start import and checks everything went good.
     @MainActor
     private func perform_mainButtonTapped_startImport() async throws {
-        guard try checkCompiler() else {
-            return
-        }
-
         let expectedResults = [
             CXFCredentialsResult(count: 12, type: .password),
             CXFCredentialsResult(count: 7, type: .passkey),
@@ -312,16 +296,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(total, 30)
         XCTAssertEqual(results, expectedResults)
-    }
-
-    /// Checks whether the appropriate compiler is being used to have the code available.
-    /// - Returns: `true` if the compiler is correct, `false`otherwise.
-    private func checkCompiler() throws -> Bool {
-        #if compiler(>=6.0.3)
-        return true
-        #else
-        throw XCTSkip("CXP Import works only from 6.0.3 compiler.")
-        #endif
     }
 
     /// Checks whether the alert is shown when not in the correct iOS version for CXF Import to work.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-16555](https://bitwarden.atlassian.net/browse/PM-16555)

## 📔 Objective

Remove compiler checks: `#if compiler(>=6.0.3)` given that now CI/CD is using Xcode 16.2.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16555]: https://bitwarden.atlassian.net/browse/PM-16555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ