### PR TITLE
PM-17864: Refactor add/edit send view to use ExpandableContent

### DIFF
--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -41,11 +41,7 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
 
                         sendDetails
 
-                        optionsButton
-
-                        if store.state.isOptionsExpanded {
-                            options
-                        }
+                        additionalOptions
                     }
                     .padding(12)
                 }
@@ -165,6 +161,53 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
         }
     }
 
+    /// Additional options.
+    @ViewBuilder private var additionalOptions: some View {
+        ExpandableContent(
+            title: Localizations.additionalOptions,
+            isExpanded: store.binding(
+                get: \.isOptionsExpanded,
+                send: { _ in AddEditSendItemAction.optionsPressed }
+            ),
+            buttonAccessibilityIdentifier: "SendShowHideOptionsButton"
+        ) {
+            accessCount
+
+            BitwardenTextField(
+                title: Localizations.newPassword,
+                text: store.binding(
+                    get: \.password,
+                    send: AddEditSendItemAction.passwordChanged
+                ),
+                footer: Localizations.passwordInfo,
+                accessibilityIdentifier: "SendNewPasswordEntry",
+                isPasswordVisible: store.binding(
+                    get: \.isPasswordVisible,
+                    send: AddEditSendItemAction.passwordVisibleChanged
+                )
+            )
+            .textFieldConfiguration(.password)
+
+            ContentBlock(dividerLeadingPadding: 16) {
+                BitwardenToggle(Localizations.hideEmail, isOn: store.binding(
+                    get: \.isHideMyEmailOn,
+                    send: AddEditSendItemAction.hideMyEmailChanged
+                ))
+                .accessibilityIdentifier("SendHideEmailSwitch")
+                .disabled(!store.state.isHideMyEmailOn && store.state.isSendHideEmailDisabled)
+            }
+
+            BitwardenTextView(
+                title: Localizations.privateNote,
+                text: store.binding(
+                    get: \.notes,
+                    send: AddEditSendItemAction.notesChanged
+                )
+            )
+        }
+        .padding(.top, 8)
+    }
+
     /// The deletion date field.
     @ViewBuilder private var deletionDate: some View {
         ContentBlock(dividerLeadingPadding: 16) {
@@ -250,64 +293,6 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
             ),
             accessibilityIdentifier: "SendNameEntry"
         )
-    }
-
-    /// Additional options.
-    @ViewBuilder private var options: some View {
-        accessCount
-
-        BitwardenTextField(
-            title: Localizations.newPassword,
-            text: store.binding(
-                get: \.password,
-                send: AddEditSendItemAction.passwordChanged
-            ),
-            footer: Localizations.passwordInfo,
-            accessibilityIdentifier: "SendNewPasswordEntry",
-            isPasswordVisible: store.binding(
-                get: \.isPasswordVisible,
-                send: AddEditSendItemAction.passwordVisibleChanged
-            )
-        )
-        .textFieldConfiguration(.password)
-
-        ContentBlock(dividerLeadingPadding: 16) {
-            BitwardenToggle(Localizations.hideEmail, isOn: store.binding(
-                get: \.isHideMyEmailOn,
-                send: AddEditSendItemAction.hideMyEmailChanged
-            ))
-            .accessibilityIdentifier("SendHideEmailSwitch")
-            .disabled(!store.state.isHideMyEmailOn && store.state.isSendHideEmailDisabled)
-        }
-
-        BitwardenTextView(
-            title: Localizations.privateNote,
-            text: store.binding(
-                get: \.notes,
-                send: AddEditSendItemAction.notesChanged
-            )
-        )
-    }
-
-    /// The options button.
-    @ViewBuilder private var optionsButton: some View {
-        Button {
-            store.send(.optionsPressed)
-        } label: {
-            HStack(spacing: 8) {
-                Text(Localizations.additionalOptions)
-                    .styleGuide(.callout, weight: .semibold)
-
-                Asset.Images.chevronDown16.swiftUIImage
-                    .imageStyle(.accessoryIcon16(scaleWithFont: true))
-                    .rotationEffect(store.state.isOptionsExpanded ? Angle(degrees: 180) : .zero)
-            }
-            .multilineTextAlignment(.leading)
-            .padding(.top, 8)
-            .foregroundStyle(Asset.Colors.textInteraction.swiftUIColor)
-        }
-        .accessibilityIdentifier("SendShowHideOptionsButton")
-        .padding(.leading, 12)
     }
 
     /// A view that displays the ability to add or switch between account profiles


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-17864](https://bitwarden.atlassian.net/browse/PM-17864)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the add/edit send view to use `ExpandableContent` introduced in #1355. The expandable additional options already existed in this view, this just updates it to use the component, so there's no visual change as part of this. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
