### PR TITLE
[PM-18265] Made cipher key encryption feature flag default value -> false

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -99,7 +99,6 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// but if `isRemotelyConfigured` is false for the flag, then the value here will be used.
     /// This is a helpful way to manage local feature flags.
     static let initialValues: [FeatureFlag: AnyCodable] = [
-        .cipherKeyEncryption: .bool(true),
         .testLocalInitialBoolFlag: .bool(true),
         .testLocalInitialIntFlag: .int(42),
         .testLocalInitialStringFlag: .string("Test String"),

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -14,7 +14,7 @@ final class FeatureFlagTests: BitwardenTestCase {
 
     /// `initialValues` returns the correct value for each flag.
     func test_initialValues() {
-        XCTAssertTrue(FeatureFlag.initialValues[.cipherKeyEncryption]?.boolValue == true)
+        XCTAssertNil(FeatureFlag.initialValues[.cipherKeyEncryption]?.boolValue)
     }
 
     /// `getter:isRemotelyConfigured` returns the correct value for each flag.

--- a/BitwardenShared/Core/Platform/Services/ClientService.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientService.swift
@@ -295,8 +295,7 @@ actor DefaultClientService: ClientService {
             }
 
             let cipherKeyEncryptionFlagEnabled: Bool = await configService.getFeatureFlag(
-                .cipherKeyEncryption,
-                defaultValue: true
+                .cipherKeyEncryption
             )
             let enableCipherKeyEncryption = cipherKeyEncryptionFlagEnabled && config.supportsCipherKeyEncryption()
 

--- a/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
@@ -215,6 +215,7 @@ final class ClientServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// `configPublisher` loads flags into the SDK.
     @MainActor
     func test_configPublisher_loadFlags() async throws {
+        configService.featureFlagsBool[.cipherKeyEncryption] = true
         configService.configSubject.send(
             MetaServerConfig(
                 isPreAuth: false,
@@ -282,11 +283,11 @@ final class ClientServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         try await waitForAsync {
             let client = try? XCTUnwrap(self.clientBuilder.clients.first)
-            return client?.platformClient.featureFlags == ["enableCipherKeyEncryption": true]
+            return client?.platformClient.featureFlags == ["enableCipherKeyEncryption": false]
         }
         XCTAssertEqual(clientBuilder.clients.count, 1)
 
-        configService.featureFlagsBool[.cipherKeyEncryption] = false
+        configService.featureFlagsBool[.cipherKeyEncryption] = true
         configService.configSubject.send(
             MetaServerConfig(
                 isPreAuth: false,
@@ -295,7 +296,7 @@ final class ClientServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
                     date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
                     responseModel: ConfigResponseModel(
                         environment: nil,
-                        featureStates: [:],
+                        featureStates: ["cipher-key-encryption": .bool(true)],
                         gitHash: "75238191",
                         server: nil,
                         version: "2024.4.0"
@@ -306,7 +307,7 @@ final class ClientServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         try await waitForAsync {
             let client = try? XCTUnwrap(self.clientBuilder.clients.first)
-            return client?.platformClient.featureFlags == ["enableCipherKeyEncryption": false]
+            return client?.platformClient.featureFlags == ["enableCipherKeyEncryption": true]
         }
         XCTAssertEqual(clientBuilder.clients.count, 1)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18265](https://bitwarden.atlassian.net/browse/PM-18265)

## 📔 Objective

Make feature flag `cipher-key-encryption` default value `false`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18265]: https://bitwarden.atlassian.net/browse/PM-18265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ