### PR TITLE
[PM-17935] Fixed CXF decoder for iOS 18.3

### DIFF
--- a/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoder+Bitwarden.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoder+Bitwarden.swift
@@ -87,13 +87,17 @@ extension JSONDecoder {
     /// Transforms the keys from Credential Exchange format handled by the Bitwarden SDK
     /// into the keys that Apple expects.
     private static func customTransformCodingKeyForCXF(key: String) -> String {
-        return switch key {
-        case "credentialId":
-            "credentialID"
-        case "rpId":
-            "rpID"
-        default:
-            key
+        guard #available(iOS 18.3, *) else {
+            return switch key {
+            case "credentialId":
+                "credentialID"
+            case "rpId":
+                "rpID"
+            default:
+                key
+            }
         }
+
+        return key
     }
 }

--- a/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
@@ -6,7 +6,41 @@ class JSONDecoderBitwardenTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `JSONDecoder.cxfDecoder` can decode Credential Exchange Format.
-    func test_cxfDecoder_decodesISO8601DateWithFractionalSeconds() {
+    func test_cxfDecoder_decodesISO8601DateWithFractionalSeconds() throws {
+        guard #available(iOS 18.3, *) else {
+            throw XCTSkip("This test only works from iOS 18.3")
+        }
+
+        let subject = JSONDecoder.cxfDecoder
+        let toDecode = #"{"credentialId":"credential","date":1697790414,"otherKey":"other","rpId":"rp"}"#
+
+        struct JSONBody: Codable, Equatable {
+            let credentialId: String
+            let date: Date
+            let otherKey: String
+            let rpId: String
+        }
+
+        let body = JSONBody(
+            credentialId: "credential",
+            date: Date(year: 2023, month: 10, day: 20, hour: 8, minute: 26, second: 54),
+            otherKey: "other",
+            rpId: "rp"
+        )
+
+        XCTAssertEqual(
+            try subject
+                .decode(JSONBody.self, from: Data(toDecode.utf8)),
+            body
+        )
+    }
+
+    /// `JSONDecoder.cxfDecoder` can decode Credential Exchange Format on iOS versions lower than iOS 18.3.
+    func test_cxfDecoder_decodesISO8601DateWithFractionalSecondsOlderiOS18dot3() throws {
+        if #available(iOS 18.3, *) {
+            throw XCTSkip("This test only works until iOS 18.3")
+        }
+
         let subject = JSONDecoder.cxfDecoder
         let toDecode = #"{"credentialId":"credential","date":1697790414,"otherKey":"other","rpId":"rp"}"#
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-17935](https://bitwarden.atlassian.net/browse/PM-17935)

## 📔 Objective

Fix Credential Exchange decoding error happening from iOS 18.3 where `credentialId` and `rpId` has changed their final `d` casing so we don't need the custom management of that anymore from that iOS version.

Prior to iOS 18.3: `credentialID` and `rpID` which doesn't match the same format as in the SDK, thus the custom logic is needed for decoding.
After iOS 18.3: `credentialId` and `rpId` which matches the same format as in the SDK.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-17935]: https://bitwarden.atlassian.net/browse/PM-17935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ