### PR TITLE
PM-17627: Reset send expiration to deletion date on edit

### DIFF
--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -170,7 +170,8 @@ extension AddEditSendItemState {
     /// Returns a `SendView` based on the properties of the `AddEditSendItemState`.
     ///
     func newSendView() -> SendView {
-        SendView(
+        let deletionDate = deletionDate.calculateDate() ?? Date()
+        return SendView(
             id: id,
             accessId: accessId,
             name: name,
@@ -186,8 +187,10 @@ extension AddEditSendItemState {
             disabled: isDeactivateThisSendOn,
             hideEmail: isHideMyEmailOn,
             revisionDate: Date(),
-            deletionDate: deletionDate.calculateDate() ?? Date(),
-            expirationDate: expirationDate
+            deletionDate: deletionDate,
+            // If the send has an expiration date, reset it to the deletion date to prevent a server
+            // error which disallows editing a send after it has expired.
+            expirationDate: expirationDate != nil ? deletionDate : nil
         )
     }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -75,7 +75,22 @@ class AddEditSendItemStateTests: BitwardenTestCase {
         XCTAssertEqual(sendView.expirationDate, nil)
     }
 
+    /// `newSendView()` sets the expiration date to the deletion date if the expiration date isn't
+    /// `nil` to allow editing an expired send.
+    func test_newSendView_text_expired() {
+        let deletionDate = Date(year: 2024, month: 1, day: 2)
+        let subject = AddEditSendItemState(
+            customDeletionDate: deletionDate,
+            deletionDate: .custom(deletionDate),
+            expirationDate: .distantPast
+        )
+        let sendView = subject.newSendView()
+        XCTAssertEqual(sendView.deletionDate, deletionDate)
+        XCTAssertEqual(sendView.expirationDate, deletionDate)
+    }
+
     func init_sendView_text() {
+        let deletionDate = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41, second: 11)
         let sendView = SendView.fixture(
             id: "ID",
             accessId: "ACCESS_ID",
@@ -92,7 +107,7 @@ class AddEditSendItemStateTests: BitwardenTestCase {
             disabled: false,
             hideEmail: false,
             revisionDate: Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41, second: 0),
-            deletionDate: Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41, second: 11),
+            deletionDate: deletionDate,
             expirationDate: Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41, second: 22)
         )
         let subject = AddEditSendItemState(sendView: sendView, hasPremium: true)
@@ -113,14 +128,8 @@ class AddEditSendItemStateTests: BitwardenTestCase {
         XCTAssertEqual(subject.currentAccessCount, 42)
         XCTAssertEqual(subject.isDeactivateThisSendOn, false)
         XCTAssertEqual(subject.isHideMyEmailOn, false)
-        XCTAssertEqual(
-            subject.customDeletionDate,
-            Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41, second: 11)
-        )
-        XCTAssertEqual(
-            subject.expirationDate,
-            Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41, second: 22)
-        )
+        XCTAssertEqual(subject.customDeletionDate, deletionDate)
+        XCTAssertEqual(subject.expirationDate, deletionDate)
     }
 
     func init_sendView_file() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-17627](https://bitwarden.atlassian.net/browse/PM-17627)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The send expiration date was removed from the UI in https://github.com/bitwarden/ios/pull/1297. Attempting to edit a send that is expired results in a server error. Since the expiration date can no longer be changed, if the send has an expiration date it will be reset to the deletion date upon saving the send. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17627]: https://bitwarden.atlassian.net/browse/PM-17627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ