### PR TITLE
PM-18244: Fix close button ui bug on ViewItem screen

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -92,8 +92,10 @@ struct ViewItemView: View {
                 store.send(.editPressed)
             }
         }
-        .task {
-            await store.perform(.appeared)
+        .onAppear {
+            Task {
+                await store.perform(.appeared)
+            }
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -93,6 +93,9 @@ struct ViewItemView: View {
             }
         }
         .onAppear {
+            // GitHub issue #1344: Changed from `.task` to `.onAppear` because the close button
+            // on the navigation bar was consistently shifting position
+            // on physical devices running iOS 16.
             Task {
                 await store.perform(.appeared)
             }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-18244](https://bitwarden.atlassian.net/browse/PM-18244)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- This will fix #1344
I was able to reproduce this bug only on my old iPhone XR which runs on iOS16. 
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
The bug was like this:
<video src=https://github.com/user-attachments/assets/6ef028af-40c6-4deb-8c3f-1c237f21d9b7 />
## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18244]: https://bitwarden.atlassian.net/browse/PM-18244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ