### PR TITLE
[PM-17544] Added compiler flags to Test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ on:
       simulator-version:
         description: "Simulator iOS version override - e.g. '18.0.1'"
         type: string
+      compiler-flags:
+        description: "Compiler Flags - e.g. 'DEBUG_MENU FEATURE2'"
+        type: string
   workflow_call:
     inputs:
       xcode-version:
@@ -30,6 +33,9 @@ on:
       simulator-version:
         description: "Simulator iOS version override - e.g. '18.0.1'"
         type: string
+      compiler-flags:
+        description: "Compiler Flags - e.g. 'DEBUG_MENU FEATURE2'"
+        type: string
 
 env:
   MINT_LINK_PATH: .mint/bin # used by mint in bootstrap.sh
@@ -39,6 +45,7 @@ env:
   _SIMULATOR_NAME: ${{ inputs.simulator-name }}
   _SIMULATOR_VERSION: ${{ inputs.simulator-version }}
   _XCODE_VERSION: ${{ inputs.xcode-version }}
+  _COMPILER_FLAGS: ${{ inputs.compiler-flags }}
   _GITHUB_ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}
 
 jobs:
@@ -99,6 +106,10 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
+
+      - name: Update local config
+        run: |
+          ./Scripts/update_test_local_config.sh "${{ env._COMPILER_FLAGS }}"
 
       - name: Install Mint and xcresultparser
         run: |

--- a/Scripts/update_test_local_config.sh
+++ b/Scripts/update_test_local_config.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# Updates the test local config setting the compiler flags.
+#
+# Usage:
+#
+#   $ ./Scripts/update_test_local_config.sh "<compiler_flags>"
+# Example:
+#  $ ./Scripts/update_test_local_config.sh DEBUG_MENU
+#  $ ./Scripts/update_test_local_config.sh "FEATURE1 FEATURE2"
+
+set -euo pipefail
+
+bold=$(tput -T ansi bold)
+normal=$(tput -T ansi sgr0)
+
+if [ $# -lt 1 ]; then
+  echo "🧱 No compiler flags to update test local config."
+  exit 0
+fi
+
+compiler_flags=${1:-''}
+
+echo "🧱 Updating Test local config..."
+echo "🛠️ Compiler flags: ${compiler_flags}"
+
+local_xcconfig_file="Configs/Local.xcconfig"
+
+cat << EOF > ${local_xcconfig_file}
+BITWARDEN_FLAGS = \$(inherited) ${compiler_flags}
+EOF
+
+echo "✅ Test local config updated successfully."


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17544](https://bitwarden.atlassian.net/browse/PM-17544)

## 📔 Objective

Add compiler flags to Test workflow as we have in the Build workflow as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
