### PR TITLE
PM-18271: Fix AboutProcessorTests if using overridden bundle ID

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
@@ -17,6 +17,9 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, Void> {
     /// Additional info to be used by this processor.
     private let aboutAdditionalInfo: AboutAdditionalInfo
 
+    /// The app's bundle identifier.
+    private let bundleIdentifier: String?
+
     /// The coordinator used to manage navigation.
     private let coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>
 
@@ -29,16 +32,19 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, Void> {
     ///
     /// - Parameters:
     ///   - aboutAdditionalInfo: Additional info to be used by this processor.
+    ///   - bundleIdentifier: The app's bundle identifier.
     ///   - coordinator: The coordinator used to manage navigation.
     ///   - services: The services used by this processor.
     ///   - state: The initial state of the processor.
     init(
         aboutAdditionalInfo: AboutAdditionalInfo,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>,
         services: Services,
         state: AboutState
     ) {
         self.aboutAdditionalInfo = aboutAdditionalInfo
+        self.bundleIdentifier = bundleIdentifier
         self.coordinator = coordinator
         self.services = services
 
@@ -89,10 +95,10 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, Void> {
 
     /// Prepare the text to be copied.
     private func handleVersionTapped() {
-        var buildVariant = switch Bundle.main.bundleIdentifier {
+        var buildVariant = switch bundleIdentifier {
         case "com.8bit.bitwarden.beta": "Beta"
         case "com.8bit.bitwarden": "Production"
-        default: "Unkown"
+        default: "Unknown"
         }
         buildVariant = "📦 \(buildVariant)"
         let hardwareInfo = "📱 \(services.systemDevice.modelIdentifier)"

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
@@ -26,6 +26,7 @@ class AboutProcessorTests: BitwardenTestCase {
 
         subject = AboutProcessor(
             aboutAdditionalInfo: aboutAdditionalInfo,
+            bundleIdentifier: "com.8bit.bitwarden",
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 environmentService: environmentService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18271](https://bitwarden.atlassian.net/browse/PM-18271)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The following tests have been failing for me because I override the bundle ID for running on device. This updates the tests to inject the bundle ID so it's not dependent on the app's bundle ID at the time of running tests.

> AboutProcessorTests.swift:158 test_receive_versionTapped_noAdditionalInfo(): XCTAssertEqual failed: ("Optional("© Bitwarden Inc. 2015–2025\n\nVersion: 2024.6.0 (1)\n📱 iPhone14,2 🍏 iOS 16.4 📦 Unkown")") is not equal to ("Optional("© Bitwarden Inc. 2015–2025\n\nVersion: 2024.6.0 (1)\n📱 iPhone14,2 🍏 iOS 16.4 📦 Production")")
> 
> AboutProcessorTests.swift:181 test_receive_versionTapped_withAdditionalInfo(): XCTAssertEqual failed: ("Optional("© Bitwarden Inc. 2015–2025\n\nVersion: 2024.6.0 (1)\n📱 iPhone14,2 🍏 iOS 16.4 📦 Unkown\n🧱 commit: bitwarden/ios/main@abc123\n💻 build source: bitwarden/ios/actions/runs/123/attempts/123\n🛠️ compiler flags: DEBUG_MENU")") is not equal to ("Optional("© Bitwarden Inc. 2015–2025\n\nVersion: 2024.6.0 (1)\n📱 iPhone14,2 🍏 iOS 16.4 📦 Production\n🧱 commit: bitwarden/ios/main@abc123\n💻 build source: bitwarden/ios/actions/runs/123/attempts/123\n🛠️ compiler flags: DEBUG_MENU")")
>
> AboutProcessorTests.swift:207 test_receive_versionTapped_additionalInfoFiltersEmptyValues(): XCTAssertEqual failed: ("Optional("© Bitwarden Inc. 2015–2025\n\nVersion: 2024.6.0 (1)\n📱 iPhone14,2 🍏 iOS 16.4 📦 Unkown\n🧱 commit: bitwarden/ios/main@abc123\n💻 build source: bitwarden/ios/actions/runs/123/attempts/123")") is not equal to ("Optional("© Bitwarden Inc. 2015–2025\n\nVersion: 2024.6.0 (1)\n📱 iPhone14,2 🍏 iOS 16.4 📦 Production\n🧱 commit: bitwarden/ios/main@abc123\n💻 build source: bitwarden/ios/actions/runs/123/attempts/123")")

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18271]: https://bitwarden.atlassian.net/browse/PM-18271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ