### PR TITLE
[PM-18460]: [RC] Fix Remove Unlock with Pin policy logic on login

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -2067,7 +2067,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `logout` successfully logs out a user clearing pins because of policy Remove unlock with pin being enabled.
-    func test_logout_successWhenClearingPins() {
+    func test_logout_successWhenClearingPins() async throws {
         let account = Account.fixture()
         stateService.accounts = [account]
         stateService.activeAccount = account
@@ -2078,11 +2078,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.encryptedPinByUserId["1"] = "1"
         policyService.policyAppliesToUserResult[.removeUnlockWithPin] = true
 
-        let task = Task {
-            try await subject.logout(userInitiated: true)
-        }
-        waitFor(!vaultTimeoutService.removedIds.isEmpty)
-        task.cancel()
+        try await subject.logout(userInitiated: true)
 
         XCTAssertEqual([account.profile.userId], stateService.accountsLoggedOut)
         XCTAssertNil(biometricsRepository.capturedUserAuthKey)

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -683,6 +683,17 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         }
     }
 
+    /// `getHasPerformedSyncAfterLogin(userId:)` returns whether the user has performed a sync after login.
+    func test_getHasPerformedSyncAfterLogin() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+        var hasPerformedSync = try await subject.getHasPerformedSyncAfterLogin(userId: "1")
+        XCTAssertFalse(hasPerformedSync)
+
+        appSettingsStore.hasPerformedSyncAfterLogin["1"] = true
+        hasPerformedSync = try await subject.getHasPerformedSyncAfterLogin()
+        XCTAssertTrue(hasPerformedSync)
+    }
+
     /// `getIntroCarouselShown()` returns whether the intro carousel screen has been shown.
     func test_getIntroCarouselShown() async {
         var hasShownCarousel = await subject.getIntroCarouselShown()
@@ -1767,6 +1778,13 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try await subject.setForcePasswordResetReason(nil)
         XCTAssertNil(appSettingsStore.state?.accounts["1"]?.profile.forcePasswordResetReason)
         XCTAssertNil(appSettingsStore.state?.accounts["2"]?.profile.forcePasswordResetReason)
+    }
+
+    /// `setHasPerformedSyncAfterLogin(_:userId:)` sets if the user has performed a sync after logging in.
+    func test_setHasPerformedSyncAfterLogin() async throws {
+        appSettingsStore.hasPerformedSyncAfterLogin["1"] = true
+        try await subject.setHasPerformedSyncAfterLogin(false, userId: "1")
+        XCTAssertFalse(appSettingsStore.hasPerformedSyncAfterLogin["1"]!)
     }
 
     /// `setLastActiveTime(userId:)` sets the user's last active time.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -168,6 +168,14 @@ protocol AppSettingsStore: AnyObject {
     ///
     func encryptedUserKey(userId: String) -> String?
 
+    /// Gets whether a sync has been done successfully after login. This is particular useful to trigger logic that
+    /// needs to be executed right after login in and after the first successful sync.
+    ///
+    /// - Parameter userId: The user ID associated with the sync after login.
+    /// - Returns: `true` if sync has already been done after login, `false` otherwise.
+    ///
+    func hasPerformedSyncAfterLogin(userId: String) -> Bool
+
     /// The user's last active time within the app.
     /// This value is set when the app is backgrounded.
     ///
@@ -365,6 +373,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the events.
     ///
     func setEvents(_ events: [EventData], userId: String)
+
+    /// Sets whether a sync has been done successfully after login. This is particular useful to trigger logic that
+    /// needs to be executed right after login in and after the first successful sync.
+    ///
+    /// - Parameters:
+    ///   - hasBeenPerformed: Whether a sync has been performed after login.
+    ///   - userId: The user ID associated with the sync after login.
+    func setHasPerformedSyncAfterLogin(_ hasBeenPerformed: Bool?, userId: String)
 
     /// Sets the last active time within the app.
     ///
@@ -714,6 +730,7 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         case encryptedPrivateKey(userId: String)
         case encryptedUserKey(userId: String)
         case events(userId: String)
+        case hasPerformedSyncAfterLogin(userId: String)
         case introCarouselShown
         case learnNewLoginActionCardStatus
         case lastActiveTime(userId: String)
@@ -789,6 +806,8 @@ extension DefaultAppSettingsStore: AppSettingsStore {
                 key = "encPrivateKey_\(userId)"
             case let .events(userId):
                 key = "events_\(userId)"
+            case let .hasPerformedSyncAfterLogin(userId):
+                key = "hasPerformedSyncAfterLogin_\(userId)"
             case .introCarouselShown:
                 key = "introCarouselShown"
             case .learnNewLoginActionCardStatus:
@@ -1006,6 +1025,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
         fetch(for: .events(userId: userId)) ?? []
     }
 
+    func hasPerformedSyncAfterLogin(userId: String) -> Bool {
+        fetch(for: .hasPerformedSyncAfterLogin(userId: userId))
+    }
+
     func lastActiveTime(userId: String) -> Date? {
         fetch(for: .lastActiveTime(userId: userId)).map { Date(timeIntervalSince1970: $0) }
     }
@@ -1106,6 +1129,10 @@ extension DefaultAppSettingsStore: AppSettingsStore {
 
     func setEvents(_ events: [EventData], userId: String) {
         store(events, for: .events(userId: userId))
+    }
+
+    func setHasPerformedSyncAfterLogin(_ hasBeenPerformed: Bool?, userId: String) {
+        store(hasBeenPerformed, for: .hasPerformedSyncAfterLogin(userId: userId))
     }
 
     func setLastActiveTime(_ date: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -427,6 +427,20 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNil(subject.debugFeatureFlag(name: ""))
     }
 
+    /// `hasPerformedSyncAfterLogin(userId:)` returns `false` if there isn't a previously stored value.
+    func test_hasPerformedSyncAfterLogin_initialValue() {
+        XCTAssertFalse(subject.hasPerformedSyncAfterLogin(userId: "0"))
+    }
+
+    /// `hasPerformedSyncAfterLogin(userId:)` returns `false` or `true` depending what is saved in user defaults.
+    func test_hasPerformedSyncAfterLogin_withValue() {
+        subject.setHasPerformedSyncAfterLogin(false, userId: "1")
+        subject.setHasPerformedSyncAfterLogin(true, userId: "2")
+
+        XCTAssertFalse(subject.hasPerformedSyncAfterLogin(userId: "1"))
+        XCTAssertTrue(subject.hasPerformedSyncAfterLogin(userId: "2"))
+    }
+
     /// `isBiometricAuthenticationEnabled` returns false if there is no previous value.
     func test_isBiometricAuthenticationEnabled_isInitiallyFalse() {
         XCTAssertFalse(subject.isBiometricAuthenticationEnabled(userId: "-1"))
@@ -884,6 +898,19 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
             ),
             config
         )
+    }
+
+    /// `setHasPerformedSyncAfterLogin(hasBeenPerformed:, userId:)` can be used to
+    /// set the has performed sync after login.
+    func test_setHasPerformedSyncAfterLogin() {
+        subject.setHasPerformedSyncAfterLogin(true, userId: "1")
+        XCTAssertTrue(userDefaults.bool(forKey: "bwPreferencesStorage:hasPerformedSyncAfterLogin_1"))
+
+        subject.setHasPerformedSyncAfterLogin(false, userId: "1")
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:hasPerformedSyncAfterLogin_1"))
+
+        subject.setHasPerformedSyncAfterLogin(nil, userId: "1")
+        XCTAssertFalse(userDefaults.bool(forKey: "bwPreferencesStorage:hasPerformedSyncAfterLogin_1"))
     }
 
     /// `syncToAuthenticator(userId:)` returns false if there isn't a previously stored value.

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -38,6 +38,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var encryptedUserKeys = [String: String]()
     var eventsByUserId = [String: [EventData]]()
     var featureFlags = [String: Bool]()
+    var hasPerformedSyncAfterLogin = [String: Bool]()
     var lastActiveTime = [String: Date]()
     var lastSyncTimeByUserId = [String: Date]()
     var manuallyLockedAccounts = [String: Bool]()
@@ -119,6 +120,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func events(userId: String) -> [EventData] {
         eventsByUserId[userId] ?? []
+    }
+
+    func hasPerformedSyncAfterLogin(userId: String) -> Bool {
+        hasPerformedSyncAfterLogin[userId] ?? false
     }
 
     func lastActiveTime(userId: String) -> Date? {
@@ -228,6 +233,14 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setEvents(_ events: [EventData], userId: String) {
         eventsByUserId[userId] = events
+    }
+
+    func setHasPerformedSyncAfterLogin(_ hasBeenPerformed: Bool?, userId: String) {
+        guard let hasBeenPerformed else {
+            hasPerformedSyncAfterLogin.removeValue(forKey: userId)
+            return
+        }
+        hasPerformedSyncAfterLogin[userId] = hasBeenPerformed
     }
 
     func setLastActiveTime(_ date: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -39,6 +39,8 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var eventsResult: Result<Void, Error> = .success(())
     var events = [String: [EventData]]()
     var forcePasswordResetReason = [String: ForcePasswordResetReason]()
+    var getHasPerformedSyncAfterLoginError: Error?
+    var hasPerformedSyncAfterLogin = [String: Bool]()
     var introCarouselShown = false
     var isAuthenticated = [String: Bool]()
     var isAuthenticatedError: Error?
@@ -65,6 +67,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var preAuthServerConfig: ServerConfig?
     var rememberedOrgIdentifier: String?
     var reviewPromptData: ReviewPromptData?
+    var setHasPerformedSyncAfterLoginError: Error?
     var showWebIcons = true
     var showWebIconsSubject = CurrentValueSubject<Bool, Never>(true)
     var timeoutAction = [String: SessionTimeoutAction]()
@@ -246,6 +249,14 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         try eventsResult.get()
         let userId = try unwrapUserId(userId)
         return events[userId] ?? []
+    }
+
+    func getHasPerformedSyncAfterLogin(userId: String?) async throws -> Bool {
+        if let getHasPerformedSyncAfterLoginError {
+            throw getHasPerformedSyncAfterLoginError
+        }
+        let userId = try unwrapUserId(userId)
+        return hasPerformedSyncAfterLogin[userId] ?? false
     }
 
     func getIntroCarouselShown() async -> Bool {
@@ -503,6 +514,14 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     func setForcePasswordResetReason(_ reason: ForcePasswordResetReason?, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         forcePasswordResetReason[userId] = reason
+    }
+
+    func setHasPerformedSyncAfterLogin(_ hasBeenPerformed: Bool, userId: String?) async throws {
+        if let setHasPerformedSyncAfterLoginError {
+            throw setHasPerformedSyncAfterLoginError
+        }
+        let userId = try unwrapUserId(userId)
+        hasPerformedSyncAfterLogin[userId] = hasBeenPerformed
     }
 
     func setIntroCarouselShown(_ shown: Bool) async {

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -72,6 +72,12 @@ protocol SyncService: AnyObject {
 /// be taken outside of the service layer.
 ///
 protocol SyncServiceDelegate: AnyObject {
+    /// Called when `fetchSync(forceSync:)` is completed successfully.
+    ///
+    /// - Parameter userId: The user ID of the account that was synced.
+    ///
+    func onFetchSyncSucceeded(userId: String) async
+
     /// The user needs to remove their master password so they can be migrated to use Key Connector.
     ///
     /// - Parameter organizationName: The organization's name that requires Key Connector.
@@ -288,6 +294,8 @@ extension DefaultSyncService {
            let organization = try await keyConnectorService.getManagingOrganization() {
             await delegate?.removeMasterPassword(organizationName: organization.name)
         }
+
+        await delegate?.onFetchSyncSucceeded(userId: userId)
     }
 
     func deleteCipher(data: SyncCipherNotification) async throws {

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -187,6 +187,7 @@ class SyncServiceTests: BitwardenTestCase {
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertEqual(client.requests[0].method, .get)
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/sync")
+        XCTAssertEqual(syncServiceDelegate.onFetchSyncSucceededCalledWithuserId, "1")
 
         try XCTAssertEqual(
             XCTUnwrap(stateService.lastSyncTimeByUserId["1"]),
@@ -655,6 +656,7 @@ class SyncServiceTests: BitwardenTestCase {
         await assertAsyncThrows {
             try await subject.fetchSync(forceSync: false)
         }
+        XCTAssertNil(syncServiceDelegate.onFetchSyncSucceededCalledWithuserId)
     }
 
     func test_deleteCipher() async throws {
@@ -763,12 +765,17 @@ class SyncServiceTests: BitwardenTestCase {
 }
 
 class MockSyncServiceDelegate: SyncServiceDelegate {
+    var onFetchSyncSucceededCalledWithuserId: String?
     var removeMasterPasswordCalled = false
     var removeMasterPasswordOrganizationName: String?
     var securityStampChangedCalled = false
     var securityStampChangedUserId: String?
     var setMasterPasswordCalled = false
     var setMasterPasswordOrgId: String?
+
+    func onFetchSyncSucceeded(userId: String) async {
+        onFetchSyncSucceededCalledWithuserId = userId
+    }
 
     func removeMasterPassword(organizationName: String) {
         removeMasterPasswordOrganizationName = organizationName


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18460](https://bitwarden.atlassian.net/browse/PM-18460)

## 📔 Objective

🍒 Cherry-picked #1377 for `release/2025.02-rc7` branch.

When Remove Unlock with Pin policy is enabled and the user logs in, if there was Pin information in cache for such user it should be removed so the feature is disabled in the app after completing the login.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18460]: https://bitwarden.atlassian.net/browse/PM-18460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ