### PR TITLE
[PM-18223] Add share error details button to error alerts without a message

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -40,6 +40,9 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// A feature flag for the import logins flow for new accounts.
     case importLoginsFlow = "import-logins-flow"
 
+    /// A feature flag to enable additional error reporting.
+    case mobileErrorReporting = "mobile-error-reporting"
+
     /// A feature flag for the intro carousel flow.
     case nativeCarouselFlow = "native-carousel-flow"
 
@@ -113,6 +116,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
         case .enableCipherKeyEncryption,
              .enableDebugAppReviewPrompt,
              .ignore2FANoticeEnvironmentCheck,
+             .mobileErrorReporting,
              .newDeviceVerificationPermanentDismiss,
              .newDeviceVerificationTemporaryDismiss,
              .testLocalFeatureFlag,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -36,6 +36,7 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertFalse(FeatureFlag.enableDebugAppReviewPrompt.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.enableCipherKeyEncryption.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.ignore2FANoticeEnvironmentCheck.isRemotelyConfigured)
+        XCTAssertFalse(FeatureFlag.mobileErrorReporting.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.testLocalFeatureFlag.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.testLocalInitialBoolFlag.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.testLocalInitialIntFlag.isRemotelyConfigured)

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -1045,6 +1045,12 @@ extension AuthCoordinator: ASAuthorizationControllerDelegate {
     }
 }
 
+// MARK: - HasErrorAlertServices
+
+extension AuthCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
 // MARK: PasswordAutoFillCoordinatorDelegate
 
 extension AuthCoordinator: PasswordAutoFillCoordinatorDelegate {

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -199,7 +199,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
             return
         }
 
-        coordinator.showAlert(.networkResponseError(error, tryAgain))
+        coordinator.showAlert(.networkResponseError(error, tryAgain: tryAgain))
         services.errorReporter.log(error: error)
     }
 

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -100,7 +100,7 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
                 organizationIdentifier: state.identifierText
             ))
         default:
-            coordinator.showAlert(.networkResponseError(error, tryAgain))
+            coordinator.showAlert(.networkResponseError(error, tryAgain: tryAgain))
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -395,7 +395,7 @@ extension TwoFactorAuthProcessor: DuoAuthenticationFlowDelegate {
         if case ASWebAuthenticationSessionError.canceledLogin = error { return }
 
         // Otherwise, show the alert and log the error.
-        coordinator.showAlert(.networkResponseError(error, tryAgain))
+        coordinator.showAlert(.networkResponseError(error, tryAgain: tryAgain))
         services.errorReporter.log(error: error)
     }
 }

--- a/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeCoordinator.swift
+++ b/BitwardenShared/UI/Auth/TwoFactorNotice/TwoFactorNoticeCoordinator.swift
@@ -9,6 +9,7 @@ final class TwoFactorNoticeCoordinator: Coordinator, HasStackNavigator {
 
     typealias Services = HasApplication
         & HasAuthRepository
+        & HasConfigService
         & HasEnvironmentService
         & HasErrorReporter
         & HasStateService
@@ -104,4 +105,10 @@ final class TwoFactorNoticeCoordinator: Coordinator, HasStackNavigator {
         )
         stackNavigator?.push(view)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension TwoFactorNoticeCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -376,6 +376,12 @@ extension AppCoordinator: DebugMenuCoordinatorDelegate {
     }
 }
 
+// MARK: - HasErrorAlertServices
+
+extension AppCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
 // MARK: - LoginRequestDelegate
 
 extension AppCoordinator: LoginRequestDelegate {

--- a/BitwardenShared/UI/Platform/Application/Extensions/Alert+Networking.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/Alert+Networking.swift
@@ -30,6 +30,8 @@ extension Alert {
     /// - Parameters:
     ///   - error: The networking error that occurred.
     ///   - isOfficialBitwardenServer: Indicates whether the request was made to the official Bitwarden server
+    ///   - shareErrorDetails: An optional action closure which will show a 'Share error details'
+    ///     button in the alert if there's no error message details to show in the alert itself.
     ///   - tryAgain: An action allowing the user to retry the request.
     ///
     /// - Returns: An alert notifying the user that a networking error occurred.
@@ -37,7 +39,8 @@ extension Alert {
     static func networkResponseError(
         _ error: Error,
         isOfficialBitwardenServer: Bool = true,
-        _ tryAgain: (() async -> Void)? = nil
+        shareErrorDetails: (@MainActor () async -> Void)? = nil,
+        tryAgain: (() async -> Void)? = nil
     ) -> Alert {
         switch error {
         case let serverError as ServerError:
@@ -66,9 +69,17 @@ extension Alert {
                 ]
             )
         default:
-            return defaultAlert(
+            return Alert(
                 title: Localizations.anErrorHasOccurred,
-                message: isOfficialBitwardenServer ? nil : Localizations.thisIsNotARecognizedServerDescriptionLong
+                message: isOfficialBitwardenServer ? nil : Localizations.thisIsNotARecognizedServerDescriptionLong,
+                alertActions: [
+                    shareErrorDetails.flatMap { shareErrorDetails in
+                        AlertAction(title: Localizations.shareErrorDetails, style: .default) { _ in
+                            await shareErrorDetails()
+                        }
+                    },
+                    AlertAction(title: Localizations.ok, style: .cancel),
+                ].compactMap { $0 }
             )
         }
     }

--- a/BitwardenShared/UI/Platform/Application/Extensions/Alert+NetworkingTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/Alert+NetworkingTests.swift
@@ -13,9 +13,10 @@ class AlertNetworkingTests: BitwardenTestCase {
     // MARK: Tests
 
     /// Tests the `networkConnectionLostError` alert contains the correct properties.
-    func test_networkConnectionLost() {
+    func test_networkConnectionLost() async throws {
         let urlError = URLError(.networkConnectionLost)
-        let subject = Alert.networkResponseError(urlError) {}
+        var tryAgainCalled = false
+        let subject = Alert.networkResponseError(urlError, tryAgain: { tryAgainCalled = true })
 
         XCTAssertEqual(subject.title, Localizations.internetConnectionRequiredTitle)
         XCTAssertEqual(subject.message, Localizations.internetConnectionRequiredMessage)
@@ -26,6 +27,9 @@ class AlertNetworkingTests: BitwardenTestCase {
         XCTAssertEqual(action.title, Localizations.tryAgain)
         XCTAssertEqual(action.style, .default)
         XCTAssertNotNil(action.handler)
+
+        try await subject.tapAction(title: Localizations.tryAgain)
+        XCTAssertTrue(tryAgainCalled)
     }
 
     /// `.networkResponseError` builds an alert to display a server error message.
@@ -45,6 +49,38 @@ class AlertNetworkingTests: BitwardenTestCase {
         XCTAssertNil(action.handler)
     }
 
+    /// `networkResponseError()` builds an alert for an unknown error and includes an option to
+    /// share the error details if a closure is provided.
+    func test_networkResponseError_unknownError_shareErrorDetails() async throws {
+        var shareErrorDetailsCalled = false
+        let subject = Alert.networkResponseError(
+            BitwardenTestError.example,
+            shareErrorDetails: { shareErrorDetailsCalled = true }
+        )
+
+        XCTAssertEqual(subject.title, Localizations.anErrorHasOccurred)
+        XCTAssertNil(subject.message)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.shareErrorDetails)
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.ok)
+
+        try await subject.tapAction(title: Localizations.shareErrorDetails)
+        XCTAssertTrue(shareErrorDetailsCalled)
+    }
+
+    /// `networkResponseError()` builds an alert for an unknown error and doesn't show the share
+    /// error details button if no closure is provided.
+    func test_networkResponseError_unknownError_withoutShareErrorDetails() async throws {
+        let subject = Alert.networkResponseError(BitwardenTestError.example)
+
+        XCTAssertEqual(subject.title, Localizations.anErrorHasOccurred)
+        XCTAssertNil(subject.message)
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.alertActions.count, 1)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.ok)
+    }
+
     /// `.networkResponseError` builds an alert to display an error message for an unofficial Bitwarden server.
     func test_networkResponseError_unofficialBitwardenServerError() {
         let error = BitwardenTestError.example
@@ -61,9 +97,10 @@ class AlertNetworkingTests: BitwardenTestCase {
     }
 
     /// Tests the `internetConnectionError` alert contains the correct properties.
-    func test_noInternetConnection() {
+    func test_noInternetConnection() async throws {
         let urlError = URLError(.notConnectedToInternet)
-        let subject = Alert.networkResponseError(urlError) {}
+        var tryAgainCalled = false
+        let subject = Alert.networkResponseError(urlError, tryAgain: { tryAgainCalled = true })
 
         XCTAssertEqual(subject.title, Localizations.internetConnectionRequiredTitle)
         XCTAssertEqual(subject.message, Localizations.internetConnectionRequiredMessage)
@@ -74,6 +111,9 @@ class AlertNetworkingTests: BitwardenTestCase {
         XCTAssertEqual(action.title, Localizations.tryAgain)
         XCTAssertEqual(action.style, .default)
         XCTAssertNotNil(action.handler)
+
+        try await subject.tapAction(title: Localizations.tryAgain)
+        XCTAssertTrue(tryAgainCalled)
     }
 
     /// `ResponseValidationError` builds an alert to display a server error message.
@@ -98,9 +138,10 @@ class AlertNetworkingTests: BitwardenTestCase {
     }
 
     /// Tests the `timeoutError` alert contains the correct properties.
-    func test_timeoutError() {
+    func test_timeoutError() async throws {
         let urlError = URLError(.timedOut)
-        let subject = Alert.networkResponseError(urlError) {}
+        var tryAgainCalled = false
+        let subject = Alert.networkResponseError(urlError, tryAgain: { tryAgainCalled = true })
 
         XCTAssertEqual(subject.message, urlError.localizedDescription)
         XCTAssertEqual(subject.preferredStyle, .alert)
@@ -110,5 +151,8 @@ class AlertNetworkingTests: BitwardenTestCase {
         XCTAssertEqual(action.title, Localizations.tryAgain)
         XCTAssertEqual(action.style, .default)
         XCTAssertNotNil(action.handler)
+
+        try await subject.tapAction(title: Localizations.tryAgain)
+        XCTAssertTrue(tryAgainCalled)
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1151,3 +1151,4 @@
 "Identification" = "Identification";
 "Owner" = "Owner";
 "VerifyYourIdentity"="Verify your identity";
+"ShareErrorDetails" = "Share error details";

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
@@ -19,8 +19,8 @@ open class AnyCoordinator<Route, Event>: Coordinator {
     /// A closure that wraps the `showAlert(_:)` method.
     private let doShowAlert: (Alert, (() -> Void)?) -> Void
 
-    /// A closure that wraps the `showErrorAlert(_:services:)` method.
-    private let doShowErrorAlert: (Error, Coordinator.ErrorAlertServices) async -> Void
+    /// A closure that wraps the `showErrorAlert(error:services:tryAgain:)` method.
+    private let doShowErrorAlert: (Error, Coordinator.ErrorAlertServices, Coordinator.ErrorAlertTryAgain) async -> Void
 
     /// A closure that wraps the `showLoadingOverlay(_:)` method.
     private let doShowLoadingOverlay: (LoadingOverlayState) -> Void
@@ -48,7 +48,7 @@ open class AnyCoordinator<Route, Event>: Coordinator {
             coordinator.navigate(to: route, context: context)
         }
         doShowAlert = { coordinator.showAlert($0, onDismissed: $1) }
-        doShowErrorAlert = { await coordinator.showErrorAlert(error: $0, services: $1) }
+        doShowErrorAlert = { await coordinator.showErrorAlert(error: $0, services: $1, tryAgain: $2) }
         doShowLoadingOverlay = { coordinator.showLoadingOverlay($0) }
         doShowToast = { coordinator.showToast($0, subtitle: $1, additionalBottomPadding: $2) }
         doStart = { coordinator.start() }
@@ -69,7 +69,15 @@ open class AnyCoordinator<Route, Event>: Coordinator {
     }
 
     func showErrorAlert(error: Error, services: Coordinator.ErrorAlertServices) async {
-        await doShowErrorAlert(error, services)
+        await doShowErrorAlert(error, services, nil)
+    }
+
+    func showErrorAlert(
+        error: Error,
+        services: Coordinator.ErrorAlertServices,
+        tryAgain: Coordinator.ErrorAlertTryAgain
+    ) async {
+        await doShowErrorAlert(error, services, tryAgain)
     }
 
     open func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
@@ -19,8 +19,8 @@ open class AnyCoordinator<Route, Event>: Coordinator {
     /// A closure that wraps the `showAlert(_:)` method.
     private let doShowAlert: (Alert, (() -> Void)?) -> Void
 
-    /// A closure that wraps the `showErrorAlert(error:services:tryAgain:)` method.
-    private let doShowErrorAlert: (Error, Coordinator.ErrorAlertServices, Coordinator.ErrorAlertTryAgain) async -> Void
+    /// A closure that wraps the `showErrorAlert(error:tryAgain:)` method.
+    private let doShowErrorAlert: (Error, (() async -> Void)?) async -> Void
 
     /// A closure that wraps the `showLoadingOverlay(_:)` method.
     private let doShowLoadingOverlay: (LoadingOverlayState) -> Void
@@ -48,7 +48,7 @@ open class AnyCoordinator<Route, Event>: Coordinator {
             coordinator.navigate(to: route, context: context)
         }
         doShowAlert = { coordinator.showAlert($0, onDismissed: $1) }
-        doShowErrorAlert = { await coordinator.showErrorAlert(error: $0, services: $1, tryAgain: $2) }
+        doShowErrorAlert = { await coordinator.showErrorAlert(error: $0, tryAgain: $1) }
         doShowLoadingOverlay = { coordinator.showLoadingOverlay($0) }
         doShowToast = { coordinator.showToast($0, subtitle: $1, additionalBottomPadding: $2) }
         doStart = { coordinator.start() }
@@ -68,16 +68,12 @@ open class AnyCoordinator<Route, Event>: Coordinator {
         doShowAlert(alert, onDismissed)
     }
 
-    func showErrorAlert(error: Error, services: Coordinator.ErrorAlertServices) async {
-        await doShowErrorAlert(error, services, nil)
+    func showErrorAlert(error: Error) async {
+        await doShowErrorAlert(error, nil)
     }
 
-    func showErrorAlert(
-        error: Error,
-        services: Coordinator.ErrorAlertServices,
-        tryAgain: Coordinator.ErrorAlertTryAgain
-    ) async {
-        await doShowErrorAlert(error, services, tryAgain)
+    func showErrorAlert(error: Error, tryAgain: (() async -> Void)?) async {
+        await doShowErrorAlert(error, tryAgain)
     }
 
     open func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
@@ -27,12 +27,29 @@ class AnyCoordinatorTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// `showErrorAlert(error:services:)` calls the `showErrorAlert()` method on the wrapped coordinator.
+    /// `showErrorAlert(error:services:)` calls the `showErrorAlert()` method on the wrapped
+    /// coordinator.
     @MainActor
     func test_showErrorAlert() async {
         let error = BitwardenTestError.example
         await subject.showErrorAlert(error: error, services: ServiceContainer.withMocks())
         XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [error])
+    }
+
+    /// `showErrorAlert(error:services:tryAgain:)` calls the `showErrorAlert()` method on the
+    /// wrapped coordinator.
+    @MainActor
+    func test_showErrorAlert_withTryAgain() async {
+        let error = BitwardenTestError.example
+        var tryAgainCalled = false
+        await subject.showErrorAlert(error: error, services: ServiceContainer.withMocks()) {
+            tryAgainCalled = true
+        }
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.map(\.error) as? [BitwardenTestError], [error])
+
+        let errorAlertWithRetry = coordinator.errorAlertsWithRetryShown[0]
+        await errorAlertWithRetry.retry()
+        XCTAssertTrue(tryAgainCalled)
     }
 
     /// `start()` calls the `start()` method on the wrapped coordinator.

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
@@ -27,22 +27,22 @@ class AnyCoordinatorTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// `showErrorAlert(error:services:)` calls the `showErrorAlert()` method on the wrapped
+    /// `showErrorAlert(error:)` calls the `showErrorAlert()` method on the wrapped
     /// coordinator.
     @MainActor
     func test_showErrorAlert() async {
         let error = BitwardenTestError.example
-        await subject.showErrorAlert(error: error, services: ServiceContainer.withMocks())
+        await subject.showErrorAlert(error: error)
         XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [error])
     }
 
-    /// `showErrorAlert(error:services:tryAgain:)` calls the `showErrorAlert()` method on the
-    /// wrapped coordinator.
+    /// `showErrorAlert(error:tryAgain:)` calls the `showErrorAlert()` method on the wrapped
+    /// coordinator.
     @MainActor
     func test_showErrorAlert_withTryAgain() async {
         let error = BitwardenTestError.example
         var tryAgainCalled = false
-        await subject.showErrorAlert(error: error, services: ServiceContainer.withMocks()) {
+        await subject.showErrorAlert(error: error) {
             tryAgainCalled = true
         }
         XCTAssertEqual(coordinator.errorAlertsWithRetryShown.map(\.error) as? [BitwardenTestError], [error])

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
@@ -25,6 +26,14 @@ class AnyCoordinatorTests: BitwardenTestCase {
     }
 
     // MARK: Tests
+
+    /// `showErrorAlert(error:services:)` calls the `showErrorAlert()` method on the wrapped coordinator.
+    @MainActor
+    func test_showErrorAlert() async {
+        let error = BitwardenTestError.example
+        await subject.showErrorAlert(error: error, services: ServiceContainer.withMocks())
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [error])
+    }
 
     /// `start()` calls the `start()` method on the wrapped coordinator.
     @MainActor

--- a/BitwardenShared/UI/Platform/Application/Utilities/CoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/CoordinatorTests.swift
@@ -1,0 +1,94 @@
+import TestHelpers
+import XCTest
+
+@testable import BitwardenShared
+
+// MARK: - CoordinatorTests
+
+@MainActor
+class CoordinatorTests: BitwardenTestCase {
+    // MARK: Types
+
+    enum TestRoute {
+        case test
+    }
+
+    class TestCoordinator: Coordinator, HasStackNavigator {
+        typealias Event = Void // swiftlint:disable:this nesting
+
+        var stackNavigator: StackNavigator?
+
+        init(mockStackNavigator: MockStackNavigator) {
+            stackNavigator = mockStackNavigator
+        }
+
+        func start() {}
+
+        func navigate(to route: TestRoute, context: AnyObject?) {}
+    }
+
+    // MARK: Properties
+
+    var configService: MockConfigService!
+    var services: Services!
+    var stackNavigator: MockStackNavigator!
+    var subject: TestCoordinator!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        configService = MockConfigService()
+        stackNavigator = MockStackNavigator()
+
+        services = ServiceContainer.withMocks(configService: configService)
+
+        subject = TestCoordinator(mockStackNavigator: stackNavigator)
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        configService = nil
+        services = nil
+        stackNavigator = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `showErrorAlert(error:services)` builds an alert to show for an error when mobile error
+    /// reporting is disabled.
+    func test_showErrorAlert_mobileErrorReportingDisabled() async {
+        configService.featureFlagsBool[.mobileErrorReporting] = false
+
+        await subject.showErrorAlert(
+            error: BitwardenTestError.example,
+            services: services
+        )
+
+        XCTAssertEqual(stackNavigator.alerts, [Alert.networkResponseError(BitwardenTestError.example)])
+    }
+
+    /// `showErrorAlert(error:services)` builds an alert to show for an error when mobile error
+    /// reporting is enabled, allowing the user to share the details of the error.
+    func test_showErrorAlert_mobileErrorReportingEnabled() async throws {
+        configService.featureFlagsBool[.mobileErrorReporting] = true
+
+        await subject.showErrorAlert(
+            error: BitwardenTestError.example,
+            services: services
+        )
+
+        XCTAssertEqual(
+            stackNavigator.alerts,
+            [Alert.networkResponseError(BitwardenTestError.example, shareErrorDetails: {})]
+        )
+
+        let alert = try XCTUnwrap(stackNavigator.alerts.first)
+        try await alert.tapAction(title: Localizations.shareErrorDetails)
+
+        // TODO: PM-18224 Show share sheet to export error details
+    }
+}

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuCoordinator.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuCoordinator.swift
@@ -82,3 +82,9 @@ final class DebugMenuCoordinator: Coordinator, HasStackNavigator {
         stackNavigator?.replace(view)
     }
 }
+
+// MARK: - HasErrorAlertServices
+
+extension DebugMenuCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionSetupCoordinator.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionSetupCoordinator.swift
@@ -6,6 +6,7 @@ final class ExtensionSetupCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasConfigService
+        & HasErrorReporter
 
     // MARK: Private Properties
 
@@ -65,4 +66,10 @@ final class ExtensionSetupCoordinator: Coordinator, HasStackNavigator {
         let view = ExtensionActivationView(store: Store(processor: processor))
         stackNavigator?.replace(view)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension ExtensionSetupCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Platform/FileSelection/FileSelectionCoordinator.swift
+++ b/BitwardenShared/UI/Platform/FileSelection/FileSelectionCoordinator.swift
@@ -10,6 +10,7 @@ class FileSelectionCoordinator: NSObject, Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasCameraService
+        & HasConfigService
         & HasErrorReporter
 
     // MARK: Properties
@@ -133,6 +134,12 @@ class FileSelectionCoordinator: NSObject, Coordinator, HasStackNavigator {
         viewController.delegate = self
         stackNavigator?.present(viewController)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension FileSelectionCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }
 
 // MARK: - FileSelectionCoordinator:UIDocumentPickerDelegate

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestCoordinator.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestCoordinator.swift
@@ -4,6 +4,7 @@ final class LoginRequestCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasAuthService
+        & HasConfigService
         & HasErrorReporter
         & HasStateService
 
@@ -66,4 +67,10 @@ final class LoginRequestCoordinator: Coordinator, HasStackNavigator {
         let view = LoginRequestView(store: Store(processor: processor))
         stackNavigator?.replace(view)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension LoginRequestCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillCoordinator.swift
@@ -88,3 +88,9 @@ class PasswordAutoFillCoordinator: NSObject, Coordinator, HasStackNavigator {
         stackNavigator?.push(view)
     }
 }
+
+// MARK: - HasErrorAlertServices
+
+extension PasswordAutoFillCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolderCoordinator.swift
@@ -8,7 +8,8 @@ import SwiftUI
 class AddEditFolderCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasSettingsRepository
 
     // MARK: Properties
@@ -65,4 +66,10 @@ class AddEditFolderCoordinator: Coordinator, HasStackNavigator {
         let view = AddEditFolderView(store: Store(processor: processor))
         stackNavigator?.replace(view)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension AddEditFolderCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -509,6 +509,12 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     }
 }
 
+// MARK: - HasErrorAlertServices
+
+extension SettingsCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
 // MARK: - ImportLoginsCoordinatorDelegate
 
 extension SettingsCoordinator: ImportLoginsCoordinatorDelegate {

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -112,6 +112,13 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         vaultCoordinator?.navigate(to: vaultRoute, context: context)
     }
 
+    func showErrorAlert(error: any Error, tryAgain: (() async -> Void)?) async {
+        errorReporter.log(error: BitwardenError.generalError(
+            type: "TabCoordinator: `showErrorAlert` Not Supported",
+            message: "`showErrorAlert(error:tryAgain:)` is not supported from TabCoordinator."
+        ))
+    }
+
     func start() {
         guard let rootNavigator, let tabNavigator, let settingsDelegate, let vaultDelegate else { return }
 

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXFCoordinator.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXFCoordinator.swift
@@ -70,6 +70,12 @@ class ExportCXFCoordinator: Coordinator, HasStackNavigator {
     }
 }
 
+// MARK: - HasErrorAlertServices
+
+extension ExportCXFCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
 // MARK: - ExportCXFProcessorDelegate
 
 extension ExportCXFCoordinator: ExportCXFProcessorDelegate {

--- a/BitwardenShared/UI/Tools/Generator/GeneratorCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Generator/GeneratorCoordinator.swift
@@ -130,3 +130,9 @@ final class GeneratorCoordinator: Coordinator, HasStackNavigator {
         stackNavigator?.present(navigationController)
     }
 }
+
+// MARK: - HasErrorAlertServices
+
+extension GeneratorCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXFCoordinator.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXFCoordinator.swift
@@ -67,3 +67,9 @@ class ImportCXFCoordinator: Coordinator, HasStackNavigator {
         stackNavigator?.replace(view)
     }
 }
+
+// MARK: - HasErrorAlertServices
+
+extension ImportCXFCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}

--- a/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryCoordinator.swift
+++ b/BitwardenShared/UI/Tools/PasswordHistory/PasswordHistoryCoordinator.swift
@@ -7,7 +7,8 @@ import BitwardenSdk
 class PasswordHistoryCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasGeneratorRepository
         & HasPasteboardService
 
@@ -63,4 +64,10 @@ class PasswordHistoryCoordinator: Coordinator, HasStackNavigator {
         let view = PasswordHistoryListView(store: Store(processor: processor))
         stackNavigator?.replace(view)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension PasswordHistoryCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -14,7 +14,8 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
     typealias Module = SendItemCoordinator.Module
         & SendItemModule
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasPasteboardService
         & HasPolicyService
         & HasSendRepository
@@ -168,4 +169,10 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
         )
         stackNavigator?.present(viewController)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension SendCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
@@ -14,6 +14,7 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
     typealias Module = FileSelectionModule
 
     typealias Services = HasAuthRepository
+        & HasConfigService
         & HasErrorReporter
         & HasPasteboardService
         & HasPolicyService
@@ -178,4 +179,10 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
         )
         stackNavigator?.present(viewController)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension SendItemCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Vault/ImportLogins/ImportLoginsCoordinator.swift
+++ b/BitwardenShared/UI/Vault/ImportLogins/ImportLoginsCoordinator.swift
@@ -17,7 +17,8 @@ class ImportLoginsCoordinator: NSObject, Coordinator, HasStackNavigator {
 
     typealias Module = ImportLoginsModule
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasSettingsRepository
         & HasStateService
         & HasVaultRepository
@@ -105,4 +106,10 @@ class ImportLoginsCoordinator: NSObject, Coordinator, HasStackNavigator {
         navigationController.isModalInPresentation = true
         stackNavigator?.present(navigationController)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension ImportLoginsCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -440,6 +440,12 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     }
 }
 
+// MARK: - HasErrorAlertServices
+
+extension VaultCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
 // MARK: - ImportLoginsCoordinatorDelegate
 
 extension VaultCoordinator: ImportLoginsCoordinatorDelegate {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -267,6 +267,8 @@ extension VaultListProcessor {
         } catch URLError.cancelled {
             // No-op: don't log or alert for cancellation errors.
         } catch {
+            services.errorReporter.log(error: error)
+
             let needsSync = try? await services.vaultRepository.needsSync()
             if needsSync == true {
                 // If the vault needs a sync and there are cached items,
@@ -283,7 +285,6 @@ extension VaultListProcessor {
             } else {
                 await coordinator.showErrorAlert(error: error)
             }
-            services.errorReporter.log(error: error)
         }
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -272,7 +272,7 @@ extension VaultListProcessor {
                 // If the vault needs a sync and there are cached items,
                 // display the cached data and show an error alert.
                 if let sections = state.loadingState.data, !sections.isEmpty {
-                    await coordinator.showErrorAlert(error: error, services: services)
+                    await coordinator.showErrorAlert(error: error)
                 } else {
                     // If the vault needs a sync and there were no cached items,
                     // show the full screen error view.
@@ -281,7 +281,7 @@ extension VaultListProcessor {
                     )
                 }
             } else {
-                await coordinator.showErrorAlert(error: error, services: services)
+                await coordinator.showErrorAlert(error: error)
             }
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -272,7 +272,7 @@ extension VaultListProcessor {
                 // If the vault needs a sync and there are cached items,
                 // display the cached data and show an error alert.
                 if let sections = state.loadingState.data, !sections.isEmpty {
-                    coordinator.showAlert(.networkResponseError(error))
+                    await coordinator.showErrorAlert(error: error, services: services)
                 } else {
                     // If the vault needs a sync and there were no cached items,
                     // show the full screen error view.
@@ -281,7 +281,7 @@ extension VaultListProcessor {
                     )
                 }
             } else {
-                coordinator.showAlert(.networkResponseError(error))
+                await coordinator.showErrorAlert(error: error, services: services)
             }
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -534,7 +534,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
         XCTAssertEqual(subject.state.loadingState, .data([section]))
     }
@@ -549,7 +549,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
         XCTAssertEqual(subject.state.loadingState, .data([section]))
     }

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/AuthenticatorKeyCaptureCoordinator.swift
@@ -44,6 +44,7 @@ final class AuthenticatorKeyCaptureCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasCameraService
+        & HasConfigService
         & HasErrorReporter
 
     // MARK: Private Properties
@@ -188,4 +189,10 @@ final class AuthenticatorKeyCaptureCoordinator: Coordinator, HasStackNavigator {
         )
         stackNavigator?.replace(view)
     }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension AuthenticatorKeyCaptureCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
@@ -440,6 +440,12 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     }
 }
 
+// MARK: - HasErrorAlertServices
+
+extension VaultItemCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
 // MARK: - View Extension
 
 extension View {

--- a/GlobalTestHelpers/MockCoordinator.swift
+++ b/GlobalTestHelpers/MockCoordinator.swift
@@ -38,12 +38,12 @@ class MockCoordinator<Route, Event>: Coordinator {
         alertOnDismissed = onDismissed
     }
 
-    func showErrorAlert(error: any Error, services: any ErrorAlertServices) async {
+    func showErrorAlert(error: any Error) async {
         errorAlertsShown.append(error)
     }
 
-    func showErrorAlert(error: any Error, services: any ErrorAlertServices, tryAgain: (() async -> Void)?) async {
-        if let tryAgain  {
+    func showErrorAlert(error: any Error, tryAgain: (() async -> Void)?) async {
+        if let tryAgain {
             errorAlertsWithRetryShown.append((error, tryAgain))
         } else {
             errorAlertsShown.append(error)

--- a/GlobalTestHelpers/MockCoordinator.swift
+++ b/GlobalTestHelpers/MockCoordinator.swift
@@ -10,6 +10,7 @@ class MockCoordinator<Route, Event>: Coordinator {
     var alertShown = [Alert]()
     var alertOnDismissed: (() -> Void)?
     var contexts: [AnyObject?] = []
+    var errorAlertsShown = [Error]()
     var events = [Event]()
     var isLoadingOverlayShowing = false
     var isStarted: Bool = false
@@ -34,6 +35,10 @@ class MockCoordinator<Route, Event>: Coordinator {
     func showAlert(_ alert: BitwardenShared.Alert, onDismissed: (() -> Void)?) {
         alertShown.append(alert)
         alertOnDismissed = onDismissed
+    }
+
+    func showErrorAlert(error: any Error, services: any ErrorAlertServices) async {
+        errorAlertsShown.append(error)
     }
 
     func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/GlobalTestHelpers/MockCoordinator.swift
+++ b/GlobalTestHelpers/MockCoordinator.swift
@@ -11,6 +11,7 @@ class MockCoordinator<Route, Event>: Coordinator {
     var alertOnDismissed: (() -> Void)?
     var contexts: [AnyObject?] = []
     var errorAlertsShown = [Error]()
+    var errorAlertsWithRetryShown = [(error: Error, retry: () async -> Void)]()
     var events = [Event]()
     var isLoadingOverlayShowing = false
     var isStarted: Bool = false
@@ -39,6 +40,14 @@ class MockCoordinator<Route, Event>: Coordinator {
 
     func showErrorAlert(error: any Error, services: any ErrorAlertServices) async {
         errorAlertsShown.append(error)
+    }
+
+    func showErrorAlert(error: any Error, services: any ErrorAlertServices, tryAgain: (() async -> Void)?) async {
+        if let tryAgain  {
+            errorAlertsWithRetryShown.append((error, tryAgain))
+        } else {
+            errorAlertsShown.append(error)
+        }
     }
 
     func showLoadingOverlay(_ state: LoadingOverlayState) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18381](https://bitwarden.atlassian.net/browse/PM-18381) - Add Feature Flag for Error Reporting
[PM-18223](https://bitwarden.atlassian.net/browse/PM-18223) - Implement 'Share error details' Button in Error Dialogs

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This adds the mobile error reporting feature flag and implements the foundational pieces to support showing the 'Share error details' button in error alerts.

The 'Share error details' button will show for any default alerts which don't already show a message. Because 'Share error details' will need access to some services and the coordinator to show a share sheet, I've changed how displaying default error alerts works.

Before: `coordinator.showAlert(.networkResponseError(error))`
After: `await coordinator.showErrorAlert(error: error, services: services)`

This was the best compromise to keep this to a one-liner in a processor when presenting this alert, while supporting this new functionality. I tried writing an extension on `Coordinator` that would allow access to `services` without needing to pass those in, but ultimately couldn't get it to work with the protocol definition that we have. I think we would instead need a `Coordinator` base class, which we could explore in the future if needed.

To keep this PR small and focused on the setup pieces, I only updated `VaultListProcessor` to use this new pattern and will follow up with another PR updating the rest of the app.

> [!NOTE]
> This introduces a few SwiftLint warnings, which will be resolved in the next PR:
> >Backward matching of the unlabeled trailing closure is deprecated; label the argument with 'tryAgain' to suppress this warning.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="557" alt="Screenshot 2025-03-17 at 10 41 52 AM" src="https://github.com/user-attachments/assets/0ffd5c2a-e58f-4e2b-99a3-f4d9807db276" /> | <img width="557" alt="Screenshot 2025-03-17 at 10 42 06 AM" src="https://github.com/user-attachments/assets/2db1fdc7-245c-4279-8719-5346303ea433" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18381]: https://bitwarden.atlassian.net/browse/PM-18381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-18223]: https://bitwarden.atlassian.net/browse/PM-18223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ