### PR TITLE
QA-1070: Fixing broken textField accessibility IDs

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -137,8 +137,6 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
     }
 
     /// The text field.
-    /// After some investigation, we found that .id(..) needs to be the final modifier
-    /// to avoid breaking accessibilityIds used on our mobile automation test suite
     private var textField: some View {
         HStack(spacing: 8) {
             ZStack {
@@ -147,6 +145,8 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
                 TextField("", text: $text)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
+                    /// After some investigation, we found that .accessibilityIdentifier(..) calls should be placed before setting an id
+                    /// or hiding the field to avoid breaking accessibilityIds used on our mobile automation test suite
                     .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                     .hidden(!isPasswordVisible && isPassword)
                     .id(title)

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -137,12 +137,13 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
     }
 
     /// The text field.
+    /// After some investigation, we found that .id(..) needs to be the final modifier
+    /// to avoid breaking accessibilityIds used on our mobile automation test suite
     private var textField: some View {
         HStack(spacing: 8) {
             ZStack {
                 let isPassword = isPasswordVisible != nil || canViewPassword == false
                 let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
-
                 TextField("", text: $text)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -146,19 +146,19 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
                 TextField("", text: $text)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
+                    .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                     .hidden(!isPasswordVisible && isPassword)
                     .id(title)
                     .introspect(.textField, on: .iOS(.v15, .v16, .v17, .v18)) { textField in
                         textField.smartDashesType = isPassword ? .no : .default
                     }
-                    .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                     .accessibilityLabel(title ?? "")
                 if isPassword, !isPasswordVisible {
                     SecureField("", text: $text)
                         .focused($isSecureFieldFocused)
+                        .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                         .styleGuide(.bodyMonospaced, includeLineSpacing: false)
                         .id(title)
-                        .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                         .accessibilityLabel(title ?? "")
                 }
             }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ