### PR TITLE
PM-16141: linked get started action with guided tour

### DIFF
--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -88,6 +88,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
             state.generatorType = .password
             await services.stateService.setLearnGeneratorActionCardStatus(.complete)
             state.isLearnGeneratorActionCardEligible = false
+            state.guidedTourViewState.showGuidedTour = true
         }
     }
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -510,12 +510,14 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     /// to `false`.
     @MainActor
     func test_perform_showLearnNewLoginGuidedTour() async {
+        subject.state.guidedTourViewState.showGuidedTour = false
         subject.state.isLearnGeneratorActionCardEligible = true
         subject.state.generatorType = .username
         await subject.perform(.showLearnGeneratorGuidedTour)
         XCTAssertFalse(subject.state.isLearnGeneratorActionCardEligible)
         XCTAssertEqual(stateService.learnGeneratorActionCardStatus, .complete)
         XCTAssertEqual(subject.state.generatorType, .password)
+        XCTAssertTrue(subject.state.guidedTourViewState.showGuidedTour)
     }
 
     /// `receive(_:)` with `.emailTypeChanged` updates the state's catch all email type.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-16141](https://bitwarden.atlassian.net/browse/PM-16141)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- fixes the generator screen ```get started``` button action with guided tour.
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-16141]: https://bitwarden.atlassian.net/browse/PM-16141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ