### PR TITLE
Fix `Build Authenticator` Action

### DIFF
--- a/Scripts-bwa/build.sh
+++ b/Scripts-bwa/build.sh
@@ -20,6 +20,7 @@ echo "🧱 Building in $(pwd)"
 echo ""
 
 echo "🌱 Generating xcode project"
+mint run xcodegen --spec "project-bwk.yml"
 mint run xcodegen --spec "project-bwa.yml"
 
 mkdir -p "${BUILD_DIR}"


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

- When creating a build for testing the authenticator sync feature, the "Build Authenticator" github action was failing due to not seeing `BitwardenKit`.  

<img width="1024" alt="Screenshot 2025-03-21 at 4 25 56 PM" src="https://github.com/user-attachments/assets/8d3bf998-4139-4f17-a68d-73484aabec2a" />


- Adding in the xcodegen command to build the kit before building the auth app. 
- Link to the [build](https://github.com/bitwarden/ios/actions/runs/14000051626) that worked successfully

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
