### PR TITLE
[PM-18417] refactor: Reorganize MainActor annotations

### DIFF
--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -119,6 +119,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
     /// 'isPasswordManagerSyncActive` should return `false` when both the
     /// `enablePasswordManagerSync` feature flag is disabled and the
     /// `AuthenticatorBridgeItemService.syncOn` is `false`.
+    @MainActor
     func test_isPasswordManagerSyncActive_bothOff() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         sharedItemService.syncOn = false
@@ -130,6 +131,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
     /// 'isPasswordManagerSyncActive` should return `false` when the
     /// `enablePasswordManagerSync` feature flag is disabled even if the
     /// `AuthenticatorBridgeItemService.syncOn` is `true`.
+    @MainActor
     func test_isPasswordManagerSyncActive_featureFlagDisabled() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         sharedItemService.syncOn = true
@@ -141,6 +143,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
     /// 'isPasswordManagerSyncActive` should return `false` when the
     /// `enablePasswordManagerSync` feature flag is enabled but the
     /// `AuthenticatorBridgeItemService.syncOn` is `false`.
+    @MainActor
     func test_isPasswordManagerSyncActive_syncOff() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         sharedItemService.syncOn = false
@@ -152,6 +155,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
     /// 'isPasswordManagerSyncActive` should return `true` when the
     /// `enablePasswordManagerSync` feature flag is enabled and the
     /// `AuthenticatorBridgeItemService.syncOn` is `true`.
+    @MainActor
     func test_isPasswordManagerSyncActive_success() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         sharedItemService.syncOn = true
@@ -291,6 +295,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
     }
 
     /// `itemListPublisher()` returns a publisher for the items.
+    @MainActor
     func test_itemListPublisher() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         let items = [
@@ -330,6 +335,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
     }
 
     /// `itemListPublisher()` returns a favorites section (when the feature flag not enabled)
+    @MainActor
     func test_itemListPublisher_favorites() async throws {
         sharedItemService.storedItems = ["userId": AuthenticatorBridgeItemDataView.fixtures()]
         sharedItemService.syncOn = true
@@ -384,6 +390,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
 
     /// `itemListPublisher()` returns a favorites section and a local codes section as normal. Adds a syncError section
     /// when the sync process if throwing an error.
+    @MainActor
     func test_itemListPublisher_syncError() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         sharedItemService.syncOn = true
@@ -422,6 +429,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
 
     /// `itemListPublisher()` returns a favorites section as before, when the feature flag is enabled, but
     /// the user has not yet enabled sync.
+    @MainActor
     func test_itemListPublisher_syncOff() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         sharedItemService.storedItems = ["userId": AuthenticatorBridgeItemDataView.fixtures()]
@@ -476,6 +484,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
 
     /// `itemListPublisher()` returns a favorites section and sections for each sync'd account when the
     /// feature flag is enabled and the user has turned on sync.
+    @MainActor
     func test_itemListPublisher_syncOn() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         sharedItemService.syncOn = true
@@ -517,6 +526,7 @@ class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:dis
 
     /// `itemListPublisher()` correctly handles the empty/nil cases for different sections of the item list when
     /// the feature flag is enabled and the user has turned on Sync for multiple accounts.
+    @MainActor
     func test_itemListPublisher_withMultipleAccountSync() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         sharedItemService.syncOn = true

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 // MARK: - AppCoordinatorTests
 
-@MainActor
 class AppCoordinatorTests: AuthenticatorTestCase {
     // MARK: Properties
 

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertPresentableTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertPresentableTests.swift
@@ -29,6 +29,7 @@ class AlertPresentableTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `present(_:)` presents a `UIAlertController` on the root view controller.
+    @MainActor
     func test_present() {
         subject.present(Alert(title: "🍎", message: "🥝", preferredStyle: .alert))
         XCTAssertNotNil(rootViewController.presentedViewController as? UIAlertController)

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 // MARK: - AnyCoordinatorTests
 
-@MainActor
 class AnyCoordinatorTests: AuthenticatorTestCase {
     // MARK: Properties
 
@@ -28,12 +27,14 @@ class AnyCoordinatorTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `start()` calls the `start()` method on the wrapped coordinator.
+    @MainActor
     func test_start() {
         subject.start()
         XCTAssertTrue(coordinator.isStarted)
     }
 
     /// `navigate(to:context:)` calls the `navigate(to:context:)` method on the wrapped coordinator.
+    @MainActor
     func test_navigate_onboarding() {
         subject.navigate(to: .tab(.itemList(.list)), context: "🤖" as NSString)
         XCTAssertEqual(coordinator.contexts as? [NSString], ["🤖" as NSString])

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/AnyRouterTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/AnyRouterTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 // MARK: - AnyRouterTests
 
-@MainActor
 class AnyRouterTests: AuthenticatorTestCase {
     // MARK: Properties
 
@@ -28,6 +27,7 @@ class AnyRouterTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `handleAndRoute()` calls the `handleAndRoute()` method on the wrapped router.
+    @MainActor
     func test_handleAndRoute() async {
         var didStart = false
         router.routeForEvent = { event in

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/RootViewControllerTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/RootViewControllerTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 // MARK: - RootViewControllerTests
 
-@MainActor
 class RootViewControllerTests: AuthenticatorTestCase {
     // MARK: Properties
 
@@ -26,6 +25,7 @@ class RootViewControllerTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `childViewController` swaps between different view controllers.
+    @MainActor
     func test_childViewController_withNewViewController() {
         let viewController1 = UIViewController()
         subject.childViewController = viewController1
@@ -38,6 +38,7 @@ class RootViewControllerTests: AuthenticatorTestCase {
     }
 
     /// `childViewController` removes the current view controller when set to `nil`.
+    @MainActor
     func test_childViewController_nil() {
         let viewController1 = UIViewController()
         subject.childViewController = viewController1
@@ -49,6 +50,7 @@ class RootViewControllerTests: AuthenticatorTestCase {
     }
 
     /// `rootViewController` returns itself, instead of the current `childViewController`.
+    @MainActor
     func test_rootViewController() {
         let viewController = UIViewController()
         subject.childViewController = viewController
@@ -56,6 +58,7 @@ class RootViewControllerTests: AuthenticatorTestCase {
     }
 
     /// `show(child:)` sets `childViewController` to the `rootViewController` on the child navigator.
+    @MainActor
     func test_show() {
         let navigator = MockStackNavigator()
         navigator.rootViewController = UIViewController()

--- a/AuthenticatorShared/UI/Platform/FileSelection/FileSelectionCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/FileSelection/FileSelectionCoordinatorTests.swift
@@ -51,6 +51,7 @@ class FileSelectionCoordinatorTests: AuthenticatorTestCase {
 
     /// `documentPicker(_,didPickDocumentsAt:)` reads the file at the specified URL and notifies the
     /// delegate.
+    @MainActor
     func test_documentPickerDidPickDocumentsAt_withUrl() throws {
         subject.navigate(to: .file)
 
@@ -74,6 +75,7 @@ class FileSelectionCoordinatorTests: AuthenticatorTestCase {
 
     /// `imagePickerController(_:,didFinishPickingMediaWithInfo:)` creates a filename for the photo
     /// and notifies the delegate for a JPG image.
+    @MainActor
     func test_imagePickerViewControllerDidFinishPickingMedia_jpg() throws {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             throw XCTSkip("Unable to unit test UIImagePickerController with a camera input on CI")
@@ -96,6 +98,7 @@ class FileSelectionCoordinatorTests: AuthenticatorTestCase {
 
     /// `imagePickerController(_:,didFinishPickingMediaWithInfo:)` creates a filename for the photo
     /// and notifies the delegate for a PNG image.
+    @MainActor
     func test_imagePickerViewControllerDidFinishPickingMedia_png() throws {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             throw XCTSkip("Unable to unit test UIImagePickerController with a camera input on CI")
@@ -117,6 +120,7 @@ class FileSelectionCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.camera` and with camera authorization presents the camera screen.
+    @MainActor
     func test_navigateTo_camera_authorized() throws {
         guard UIImagePickerController.isSourceTypeAvailable(.camera) else {
             throw XCTSkip("Unable to unit test UIImagePickerController with a camera input on CI")
@@ -139,6 +143,7 @@ class FileSelectionCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.camera` and without camera authorization does not present the camera
     /// screen.
+    @MainActor
     func test_navigateTo_camera_denied() throws {
         cameraService.cameraAuthorizationStatus = .denied
         let delegate = MockFileSelectionDelegate()
@@ -148,6 +153,7 @@ class FileSelectionCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.fileBrowser` presents the file browser screen.
+    @MainActor
     func test_navigateTo_file() throws {
         let delegate = MockFileSelectionDelegate()
         subject.navigate(to: .file, context: delegate)

--- a/AuthenticatorShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -41,6 +41,7 @@ class AlertSettingsTests: AuthenticatorTestCase {
     }
 
     /// `languageChanged(to:)` constructs an `Alert` with the title and ok buttons.
+    @MainActor
     func test_languageChanged() {
         let subject = Alert.languageChanged(to: "Thai") {}
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsProcessorTests.swift
@@ -46,6 +46,7 @@ class ExportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// `.receive()` with `.dismiss` dismisses the view and clears any files.
+    @MainActor
     func test_receive_dismiss() {
         subject.receive(.dismiss)
 
@@ -54,6 +55,7 @@ class ExportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// `.receive()` with `.exportItemsTapped` shows the confirm alert for unencrypted formats.
+    @MainActor
     func test_receive_exportItemsTapped_unencrypted() {
         subject.state.fileFormat = .json
         subject.receive(.exportItemsTapped)
@@ -63,6 +65,7 @@ class ExportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// `.receive()` with  `.exportItemsTapped` logs an error on export failure.
+    @MainActor
     func test_receive_exportItemsTapped_unencrypted_error() throws {
         exportService.exportFileContentResult = .failure(AuthenticatorTestError.example)
         subject.state.fileFormat = .csv
@@ -79,6 +82,7 @@ class ExportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// `.receive()` with  `.exportItemsTapped` passes a file url to the coordinator on success.
+    @MainActor
     func test_receive_exportItemsTapped_unencrypted_success() throws {
         let testURL = URL(string: "www.bitwarden.com")!
         exportService.exportFileContentResult = .success("")
@@ -97,6 +101,7 @@ class ExportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// `.receive()` with `.fileFormatTypeChanged()` updates the file format.
+    @MainActor
     func test_receive_fileFormatTypeChanged() {
         subject.receive(.fileFormatTypeChanged(.csv))
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsViewTests.swift
@@ -30,6 +30,7 @@ class ExportItemsViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Tapping the cancel button dispatches the `.dismiss` action.
+    @MainActor
     func test_cancelButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.cancel)
         try button.tap()
@@ -37,6 +38,7 @@ class ExportItemsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the export items button sends the `.exportItemsTapped` action.
+    @MainActor
     func test_exportItemsButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.exportItems)
         try button.tap()
@@ -45,6 +47,7 @@ class ExportItemsViewTests: AuthenticatorTestCase {
     }
 
     /// Updating the value of the file format sends the  `.fileFormatTypeChanged()` action.
+    @MainActor
     func test_fileFormatMenu_updateValue() throws {
         processor.state.fileFormat = .json
         let menuField = try subject.inspect().find(bitwardenMenuField: Localizations.fileFormat)

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessorTests.swift
@@ -44,6 +44,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// When the import process throws a `dataCorrupted` error, the processor shows an error alert.
+    @MainActor
     func test_fileSelectionCompleted_corruptedFile() async throws {
         importItemsService.errorToThrow = DecodingError.dataCorrupted(
             DecodingError.Context(codingPath: [], debugDescription: "Not valid JSON")
@@ -62,6 +63,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the import process throws a `keyNotFound` error, the processor shows an error alert.
+    @MainActor
     func test_fileSelectionCompleted_missingKey() async throws {
         importItemsService.errorToThrow = DecodingError.keyNotFound(
             AnyCodingKey(stringValue: "missingKey"),
@@ -87,6 +89,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the import process throws a `keyNotFound` error, the processor shows an error alert.
+    @MainActor
     func test_fileSelectionCompleted_missingValue() async throws {
         importItemsService.errorToThrow = DecodingError.valueNotFound(
             String.self,
@@ -113,6 +116,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
 
     /// The processor hands the data returned from the file selector to the `ImportItemsService`. Upon
     /// successful import, it shows a Toast.
+    @MainActor
     func test_fileSelectionCompleted_success() async throws {
         let data = "Test Data".data(using: .utf8)!
         subject.fileSelectionCompleted(fileName: "Filename", data: data)
@@ -124,6 +128,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
 
     /// When the import process throws a `TwoFasImporterError.passwordProtectedFile` error,
     /// the processor shows an error alert.
+    @MainActor
     func test_fileSelectionCompleted_twoFasPasswordProtected() async throws {
         importItemsService.errorToThrow = TwoFasImporterError.passwordProtectedFile
         let data = "Test Data".data(using: .utf8)!
@@ -135,6 +140,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the import process throws a `keyNotFound` error, the processor shows an error alert.
+    @MainActor
     func test_fileSelectionCompleted_typeMismatch() async throws {
         importItemsService.errorToThrow = DecodingError.typeMismatch(
             Int.self,
@@ -160,6 +166,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the import process throws an unexpected error, the processor logs the error..
+    @MainActor
     func test_fileSelectionCompleted_unknownError() async throws {
         importItemsService.errorToThrow = AuthenticatorTestError.example
         let data = "Test Data".data(using: .utf8)!
@@ -172,6 +179,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the Processor receives a `.clearURL` action, it clears the url in the state.
+    @MainActor
     func test_receive_clearURL() {
         subject.state.url = ExternalLinksConstants.helpAndFeedback
         subject.receive(.clearURL)
@@ -179,18 +187,21 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the Processor receives a `.dismiss` action, it navigates to `.dismiss`.
+    @MainActor
     func test_receive_dismiss() {
         subject.receive(.dismiss)
         XCTAssertEqual(coordinator.routes.last, .dismiss)
     }
 
     /// When the Processor receives a `.fileFormatTypeChanged(_)` action, it sets the file format type in the state.
+    @MainActor
     func test_receive_fileFormatTypeChanged() {
         subject.receive(.fileFormatTypeChanged(.bitwardenJson))
         XCTAssertEqual(subject.state.fileFormat, .bitwardenJson)
     }
 
     /// When the Processor receives a `.importItemsTapped` action, it navigates to `.importItemsFileSelection`.
+    @MainActor
     func test_receive_importItemsTapped_fileImport() {
         subject.state.fileFormat = .bitwardenJson
         subject.receive(.importItemsTapped)
@@ -198,6 +209,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the Processor receives a `.importItemsTapped` action and a `nil` route, it sends the event
+    @MainActor
     func test_receive_importItemsTapped_qrScan() async throws {
         subject.state.fileFormat = .googleQr
         subject.receive(.importItemsTapped)
@@ -206,6 +218,7 @@ class ImportItemsProcessorTests: AuthenticatorTestCase {
     }
 
     /// When the Processor receives a `.toastShown(_)` action, it sets the toast in the state.
+    @MainActor
     func test_receive_toastShown() {
         let toast = Toast(text: "TOAST!")
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsViewTests.swift
@@ -30,6 +30,7 @@ class ImportItemsViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Tapping the cancel button dispatches the `.dismiss` action.
+    @MainActor
     func test_cancelButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.cancel)
         try button.tap()
@@ -37,6 +38,7 @@ class ImportItemsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the import items button sends the `.importItemsTapped` action.
+    @MainActor
     func test_importItemsButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.importItems)
         try button.tap()
@@ -45,6 +47,7 @@ class ImportItemsViewTests: AuthenticatorTestCase {
     }
 
     /// Updating the value of the file format sends the  `.fileFormatTypeChanged()` action.
+    @MainActor
     func test_fileFormatMenu_updateValue() throws {
         processor.state.fileFormat = .bitwardenJson
         let menuField = try subject.inspect().find(bitwardenMenuField: Localizations.fileFormat)

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageProcessorTests.swift
@@ -44,6 +44,7 @@ class SelectLanguageProcessorTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `.receive(_:)` with `.dismiss` dismisses the view.
+    @MainActor
     func test_receive_dismiss() {
         subject.receive(.dismiss)
         XCTAssertEqual(coordinator.routes.last, .dismiss)
@@ -51,6 +52,7 @@ class SelectLanguageProcessorTests: AuthenticatorTestCase {
 
     /// `.receive(_:)` with `.languageTapped` with a new language saves the selection and shows
     /// the confirmation alert.
+    @MainActor
     func test_receive_languageTapped() async throws {
         subject.receive(.languageTapped(.custom(languageCode: "th")))
 
@@ -67,6 +69,7 @@ class SelectLanguageProcessorTests: AuthenticatorTestCase {
     }
 
     /// `.receive(_:)` with `.languageTapped` with the same language has no effect.
+    @MainActor
     func test_receive_languageTapped_noChange() {
         subject.receive(.languageTapped(.default))
         XCTAssertTrue(coordinator.alertShown.isEmpty)

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageViewTests.swift
@@ -32,6 +32,7 @@ class SelectLanguageViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Tapping the cancel button dispatches the `.dismiss` action.
+    @MainActor
     func test_cancelButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.cancel)
         try button.tap()
@@ -39,6 +40,7 @@ class SelectLanguageViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping a language button dispatches the `.languageTapped(_)` action.
+    @MainActor
     func test_languageButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.defaultSystem)
         try button.tap()

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -52,6 +52,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Performing `.loadData` sets the 'defaultSaveOption' to the current value in 'AppSettingsStore'.
+    @MainActor
     func test_perform_loadData_defaultSaveOption() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         appSettingsStore.defaultSaveOption = .saveToBitwarden
@@ -62,6 +63,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.loadData` sets the sync related flags correctly when the feature flag is
     /// disabled and the sync is off.
+    @MainActor
     func test_perform_loadData_syncFlagDisabled_syncOff() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         authItemRepository.pmSyncEnabled = false
@@ -73,6 +75,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.loadData` sets the sync related flags correctly when the feature flag is
     /// enabled and the sync is off.
+    @MainActor
     func test_perform_loadData_syncFlagEnabled_syncOff() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         authItemRepository.pmSyncEnabled = false
@@ -84,6 +87,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.loadData` sets the sync related flags correctly when the feature flag is
     /// disabled and the sync is on.
+    @MainActor
     func test_perform_loadData_syncFlagDisabled_syncOn() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         authItemRepository.pmSyncEnabled = true
@@ -95,6 +99,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.loadData` sets the sync related flags correctly when the feature flag is
     /// enabled and the sync is on.
+    @MainActor
     func test_perform_loadData_syncFlagEnabled_syncOn() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         authItemRepository.pmSyncEnabled = true
@@ -105,6 +110,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     }
 
     /// Performing `.loadData` sets the session timeout to `.never` if biometrics are disabled.
+    @MainActor
     func test_perform_loadData_vaultTimeout_biometricsDisabled() async throws {
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: false, hasValidIntegrity: true)
@@ -115,6 +121,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     }
 
     /// Performing `.loadData` sets the session timeout correctly when it is set in app settings..
+    @MainActor
     func test_perform_loadData_vaultTimeout_fifteenMinutes() async throws {
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: true)
@@ -126,6 +133,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.loadData` sets the session timeout to `.never` when there is no timeout
     /// set and biometrics is not available or not enabled.
+    @MainActor
     func test_perform_loadData_vaultTimeout_nil() async throws {
         await subject.perform(.loadData)
         XCTAssertEqual(subject.state.sessionTimeoutValue, .never)
@@ -133,6 +141,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.loadData` sets the session timeout to `.onAppRestart` when there is no timeout
     /// set and biometrics is turned enabled.
+    @MainActor
     func test_perform_loadData_vaultTimeout_nilWithBiometrics() async throws {
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: true)
@@ -144,6 +153,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     /// Receiving `.sessionTimeoutValueChanged` when a user has not yet enabled biometrics enables
     /// biometrics and sets the value.
     ///
+    @MainActor
     func test_perform_sessionTimeoutValueChanged_biometricsDisabled() async throws {
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: true)
@@ -158,6 +168,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     }
 
     /// Receiving `.sessionTimeoutValueChanged` updates the user's `vaultTimeout` app setting.
+    @MainActor
     func test_perform_sessionTimeoutValueChanged_success() async throws {
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: true)
@@ -172,6 +183,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.toggleUnlockWithBiometrics` with a `false` value disables biometric unlock and resets the
     /// session timeout to `.never`
+    @MainActor
     func test_perform_toggleUnlockWithBiometrics_off() async throws {
         biometricsRepository.capturedUserAuthKey = "key"
         biometricsRepository.biometricUnlockStatus = .success(
@@ -188,6 +200,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Performing `.toggleUnlockWithBiometrics` with a `true` value enables biometric unlock and defaults the
     /// session timeout to `.onAppRestart`.
+    @MainActor
     func test_perform_toggleUnlockWithBiometrics_on() async throws {
         biometricsRepository.biometricUnlockStatus = .success(
             .available(.faceID, enabled: true, hasValidIntegrity: true)
@@ -200,6 +213,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     }
 
     /// Receiving `.backupTapped` shows an alert for the backup information.
+    @MainActor
     func test_receive_backupTapped() async throws {
         subject.receive(.backupTapped)
 
@@ -209,6 +223,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     }
 
     /// Receiving `.defaultSaveChanged` updates the user's `defaultSaveOption` app setting.
+    @MainActor
     func test_receive_defaultSaveChanged() {
         subject.state.defaultSaveOption = .none
         subject.receive(.defaultSaveChanged(.saveHere))
@@ -218,6 +233,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
     }
 
     /// Receiving `.exportItemsTapped` navigates to the export vault screen.
+    @MainActor
     func test_receive_exportVaultTapped() {
         subject.receive(.exportItemsTapped)
 
@@ -226,6 +242,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Receiving `.syncWithBitwardenAppTapped` adds the Password Manager settings URL to the state to
     /// navigate the user to the PM app's settings.
+    @MainActor
     func test_receive_syncWithBitwardenAppTapped_installed() {
         application.canOpenUrlResponse = true
         subject.receive(.syncWithBitwardenAppTapped)
@@ -235,6 +252,7 @@ class SettingsProcessorTests: AuthenticatorTestCase {
 
     /// Receiving `.syncWithBitwardenAppTapped` adds the Password Manager settings App Store URL to
     /// the state to navigate the user to the App Store when the PM app is not installed..
+    @MainActor
     func test_receive_syncWithBitwardenAppTapped_notInstalled() {
         application.canOpenUrlResponse = false
         subject.receive(.syncWithBitwardenAppTapped)

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
@@ -35,6 +35,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Updating the value of the app theme sends the  `.appThemeChanged()` action.
+    @MainActor
     func test_appThemeChanged_updateValue() throws {
         processor.state.appTheme = .light
         let menuField = try subject.inspect().find(settingsMenuField: Localizations.theme)
@@ -43,6 +44,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the backup button dispatches the `.backupTapped` action.
+    @MainActor
     func test_backupButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.backup)
         try button.tap()
@@ -50,6 +52,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Updating the value of the default save option sends the  `.defaultSaveOptionChanged()` action.
+    @MainActor
     func test_defaultSaveOptionChanged_updateValue() throws {
         processor.state.shouldShowDefaultSaveOption = true
         processor.state.shouldShowSyncButton = true
@@ -60,6 +63,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the export button dispatches the `.exportItemsTapped` action.
+    @MainActor
     func test_exportButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.export)
         try button.tap()
@@ -67,6 +71,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the help center button dispatches the `.helpCenterTapped` action.
+    @MainActor
     func test_helpCenterButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.bitwardenHelpCenter)
         try button.tap()
@@ -74,6 +79,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the privacy policy button dispatches the `.privacyPolicyTapped` action.
+    @MainActor
     func test_privacyPolicyButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.privacyPolicy)
         try button.tap()
@@ -81,6 +87,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Updating the value of the `sessionTimeoutValue` sends the  `.sessionTimeoutValueChanged()` action.
+    @MainActor
     func test_sessionTimeoutValue_updateValue() throws {
         processor.state.biometricUnlockStatus = .available(.faceID, enabled: false, hasValidIntegrity: true)
         processor.state.sessionTimeoutValue = .never
@@ -92,6 +99,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the sync with Bitwarden app button dispatches the `.syncWithBitwardenAppTapped` action.
+    @MainActor
     func test_syncWithBitwardenButton_tap() throws {
         processor.state.shouldShowSyncButton = true
         let button = try subject.inspect().find(button: Localizations.syncWithBitwardenApp)
@@ -100,6 +108,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the tutorial button dispatches the `.tutorialTapped` action.
+    @MainActor
     func test_tutorialButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.launchTutorial)
         try button.tap()
@@ -107,6 +116,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the version button dispatches the `.versionTapped` action.
+    @MainActor
     func test_versionButton_tap() throws {
         let button = try subject.inspect().find(button: version)
         try button.tap()
@@ -122,6 +132,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tests the view renders correctly.
+    @MainActor
     func test_viewRenderWithBiometricsAvailable() {
         processor.state.biometricUnlockStatus = .available(.faceID, enabled: false, hasValidIntegrity: true)
         assertSnapshots(
@@ -131,6 +142,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tests the view renders correctly with the `shouldShowSyncButton` set to `true`.
+    @MainActor
     func test_viewRenderWithSyncRow() {
         processor.state.shouldShowSyncButton = true
         assertSnapshots(
@@ -140,6 +152,7 @@ class SettingsViewTests: AuthenticatorTestCase {
     }
 
     /// Tests the view renders correctly with `shouldShowDefaultSaveOption` and `shouldShowSyncButton` set to `true`.
+    @MainActor
     func test_viewRenderWithSyncRowAndDefaultSaveOption() {
         processor.state.shouldShowDefaultSaveOption = true
         processor.state.shouldShowSyncButton = true

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -36,6 +36,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `navigate(to:)` with `.alert` has the stack navigator present the alert.
+    @MainActor
     func test_navigateTo_alert() throws {
         let alert = Alert.defaultAlert(
             title: Localizations.anErrorHasOccurred,
@@ -47,6 +48,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.dismiss` dismisses the view.
+    @MainActor
     func test_navigate_dismiss() throws {
         subject.navigate(to: .dismiss)
 
@@ -55,6 +57,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.exportItems` presents the export vault view.
+    @MainActor
     func test_navigateTo_exportVault() throws {
         subject.navigate(to: .exportItems)
 
@@ -64,6 +67,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.selectLanguage()` presents the select language view.
+    @MainActor
     func test_navigateTo_selectLanguage() throws {
         subject.navigate(to: .selectLanguage(currentLanguage: .default))
 
@@ -73,6 +77,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.settings` pushes the settings view onto the stack navigator.
+    @MainActor
     func test_navigateTo_settings() throws {
         subject.navigate(to: .settings)
 
@@ -82,6 +87,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `showLoadingOverlay()` and `hideLoadingOverlay()` can be used to show and hide the loading overlay.
+    @MainActor
     func test_show_hide_loadingOverlay() throws {
         stackNavigator.rootViewController = UIViewController()
         try setKeyWindowRoot(viewController: XCTUnwrap(stackNavigator.rootViewController))
@@ -97,6 +103,7 @@ class SettingsCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `start()` navigates to the settings view.
+    @MainActor
     func test_start() {
         subject.start()
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -75,6 +75,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     // MARK: Tests
 
     /// `itemDeleted()` delegate method shows the expected toast.
+    @MainActor
     func test_delegate_itemDeleted() {
         XCTAssertNil(subject.state.toast)
 
@@ -84,6 +85,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.addItemPressed` and authorized camera
     /// navigates to `.showScanCode`
+    @MainActor
     func test_perform_addItemPressed_authorizedCamera() {
         cameraService.deviceHasCamera = true
         cameraService.cameraAuthorizationStatus = .authorized
@@ -97,6 +99,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.addItemPressed` and denied camera
     /// navigates to `.setupTotpManual`
+    @MainActor
     func test_perform_addItemPressed_deniedCamera() {
         cameraService.deviceHasCamera = true
         cameraService.cameraAuthorizationStatus = .denied
@@ -110,6 +113,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.addItemPressed` and no camera
     /// navigates to `.setupTotpManual`
+    @MainActor
     func test_perform_addItemPressed_noCamera() {
         cameraService.deviceHasCamera = false
         let task = Task {
@@ -121,6 +125,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `perform(_:)` with `.appeared` starts streaming vault items.
+    @MainActor
     func test_perform_appeared() {
         let result = ItemListItem.fixture(
             totp: .fixture(
@@ -163,6 +168,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.appeared` handles TOTP Code expiration
     /// with updates the state's TOTP codes.
+    @MainActor
     func test_perform_appeared_totpExpired_single() throws { // swiftlint:disable:this function_body_length
         let firstItem = ItemListItem.fixture(
             totp: .fixture(
@@ -223,6 +229,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.copyPressed()` with a local item copies the code to the pasteboard
     /// and updates the toast in the state.
+    @MainActor
     func test_perform_copyPressed_localItem() {
         let totpCode = "654321"
         let totpModel = TOTPCodeModel(code: totpCode,
@@ -247,6 +254,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.copyPressed()` with a local item copies the code to the pasteboard
     /// and updates the toast in the state.
+    @MainActor
     func test_perform_copyPressed_error() {
         let localItem = ItemListItem.fixture()
         totpService.getTotpCodeResult = .failure(AuthenticatorTestError.example)
@@ -264,6 +272,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.copyPressed()` with a shared item copies the code to the pasteboard
     /// and updates the toast in the state.
+    @MainActor
     func test_perform_copyPressed_sharedItem() {
         let totpCode = "654321"
         let totpModel = TOTPCodeModel(code: totpCode,
@@ -288,6 +297,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.copyPressed()` with a `.syncError` item does not throw
     /// and produces no result.
+    @MainActor
     func test_perform_copyPressed_syncError() async {
         await assertAsyncDoesNotThrow {
             await subject.perform(.copyPressed(.syncError()))
@@ -298,6 +308,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.moveToBitwardenPressed()` with a local item stores the item in the shared
     /// store and launches the Bitwarden app via the new item  deep link.
+    @MainActor
     func test_perform_moveToBitwardenPressed_localItem() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -313,6 +324,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.moveToBitwardenPressed()` captures any errors thrown, logs them, and shows an
     /// error alert.
+    @MainActor
     func test_perform_moveToBitwardenPressed_error() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -329,6 +341,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.moveToBitwardenPressed()` does nothing when the `enablePasswordManagerSync`
     /// feature flag is disabled.
+    @MainActor
     func test_perform_moveToBitwardenPressed_featureFlagDisabled() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         application.canOpenUrlResponse = true
@@ -343,6 +356,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(:_)` with `.moveToBitwardenPressed()` does nothing when the Password Manager app is not
     /// installed - i.e. the `bitwarden://` urls cannot be opened.
+    @MainActor
     func test_perform_moveToBitwardenPressed_passwordManagerAppNotInstalled() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         application.canOpenUrlResponse = false
@@ -356,6 +370,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `perform(:_)` with `.moveToBitwardenPressed()` does nothing when called with a shared item.
+    @MainActor
     func test_perform_moveToBitwardenPressed_sharedItem() async throws {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         application.canOpenUrlResponse = true
@@ -369,6 +384,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `perform(:_)` with `.search` updates search results in the state.
+    @MainActor
     func test_perform_search() {
         let result = ItemListItem.fixture(
             totp: .fixture(
@@ -395,6 +411,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `perform(:_)` with `.search` with an empty string gets empty search results
+    @MainActor
     func test_perform_search_emptyString() async {
         await subject.perform(.search("   "))
         XCTAssertEqual(subject.state.searchResults.count, 0)
@@ -405,6 +422,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `perform(.search)` throws error and error is logged.
+    @MainActor
     func test_perform_search_error() async {
         authItemRepository.searchItemListSubject.send(completion: .failure(AuthenticatorTestError.example))
         await subject.perform(.search("example"))
@@ -419,6 +437,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(.search)` handles TOTP Code expiration
     /// with updates the state's TOTP codes.
+    @MainActor
     func test_perform_search_totpExpired() throws {
         let firstItem = ItemListItem.fixture(
             totp: .fixture(
@@ -470,6 +489,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.streamItemList` starts streaming vault items. When there are no shared
     /// account items, does not show a toast.
+    @MainActor
     func test_perform_streamItemList() {
         let totpCode = TOTPCodeModel(code: "654321",
                                      codeGenerationDate: Date(year: 2023, month: 12, day: 31),
@@ -495,6 +515,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `perform(_:)` with `.streamItemList` starts streaming vault items. Item List is sorted by name
+    @MainActor
     func test_perform_streamItemList_sorted() {
         let results = [
             ItemListItem.fixture(name: "Gamma"),
@@ -535,6 +556,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     /// from an account the user has not synced with previously, it should show a toast stating that the account
     /// was synced.
     ///
+    @MainActor
     func test_perform_streamItemList_withAccountSyncToast() {
         let accountName = "test@example.com | vault.example.com"
         let totpCode = TOTPCodeModel(code: "654321",
@@ -564,6 +586,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     /// `perform(_:)` with `.streamItemList` starts streaming vault items. When there are shared items
     /// from an account the user *has* synced with previously, it should *not* show a toast.
     ///
+    @MainActor
     func test_perform_streamItemList_withPreviouslySyncedAccount() {
         let accountName = "test@example.com | vault.example.com"
         let totpCode = TOTPCodeModel(code: "654321",
@@ -592,6 +615,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.streamItemList` sets `showMoveToBitwarden` to `false` when the feature flag is disabled
     /// or the user has not yet turned sync on for at least one account.
+    @MainActor
     func test_perform_streamItemList_showMoveToBitwarden_false() {
         authItemRepository.pmSyncEnabled = false
         let totpCode = TOTPCodeModel(code: "654321",
@@ -618,6 +642,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `perform(_:)` with `.streamItemList` sets `showMoveToBitwarden` to `true` when the feature flag is enabled
     /// and the user has turned sync on for at least one account.
+    @MainActor
     func test_perform_appeared_showMoveToBitwarden_true() {
         authItemRepository.pmSyncEnabled = true
         let totpCode = TOTPCodeModel(code: "654321",
@@ -643,6 +668,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `.receive` with `.clearURL` sets the `state.url` to `nil`.
+    @MainActor
     func test_receive_clearURL() throws {
         subject.state.url = .example
         subject.receive(.clearURL)
@@ -651,6 +677,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `setupForegroundNotification()` is called as part of `init()` and subscribes to any
     ///  foreground notification, performing `.refresh` when it receives a notification.
+    @MainActor
     func test_setupForegroundNotification() async throws {
         let item = ItemListItem.fixture()
         let resultSection = ItemListSection(id: "", items: [item], name: "Items")
@@ -666,6 +693,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     // MARK: AuthenticatorKeyCaptureDelegate Tests
 
     /// `didCompleteAutomaticCapture` failure when the user has opted to save locally by default.
+    @MainActor
     func test_didCompleteAutomaticCapture_failure() {
         appSettingsStore.hasSeenDefaultSaveOptionPrompt = true
         appSettingsStore.defaultSaveOption = .saveHere
@@ -696,6 +724,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `didCompleteAutomaticCapture` success when the user has opted to be asked by default and
     /// chooses the save locally option.
+    @MainActor
     func test_didCompleteAutomaticCapture_hasSeenPrompt_noneLocalSaveChosen() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -731,6 +760,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `didCompleteAutomaticCapture` success when the user has opted to be asked by default and
     /// chooses the save locally option.
+    @MainActor
     func test_didCompleteAutomaticCapture_hasSeenPrompt_noneSaveToBitwardenChosen() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -767,6 +797,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `didCompleteAutomaticCapture` success when the user has opted to save locally by default.
+    @MainActor
     func test_didCompleteAutomaticCapture_hasSeenPrompt_saveLocally() async throws {
         appSettingsStore.hasSeenDefaultSaveOptionPrompt = true
         appSettingsStore.defaultSaveOption = .saveHere
@@ -791,6 +822,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `didCompleteAutomaticCapture` success when the user has opted to save to Bitwarden by default.
+    @MainActor
     func test_didCompleteAutomaticCapture_hasSeenPrompt_saveToBitwarden() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -819,6 +851,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `didCompleteAutomaticCapture` success when the user has no default save option set, chooses
     /// to save locally and choose to not set that as their default.
+    @MainActor
     func test_didCompleteAutomaticCapture_noDefault_saveLocally_noToDefault() async throws {
         authItemRepository.pmSyncEnabled = true
         appSettingsStore.hasSeenDefaultSaveOptionPrompt = false
@@ -863,6 +896,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `didCompleteAutomaticCapture` success when the user has no default save option set, chooses
     /// to save locally and choose to set that as their default.
+    @MainActor
     func test_didCompleteAutomaticCapture_noDefault_saveLocally_yesToDefault() async throws {
         authItemRepository.pmSyncEnabled = true
         appSettingsStore.hasSeenDefaultSaveOptionPrompt = false
@@ -907,6 +941,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `didCompleteAutomaticCapture` success when the user has no default save option set, chooses
     /// to save to Bitwarden and choose to not set that as their default.
+    @MainActor
     func test_didCompleteAutomaticCapture_noDefault_saveToBitwarden_noToDefault() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -951,6 +986,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// `didCompleteAutomaticCapture` success when the user has no default save option set, chooses
     /// to save to Bitwarden and choose to set that as their default.
+    @MainActor
     func test_didCompleteAutomaticCapture_noDefault_saveToBitwarden_yesToDefault() async throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -996,6 +1032,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     /// `didCompleteAutomaticCapture` should not show any prompts or look at the defaults when the sync
     /// is not active (either feature flag is disabled, or the user hasn't yet turned sync on). It should revert to the
     /// pre-existing behavior and save the code locally.
+    @MainActor
     func test_didCompleteAutomaticCapture_syncNotActive() async throws {
         authItemRepository.pmSyncEnabled = false
         let key = String.base32Key
@@ -1019,6 +1056,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `didCompleteManualCapture` failure
+    @MainActor
     func test_didCompleteManualCapture_failure() {
         totpService.getTOTPConfigResult = .failure(TOTPServiceError.invalidKeyFormat)
         let captureCoordinator = MockCoordinator<AuthenticatorKeyCaptureRoute, AuthenticatorKeyCaptureEvent>()
@@ -1048,6 +1086,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `didCompleteManualCapture` success with a locally saved item
+    @MainActor
     func test_didCompleteManualCapture_localSuccess() throws {
         let key = String.base32Key
         let keyConfig = try XCTUnwrap(TOTPKeyModel(authenticatorKey: key))
@@ -1072,6 +1111,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// `didCompleteManualCapture` success with `sendToBitwarden` item
+    @MainActor
     func test_didCompleteManualCapture_sendToBitwardenSuccess() throws {
         authItemRepository.pmSyncEnabled = true
         application.canOpenUrlResponse = true
@@ -1100,6 +1140,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// Tests that the `itemListCardState` is set to `none` if the download card has been closed.
+    @MainActor
     func test_determineItemListCardState_closed_download() async {
         configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         application.canOpenUrlResponse = false
@@ -1108,6 +1149,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// Tests that the `itemListCardState` is set to `none` if the sync card has been closed.
+    @MainActor
     func test_determineItemListCardState_closed_sync() async {
         configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         application.canOpenUrlResponse = true
@@ -1117,6 +1159,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// Tests that the `showPasswordManagerSyncCard` and `showPasswordManagerDownloadCard` are set
     /// to false if the feature flag is turned off.
+    @MainActor
     func test_determineItemListCardState_FeatureFlag_off() {
         subject.state.itemListCardState = .passwordManagerSync
         configService.featureFlagsBool = [.enablePasswordManagerSync: false]
@@ -1129,6 +1172,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// Tests that the `itemListCardState` is set to `passwordManagerDownload` if the feature flag is turned on.
+    @MainActor
     func test_determineItemListCardState_FeatureFlag_on_download() {
         configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         application.canOpenUrlResponse = false
@@ -1141,6 +1185,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
     }
 
     /// Tests that the `itemListCardState` is set to `passwordManagerSync` if the feature flag is turned on.
+    @MainActor
     func test_determineItemListCardState_FeatureFlag_on_sync() {
         configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         application.canOpenUrlResponse = true
@@ -1154,6 +1199,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// Tests that the `itemListCardState` is set to `none` if the user has already enabled sync in the PM app
     /// (when the PM app is not installed).
+    @MainActor
     func test_determineItemListCardState_syncAlreadyOn_download() {
         configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         authItemRepository.pmSyncEnabled = true
@@ -1169,6 +1215,7 @@ class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this 
 
     /// Tests that the `itemListCardState` is set to `none` if the user has already enabled sync in the PM app
     /// (when the PM app is installed).
+    @MainActor
     func test_determineItemListCardState_syncAlreadyOn_sync() {
         configService.featureFlagsBool = [.enablePasswordManagerSync: true]
         authItemRepository.pmSyncEnabled = true

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
@@ -54,6 +54,7 @@ class ItemListViewTests: AuthenticatorTestCase {
     }
 
     /// Test a snapshot of the ItemListView showing the download card with an empty result.
+    @MainActor
     func test_snapshot_ItemListView_card_download_empty() {
         let state = ItemListState(
             itemListCardState: .passwordManagerDownload,
@@ -69,6 +70,7 @@ class ItemListViewTests: AuthenticatorTestCase {
     }
 
     /// Test a snapshot of the ItemListView showing the download card with results.
+    @MainActor
     func test_snapshot_ItemListView_card_download_with_items() {
         let state = ItemListState(
             itemListCardState: .passwordManagerDownload,
@@ -84,6 +86,7 @@ class ItemListViewTests: AuthenticatorTestCase {
     }
 
     /// Test a snapshot of the ItemListView showing the sync card with an empty result.
+    @MainActor
     func test_snapshot_ItemListView_card_sync_empty() {
         let state = ItemListState(
             itemListCardState: .passwordManagerSync,
@@ -99,6 +102,7 @@ class ItemListViewTests: AuthenticatorTestCase {
     }
 
     /// Test a snapshot of the ItemListView showing the sync card with results.
+    @MainActor
     func test_snapshot_ItemListView_card_sync_with_items() {
         let state = ItemListState(
             itemListCardState: .passwordManagerSync,
@@ -114,6 +118,7 @@ class ItemListViewTests: AuthenticatorTestCase {
     }
 
     /// Test the close taps trigger the associated effect.
+    @MainActor
     func test_itemListCardView_close_download() throws {
         let state = ItemListState(
             itemListCardState: .passwordManagerDownload,
@@ -133,6 +138,7 @@ class ItemListViewTests: AuthenticatorTestCase {
     }
 
     /// Test the close taps trigger the associated effect.
+    @MainActor
     func test_itemListCardView_close_sync() throws {
         let state = ItemListState(
             itemListCardState: .passwordManagerSync,

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinatorTests.swift
@@ -48,6 +48,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.addManual` instructs the delegate that the capture flow has
     /// completed. Passing `false` to `sendToBitwarden` passes `false` to the delegate.
+    @MainActor
     func test_navigateTo_addManual() {
         delegate.didCompleteManualCaptureSendToBitwarden = true
         let name = "manual name"
@@ -62,6 +63,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.addManual` instructs the delegate that the capture flow has
     /// completed. Passing `true` to `sendToBitwarden` passes `true` to the delegate.
+    @MainActor
     func test_navigateTo_addManual_sendToBitwarden() {
         let name = "manual name"
         let entry = "manuallyManagedMagic"
@@ -75,6 +77,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.complete` instructs the delegate that the capture flow has
     /// completed.
+    @MainActor
     func test_navigateTo_complete() {
         let result = ScanResult(content: "example.com", codeType: .qr)
         subject.navigate(to: .complete(value: result))
@@ -84,6 +87,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.dismiss` dismisses the view.
+    @MainActor
     func test_navigateTo_dismiss_noAction() throws {
         subject.navigate(to: .dismiss())
         let lastAction = try XCTUnwrap(stackNavigator.actions.last)
@@ -91,6 +95,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.dismiss` dismisses the view.
+    @MainActor
     func test_navigateTo_dismiss_withAction() throws {
         var didRun = false
         subject.navigate(to: .dismiss(DismissAction(action: { didRun = true })))
@@ -101,6 +106,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.setupTotpManual` presents the manual entry view. When the camera is
     /// present but the user has denied access, it sets `deviceSupportsCamera` to `false`.
+    @MainActor
     func test_navigateTo_setupTotpManual_cameraNotAuthorized() throws {
         cameraService.deviceHasCamera = true
         cameraService.cameraAuthorizationStatus = .denied
@@ -114,6 +120,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.setupTotpManual` presents the manual entry view. When the camera is
     /// present and `.authorized`, it sets `deviceSupportsCamera` to `true`.
+    @MainActor
     func test_navigateTo_setupTotpManual_cameraPresentAndAuthorized() throws {
         cameraService.deviceHasCamera = true
         cameraService.cameraAuthorizationStatus = .authorized
@@ -127,6 +134,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
 
     /// `navigate(to:)` with `.setupTotpManual` presents the manual entry view. When the camera is
     /// not present, it sets `deviceSupportsCamera` to `false`.
+    @MainActor
     func test_navigateTo_setupTotpManual_noCamera() throws {
         cameraService.deviceHasCamera = false
         subject.navigate(to: .manualKeyEntry)
@@ -138,6 +146,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.setupTotpManual` presents the manual entry view.
+    @MainActor
     func test_navigateTo_setupTotpManual_nonEmptyStack() throws {
         stackNavigator.isEmpty = false
         subject.navigate(to: .manualKeyEntry)
@@ -146,6 +155,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateTo_scanCode() throws {
         cameraService.deviceHasCamera = true
         let task = Task {
@@ -161,6 +171,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateTo_scanCode_nonEmptyStack() throws {
         stackNavigator.isEmpty = false
         cameraService.deviceHasCamera = true
@@ -173,6 +184,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `showLoadingOverlay()` and `hideLoadingOverlay()` can be used to show and hide the loading overlay.
+    @MainActor
     func test_show_hide_loadingOverlay() throws {
         stackNavigator.rootViewController = UIViewController()
         try setKeyWindowRoot(viewController: XCTUnwrap(stackNavigator.rootViewController))
@@ -188,6 +200,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateAsyncTo_scanCode() throws {
         cameraService.deviceHasCamera = true
         let task = Task {
@@ -203,6 +216,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateAsyncTo_scanCode_cameraSessionError() throws {
         cameraService.deviceHasCamera = true
         struct TestError: Error, Equatable {}
@@ -221,6 +235,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateAsyncTo_scanCode_declineAuthorization() throws {
         cameraService.deviceHasCamera = true
         cameraService.cameraAuthorizationStatus = .denied
@@ -237,6 +252,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateAsyncTo_scanCode_noCamera() throws {
         cameraService.deviceHasCamera = false
         let task = Task {
@@ -252,6 +268,7 @@ class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
     }
 
     /// `navigate(to:)` with `.scanCode` shows the scan view.
+    @MainActor
     func test_navigateAsyncTo_scanCode_nonEmptyStack() throws {
         stackNavigator.isEmpty = false
         cameraService.deviceHasCamera = true

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
@@ -40,6 +40,7 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
 
     /// `receive()` with `.appeared` sets the `isPasswordManagerSyncActive` to true when both
     /// the `.enablePasswordManagerSync` feature flag is enabled and sync is turned on.
+    @MainActor
     func test_perform_appeared_allActive() async {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         authItemRepository.pmSyncEnabled = true
@@ -50,6 +51,7 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
 
     /// `receive()` with `.appeared` sets the `isPasswordManagerSyncActive` to false when both
     /// the `.enablePasswordManagerSync` feature flag is disabled and sync is turned off.
+    @MainActor
     func test_perform_appeared_bothFalse() async {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         authItemRepository.pmSyncEnabled = false
@@ -60,6 +62,7 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
 
     /// `receive()` with `.appeared` sets the `isPasswordManagerSyncActive` to false when
     /// the `.enablePasswordManagerSync` feature flag is disabled and sync is turned on.
+    @MainActor
     func test_perform_appeared_flagDisabled() async {
         configService.featureFlagsBool[.enablePasswordManagerSync] = false
         authItemRepository.pmSyncEnabled = true
@@ -70,6 +73,7 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
 
     /// `receive()` with `.appeared` sets the `isPasswordManagerSyncActive` to false when both
     /// the `.enablePasswordManagerSync` feature flag is enabled but sync is turned off.
+    @MainActor
     func test_perform_appeared_syncOff() async {
         configService.featureFlagsBool[.enablePasswordManagerSync] = true
         authItemRepository.pmSyncEnabled = false
@@ -80,6 +84,7 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
 
     /// `receive()` with `.appeared` sets the `defaultSaveOption` in the state based on the user's
     /// stored default save option.
+    @MainActor
     func test_perform_appeared_defaultSaveOption() async {
         appSettingsStore.defaultSaveOption = .none
         await subject.perform(.appeared)
@@ -95,12 +100,14 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
     }
 
     /// `receive()` with `.scanCodePressed` navigates to `.scanCode`.
+    @MainActor
     func test_perform_scanCodePressed() async {
         await subject.perform(.scanCodePressed)
         XCTAssertEqual(coordinator.events, [.showScanCode])
     }
 
     /// `receive()` with `.addPressed(:)` navigates to `.addManual(:)`.
+    @MainActor
     func test_receive_addPressed() async {
         subject.state.authenticatorKey = "YouNeedUniqueNewYork"
         subject.state.name = "NewYork"
@@ -112,12 +119,14 @@ final class ManualEntryProcessorTests: AuthenticatorTestCase {
     }
 
     /// `receive()` with `.authenticatorKeyChanged(:)` updates the state.
+    @MainActor
     func test_receive_authenticatorKeyChanged() async {
         subject.receive(.authenticatorKeyChanged("YouNeedUniqueNewYork"))
         XCTAssertEqual(subject.state.authenticatorKey, "YouNeedUniqueNewYork")
     }
 
     /// `receive()` with `.dismissPressed` navigates to dismiss.
+    @MainActor
     func test_receive_dismissPressed() {
         subject.receive(.dismissPressed)
         XCTAssertEqual(coordinator.routes, [.dismiss()])

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
@@ -32,6 +32,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Tapping the add local code button dispatches the `.addPressed(:)` action.
+    @MainActor
     func test_addButton_tap_empty() throws {
         let button = try subject.inspect().find(button: Localizations.addCode)
         try button.tap()
@@ -42,6 +43,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the add local code button dispatches the `.addPressed(:)` action.
+    @MainActor
     func test_addButton_tap_new() throws {
         processor.state.name = "wayne"
         processor.state.authenticatorKey = "pasta-batman"
@@ -54,6 +56,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the Save here button dispatches the `.addPressed(:)` action.
+    @MainActor
     func test_addLocallyButton_tap_empty() throws {
         processor.state.isPasswordManagerSyncActive = true
         let button = try subject.inspect().find(button: Localizations.saveHere)
@@ -65,6 +68,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the Save here button dispatches the `.addPressed(:)` action.
+    @MainActor
     func test_addLocallyButton_tap_textEntered() throws {
         processor.state.name = "wayne"
         processor.state.authenticatorKey = "pasta-batman"
@@ -78,6 +82,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the add to Bitwarden button dispatches the `.addPressed(:)` action.
+    @MainActor
     func test_addToBitwardenButton_tap_empty() throws {
         processor.state.isPasswordManagerSyncActive = true
         let button = try subject.inspect().find(button: Localizations.saveToBitwarden)
@@ -89,6 +94,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the add to Bitwarden button dispatches the `.addPressed(:)` action.
+    @MainActor
     func test_addToBitwardenButton_tap_textEntered() throws {
         processor.state.name = "wayne"
         processor.state.authenticatorKey = "pasta-batman"
@@ -102,6 +108,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the cancel button dispatches the `.dismiss` action.
+    @MainActor
     func test_closeButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.cancel)
         try button.tap()
@@ -109,6 +116,7 @@ class ManualEntryViewTests: AuthenticatorTestCase {
     }
 
     /// Tapping the scan code button dispatches the `.scanCodePressed` action.
+    @MainActor
     func test_scanCodeButton_tap() throws {
         let button = try subject.inspect().find(
             button: Localizations.cannotAddAuthenticatorKey + " " + Localizations.scanQRCode

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessorTests.swift
@@ -39,6 +39,7 @@ final class ScanCodeProcessorTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// `perform()` with `.appeared` logs errors when starting the camera fails.
+    @MainActor
     func test_perform_appeared_failure() async {
         cameraService.deviceHasCamera = false
         await subject.perform(.appeared)
@@ -46,6 +47,7 @@ final class ScanCodeProcessorTests: AuthenticatorTestCase {
     }
 
     /// `perform()` with `.appeared` sets up the camera observation and responds to QR code scans
+    @MainActor
     func test_perform_appeared_qrScan() {
         let publisher = MockCameraService.ScanPublisher(nil)
         cameraService.startResult = .success(AVCaptureSession())
@@ -61,6 +63,7 @@ final class ScanCodeProcessorTests: AuthenticatorTestCase {
     }
 
     /// `perform()` with `.appeared` sets up the camera.
+    @MainActor
     func test_perform_appeared_noCamera() async {
         cameraService.deviceHasCamera = false
         await subject.perform(.appeared)
@@ -75,12 +78,14 @@ final class ScanCodeProcessorTests: AuthenticatorTestCase {
     }
 
     /// `receive()` with `.dismissPressed` navigates to dismiss.
+    @MainActor
     func test_receive_dismissPressed() {
         subject.receive(.dismissPressed)
         XCTAssertEqual(coordinator.routes, [.dismiss()])
     }
 
     /// `receive()` with `.manualEntryPressed` navigates to `.setupTotpManual`.
+    @MainActor
     func test_receive_manualEntryPressed() async {
         subject.receive(.manualEntryPressed)
         XCTAssertEqual(coordinator.routes, [.manualKeyEntry])

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
@@ -34,6 +34,7 @@ class ScanCodeViewTests: AuthenticatorTestCase {
     // MARK: Tests
 
     /// Tapping the cancel button dispatches the `.dismiss` action.
+    @MainActor
     func test_cancelButton_tap() throws {
         let button = try subject.inspect().find(button: Localizations.cancel)
         try button.tap()

--- a/GlobalTestHelpers-bwa/Support/AuthenticatorTestCase.swift
+++ b/GlobalTestHelpers-bwa/Support/AuthenticatorTestCase.swift
@@ -3,7 +3,6 @@ import SnapshotTesting
 import SwiftUI
 import XCTest
 
-@MainActor
 open class AuthenticatorTestCase: XCTestCase {
     /// The window being used for testing. Defaults to a new window with the same size as `UIScreen.main.bounds`.
     public var window: UIWindow!


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18417

## 📔 Objective

Currently, the `AuthenticatorTestCase` annotates itself as `@MainActor`, so a lot of tests don't need to be annotated as such. However, the `BaseBitwardenTestCase` is *not* so annotated, and instead in the `Bitwarden` project, tests were themselves annotated. This updates the `Authenticator` test cases to annotate at the test level rather than case level. This is a separate PR from other work unifying the testing infrastructure between the two apps in order to reduce noise on https://github.com/bitwarden/ios/pull/1379

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
