### PR TITLE
[PM-8222] New device verification page fixes

### DIFF
--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -179,6 +179,8 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
             coordinator.showAlert(Alert.inputValidationAlert(error: error))
         } catch let IdentityTokenRequestError.captchaRequired(hCaptchaSiteCode) {
             launchCaptchaFlow(with: hCaptchaSiteCode)
+        } catch IdentityTokenRequestError.newDeviceNotVerified {
+            coordinator.showAlert(.defaultAlert(title: Localizations.invalidVerificationCode))
         } catch let authError as AuthError {
             if authError == .requireSetPassword,
                let orgId = state.orgIdentifier {

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -93,7 +93,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
             state.toast = newValue
         case let .verificationCodeChanged(newValue):
             state.verificationCode = newValue
-            state.continueEnabled = (newValue.count >= 6)
+            state.continueEnabled = newValue.count >= (state.deviceVerificationRequired ? 8 : 6)
         }
     }
 

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -729,6 +729,20 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertEqual(subject.state.verificationCode, "123456")
         XCTAssertTrue(subject.state.continueEnabled)
     }
+
+    /// `receive(_:)` with `.verificationCodeChanged` updates the value in the state and enables the button if
+    /// applicable if device needs verification and code length is at least 8 characters.
+    @MainActor
+    func test_receive_verificationCodeChanged_deviceNeedsVerification() {
+        subject.state.deviceVerificationRequired = true
+        subject.receive(.verificationCodeChanged("123456"))
+        XCTAssertEqual(subject.state.verificationCode, "123456")
+        XCTAssertFalse(subject.state.continueEnabled)
+
+        subject.receive(.verificationCodeChanged("12345678"))
+        XCTAssertEqual(subject.state.verificationCode, "12345678")
+        XCTAssertTrue(subject.state.continueEnabled)
+    }
 }
 
 // MARK: - MockWebAuthnFlowDelegate

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
@@ -41,6 +41,14 @@ struct TwoFactorAuthState: Equatable, Sendable {
     /// User organization idenfier if came from SSO flow
     var orgIdentifier: String?
 
+    /// The text to display in the detailed instructions.
+    var titleText: String {
+        if deviceVerificationRequired {
+            return Localizations.verifyYourIdentity
+        }
+        return authMethod.title
+    }
+
     /// A toast message to show in the view.
     var toast: Toast?
 

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthView.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthView.swift
@@ -36,7 +36,7 @@ struct TwoFactorAuthView: View {
                 get: \.toast,
                 send: TwoFactorAuthAction.toastShown
             ))
-            .navigationBar(title: store.state.authMethod.title, titleDisplayMode: .inline)
+            .navigationBar(title: store.state.titleText, titleDisplayMode: .inline)
             .task(id: store.state.authMethod) {
                 guard store.state.authMethod == .yubiKey else { return }
                 await store.perform(.listenForNFC)

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1150,3 +1150,4 @@
 "ContactInfo" = "Contact info";
 "Identification" = "Identification";
 "Owner" = "Owner";
+"VerifyYourIdentity"="Verify your identity";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-8222

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When device needs verification:
- Change title to `Verify your identity`
- Change continue button enabled to 8 chars instead of 6.
- Show error message `Invalid verification code` when the verification code is invalid.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
**Title fix:**
![Simulator Screenshot - iPhone 16 Pro - 2025-02-25 at 16 30 31 Medium](https://github.com/user-attachments/assets/f922d508-833e-4ed3-811f-ba0e466654f7)

**Continue button enabled:**
![Simulator Screenshot - iPhone 16 Pro - 2025-02-25 at 16 26 53 Medium](https://github.com/user-attachments/assets/d2f5dc6d-ef45-41f1-b77e-c4f8e222599e)
![Simulator Screenshot - iPhone 16 Pro - 2025-02-25 at 16 26 58 Medium](https://github.com/user-attachments/assets/ab3fffdd-38f5-45ba-838d-67878826301b)

**Error message:**
![Simulator Screenshot - iPhone 16 Pro - 2025-02-25 at 16 27 11 Medium](https://github.com/user-attachments/assets/ccee0cd8-9b2b-4263-abf6-ed07c78d3053)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
