### PR TITLE
[PM-11712] Fix scroll going back to focus when scrolling and dismissing the keyboard

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -145,8 +145,9 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
                 TextField("", text: $text)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
-                    /// After some investigation, we found that .accessibilityIdentifier(..) calls should be placed before setting an id
-                    /// or hiding the field to avoid breaking accessibilityIds used on our mobile automation test suite
+                    // After some investigation, we found that .accessibilityIdentifier(..)
+                    // calls should be placed before setting an id
+                    // or hiding the field to avoid breaking accessibilityIds used on our mobile automation test suite
                     .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                     .hidden(!isPasswordVisible && isPassword)
                     .id(title)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -8,9 +8,6 @@ import SwiftUI
 struct AddEditItemView: View {
     // MARK: Private Properties
 
-    /// A responder to keyboard visibility events.
-    @ObservedObject private var keyboard = KeyboardResponder()
-
     /// An object used to open urls in this view.
     @Environment(\.openURL) private var openURL
 
@@ -98,7 +95,7 @@ struct AddEditItemView: View {
                 .ignoresSafeArea()
         )
         .navigationBarTitleDisplayMode(.inline)
-        .backport.scrollContentMargins(Edge.Set.bottom, keyboard.isShown ? 30.0 : 0.0)
+        .backport.scrollContentMargins(Edge.Set.bottom, 30.0)
     }
 
     @ViewBuilder private var cardItems: some View {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-11712](https://bitwarden.atlassian.net/browse/PM-11712)

## 📔 Objective

Given the previous fix #1292 the scroll was behaving incorrectly and scrolling back to the field focused when scrolling away from such field causing a lot of confusion. So this PR fixes it by removing the `KeyboardResponder` and setting the `scrollContentMargins` constantly instead of depending on whether the keyboard is shown which has a better UX given that the animation doesn't jump and fixes the aforementioned issue.

## 📸 Screenshots

### Before

https://github.com/user-attachments/assets/c053b101-c508-4d9e-8136-5c2acae185cf

### After fix

https://github.com/user-attachments/assets/686d41ca-f95d-4301-9efc-224cdbbe40ea



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-11712]: https://bitwarden.atlassian.net/browse/PM-11712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ