### PR TITLE
[PM-17467] 🍒 Wrapped Credential Exchange related APIs into SUPPORTS_CXP compiler flag (#1295)

### DIFF
--- a/Bitwarden/Application/SceneDelegate.swift
+++ b/Bitwarden/Application/SceneDelegate.swift
@@ -73,7 +73,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                 appProcessor.handleAppLinks(incomingURL: incomingURL)
             }
 
-            #if compiler(>=6.0.3)
+            #if SUPPORTS_CXP
 
             if #available(iOS 18.2, *),
                let userActivity = connectionOptions.userActivities.first {
@@ -97,7 +97,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             appProcessor.handleAppLinks(incomingURL: incomingURL)
         }
 
-        #if compiler(>=6.0.3)
+        #if SUPPORTS_CXP
 
         if #available(iOS 18.2, *) {
             Task {
@@ -182,7 +182,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 // MARK: - SceneDelegate 18.2
 
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 
 @available(iOS 18.2, *)
 extension SceneDelegate {

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepository.swift
@@ -68,7 +68,7 @@ extension DefaultImportCiphersRepository: ImportCiphersRepository {
         credentialImportToken: UUID,
         onProgress: @MainActor (Double) -> Void
     ) async throws -> [ImportedCredentialsResult] {
-        #if compiler(>=6.0.3)
+        #if SUPPORTS_CXP
 
         let credentialData = try await credentialManagerFactory.createImportManager().importCredentials(
             token: credentialImportToken

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 import AuthenticationServices
 import XCTest
 

--- a/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactory.swift
+++ b/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactory.swift
@@ -18,7 +18,12 @@ protocol CredentialImportManager: AnyObject {
     func importCredentials(token: UUID) async throws -> ASExportedCredentialData
 }
 
-#if compiler(>=6.0.3)
+// MARK: - Helpers
+
+// This section is needed for compiling the project on Xcode version < 16.2
+// and to ease unit testing.
+
+#if SUPPORTS_CXP
 
 @available(iOS 18.2, *)
 extension ASCredentialImportManager: CredentialImportManager {}

--- a/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactoryTests.swift
+++ b/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactoryTests.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 import AuthenticationServices
 #endif
 import XCTest

--- a/BitwardenShared/Core/Tools/Utilities/TestHelpers/MockCredentialManagerFactory.swift
+++ b/BitwardenShared/Core/Tools/Utilities/TestHelpers/MockCredentialManagerFactory.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 import AuthenticationServices
 import BitwardenSdk
 

--- a/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
@@ -43,7 +43,7 @@ protocol ExportVaultService: AnyObject {
     ///
     func exportVaultFileContents(format: ExportFileType) async throws -> String
 
-    #if compiler(>=6.0.3)
+    #if SUPPORTS_CXP
     /// Exports the vault creating the `ASImportableAccount` to be used in Credential Exchange Protocol.
     /// - Returns: An `ASImportableAccount`
     @available(iOS 18.2, *)
@@ -196,7 +196,7 @@ class DefultExportVaultService: ExportVaultService {
         )
     }
 
-    #if compiler(>=6.0.3)
+    #if SUPPORTS_CXP
 
     @available(iOS 18.2, *)
     func exportVaultForCXP() async throws -> ASImportableAccount {

--- a/BitwardenShared/Core/Vault/Services/ExportVaultServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultServiceTests.swift
@@ -193,7 +193,7 @@ final class ExportVaultServiceTests: BitwardenTestCase { // swiftlint:disable:th
 
     // MARK: Tests
 
-    #if compiler(>=6.0.3)
+    #if SUPPORTS_CXP
 
     /// `exportVaultForCXP()` CXP exporting the vault succeeds.
     func test_exportVaultForCXP_success() async throws {

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableAccount+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableAccount+Extensions.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 
 import AuthenticationServices
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableItem+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/ASImportableItem+Extensions.swift
@@ -1,4 +1,4 @@
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 import AuthenticationServices
 
 @available(iOS 18.2, *)

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockExportVaultService.swift
@@ -19,7 +19,7 @@ class MockExportVaultService: ExportVaultService {
         didClearFiles = true
     }
 
-    #if compiler(>=6.0.3)
+    #if SUPPORTS_CXP
     @available(iOS 18.2, *)
     func exportVaultForCXP() async throws -> ASImportableAccount {
         guard let result = try exportVaultForCXPResult.get() as? ASImportableAccount else {
@@ -48,7 +48,7 @@ class MockExportVaultService: ExportVaultService {
 
 protocol ImportableAccountProxy {}
 
-#if compiler(>=6.0.3)
+#if SUPPORTS_CXP
 @available(iOS 18.2, *)
 extension ASImportableAccount: ImportableAccountProxy {}
 #endif

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -343,7 +343,13 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     ///
     @MainActor
     private func showExportVault() async {
-        guard await services.configService.getFeatureFlag(.cxpExportMobile) else {
+        #if SUPPORTS_CXP
+        let cxpEnabled = true
+        #else
+        let cxpEnabled = false
+        #endif
+
+        guard cxpEnabled, await services.configService.getFeatureFlag(.cxpExportMobile) else {
             navigate(to: .exportVaultToFile)
             return
         }

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -201,6 +201,8 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
         }
         defer { task.cancel() }
 
+        #if SUPPORTS_CXP
+
         try await waitForAsync { [weak self] in
             guard let self else { return true }
             return stackNavigator.actions.last != nil
@@ -209,6 +211,19 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .pushed)
         XCTAssertTrue(action.view is UIHostingController<ExportSettingsView>)
+
+        #else
+
+        try await waitForAsync { [weak self] in
+            guard let self else { return true }
+            return stackNavigator.actions.last?.view is UINavigationController
+        }
+
+        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
+        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
+        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ExportVaultView>)
+
+        #endif
     }
 
     /// `navigate(to:)` with `.exportVaultToFile` presents the export vault to file view.

--- a/BitwardenShared/UI/Tools/ImportCXP/ImportCXP/ImportCXPProcessor.swift
+++ b/BitwardenShared/UI/Tools/ImportCXP/ImportCXP/ImportCXPProcessor.swift
@@ -72,7 +72,7 @@ class ImportCXPProcessor: StateProcessor<ImportCXPState, Void, ImportCXPEffect> 
 
     /// Starts the import process.
     private func startImport() async {
-        #if compiler(>=6.0.3)
+        #if SUPPORTS_CXP
 
         guard #available(iOS 18.2, *), let credentialImportToken = state.credentialImportToken else {
             coordinator.showAlert(

--- a/BitwardenShared/UI/Tools/ImportCXP/ImportCXP/ImportCXPProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/ImportCXP/ImportCXP/ImportCXPProcessorTests.swift
@@ -290,7 +290,7 @@ class ImportCXPProcessorTests: BitwardenTestCase {
     /// Checks whether the appropriate compiler is being used to have the code available.
     /// - Returns: `true` if the compiler is correct, `false`otherwise.
     private func checkCompiler() throws -> Bool {
-        #if compiler(>=6.0.3)
+        #if SUPPORTS_CXP
         return true
         #else
         throw XCTSkip("CXP Import works only from 6.0.3 compiler.")

--- a/Configs/BitwardenSharedTests-Debug.xcconfig
+++ b/Configs/BitwardenSharedTests-Debug.xcconfig
@@ -1,0 +1,4 @@
+#include "./Base-Debug.xcconfig"
+#include? "./Local.xcconfig"
+
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) $(BITWARDEN_FLAGS)

--- a/Configs/BitwardenSharedTests-Release.xcconfig
+++ b/Configs/BitwardenSharedTests-Release.xcconfig
@@ -1,0 +1,4 @@
+#include "./Base-Release.xcconfig"
+#include? "./Local.xcconfig"
+
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) $(BITWARDEN_FLAGS)

--- a/project.yml
+++ b/project.yml
@@ -418,6 +418,9 @@ targets:
   BitwardenSharedTests:
     type: bundle.unit-test
     platform: iOS
+    configFiles:
+      Debug: Configs/BitwardenSharedTests-Debug.xcconfig
+      Release: Configs/BitwardenSharedTests-Release.xcconfig
     settings:
       base:
         BUNDLE_LOADER: "$(TEST_HOST)"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17467](https://bitwarden.atlassian.net/browse/PM-17467)

## 📔 Objective

**Cherry pick of #1295 but targeting release branch.**

Wrap all Credential Exchange related APIs into the compiler flag `SUPPORTS_CXP` so those symbols are not added to the final IPA until Apple has the final version of the APIs. If we don't wrap them, then if Apple decides to do a breaking change in those APIs it could lead to a crash in the app.

Additionally, configs files were added and `project-pm.yml` has been updated so BitwardenSharedTests target can also have `SWIFT_ACTIVE_COMPILATION_CONDITIONS` available automatically depending on what's being set on the config.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17467]: https://bitwarden.atlassian.net/browse/PM-17467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ