### PR TITLE
[PM-8222] Identity new device verification

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModel.swift
@@ -29,6 +29,9 @@ struct IdentityTokenRequestModel {
     /// The id of the associated login with device request, if applicable.
     let loginRequestId: String?
 
+    /// The otp to verify a new device
+    var newDeviceOtp: String?
+
     /// The two-factor authentication code.
     var twoFactorCode: String?
 
@@ -82,6 +85,10 @@ extension IdentityTokenRequestModel: FormURLEncodedRequestBody {
                 URLQueryItem(name: "twoFactorProvider", value: "\(twoFactorMethod.rawValue)"),
                 URLQueryItem(name: "twoFactorRemember", value: twoFactorRemember ? "1" : "0"),
             ])
+        }
+
+        if let newDeviceOtp {
+            queryItems.append(URLQueryItem(name: "newdeviceotp", value: newDeviceOtp))
         }
 
         return queryItems

--- a/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModelTests.swift
@@ -117,6 +117,23 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
         XCTAssertEqual(valuesByKey["twoFactorRemember"], "1")
     }
 
+    /// `values` contains the new device verification information if it's provided.
+    func test_values_withNewDeviceVerificationInformation() {
+        let subject = IdentityTokenRequestModel(
+            authenticationMethod: .password(
+                username: "user@example.com",
+                password: "password"
+            ),
+            captchaToken: nil,
+            deviceInfo: .fixture(),
+            loginRequestId: nil,
+            newDeviceOtp: "onetimepass"
+        )
+        let valuesByKey = valuesByKey(subject.values)
+
+        XCTAssertEqual(valuesByKey["newdeviceotp"], "onetimepass")
+    }
+
     // MARK: Private
 
     /// Converts the list of `URLQueryItem`s to a dictionary keyed by the item's name.

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
@@ -14,6 +14,7 @@ struct IdentityTokenErrorModel: Codable {
         case siteCode = "hcaptchaSitekey"
         case ssoToken = "ssoEmail2faSessionToken"
         case twoFactorProvidersData = "twoFactorProviders2"
+        case error
     }
 
     static let decoder = JSONDecoder.pascalOrSnakeCaseDecoder
@@ -22,6 +23,9 @@ struct IdentityTokenErrorModel: Codable {
 
     /// The captcha bypass token to use on subsequent requests to bypass captcha.
     let captchaBypassToken: String?
+
+    /// The error type.
+    let error: String?
 
     /// The master password policies that the org has enabled.
     let masterPasswordPolicy: MasterPasswordPolicyResponseModel?

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
@@ -1,5 +1,13 @@
 import Foundation
 
+// MARK: - IdentityTokenErrors
+
+/// An error enumeration for `IdentityTokenRequest`.
+///
+enum IdentityTokenError {
+    static let deviceError = "device_error"
+}
+
 // MARK: - IdentityTokenErrorModel
 
 /// An error model for `IdentityTokenRequest`.

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenErrorModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - IdentityTokenErrors
 
-/// An error enumeration for `IdentityTokenRequest`.
+/// Constants for the `error` type returned in `IdentityTokenErrorModel`.
 ///
 enum IdentityTokenError {
     static let deviceError = "device_error"

--- a/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIServiceTests.swift
@@ -92,6 +92,26 @@ class AuthAPIServiceTests: BitwardenTestCase {
         }
     }
 
+    /// `getIdentityToken()` throws a `.newDeviceNotVerified` error when a `400` http response with the correct data
+    /// is returned.
+    func test_getIdentityToken_newDeviceNotVerified() async throws {
+        client.result = .httpFailure(
+            statusCode: 400,
+            data: APITestData.identityTokenNewDeviceError.data
+        )
+
+        await assertAsyncThrows(error: IdentityTokenRequestError.newDeviceNotVerified) {
+            _ = try await subject.getIdentityToken(
+                IdentityTokenRequestModel(
+                    authenticationMethod: .password(username: "username", password: "password"),
+                    captchaToken: nil,
+                    deviceInfo: .fixture(),
+                    loginRequestId: nil
+                )
+            )
+        }
+    }
+
     /// `getPendingLoginRequest(withId:)` successfully decodes the pending login request response.
     func test_getPendingLoginRequest() async throws {
         client.result = .httpSuccess(testData: .authRequestSuccess)

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/APITestData+Auth.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/APITestData+Auth.swift
@@ -20,4 +20,5 @@ extension APITestData {
     static let identityTokenTrustedDevice = loadFromJsonBundle(resource: "IdentityTokenTrustedDevice")
     static let identityTokenTwoFactorError = loadFromJsonBundle(resource: "IdentityTokenTwoFactorFailure")
     static let preValidateSingleSignOn = loadFromJsonBundle(resource: "preValidateSingleSignOn")
+    static let identityTokenNewDeviceError = loadFromJsonBundle(resource: "IdentityTokenNewDeviceError")
 }

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenNewDeviceError.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenNewDeviceError.json
@@ -1,0 +1,8 @@
+{
+  "error": "device_error",
+  "error_description": "New device verification required",
+  "ErrorModel": {
+    "Message": "new device verification required",
+    "Object": "error"
+  }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
@@ -100,7 +100,7 @@ struct IdentityTokenRequest: Request {
                 // Throw the captcha error if the captcha site key can be found.
                 throw IdentityTokenRequestError.captchaRequired(hCaptchaSiteCode: siteCode)
             } else if let error = errorModel.error,
-                      errorModel.error == IdentityTokenError.deviceError {
+                      error == IdentityTokenError.deviceError {
                 throw IdentityTokenRequestError.newDeviceNotVerified
             }
         default:

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
@@ -11,6 +11,9 @@ enum IdentityTokenRequestError: Error, Equatable {
     ///
     case captchaRequired(hCaptchaSiteCode: String)
 
+    /// The new device is not verified.
+    case newDeviceNotVerified
+
     /// Two-factor authentication is required for this login attempt.
     ///
     /// - Parameters:
@@ -96,6 +99,9 @@ struct IdentityTokenRequest: Request {
             } else if let siteCode = errorModel.siteCode {
                 // Throw the captcha error if the captcha site key can be found.
                 throw IdentityTokenRequestError.captchaRequired(hCaptchaSiteCode: siteCode)
+            } else if let error = errorModel.error,
+                      errorModel.error == IdentityTokenError.deviceError {
+                throw IdentityTokenRequestError.newDeviceNotVerified
             }
         default:
             return

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
@@ -119,6 +119,19 @@ class IdentityTokenRequestTests: BitwardenTestCase {
         XCTAssertNoThrow(try subjectAuthorizationCode.validate(response))
     }
 
+    /// `validate(_:)` with a `400` status code and device error in the response body throws a `.newDeviceNotVerified`
+    /// error.
+    func test_validate_with400NewDeviceError() {
+        let response = HTTPResponse.failure(
+            statusCode: 400,
+            body: APITestData.identityTokenNewDeviceError.data
+        )
+
+        XCTAssertThrowsError(try subjectAuthorizationCode.validate(response)) { error in
+            XCTAssertEqual(error as? IdentityTokenRequestError, .newDeviceNotVerified)
+        }
+    }
+
     /// `validate(_:)` with a `400` status code and two-factor error in the response body throws a `.twoFactorRequired`
     /// error.
     func test_validate_with400TwoFactorError() {

--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -161,6 +161,9 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
                 )
             case .twoFactorProvidersNotConfigured:
                 await handleErrorResponse(error)
+            case .newDeviceNotVerified:
+                // TODO: PM-8222: handle new response and do proper navigation
+                services.errorReporter.log(error: error)
             }
         } catch {
             await handleErrorResponse(error)

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -193,6 +193,8 @@ final class LoginWithDeviceProcessor: StateProcessor<
                 coordinator.navigate(to: .twoFactor(state.email, unlockMethod, authMethodsData, nil))
             case .twoFactorProvidersNotConfigured:
                 services.errorReporter.log(error: error)
+            case .newDeviceNotVerified:
+                services.errorReporter.log(error: error)
             }
             return
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8222](https://bitwarden.atlassian.net/browse/PM-8222)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Identity will now send error 400 when a user tries to get a token with a new device. 
To verify the device, the user will have to send an otp code.
This PR updates the network layer request models to handle this error.

```
{
    "error": "device_error",
    "error_description": "New device verification required",
    "ErrorModel": {
        "Message": "new device verification required",
        "Object": "error"
    }
}
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8222]: https://bitwarden.atlassian.net/browse/PM-8222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ