### PR TITLE
[PM-18486] Fix register Fido2 credential excluded credential found flow

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListEffect.swift
@@ -5,6 +5,9 @@ import BitwardenSdk
 /// Actions that can be processed by a `VaultAutofillListProcessor`.
 ///
 enum VaultAutofillListEffect: Equatable {
+    /// Triggered when `excludedCredentialFound` state changed.
+    case excludedCredentialFoundChaged
+
     /// Fido2 flow should be initialized if needed..
     case initFido2
 

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -118,6 +118,10 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
 
     override func perform(_ effect: VaultAutofillListEffect) async {
         switch effect {
+        case .excludedCredentialFoundChaged:
+            if let cipherIdFound = state.excludedCredentialIdFound {
+                await updateExcludedCredentialSection(from: cipherIdFound)
+            }
         case let .vaultItemTapped(vaultItem):
             switch vaultItem.itemType {
             case let .cipher(cipher, fido2CredentialAutofillView):
@@ -374,7 +378,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
                 rpID: autofillAppExtensionDelegate?.rpID,
                 uri: uri
             ) {
-                guard !state.excludedCredentialFound else {
+                guard state.excludedCredentialIdFound == nil else {
                     break
                 }
 
@@ -392,22 +396,18 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
     /// Updates the vault list sections with the section including the excluded credential found.
     /// This is necessary in case the user edits the item so we get the new value from the publisher.
     ///
-    /// - Parameter cipherView: The `CipherView` to found as excluded credential.
+    /// - Parameter cipherId: The cipher ID found as excluded credential.
     @MainActor
-    private func updateExcludedCredentialSection(from cipherView: CipherView) async {
+    private func updateExcludedCredentialSection(from cipherId: String) async {
         do {
-            guard let cipherId = cipherView.id else {
-                return
-            }
-
             for try await cipher in try await services.vaultRepository.cipherDetailsPublisher(id: cipherId) {
-                guard state.excludedCredentialFound else {
+                guard state.excludedCredentialIdFound != nil else {
                     break
                 }
                 guard let cipher else { continue }
 
                 guard cipher.hasFido2Credentials else {
-                    state.excludedCredentialFound = false
+                    state.excludedCredentialIdFound = nil
                     break
                 }
 
@@ -490,11 +490,7 @@ extension VaultAutofillListProcessor: Fido2UserInterfaceHelperDelegate {
     // MARK: Methods
 
     func informExcludedCredentialFound(cipherView: CipherView) async {
-        state.excludedCredentialFound = true
-        Task { [weak self] in
-            guard let self else { return }
-            await updateExcludedCredentialSection(from: cipherView)
-        }
+        state.excludedCredentialIdFound = cipherView.id
     }
 
     func onNeedsUserInteraction() async throws {
@@ -527,7 +523,7 @@ extension VaultAutofillListProcessor {
                 state.emptyViewButtonText = Localizations.savePasskeyAsNewLogin
                 services.fido2UserInterfaceHelper.setupDelegate(fido2UserInterfaceHelperDelegate: self)
 
-                guard !state.excludedCredentialFound else {
+                guard state.excludedCredentialIdFound == nil else {
                     return
                 }
 
@@ -623,7 +619,7 @@ extension VaultAutofillListProcessor {
                 )
             )
         } catch {
-            guard !state.excludedCredentialFound else {
+            guard state.excludedCredentialIdFound == nil else {
                 return
             }
 
@@ -640,7 +636,7 @@ extension VaultAutofillListProcessor {
         }
 
         if autofillAppExtensionDelegate.isCreatingFido2Credential {
-            guard !state.excludedCredentialFound else {
+            guard state.excludedCredentialIdFound == nil else {
                 guard let cipherId = state.vaultListSections.first?.items.first?.id else {
                     coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
                     return
@@ -730,9 +726,9 @@ extension VaultAutofillListProcessor: CipherItemOperationDelegate {
         // If an excluded credential was found and we get here
         // then such item was deleted so we can safely say
         // there are no excluded credential found now.
-        if state.excludedCredentialFound {
+        if state.excludedCredentialIdFound != nil {
             state.toast = Toast(title: Localizations.itemSoftDeleted)
-            state.excludedCredentialFound = false
+            state.excludedCredentialIdFound = nil
         }
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListState.swift
@@ -17,8 +17,8 @@ struct VaultAutofillListState: Equatable, Sendable {
     /// The text to be displayed in the button of the empty view.
     var emptyViewButtonText: String = Localizations.newItem
 
-    /// Whether an excluded Fido2 credential was found when registering.
-    var excludedCredentialFound: Bool = false
+    /// The excluded Fido2 credential id that was found when registering.
+    var excludedCredentialIdFound: String?
 
     /// The group filter.
     var group: VaultListGroup?
@@ -58,6 +58,6 @@ struct VaultAutofillListState: Equatable, Sendable {
 
     /// Whether to show the add item button.
     var showAddItemButton: Bool {
-        !isAutofillingTotpList && !isAutofillingTextToInsertList && !excludedCredentialFound
+        !isAutofillingTotpList && !isAutofillingTextToInsertList && excludedCredentialIdFound == nil
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -26,7 +26,7 @@ struct VaultAutofillListView: View {
             profileSwitcher
         }
         .navigationBar(title: store.state.group?.navigationTitle ?? Localizations.items, titleDisplayMode: .inline)
-        .if(!store.state.excludedCredentialFound) { view in
+        .if(store.state.excludedCredentialIdFound == nil) { view in
             view.searchable(
                 text: store.binding(
                     get: \.searchText,
@@ -106,6 +106,9 @@ private struct VaultAutofillListSearchableView: View {
             }
             .task(id: store.state.searchText) {
                 await store.perform(.search(store.state.searchText))
+            }
+            .task(id: store.state.excludedCredentialIdFound) {
+                await store.perform(.excludedCredentialFoundChaged)
             }
             .toast(
                 store.binding(

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListViewTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListViewTests.swift
@@ -394,7 +394,7 @@ class VaultAutofillListViewTests: BitwardenTestCase { // swiftlint:disable:this 
         processor.state.profileSwitcherState.accounts = [account]
         processor.state.profileSwitcherState.activeAccountId = account.userId
         processor.state.isCreatingFido2Credential = true
-        processor.state.excludedCredentialFound = true
+        processor.state.excludedCredentialIdFound = "1"
         processor.state.vaultListSections = [
             VaultListSection(
                 id: Localizations.aPasskeyAlreadyExistsForThisApplication,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18486](https://bitwarden.atlassian.net/browse/PM-18486)

## 📔 Objective

Fix on Fido2 credential creation excluded credential found flow, that when a user edits such excluded credential found and removes the passkey from it. Then on going back to the list screen the previous excluded credential shouldn't be shown and the normal Fido2 credential creation flow list should be shown.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18486]: https://bitwarden.atlassian.net/browse/PM-18486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ