### PR TITLE
[PM-18386] Fix crash when viewing long passwords

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/PasswordText.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/PasswordText.swift
@@ -15,7 +15,7 @@ struct PasswordText: View {
     var body: some View {
         (
             isPasswordVisible
-                ? colorCodedText(for: password)
+                ? Text(colorCodedText(for: password))
                 : Text(String(repeating: "•", count: Constants.hiddenPasswordLength))
         )
         .styleGuide(.bodyMonospaced)
@@ -23,7 +23,7 @@ struct PasswordText: View {
 
     // MARK: Private Properties
 
-    /// A color-coded evaluation of the provided string.
+    /// Returns an `AttributedString` containing a color-coded evaluation of the provided string.
     ///
     /// The following foreground color is applied to each character:
     /// - Letters: `textPrimary`
@@ -31,24 +31,23 @@ struct PasswordText: View {
     /// - Symbols: `textCodePink`
     ///
     /// - Parameter value: The value to color code.
-    /// - Returns: A color-coded `Text` view containing the provided string.
+    /// - Returns: A color-coded `AttributedString` of the provided string.
     ///
-    @ViewBuilder
-    private func colorCodedText(for value: String) -> Text {
-        password.reduce(Text("")) { text, character in
-            let foregroundColor: Color = {
-                if character.isNumber {
-                    return Asset.Colors.textCodeBlue.swiftUIColor
-                } else if character.isSymbol || character.isPunctuation {
-                    return Asset.Colors.textCodePink.swiftUIColor
-                } else {
-                    return Asset.Colors.textPrimary.swiftUIColor
-                }
-            }()
+    private func colorCodedText(for value: String) -> AttributedString {
+        value.reduce(into: AttributedString()) { partialResult, character in
+            let foregroundColor: Color = if character.isNumber {
+                Asset.Colors.textCodeBlue.swiftUIColor
+            } else if character.isSymbol || character.isPunctuation {
+                Asset.Colors.textCodePink.swiftUIColor
+            } else {
+                Asset.Colors.textPrimary.swiftUIColor
+            }
+
             // Add a zero-width space (U+200B) after each character to ensure text will wrap on any
             // character boundary.
-            let string = "\(character)\(String.zeroWidthSpace)"
-            return text + Text(string).foregroundColor(foregroundColor)
+            var characterString = AttributedString("\(character)\(String.zeroWidthSpace)")
+            characterString.foregroundColor = foregroundColor
+            partialResult += characterString
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18386](https://bitwarden.atlassian.net/browse/PM-18386)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a crash when viewing the color coded unmasked password for long passwords in view item. I was able to reproduce this with a password length of 2000. The crash didn't contain much information, but the contained the following line in the stack trace:

```
#0	0x000000026190e338 in SwiftUI.ConcatenatedTextStorage.resolve<τ_0_0 where τ_0_0: SwiftUI.ResolvedTextContainer>(into: inout τ_0_0, in: SwiftUI.EnvironmentValues, with: SwiftUI.Text.ResolveOptions) -> () ()
```

It seemed like this was due to concatenating `Text` instances when displaying the color coded unmasked password. I switched to using AttributedString and haven't been able to reproduce it.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18386]: https://bitwarden.atlassian.net/browse/PM-18386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ