### PR TITLE
[PM-17935] Filtered out organization items on Credential Exchange export

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
@@ -102,7 +102,7 @@ class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
 
     func getAllCiphersToExportCXF() async throws -> [Cipher] {
         try await cipherService.fetchAllCiphers()
-            .filter { $0.deletedDate == nil }
+            .filter { $0.deletedDate == nil && $0.organizationId == nil }
     }
 
     #if SUPPORTS_CXP

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
@@ -108,6 +108,8 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
             .fixture(deletedDate: .now, id: "del1"),
             .fixture(deletedDate: .now, id: "del2"),
             .fixture(id: "2"),
+            .fixture(id: "org1", organizationId: "someorg1"),
+            .fixture(id: "org5", organizationId: "someorg2"),
             .fixture(deletedDate: .now, id: "del3"),
         ])
         let result = try await subject.getAllCiphersToExportCXF()


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17935](https://bitwarden.atlassian.net/browse/PM-17935)
[PM-17936](https://bitwarden.atlassian.net/browse/PM-17936)

## 📔 Objective

Filtered out organization items on Credential Exchange export as the SDK doesn't fully support them yet.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17935]: https://bitwarden.atlassian.net/browse/PM-17935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-17936]: https://bitwarden.atlassian.net/browse/PM-17936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ