### PR TITLE
[PM-19372] feat: Log out all accounts App Intent

### DIFF
--- a/Bitwarden/Application/AppIntents/LogoutAllAccountsIntent.swift
+++ b/Bitwarden/Application/AppIntents/LogoutAllAccountsIntent.swift
@@ -12,10 +12,10 @@ struct LogoutAllAccountsIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        let errorReporter = ErrorReporterFactory.createDefaultErrorReporter()
+        let errorReporter = ErrorReporterFactory.makeDefaultErrorReporter()
         do {
             let services = ServiceContainer(
-                appContext: .appIntent(.logoutAll),
+                appContext: .appIntent(.logOutAll),
                 errorReporter: errorReporter
             )
             let appProcessor = AppProcessor(appModule: DefaultAppModule(services: services), services: services)

--- a/Bitwarden/Application/AppIntents/LogoutAllAccountsIntent.swift
+++ b/Bitwarden/Application/AppIntents/LogoutAllAccountsIntent.swift
@@ -1,0 +1,35 @@
+import AppIntents
+import BitwardenShared
+
+/// App intent that log out all accounts.
+@available(iOS 16.0, *)
+struct LogoutAllAccountsIntent: AppIntent {
+    static var title: LocalizedStringResource = "LogOutAllAccounts"
+
+    static var description = IntentDescription("LogOutAllAccounts")
+
+    static var openAppWhenRun: Bool = false
+
+    @MainActor
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        let errorReporter = ServiceContainer.createDefaultErrorReporter()
+        do {
+            let services = ServiceContainer(
+                appContext: .appIntent(.logoutAll),
+                errorReporter: errorReporter
+            )
+            let appProcessor = AppProcessor(appModule: DefaultAppModule(services: services), services: services)
+            let appIntentMediator = appProcessor.getAppIntentMediator()
+
+            guard await appIntentMediator.canRunAppIntents() else {
+                return .result(dialog: "ThisOperationIsNotAllowedOnThisAccount")
+            }
+
+            try await appIntentMediator.logoutAllUsers()
+            return .result(dialog: "AllAccountsHaveBeenLoggedOut")
+        } catch {
+            errorReporter.log(error: error)
+            return .result(dialog: "AnErrorOccurredWhileTryingToLogOutAllAccounts")
+        }
+    }
+}

--- a/Bitwarden/Application/AppIntents/LogoutAllAccountsIntent.swift
+++ b/Bitwarden/Application/AppIntents/LogoutAllAccountsIntent.swift
@@ -12,7 +12,7 @@ struct LogoutAllAccountsIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {
-        let errorReporter = ServiceContainer.createDefaultErrorReporter()
+        let errorReporter = ErrorReporterFactory.createDefaultErrorReporter()
         do {
             let services = ServiceContainer(
                 appContext: .appIntent(.logoutAll),

--- a/Bitwarden/Application/AppIntents/ShortcutsProvider.swift
+++ b/Bitwarden/Application/AppIntents/ShortcutsProvider.swift
@@ -13,5 +13,13 @@ struct ShortcutsProvider: AppShortcutsProvider {
             shortTitle: "LockAllAccounts",
             systemImageName: "lock.circle.dotted"
         )
+        AppShortcut(
+            intent: LogoutAllAccountsIntent(),
+            phrases: [
+                "Log out all \(.applicationName) accounts",
+            ],
+            shortTitle: "LogOutAllAccounts",
+            systemImageName: "person.crop.circle.badge.xmark"
+        )
     }
 }

--- a/Bitwarden/Application/Support/AppShortcutsLocalizations/en.lproj/AppShortcuts.strings
+++ b/Bitwarden/Application/Support/AppShortcutsLocalizations/en.lproj/AppShortcuts.strings
@@ -1,1 +1,2 @@
 "Lock all ${applicationName} accounts" = "Lock all ${applicationName} accounts";
+"Log out all ${applicationName} accounts" = "Log out all ${applicationName} accounts";

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -39,7 +39,9 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var lockVaultUserId: String?
     var lockVaultUserIds: [String?] = []
     var logoutCalled = false
+    var logoutErrorByUserId = [String?: Error]()
     var logoutUserId: String?
+    var logoutUserIds: [String?] = []
     var logoutUserInitiated = false
     var logoutResult: Result<Void, Error> = .success(())
     var migrateUserToKeyConnectorCalled = false
@@ -249,7 +251,11 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     }
 
     func logout(userId: String?, userInitiated: Bool) async throws {
+        if let logoutError = logoutErrorByUserId[userId] {
+            throw logoutError
+        }
         logoutUserId = userId
+        logoutUserIds.append(userId)
         logoutUserInitiated = userInitiated
         try await logout()
     }

--- a/BitwardenShared/UI/Platform/Application/AppContext.swift
+++ b/BitwardenShared/UI/Platform/Application/AppContext.swift
@@ -39,5 +39,5 @@ public enum AppIntentAction {
     case lockAll
 
     /// Logs out all users.
-    case logoutAll
+    case logOutAll
 }

--- a/BitwardenShared/UI/Platform/Application/AppContext.swift
+++ b/BitwardenShared/UI/Platform/Application/AppContext.swift
@@ -37,4 +37,7 @@ public enum AppContext: Equatable {
 public enum AppIntentAction {
     /// Locks all users.
     case lockAll
+
+    /// Logs out all users.
+    case logoutAll
 }

--- a/BitwardenShared/UI/Platform/Application/AppIntentMediator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppIntentMediator.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 /// A mediator to process `AppIntent` actions.
 public protocol AppIntentMediator {
     /// Whether app intents can be run.

--- a/BitwardenShared/UI/Platform/Application/AppIntentMediatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppIntentMediatorTests.swift
@@ -10,6 +10,8 @@ class AppIntentMediatorTests: BitwardenTestCase {
 
     var authRepository: MockAuthRepository!
     var configService: MockConfigService!
+    var errorReporter: MockErrorReporter!
+    var stateService: MockStateService!
     var subject: AppIntentMediator!
 
     // MARK: Setup & Teardown
@@ -19,7 +21,14 @@ class AppIntentMediatorTests: BitwardenTestCase {
 
         authRepository = MockAuthRepository()
         configService = MockConfigService()
-        subject = DefaultAppIntentMediator(authRepository: authRepository, configService: configService)
+        errorReporter = MockErrorReporter()
+        stateService = MockStateService()
+        subject = DefaultAppIntentMediator(
+            authRepository: authRepository,
+            configService: configService,
+            errorReporter: errorReporter,
+            stateService: stateService
+        )
     }
 
     override func tearDown() {
@@ -27,6 +36,8 @@ class AppIntentMediatorTests: BitwardenTestCase {
 
         authRepository = nil
         configService = nil
+        errorReporter = nil
+        stateService = nil
         subject = nil
     }
 
@@ -61,5 +72,45 @@ class AppIntentMediatorTests: BitwardenTestCase {
         await assertAsyncThrows(error: BitwardenTestError.example) {
             try await subject.lockAllUsers()
         }
+    }
+
+    /// `logoutAllUsers()` logs out all accounts.
+    func test_logoutAllUsers() async throws {
+        stateService.accounts = [
+            .fixture(profile: .fixture(userId: "1")),
+            .fixture(profile: .fixture(userId: "2")),
+            .fixture(profile: .fixture(userId: "3")),
+        ]
+        try await subject.logoutAllUsers()
+        XCTAssertEqual(authRepository.logoutUserIds, ["1", "2", "3"])
+    }
+
+    /// `logoutAllUsers()` logs out some accounts because one of them throws.
+    func test_logoutAllUsers_someThrows() async throws {
+        stateService.accounts = [
+            .fixture(profile: .fixture(userId: "1")),
+            .fixture(profile: .fixture(userId: "2")),
+            .fixture(profile: .fixture(userId: "3")),
+        ]
+        authRepository.logoutErrorByUserId = ["2": BitwardenTestError.example]
+        try await subject.logoutAllUsers()
+        XCTAssertEqual(authRepository.logoutUserIds, ["1", "3"])
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `logoutAllUsers()` does nothing when there are no accounts.
+    func test_logoutAllUsers_noAccounts() async throws {
+        stateService.accounts = []
+        try await subject.logoutAllUsers()
+        XCTAssertTrue(authRepository.logoutUserIds.isEmpty)
+        XCTAssertFalse(authRepository.logoutCalled)
+    }
+
+    /// `logoutAllUsers()` does nothing when getting accounts throw.
+    func test_logoutAllUsers_throwGettingAccounts() async throws {
+        stateService.accounts = nil
+        try await subject.logoutAllUsers()
+        XCTAssertTrue(authRepository.logoutUserIds.isEmpty)
+        XCTAssertFalse(authRepository.logoutCalled)
     }
 }

--- a/BitwardenShared/UI/Platform/Application/AppIntentMediatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppIntentMediatorTests.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+import BitwardenKitMocks
 import TestHelpers
 import XCTest
 

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -343,7 +343,9 @@ public class AppProcessor {
         appIntentMediator
             ?? DefaultAppIntentMediator(
                 authRepository: services.authRepository,
-                configService: services.configService
+                configService: services.configService,
+                errorReporter: services.errorReporter,
+                stateService: services.stateService
             )
     }
 

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1173,3 +1173,6 @@
 "ExpiresToday" = "Expires today";
 "ExpiresInXDays" = "Expires in %1$@ days";
 "DateRangeXToY" = "%1$@ to %2$@";
+"LogOutAllAccounts" = "Log out all accounts";
+"AllAccountsHaveBeenLoggedOut" = "All accounts have been logged out";
+"AnErrorOccurredWhileTryingToLogOutAllAccounts" = "An error occurred while trying to log out all accounts";

--- a/BitwardenShared/UI/Platform/Application/TestHelpers/MockAppIntentMediator.swift
+++ b/BitwardenShared/UI/Platform/Application/TestHelpers/MockAppIntentMediator.swift
@@ -3,6 +3,7 @@
 class MockAppIntentMediator: AppIntentMediator {
     var canRunAppIntentsResult = false
     var lockAllUsersCalled = false
+    var logoutAllUsersCalled = false
 
     func canRunAppIntents() async -> Bool {
         canRunAppIntentsResult
@@ -10,5 +11,9 @@ class MockAppIntentMediator: AppIntentMediator {
 
     func lockAllUsers() async throws {
         lockAllUsersCalled = true
+    }
+
+    func logoutAllUsers() async throws {
+        logoutAllUsersCalled = true
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-19372](https://bitwarden.atlassian.net/browse/PM-19372)

## 📔 Objective

Implemented Log out all accounts App Intent and its Shortcut configuration.

ℹ️ No need for `PendingAppIntentAction` as the logout will be triggered in `AppProcessor -> checkIfExtensionSwitchedAccounts()` when going back to foreground.

⚠️ Merge #1443 first to the app intents feature branch.

## 📸 Screenshots

### Log out all accounts shortcut
<img width="314" alt="Log out all accounts shortcut" src="https://github.com/user-attachments/assets/e3d54ab0-1c2c-4775-8ff9-69d994f4d7eb">


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19372]: https://bitwarden.atlassian.net/browse/PM-19372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ