### PR TITLE
[PM-14680] Change username entry to have an email address keyboard

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
@@ -49,7 +49,7 @@ extension TextFieldConfiguration {
     /// A `TextFieldConfiguration` for applying common properties to username text fields.
     static let username = TextFieldConfiguration(
         isAutocorrectionDisabled: true,
-        keyboardType: .default,
+        keyboardType: .emailAddress,
         textContentType: .username,
         textInputAutocapitalization: .never
     )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-14680
https://github.com/bitwarden/ios/issues/1123

## 📔 Objective

Some users use [Text Replacements](https://support.apple.com/guide/iphone/use-text-replacements-iph6d01d862/ios) in order to quickly fill out their email or common usernames in various forms. However, the Username field on the Add/Edit Login screen does not allow for doing Text Replacement, because autocorrect has been turned off on the field, and with the `.default` keyboard turning off autocomplete also turns off Text Replacement. This changes the keyboard for username fields to be an `.emailAddress` keyboard, which allows for Text Replacement while still keeping autocorrect off; note that this does not mark the field as an email address field, just the keyboard that shows up is one optimized for email entry. As a large number of usernames are themselves emails, this actually improves entry of those as well.

Further discussion on the ticket.

## 📸 Screenshots

<img width="314" src="https://github.com/user-attachments/assets/84c912ac-4876-4c4f-8323-ddd9f49ae33a" />

<img width="314" src="https://github.com/user-attachments/assets/819c4b30-f61f-4e98-95a6-23028bcadc05" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
