### PR TITLE
[PM-18461] [Backport] Remove unlock with pin policy admin not exempt

### DIFF
--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -95,7 +95,7 @@ actor DefaultPolicyService: PolicyService {
     /// - Returns: Whether the organization is exempt from the policy.
     ///
     private func isOrganization(_ organization: Organization, exemptFrom policyType: PolicyType) -> Bool {
-        if policyType == .passwordGenerator {
+        if policyType == .passwordGenerator || policyType == .removeUnlockWithPin {
             return false
         }
 

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -506,6 +506,17 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertFalse(policyApplies)
     }
 
+    /// `policyAppliesToUser(_:)` returns `true` when the policy applies to the user when the
+    /// organization user is `admin`.
+    func test_policyAppliesToUser_organizationNotExemptWhenPolicyIsRemoveUnlockWithPin() async {
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture(type: .admin)])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .removeUnlockWithPin)])
+
+        let policyApplies = await subject.policyAppliesToUser(.removeUnlockWithPin)
+        XCTAssertTrue(policyApplies)
+    }
+
     /// `policyAppliesToUser(_:)` returns whether the policy applies to the user when the
     /// organization doesn't use policies.
     func test_policyAppliesToUser_organizationDoesNotUsePolicies() async {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18461](https://bitwarden.atlassian.net/browse/PM-18461)

## 📔 Objective

Backport of #1388.

Fix "Remove unlock with pin" policy not to be exempt from organizations where the user is Admin or Owner given that this policy applies to all members.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18461]: https://bitwarden.atlassian.net/browse/PM-18461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ