### PR TITLE
[PM-17461][PM-14800] Fix: CXP build fails due to wrong script path

### DIFF
--- a/Scripts/alpha_update_cxp_infoplist.sh
+++ b/Scripts/alpha_update_cxp_infoplist.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #
-#   $ ./alpha_update_cxp_infoplist.sh
+#   $ ./Scripts/alpha_update_cxp_infoplist.sh
 
 set -euo pipefail
 

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -6,7 +6,7 @@
 #
 # Usage:
 #
-#   $ ./build.sh <build_mode>
+#   $ ./Scripts/build.sh <build_mode>
 #
 # Where mode is one of:
 #   - Device: Build for physical iOS devices

--- a/Scripts/select_variant.sh
+++ b/Scripts/select_variant.sh
@@ -4,11 +4,11 @@
 #
 # Usage:
 #
-#   $ ./select_variant.sh <variant - {Production|Beta}> "<compiler_flags>"
+#   $ ./Scripts/select_variant.sh <variant - {Production|Beta}> "<compiler_flags>"
 # Example:
-#  $ ./select_variant.sh Production
-#  $ ./select_variant.sh Beta DEBUG_MENU
-#  $ ./select_variant.sh Beta "FEATURE1 FEATURE2"
+#  $ ./Scripts/select_variant.sh Production
+#  $ ./Scripts/select_variant.sh Beta DEBUG_MENU
+#  $ ./Scripts/select_variant.sh Beta "FEATURE1 FEATURE2"
 
 set -euo pipefail
 
@@ -90,5 +90,5 @@ cat << EOF > ${export_options_file}
 EOF
 
 if [[ $compiler_flags == *"SUPPORTS_CXP"* ]]; then
-  ./alpha_update_cxp_infoplist.sh
+  ./Scripts/alpha_update_cxp_infoplist.sh
 fi

--- a/Scripts/update_app_ci_build_info.sh
+++ b/Scripts/update_app_ci_build_info.sh
@@ -16,8 +16,6 @@ if [ $# -ne 6 ]; then
     exit 1
 fi
 
-set -euo pipefail
-
 repository=$1
 branch=$2
 commit_hash=$3


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Fix build.yml failing when CXP compiler flag is used due to missing `alpha_update_cxp_infoplist.sh`. This is due to build scripts being called from the repo root instead of the `Scripts` folder. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
