### PR TITLE
PM-18808: Added login item name for Autofill selection.

### DIFF
--- a/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactory.swift
+++ b/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactory.swift
@@ -46,7 +46,7 @@ struct DefaultCredentialIdentityFactory: CredentialIdentityFactory {
 
         return ASPasswordCredentialIdentity(
             serviceIdentifier: serviceIdentifier,
-            user: username,
+            user:  Localizations.itemNameUserName(cipher.name, username),
             recordIdentifier: cipher.id
         )
     }

--- a/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactory.swift
+++ b/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactory.swift
@@ -46,7 +46,7 @@ struct DefaultCredentialIdentityFactory: CredentialIdentityFactory {
 
         return ASPasswordCredentialIdentity(
             serviceIdentifier: serviceIdentifier,
-            user:  Localizations.itemNameUserName(cipher.name, username),
+            user: Localizations.itemNameUserName(cipher.name, username),
             recordIdentifier: cipher.id
         )
     }

--- a/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactoryTests.swift
@@ -35,6 +35,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
         let expectedName = "CipherName"
         let expectedUri = "https://example.com"
         let expectedUsername = "test"
+        let displayName = Localizations.itemNameUserName(expectedName, expectedUsername)
         let cipher = CipherView.fixture(
             login: .fixture(
                 password: "1234",
@@ -64,7 +65,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
             passwordIdentity.serviceIdentifier.type,
             ASCredentialServiceIdentifier.IdentifierType.URL
         )
-        XCTAssertEqual(passwordIdentity.user, expectedUsername)
+        XCTAssertEqual(passwordIdentity.user, displayName)
         XCTAssertEqual(passwordIdentity.recordIdentifier, cipher.id)
     }
 
@@ -78,6 +79,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
         let expectedName = "CipherName"
         let expectedUri = "https://example.com"
         let expectedUsername = "test"
+        let displayName = Localizations.itemNameUserName(expectedName, expectedUsername)
         let cipher = CipherView.fixture(
             login: .fixture(
                 password: "1234",
@@ -111,7 +113,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
             passwordIdentity.serviceIdentifier.type,
             ASCredentialServiceIdentifier.IdentifierType.URL
         )
-        XCTAssertEqual(passwordIdentity.user, expectedUsername)
+        XCTAssertEqual(passwordIdentity.user, displayName)
         XCTAssertEqual(passwordIdentity.recordIdentifier, cipher.id)
     }
 
@@ -155,6 +157,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
 
         let expectedUri = "https://example.com"
         let expectedUsername = "test"
+        let displayName = Localizations.itemNameUserName("Bitwarden", expectedUsername)
         let cipher = CipherView.fixture(
             login: .fixture(
                 password: "1234",
@@ -173,7 +176,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
             passwordIdentity.serviceIdentifier.type,
             ASCredentialServiceIdentifier.IdentifierType.URL
         )
-        XCTAssertEqual(passwordIdentity.user, expectedUsername)
+        XCTAssertEqual(passwordIdentity.user, displayName)
         XCTAssertEqual(passwordIdentity.recordIdentifier, cipher.id)
     }
 
@@ -274,6 +277,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
     func test_tryCreatePasswordCredentialIdentity_success() throws {
         let expectedUri = "https://example.com"
         let expectedUsername = "test"
+        let displayName = Localizations.itemNameUserName("Bitwarden", expectedUsername)
         let cipher = CipherView.fixture(
             login: .fixture(
                 password: "1234",
@@ -288,7 +292,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
         )
         XCTAssertEqual(passwordIdentity.serviceIdentifier.identifier, expectedUri)
         XCTAssertEqual(passwordIdentity.serviceIdentifier.type, ASCredentialServiceIdentifier.IdentifierType.URL)
-        XCTAssertEqual(passwordIdentity.user, expectedUsername)
+        XCTAssertEqual(passwordIdentity.user, displayName)
         XCTAssertEqual(passwordIdentity.recordIdentifier, cipher.id)
     }
 

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -437,6 +437,7 @@
 "ThirtyMinutes" = "30 minutes";
 "SetPINDescription" = "Set your PIN code for unlocking Bitwarden. Your PIN settings will be reset if you ever fully log out of the application.";
 "LoggedInAsOn" = "Logged in as %1$@ on %2$@.";
+"ItemNameUserName" = "item name: %1$@, user name: %2$@";
 "VaultLockedMasterPassword" = "Your vault is locked. Verify your master password to continue.";
 "VaultLockedPIN" = "Your vault is locked. Verify your PIN code to continue.";
 "VaultLockedIdentity" = "Your vault is locked. Verify your identity to continue.";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-18808](https://bitwarden.atlassian.net/browse/PM-18808)
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
- Added item name to the autofill password selection items.
#1403 
https://community.bitwarden.com/t/on-apple-devices-show-item-name-in-auto-fill-selection-window/37110
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
|--------|--------|
| <img width="557" alt="before" src="https://github.com/user-attachments/assets/e489e6b9-adea-4fe2-91d9-06be144f8493" /> | <img width="557" alt="after" src="https://github.com/user-attachments/assets/f56f311b-4dc2-451e-94b2-8de6506866b7" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18808]: https://bitwarden.atlassian.net/browse/PM-18808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ