### PR TITLE
[PM-18417] refactor: Rename AuthenticatorTestCase to BitwardenTestCase

### DIFF
--- a/AuthenticatorShared/Core/Auth/Models/Response/ErrorResponseModelTests.swift
+++ b/AuthenticatorShared/Core/Auth/Models/Response/ErrorResponseModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - ErrorResponseModelTests
 
-class ErrorResponseModelTests: AuthenticatorTestCase {
+class ErrorResponseModelTests: BitwardenTestCase {
     /// Tests that `singleMessage()` returns the validation error's message.
     func testSingleMessage() throws {
         let json = APITestData.createAccountAccountAlreadyExists.data

--- a/AuthenticatorShared/Core/Auth/Models/Response/ResponseValidationErrorModelTests.swift
+++ b/AuthenticatorShared/Core/Auth/Models/Response/ResponseValidationErrorModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - ResponseValidationErrorModelTests
 
-class ResponseValidationErrorModelTests: AuthenticatorTestCase {
+class ResponseValidationErrorModelTests: BitwardenTestCase {
     // MARK: - Tests
 
     /// Tests that a response is initialized correctly.

--- a/AuthenticatorShared/Core/Platform/Extentions/ErrorNetworkingTests.swift
+++ b/AuthenticatorShared/Core/Platform/Extentions/ErrorNetworkingTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ErrorNetworkingTests: AuthenticatorTestCase {
+class ErrorNetworkingTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `isNetworkingError` returns `false` for non-networking errors.

--- a/AuthenticatorShared/Core/Platform/Extentions/PublisherAsyncTests.swift
+++ b/AuthenticatorShared/Core/Platform/Extentions/PublisherAsyncTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class PublisherAsyncTests: AuthenticatorTestCase {
+class PublisherAsyncTests: BitwardenTestCase {
     // MARK: Properties
 
     var cancellable: AnyCancellable?

--- a/AuthenticatorShared/Core/Platform/Extentions/SequenceAsyncTests.swift
+++ b/AuthenticatorShared/Core/Platform/Extentions/SequenceAsyncTests.swift
@@ -2,7 +2,7 @@
 
 import XCTest
 
-final class SequenceAsyncTests: AuthenticatorTestCase {
+final class SequenceAsyncTests: BitwardenTestCase {
     /// `asyncMap` correctly maps each element.
     func test_asyncMap_success() async {
         let input = [1, 2, 3]

--- a/AuthenticatorShared/Core/Platform/Models/Data/ManagedObjectTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Data/ManagedObjectTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ManagedObjectTests: AuthenticatorTestCase {
+class ManagedObjectTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `fetchRequest()` returns a `NSFetchRequest` for the entity.

--- a/AuthenticatorShared/Core/Platform/Models/Domain/ServerConfigTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Domain/ServerConfigTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class ServerConfigTests: AuthenticatorTestCase {
+final class ServerConfigTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `init` properly converts feature flags

--- a/AuthenticatorShared/Core/Platform/Models/Enum/AppThemeTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/AppThemeTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AppThemeTests: AuthenticatorTestCase {
+class AppThemeTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `init` returns the expected values.

--- a/AuthenticatorShared/Core/Platform/Models/Enum/ClearClipboardValueTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/ClearClipboardValueTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ClearClipboardValueTests: AuthenticatorTestCase {
+class ClearClipboardValueTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `localizedName` returns the correct values.

--- a/AuthenticatorShared/Core/Platform/Models/Enum/DefaultSaveOptionTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/DefaultSaveOptionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class DefaultSaveOptionTests: AuthenticatorTestCase {
+class DefaultSaveOptionTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `allCases` returns all of the cases in the correct order.

--- a/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class FeatureFlagTests: AuthenticatorTestCase {
+final class FeatureFlagTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `debugMenuFeatureFlags` does not include any test flags

--- a/AuthenticatorShared/Core/Platform/Models/Enum/LanguageOptionTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/LanguageOptionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class LanguageOptionTests: AuthenticatorTestCase {
+class LanguageOptionTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `allCases` returns the expected result.

--- a/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class SessionTimeoutValueTests: AuthenticatorTestCase {
+final class SessionTimeoutValueTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `allCases` returns all of the cases in the correct order.

--- a/AuthenticatorShared/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class JSONDecoderBitwardenTests: AuthenticatorTestCase {
+class JSONDecoderBitwardenTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `JSONDecoder.defaultDecoder` can decode ISO8601 dates with fractional seconds.

--- a/AuthenticatorShared/Core/Platform/Services/API/Extensions/JSONEncoderBitwardenTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/Extensions/JSONEncoderBitwardenTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class JSONEncoderBitwardenTests: AuthenticatorTestCase {
+class JSONEncoderBitwardenTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `JSONEncoder.defaultEncoder` can encode ISO8601 dates without fractional seconds.

--- a/AuthenticatorShared/Core/Platform/Services/API/Handlers/ResponseValidationHandlerTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/Handlers/ResponseValidationHandlerTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ResponseValidationHandlerTests: AuthenticatorTestCase {
+class ResponseValidationHandlerTests: BitwardenTestCase {
     // MARK: Properties
 
     var subject: ResponseValidationHandler!

--- a/AuthenticatorShared/Core/Platform/Services/API/TestHelpers/APITestData.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/TestHelpers/APITestData.swift
@@ -6,7 +6,7 @@ struct APITestData {
     let data: Data
 
     static func loadFromBundle(resource: String, extension: String) -> APITestData {
-        let bundle = Bundle(for: AuthenticatorTestCase.self)
+        let bundle = Bundle(for: BitwardenTestCase.self)
         guard let url = bundle.url(forResource: resource, withExtension: `extension`) else {
             fatalError("Unable to locate file \(resource).\(`extension`) in the bundle.")
         }

--- a/AuthenticatorShared/Core/Platform/Services/ConfigServiceTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/ConfigServiceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class ConfigServiceTests: AuthenticatorTestCase {
+final class ConfigServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var appSettingsStore: MockAppSettingsStore!

--- a/AuthenticatorShared/Core/Platform/Services/NotificationCenterServiceTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/NotificationCenterServiceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class NotificationCenterServiceTests: AuthenticatorTestCase {
+final class NotificationCenterServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var notificationCenter: NotificationCenter!

--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - AppSettingsStoreTests
 
-class AppSettingsStoreTests: AuthenticatorTestCase {
+class AppSettingsStoreTests: BitwardenTestCase {
     // MARK: Properties
 
     var subject: AppSettingsStore!

--- a/AuthenticatorShared/Core/Platform/Utilities/AnyCodableTests.swift
+++ b/AuthenticatorShared/Core/Platform/Utilities/AnyCodableTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AnyCodableTests: AuthenticatorTestCase {
+class AnyCodableTests: BitwardenTestCase {
     // MARK: Properties
 
     /// `boolValue` returns the bool associated value if the type is a `bool`.

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AuthenticatorItemRepositoryTests: AuthenticatorTestCase { // swiftlint:disable:this type_body_length
+class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var authItemService: MockAuthenticatorItemService!

--- a/AuthenticatorShared/Core/Vault/Services/AuthenticatorItemServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/AuthenticatorItemServiceTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AuthenticatorItemServiceTests: AuthenticatorTestCase {
+class AuthenticatorItemServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var authenticatorItemDataStore: MockAuthenticatorItemDataStore!

--- a/AuthenticatorShared/Core/Vault/Services/CryptographyServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/CryptographyServiceTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 // MARK: - CryptographyServiceTests
 
-class CryptographyServiceTests: AuthenticatorTestCase {
+class CryptographyServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var stateService: MockStateService!

--- a/AuthenticatorShared/Core/Vault/Services/ExportItemsServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/ExportItemsServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - ExportItemsServiceTests
 
-final class ExportItemsServiceTests: AuthenticatorTestCase {
+final class ExportItemsServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var authItemRepository: MockAuthenticatorItemRepository!

--- a/AuthenticatorShared/Core/Vault/Services/Importers/BitwardenImporterTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/BitwardenImporterTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class BitwardenImporterTests: AuthenticatorTestCase {
+final class BitwardenImporterTests: BitwardenTestCase {
     /// Can import Bitwarden JSON
     func test_raivoImport() throws {
         let data = ImportTestData.bitwardenJson.data

--- a/AuthenticatorShared/Core/Vault/Services/Importers/GoogleImporterTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/GoogleImporterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import AuthenticatorShared
 
 // swiftlint:disable line_length
-final class GoogleImporterTests: AuthenticatorTestCase {
+final class GoogleImporterTests: BitwardenTestCase {
     /// Can import Google protobuf
     func test_googleImport() throws {
         let data = "otpauth-migration://offline?data=ChgKCkhlbGxvId6tvu8SBE5hbWUgASgBMAIKGwoMAESNbONNjj/vBKjSEgVOYW1lMiABKAEwAhACGAEgAA%3D%3D".data(using: .utf8)!

--- a/AuthenticatorShared/Core/Vault/Services/Importers/LastpassImporterTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/LastpassImporterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import AuthenticatorShared
 
 // swiftlint:disable line_length
-final class LastpassImporterTests: AuthenticatorTestCase {
+final class LastpassImporterTests: BitwardenTestCase {
     /// Can import Raivo JSON
     func test_lastpassImport() throws {
         let data = ImportTestData.lastpassJson.data

--- a/AuthenticatorShared/Core/Vault/Services/Importers/RaivoImporterTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/RaivoImporterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import AuthenticatorShared
 
 // swiftlint:disable line_length
-final class RaivoImporterTests: AuthenticatorTestCase {
+final class RaivoImporterTests: BitwardenTestCase {
     /// Can import Raivo JSON
     func test_raivoImport() throws {
         let data = ImportTestData.raivoJson.data

--- a/AuthenticatorShared/Core/Vault/Services/Importers/TwoFasImporterTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/TwoFasImporterTests.swift
@@ -3,7 +3,7 @@ import XCTest
 @testable import AuthenticatorShared
 
 // swiftlint:disable line_length
-final class TwoFasImporterTests: AuthenticatorTestCase {
+final class TwoFasImporterTests: BitwardenTestCase {
     /// Can import 2FAS JSON
     func test_twoFasImport() throws {
         let data = ImportTestData.twoFasJson.data

--- a/AuthenticatorShared/Core/Vault/Services/Stores/AuthenticatorItemDataStoreTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Stores/AuthenticatorItemDataStoreTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AuthenticatorItemDataStoreTests: AuthenticatorTestCase {
+class AuthenticatorItemDataStoreTests: BitwardenTestCase {
     // MARK: Properties
 
     var subject: DataStore!

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - OTPAuthModelTests
 
-class OTPAuthModelTests: AuthenticatorTestCase {
+class OTPAuthModelTests: BitwardenTestCase {
     // MARK: Tests
 
     // MARK: Init Success

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPCodeConfigTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPCodeConfigTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - TOTPCodeConfigTests
 
-final class TOTPCodeConfigTests: AuthenticatorTestCase {
+final class TOTPCodeConfigTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Tests that a malformed string does not create a model.

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPCodeModelTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPCodeModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class TOTPCodeModelTests: AuthenticatorTestCase {
+final class TOTPCodeModelTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `displayCode` groups digits correctly

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPExpirationCalculatorTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPExpirationCalculatorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class TOTPExpirationCalculatorTests: AuthenticatorTestCase {
+final class TOTPExpirationCalculatorTests: BitwardenTestCase {
     // MARK: Tests
 
     func test_hasCodeExpired_codesOlderThanPeriod() {

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - TOTPServiceTests
 
-final class TOTPServiceTests: AuthenticatorTestCase {
+final class TOTPServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var clientService: MockClientService!

--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/ImportTestData.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/ImportTestData.swift
@@ -6,7 +6,7 @@ struct ImportTestData {
     let data: Data
 
     static func loadFromBundle(resource: String, extension: String) -> ImportTestData {
-        let bundle = Bundle(for: AuthenticatorTestCase.self)
+        let bundle = Bundle(for: BitwardenTestCase.self)
         guard let url = bundle.url(forResource: resource, withExtension: `extension`) else {
             fatalError("Unable to locate file \(resource).\(`extension`) in the bundle.")
         }

--- a/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
+++ b/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 // MARK: - VaultUnlockViewTests
 
-class VaultUnlockViewTests: AuthenticatorTestCase {
+class VaultUnlockViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<VaultUnlockState, VaultUnlockAction, VaultUnlockEffect>!

--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuCoordinatorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class DebugMenuCoordinatorTests: AuthenticatorTestCase {
+class DebugMenuCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var appSettingsStore: MockAppSettingsStore!

--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuProcessorTests.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuProcessorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class DebugMenuProcessorTests: AuthenticatorTestCase {
+class DebugMenuProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var configService: MockConfigService!

--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuViewTests.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuViewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - DebugMenuViewTests
 
-class DebugMenuViewTests: AuthenticatorTestCase {
+class DebugMenuViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<DebugMenuState, DebugMenuAction, DebugMenuEffect>!

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - AppCoordinatorTests
 
-class AppCoordinatorTests: AuthenticatorTestCase {
+class AppCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var module: MockAppModule!

--- a/AuthenticatorShared/UI/Platform/Application/AppModuleTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppModuleTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AppModuleTests: AuthenticatorTestCase {
+class AppModuleTests: BitwardenTestCase {
     // MARK: Properties
 
     var rootViewController: RootViewController!

--- a/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AppProcessorTests: AuthenticatorTestCase {
+class AppProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var appModule: MockAppModule!

--- a/AuthenticatorShared/UI/Platform/Application/Appearance/StyleGuideFontTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/StyleGuideFontTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class StyleGuideFontTests: AuthenticatorTestCase {
+final class StyleGuideFontTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Test a snapshot of the StyleGuideFonts.

--- a/AuthenticatorShared/UI/Platform/Application/Appearance/UITests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/UITests.swift
@@ -6,7 +6,7 @@ import XCTest
 // MARK: - UITests
 
 @MainActor
-class UITests: AuthenticatorTestCase {
+class UITests: BitwardenTestCase {
     // MARK: Tests
 
     func test_duration_animated() {

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/Alert+NetworkingTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/Alert+NetworkingTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 // MARK: - Alert+NetworkingTests
 
-class AlertNetworkingTests: AuthenticatorTestCase {
+class AlertNetworkingTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Tests the `networkConnectionLostError` alert contains the correct properties.

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/CollectionTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/CollectionTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class CollectionTests: AuthenticatorTestCase {
+class CollectionTests: BitwardenTestCase {
     /// `nilIfEmpty` returns the array if it's not empty or `nil` if it's empty.
     func test_nilIfEmpty_array() {
         XCTAssertEqual([1].nilIfEmpty, [1])

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/StringTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/StringTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - StringTests
 
-class StringTests: AuthenticatorTestCase {
+class StringTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `hashColor` returns a color generated from a hash of the string's characters.

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/UIViewControllerTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/UIViewControllerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class UIViewControllerTests: AuthenticatorTestCase {
+class UIViewControllerTests: BitwardenTestCase {
     /// `topmostViewController` returns the top view controller for a view controller.
     func test_topmostViewController_isViewController() {
         let subject = UIViewController()

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertErrorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertErrorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AlertErrorTests: AuthenticatorTestCase {
+class AlertErrorTests: BitwardenTestCase {
     /// `defaultAlert(title:message:)` constructs an `Alert` with the title, message, and an OK button.
     func test_defaultAlert() {
         let subject = Alert.defaultAlert(title: "title", message: "message")

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertPresentableTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertPresentableTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - AlertPresentableTests
 
-class AlertPresentableTests: AuthenticatorTestCase {
+class AlertPresentableTests: BitwardenTestCase {
     // MARK: Properties
 
     var rootViewController: UIViewController!

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - AlertTests
 
-class AlertTests: AuthenticatorTestCase {
+class AlertTests: BitwardenTestCase {
     // MARK: Properties
 
     var subject: Alert!

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - AnyCoordinatorTests
 
-class AnyCoordinatorTests: AuthenticatorTestCase {
+class AnyCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<AppRoute, AppEvent>!

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/AnyRouterTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/AnyRouterTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - AnyRouterTests
 
-class AnyRouterTests: AuthenticatorTestCase {
+class AnyRouterTests: BitwardenTestCase {
     // MARK: Properties
 
     var router: MockRouter<AuthEvent, AuthRoute>!

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/InputValidator/Validators/EmptyInputValidatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/InputValidator/Validators/EmptyInputValidatorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class EmptyInputValidatorTests: AuthenticatorTestCase {
+class EmptyInputValidatorTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `validate(input:)` doesn't throw an error if the input is valid.

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/RootViewControllerTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/RootViewControllerTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - RootViewControllerTests
 
-class RootViewControllerTests: AuthenticatorTestCase {
+class RootViewControllerTests: BitwardenTestCase {
     // MARK: Properties
 
     var subject: RootViewController!

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/StackNavigatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/StackNavigatorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import AuthenticatorShared
 
 @MainActor
-class StackNavigatorTests: AuthenticatorTestCase {
+class StackNavigatorTests: BitwardenTestCase {
     var subject: UINavigationController!
 
     override func setUp() {

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/StoreTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/StoreTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import AuthenticatorShared
 
 @MainActor
-class StoreTests: AuthenticatorTestCase {
+class StoreTests: BitwardenTestCase {
     var processor: MockProcessor<TestState, TestAction, TestEffect>!
     var subject: Store<TestState, TestAction, TestEffect>!
 

--- a/AuthenticatorShared/UI/Platform/Application/Views/AsyncButtonTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/AsyncButtonTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - AsyncButtonTests
 
-class AsyncButtonTests: AuthenticatorTestCase {
+class AsyncButtonTests: BitwardenTestCase {
     // MARK: Tests
 
     func test_button_tap() throws {

--- a/AuthenticatorShared/UI/Platform/Application/Views/BitwardenMenuFieldTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/BitwardenMenuFieldTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class BitwardenMenuFieldTests: AuthenticatorTestCase {
+class BitwardenMenuFieldTests: BitwardenTestCase {
     // MARK: Types
 
     enum TestValue: String, CaseIterable, Menuable {

--- a/AuthenticatorShared/UI/Platform/Application/Views/LoadingOverlay/LoadingOverlayDisplayHelperTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/LoadingOverlay/LoadingOverlayDisplayHelperTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class LoadingOverlayDisplayHelperTests: AuthenticatorTestCase {
+class LoadingOverlayDisplayHelperTests: BitwardenTestCase {
     /// `show(in:state:)` shows the loading overlay in the parent view controller.
     func test_show() throws {
         let parentViewController = UIViewController()

--- a/AuthenticatorShared/UI/Platform/Application/Views/LoadingOverlay/LoadingOverlayViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/LoadingOverlay/LoadingOverlayViewTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class LoadingOverlayViewTests: AuthenticatorTestCase {
+class LoadingOverlayViewTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Test a snapshot of the loading overlay.

--- a/AuthenticatorShared/UI/Platform/Application/Views/SectionViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/SectionViewTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class SectionViewTests: AuthenticatorTestCase {
+class SectionViewTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Test a snapshot of the sectionView.

--- a/AuthenticatorShared/UI/Platform/Application/Views/SettingsMenuFieldTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/SettingsMenuFieldTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class SettingsMenuFieldTests: AuthenticatorTestCase {
+class SettingsMenuFieldTests: BitwardenTestCase {
     // MARK: Types
 
     enum TestValue: String, CaseIterable, Menuable {

--- a/AuthenticatorShared/UI/Platform/Application/Views/ToastDisplayHelperTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/ToastDisplayHelperTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ToastDisplayHelperTests: AuthenticatorTestCase {
+class ToastDisplayHelperTests: BitwardenTestCase {
     /// `show(in:state:)` shows the toast in the parent view controller.
     func test_show() throws {
         let parentViewController = UIViewController()

--- a/AuthenticatorShared/UI/Platform/Application/Views/ToastViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/ToastViewTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class ToastViewTests: AuthenticatorTestCase {
+final class ToastViewTests: BitwardenTestCase {
     // MARK: Snapshots
 
     /// Tests all previews for the toast view.

--- a/AuthenticatorShared/UI/Platform/FileSelection/FileSelectionCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/FileSelection/FileSelectionCoordinatorTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 // MARK: - FileSelectionCoordinatorTests
 
-class FileSelectionCoordinatorTests: AuthenticatorTestCase {
+class FileSelectionCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var cameraService: MockCameraService!

--- a/AuthenticatorShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AlertSettingsTests: AuthenticatorTestCase {
+class AlertSettingsTests: BitwardenTestCase {
     /// `backupInformation(action:)` constructs an `Alert`
     /// with the correct title, message, and buttons.
     func test_backupInformationAlert() {

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsProcessorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ExportItemsProcessorTests: AuthenticatorTestCase {
+class ExportItemsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsViewTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ExportItemsViewTests: AuthenticatorTestCase {
+class ExportItemsViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<ExportItemsState, ExportItemsAction, ExportItemsEffect>!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ImportItemsProcessorTests: AuthenticatorTestCase {
+class ImportItemsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var application: MockApplication!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsViewTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class ImportItemsViewTests: AuthenticatorTestCase {
+class ImportItemsViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<ImportItemsState, ImportItemsAction, ImportItemsEffect>!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageProcessorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - SelectLanguageProcessorTests
 
-class SelectLanguageProcessorTests: AuthenticatorTestCase {
+class SelectLanguageProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageViewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class SelectLanguageViewTests: AuthenticatorTestCase {
+class SelectLanguageViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<SelectLanguageState, SelectLanguageAction, Void>!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class SettingsProcessorTests: AuthenticatorTestCase {
+class SettingsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var application: MockApplication!

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class SettingsViewTests: AuthenticatorTestCase {
+class SettingsViewTests: BitwardenTestCase {
     // MARK: Properties
 
     let copyrightText = "© Bitwarden Inc. 2015-2024"

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class SettingsCoordinatorTests: AuthenticatorTestCase {
+class SettingsCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var module: MockAppModule!

--- a/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 // MARK: - TutorialViewTests
 
-class TutorialViewTests: AuthenticatorTestCase {
+class TutorialViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<TutorialState, TutorialAction, TutorialEffect>!

--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 // MARK: - EditAuthenticatorItemViewTests
 
-class EditAuthenticatorItemViewTests: AuthenticatorTestCase {
+class EditAuthenticatorItemViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardViewTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 // MARK: - ItemListCardViewTests
 
-class ItemListCardViewTests: AuthenticatorTestCase {
+class ItemListCardViewTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Test a snapshot of the ItemListView previews.

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItemTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItemTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 // MARK: - ItemListItemTests
 
-class ItemListItemTests: AuthenticatorTestCase {
+class ItemListItemTests: BitwardenTestCase {
     var subject: ItemListItem!
 
     func test_localizedNameComparator() {

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 // MARK: - ItemListProcessorTests
 
-class ItemListProcessorTests: AuthenticatorTestCase { // swiftlint:disable:this type_body_length
+class ItemListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var application: MockApplication!

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 // MARK: - ItemListViewTests
 
-class ItemListViewTests: AuthenticatorTestCase {
+class ItemListViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<ItemListState, ItemListAction, ItemListEffect>!

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinatorTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-class AuthenticatorKeyCaptureCoordinatorTests: AuthenticatorTestCase {
+class AuthenticatorKeyCaptureCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var cameraService: MockCameraService!

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class ManualEntryProcessorTests: AuthenticatorTestCase {
+final class ManualEntryProcessorTests: BitwardenTestCase {
     var appSettingsStore: MockAppSettingsStore!
     var authItemRepository: MockAuthenticatorItemRepository!
     var configService: MockConfigService!

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
@@ -6,7 +6,7 @@ import XCTest
 
 // MARK: - ManualEntryViewTests
 
-class ManualEntryViewTests: AuthenticatorTestCase {
+class ManualEntryViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<ManualEntryState, ManualEntryAction, ManualEntryEffect>!

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessorTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class ScanCodeProcessorTests: AuthenticatorTestCase {
+final class ScanCodeProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var cameraService: MockCameraService!

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
@@ -7,7 +7,7 @@ import XCTest
 
 // MARK: - ScanCodeViewTests
 
-class ScanCodeViewTests: AuthenticatorTestCase {
+class ScanCodeViewTests: BitwardenTestCase {
     // MARK: Properties
 
     var processor: MockProcessor<ScanCodeState, ScanCodeAction, ScanCodeEffect>!

--- a/AuthenticatorShared/UI/Vault/Views/CircularProgressShapeTests.swift
+++ b/AuthenticatorShared/UI/Vault/Views/CircularProgressShapeTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class CircularProgressShapeTests: AuthenticatorTestCase {
+final class CircularProgressShapeTests: BitwardenTestCase {
     // MARK: Tests
 
     func test_snapshot_progress() {

--- a/AuthenticatorShared/UI/Vault/Views/IconImageHelperTests.swift
+++ b/AuthenticatorShared/UI/Vault/Views/IconImageHelperTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class IconImageHelperTests: AuthenticatorTestCase {
+final class IconImageHelperTests: BitwardenTestCase {
     // MARK: Parameters
 
     let defaultURL = URL(string: "https://icons.bitwarden.net")!

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerTests.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import AuthenticatorShared
 
-final class TOTPCountdownTimerTests: AuthenticatorTestCase {
+final class TOTPCountdownTimerTests: BitwardenTestCase {
     // MARK: Properties
 
     var subject: TOTPCountdownTimer!

--- a/GlobalTestHelpers-bwa/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers-bwa/Support/BitwardenTestCase.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import TestHelpers
 import XCTest
 
-open class AuthenticatorTestCase: BaseBitwardenTestCase {
+open class BitwardenTestCase: BaseBitwardenTestCase {
     @MainActor
     override open class func setUp() {
         // Apply default appearances for snapshot tests.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-18417

## 📔 Objective

As part of the consolidation of test case infrastructure, it makes sense for the framework-specific subclass of `BaseBitwardenTestCase` to be `BitwardenTestCase` across the board. This necessitates changing `AuthenticatorTestCase`, primarily. See further discussion in https://github.com/bitwarden/ios/pull/1379

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
