### PR TITLE
[PM-18594] [RC] Hide coach marks if user has existing login items

### DIFF
--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -434,6 +434,11 @@ extension VaultListProcessor {
                 if !value.isEmpty, await services.configService.getFeatureFlag(.nativeCreateAccountFlow) {
                     await setImportLoginsProgress(.complete)
                 }
+                // Dismiss the coach mark action cards once the vault has at least one login item in it.
+                if await services.configService.getFeatureFlag(.nativeCreateAccountFlow), value.hasLoginItems {
+                    await services.stateService.setLearnNewLoginActionCardStatus(.complete)
+                    await services.stateService.setLearnGeneratorActionCardStatus(.complete)
+                }
             }
         } catch {
             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -830,6 +830,54 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         task.cancel()
     }
 
+    /// `perform(_:)` with `.streamVaultList` dismisses the coach marks if the vault contains any
+    /// login items.
+    @MainActor
+    func test_perform_streamVaultList_coachMarkDismiss_vaultContainsLogins() async throws {
+        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        stateService.activeAccount = .fixture()
+
+        let task = Task {
+            await subject.perform(.streamVaultList)
+        }
+        defer { task.cancel() }
+
+        let section = VaultListSection(
+            id: "1",
+            items: [.fixtureGroup(id: "1", group: .login, count: 1)],
+            name: "Section"
+        )
+        vaultRepository.vaultListSubject.send([section])
+
+        try await waitForAsync { self.subject.state.loadingState == .data([section]) }
+        XCTAssertEqual(stateService.learnGeneratorActionCardStatus, .complete)
+        XCTAssertEqual(stateService.learnNewLoginActionCardStatus, .complete)
+    }
+
+    /// `perform(_:)` with `.streamVaultList` doesn't dismiss the coach marks if the vault contains
+    /// no login items.
+    @MainActor
+    func test_perform_streamVaultList_coachMarkDismiss_vaultWithoutLogins() async throws {
+        configService.featureFlagsBool[.nativeCreateAccountFlow] = true
+        stateService.activeAccount = .fixture()
+
+        let task = Task {
+            await subject.perform(.streamVaultList)
+        }
+        defer { task.cancel() }
+
+        let section = VaultListSection(
+            id: "1",
+            items: [.fixtureGroup(id: "1", group: .card, count: 1)],
+            name: "Section"
+        )
+        vaultRepository.vaultListSubject.send([section])
+
+        try await waitForAsync { self.subject.state.loadingState == .data([section]) }
+        XCTAssertNil(stateService.learnGeneratorActionCardStatus)
+        XCTAssertNil(stateService.learnNewLoginActionCardStatus)
+    }
+
     /// `perform(_:)` with `.streamVaultList` updates the state's vault list whenever it changes.
     @MainActor
     func test_perform_streamVaultList_doesntNeedSync() throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
@@ -20,7 +20,7 @@ extension [VaultListSection] {
     var hasLoginItems: Bool {
         flatMap(\.items)
             .contains { item in
-                if case let .group(group, count) = item.itemType, group == .login {
+                if case let .group(group, count) = item.itemType, group == .login || group == .totp {
                     count > 0 // swiftlint:disable:this empty_count
                 } else if case let .cipher(cipherView, _) = item.itemType, cipherView.type == .login {
                     true

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
@@ -24,6 +24,8 @@ extension [VaultListSection] {
                     count > 0 // swiftlint:disable:this empty_count
                 } else if case let .cipher(cipherView, _) = item.itemType, cipherView.type == .login {
                     true
+                } else if case .totp = item.itemType {
+                    true
                 } else {
                     false
                 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSection.swift
@@ -12,3 +12,21 @@ public struct VaultListSection: Equatable, Identifiable, Sendable {
     /// The name of the section, displayed as section header.
     public let name: String
 }
+
+// MARK: - [VaultListSection]
+
+extension [VaultListSection] {
+    /// Returns whether any login items exist within the vault list sections.
+    var hasLoginItems: Bool {
+        flatMap(\.items)
+            .contains { item in
+                if case let .group(group, count) = item.itemType, group == .login {
+                    count > 0 // swiftlint:disable:this empty_count
+                } else if case let .cipher(cipherView, _) = item.itemType, cipherView.type == .login {
+                    true
+                } else {
+                    false
+                }
+            }
+    }
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSectionTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSectionTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class VaultListSectionTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `hasLoginItems` returns `false` if there's no login items within the sections.
+    func test_vaultListSectionArray_hasLoginItems_false() {
+        let subjectEmpty = [VaultListSection]()
+        XCTAssertFalse(subjectEmpty.hasLoginItems)
+
+        let subjectWithoutLogin = [
+            VaultListSection(id: "2", items: [.fixtureGroup(group: .card, count: 2)], name: "Cards"),
+            VaultListSection(id: "3", items: [.fixtureGroup(group: .identity, count: 3)], name: "Identities"),
+            VaultListSection(id: "4", items: [.fixtureGroup(group: .secureNote, count: 0)], name: "Notes"),
+        ]
+        XCTAssertFalse(subjectWithoutLogin.hasLoginItems)
+
+        let subjectLoginsEmpty = [
+            VaultListSection(id: "1", items: [.fixtureGroup(group: .login, count: 0)], name: "Logins"),
+            VaultListSection(id: "2", items: [.fixtureGroup(group: .card, count: 2)], name: "Cards"),
+            VaultListSection(id: "3", items: [.fixtureGroup(group: .identity, count: 3)], name: "Identities"),
+            VaultListSection(id: "4", items: [.fixtureGroup(group: .secureNote, count: 0)], name: "Notes"),
+        ]
+        XCTAssertFalse(subjectLoginsEmpty.hasLoginItems)
+
+        let subjectCiphersNoLogins = [
+            VaultListSection(id: "5", items: [.fixture(cipherView: .fixture(type: .identity))], name: "Items"),
+        ]
+        XCTAssertFalse(subjectCiphersNoLogins.hasLoginItems)
+    }
+
+    /// `hasLoginItems` returns `true` if there's a login group with more than one item or a login
+    /// cipher within the sections.
+    func test_vaultListSectionArray_hasLoginItems_true() {
+        let subjectWithLogin = [
+            VaultListSection(id: "1", items: [.fixtureGroup(group: .login, count: 1)], name: "Logins"),
+        ]
+        XCTAssertTrue(subjectWithLogin.hasLoginItems)
+
+        let subjectWithMultipleSections = [
+            VaultListSection(id: "1", items: [.fixtureGroup(group: .login, count: 1)], name: "Logins"),
+            VaultListSection(id: "2", items: [.fixtureGroup(group: .card, count: 2)], name: "Cards"),
+            VaultListSection(id: "3", items: [.fixtureGroup(group: .identity, count: 3)], name: "Identities"),
+            VaultListSection(id: "4", items: [.fixtureGroup(group: .secureNote, count: 0)], name: "Notes"),
+        ]
+        XCTAssertTrue(subjectWithMultipleSections.hasLoginItems)
+
+        let subjectWithCipher = [
+            VaultListSection(id: "2", items: [.fixtureGroup(group: .card, count: 2)], name: "Cards"),
+            VaultListSection(id: "5", items: [.fixture(cipherView: .fixture(type: .login))], name: "Items"),
+        ]
+        XCTAssertTrue(subjectWithCipher.hasLoginItems)
+    }
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSectionTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSectionTests.swift
@@ -52,5 +52,10 @@ class VaultListSectionTests: BitwardenTestCase {
             VaultListSection(id: "5", items: [.fixture(cipherView: .fixture(type: .login))], name: "Items"),
         ]
         XCTAssertTrue(subjectWithCipher.hasLoginItems)
+
+        let subjectWithTOTP = [
+            VaultListSection(id: "2", items: [.fixtureGroup(group: .totp, count: 2)], name: "TOTP"),
+        ]
+        XCTAssertTrue(subjectWithTOTP.hasLoginItems)
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSectionTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListSectionTests.swift
@@ -54,8 +54,13 @@ class VaultListSectionTests: BitwardenTestCase {
         XCTAssertTrue(subjectWithCipher.hasLoginItems)
 
         let subjectWithTOTP = [
-            VaultListSection(id: "2", items: [.fixtureGroup(group: .totp, count: 2)], name: "TOTP"),
+            VaultListSection(id: "1", items: [.fixtureTOTP(totp: .fixture())], name: "TOTP"),
         ]
         XCTAssertTrue(subjectWithTOTP.hasLoginItems)
+
+        let subjectWithTOTPGroup = [
+            VaultListSection(id: "2", items: [.fixtureGroup(group: .totp, count: 2)], name: "TOTP"),
+        ]
+        XCTAssertTrue(subjectWithTOTPGroup.hasLoginItems)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18594](https://bitwarden.atlassian.net/browse/PM-18594)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If a user has existing login items in their vault, the coach marks for add login and in the generator should be dismissed.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18594]: https://bitwarden.atlassian.net/browse/PM-18594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ