### PR TITLE
[PM-18439] Fix flaky tests

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -2033,7 +2033,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `logout` successfully logs out a user.
-    func test_logout_success() {
+    func test_logout_success() async throws {
         let account = Account.fixture()
         stateService.accounts = [account]
         stateService.activeAccount = account
@@ -2042,11 +2042,8 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         biometricsRepository.setBiometricUnlockKeyError = nil
         stateService.pinProtectedUserKeyValue["1"] = "1"
         stateService.encryptedPinByUserId["1"] = "1"
-        let task = Task {
-            try await subject.logout(userInitiated: true)
-        }
-        waitFor(!vaultTimeoutService.removedIds.isEmpty)
-        task.cancel()
+
+        try await subject.logout(userInitiated: true)
 
         XCTAssertEqual([account.profile.userId], stateService.accountsLoggedOut)
         XCTAssertNil(biometricsRepository.capturedUserAuthKey)

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @testable import BitwardenShared
 
+@MainActor
 class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
@@ -122,8 +123,8 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         accountAPIService = nil
         authService = nil
@@ -961,7 +962,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` returns the organization identifier when
     /// the feature flag `.refactorSsoDetailsEndpoint` is on.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_successFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpSuccess(testData: .singleSignOnDomainsVerified)
@@ -971,7 +971,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` returns the first organization identifier when
     /// the feature flag `.refactorSsoDetailsEndpoint` is on and there are multiple results in response.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_successInMultipleFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpSuccess(testData: .singleSignOnDomainsVerifiedMultiple)
@@ -981,7 +980,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` returns `nil` when
     /// the feature flag `.refactorSsoDetailsEndpoint` is on and there is no data.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_noDataFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpSuccess(testData: .singleSignOnDomainsVerifiedNoData)
@@ -991,7 +989,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` returns `nil` when
     /// the feature flag `.refactorSsoDetailsEndpoint` is on and data array is empty.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_emptyDataFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpSuccess(testData: .singleSignOnDomainsVerifiedEmptyData)
@@ -1001,7 +998,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` returns `nil` when
     /// the feature flag `.refactorSsoDetailsEndpoint` is on and there is no organization identifier.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_noOrgIdFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpSuccess(testData: .singleSignOnDomainsVerifiedNoOrgId)
@@ -1011,7 +1007,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` returns `nil` when
     /// the feature flag `.refactorSsoDetailsEndpoint` is on and empty organization identifier.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_emptyOrgIdFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpSuccess(testData: .singleSignOnDomainsVerifiedEmptyOrgId)
@@ -1021,7 +1016,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `getSingleSignOnOrganizationIdentifier(email:)` throws when calling the API
     /// and the feature flag `.refactorSsoDetailsEndpoint` is on.
-    @MainActor
     func test_getSingleSignOnOrganizationIdentifier_throwsFeatureFlagOn() async throws {
         configService.featureFlagsBool[.refactorSsoDetailsEndpoint] = true
         client.result = .httpFailure(BitwardenTestError.example)
@@ -1126,7 +1120,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `isUserManagedByOrganization` returns false when the user isn't managed by an organization.
-    @MainActor
     func test_isUserManagedByOrganization_false_featureFlagON() async throws {
         configService.featureFlagsBool[.accountDeprovisioning] = true
         stateService.accounts = [.fixture(profile: .fixture(userId: "1"))]
@@ -1138,7 +1131,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `isUserManagedByOrganization` returns false when the user doesn't belong to an organization.
-    @MainActor
     func test_isUserManagedByOrganization_noOrgs_featureFlagON() async throws {
         configService.featureFlagsBool[.accountDeprovisioning] = true
         stateService.accounts = [.fixture(profile: .fixture(userId: "1"))]
@@ -1150,7 +1142,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `isUserManagedByOrganization` returns true if the user is managed by an organization.
-    @MainActor
     func test_isUserManagedByOrganization_true_featureFlagON() async throws {
         configService.featureFlagsBool[.accountDeprovisioning] = true
         stateService.accounts = [.fixture(profile: .fixture(userId: "1"))]
@@ -1163,7 +1154,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `isUserManagedByOrganization` returns true if the user is managed by at least one organization.
-    @MainActor
     func test_isUserManagedByOrganization_true_multipleOrgs_featureON() async throws {
         configService.featureFlagsBool[.accountDeprovisioning] = true
         stateService.accounts = [.fixture(profile: .fixture(userId: "1"))]

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -456,10 +456,10 @@ extension DefaultAutofillCredentialService: AutofillCredentialService {
         rpId: String,
         clientDataHash: Data
     ) async throws -> ASPasskeyAssertionCredential {
-        fido2UserInterfaceHelper.setupDelegate(
+        await fido2UserInterfaceHelper.setupDelegate(
             fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate
         )
-        fido2UserInterfaceHelper.setupCurrentUserVerificationPreference(
+        await fido2UserInterfaceHelper.setupCurrentUserVerificationPreference(
             userVerificationPreference: request.options.uv
         )
 

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -297,7 +297,7 @@ class DefaultAutofillCredentialService {
     ///
     private func tryUnlockVaultWithoutUserInteraction(delegate: AutofillCredentialServiceDelegate) async throws {
         let userId = try await stateService.getActiveAccountId()
-        let isLocked = vaultTimeoutService.isLocked(userId: userId)
+        let isLocked = await vaultTimeoutService.isLocked(userId: userId)
         let isManuallyLocked = await (try? stateService.getManuallyLockedAccount(userId: userId)) == true
         let vaultTimeout = try? await vaultTimeoutService.sessionTimeoutValue(userId: nil)
         guard vaultTimeout == .never, isLocked, !isManuallyLocked else {

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @testable import BitwardenShared
 
+@MainActor
 class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
@@ -69,8 +70,8 @@ class AutofillCredentialServiceTests: BitwardenTestCase { // swiftlint:disable:t
         identityStore.removeAllCredentialIdentitiesCalled = false
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         autofillCredentialServiceDelegate = nil
         cipherService = nil

--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
@@ -275,7 +275,7 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
             _ = await enableSyncTask?.result
 
             do {
-                guard !vaultTimeoutService.isLocked(userId: userId) else {
+                guard await !vaultTimeoutService.isLocked(userId: userId) else {
                     let authVaultKey = try? await keychainRepository.getAuthenticatorVaultKey(userId: userId)
                     if authVaultKey != nil {
                         subscribeToCipherUpdates(userId: userId)
@@ -318,7 +318,7 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
     ///
     private func writeCiphers(ciphers: [Cipher], userId: String) async throws {
         let account = try await stateService.getAccount(userId: userId)
-        let useKey = vaultTimeoutService.isLocked(userId: userId)
+        let useKey = await vaultTimeoutService.isLocked(userId: userId)
 
         do {
             if useKey {

--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
@@ -803,7 +803,7 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
     }
 
     /// When the feature flag is off, determineSyncForUserId should return early and do nothing.
-    /// 
+    ///
     @MainActor
     func test_determineSyncForUserId_featureFlagOff_doesNothing() async throws {
         setupInitialState()
@@ -962,7 +962,7 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
             ),
         ])
 
-        waitFor(authBridgeItemService.storedItems["1"]?.first != nil)
+        try await waitForAsync { self.authBridgeItemService.storedItems["1"]?.first != nil }
         let items = try XCTUnwrap(authBridgeItemService.storedItems["1"])
         XCTAssertEqual(items.count, 1)
         XCTAssertEqual(items.first?.id, "1234")
@@ -994,7 +994,7 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
             ),
         ])
 
-        waitFor(!errorReporter.errors.isEmpty)
+        try await waitForAsync { !self.errorReporter.errors.isEmpty }
         XCTAssertTrue(vaultTimeoutService.isLocked(userId: "1"))
     }
 

--- a/BitwardenShared/Core/Platform/Services/ConfigServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ConfigServiceTests.swift
@@ -3,6 +3,7 @@ import XCTest
 
 @testable import BitwardenShared
 
+@MainActor
 final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
@@ -38,8 +39,8 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         stateService.activeAccount = account
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         appSettingsStore = nil
         client = nil
@@ -109,7 +110,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(response?.gitHash, "75238192")
 
         try await waitForAsync {
-            self.client.requests.count == 1
+            self.stateService.serverConfig["1"]?.gitHash == "75238191"
         }
 
         XCTAssertEqual(stateService.serverConfig["1"]?.gitHash, "75238191")
@@ -135,7 +136,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(response?.gitHash, "75238192")
 
         try await waitForAsync {
-            self.client.requests.count == 1
+            !self.errorReporter.errors.isEmpty
         }
 
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
@@ -166,7 +167,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertNil(response)
 
         try await waitForAsync {
-            self.client.requests.count == 1
+            self.stateService.serverConfig["1"] != nil
         }
 
         XCTAssertEqual(stateService.serverConfig["1"]?.gitHash, "75238191")
@@ -250,7 +251,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(response?.gitHash, "75238192")
 
         try await waitForAsync {
-            self.client.requests.count == 1
+            self.stateService.preAuthServerConfig?.gitHash == "75238191"
         }
 
         XCTAssertEqual(stateService.preAuthServerConfig?.gitHash, "75238191")
@@ -277,7 +278,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(response?.gitHash, "75238192")
 
         try await waitForAsync {
-            self.client.requests.count == 1
+            !self.errorReporter.errors.isEmpty
         }
 
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
@@ -311,7 +312,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertNil(response)
 
         try await waitForAsync {
-            self.client.requests.count == 1
+            self.stateService.preAuthServerConfig != nil
         }
 
         XCTAssertEqual(stateService.preAuthServerConfig?.gitHash, "75238191")

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -233,6 +233,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     ///   - vaultTimeoutService: The service used by the application to manage vault access.
     ///   - watchService: The service used by the application to connect to and communicate with the watch app.
     ///
+    @MainActor
     init( // swiftlint:disable:this function_body_length
         apiService: APIService,
         appIdService: AppIdService,
@@ -346,6 +347,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - nfcReaderService: The service used by the application to read NFC tags.
     ///
+    @MainActor
     public convenience init( // swiftlint:disable:this function_body_length
         application: Application? = nil,
         errorReporter: ErrorReporter,

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1394,7 +1394,7 @@ actor DefaultStateService: StateService { // swiftlint:disable:this type_body_le
         showWebIconsSubject = CurrentValueSubject(!appSettingsStore.disableWebIcons)
 
         Task {
-            for await activeUserId in self.appSettingsStore.activeAccountIdPublisher().values {
+            for await activeUserId in await self.appSettingsStore.activeAccountIdPublisher().values {
                 errorReporter.setUserId(activeUserId)
             }
         }

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -64,7 +64,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var unsuccessfulUnlockAttempts = [String: Int]()
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
-    lazy var activeIdSubject = CurrentValueSubject<String?, Never>(self.state?.activeUserId)
+    var activeIdSubject = CurrentValueSubject<String?, Never>(nil)
 
     func accountSetupAutofill(userId: String) -> AccountSetupProgress? {
         accountSetupAutofill[userId]

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
@@ -4,6 +4,7 @@ import Networking
 @testable import BitwardenShared
 
 extension ServiceContainer {
+    @MainActor
     static func withMocks( // swiftlint:disable:this function_body_length
         application: Application? = nil,
         appInfoService: AppInfoService = MockAppInfoService(),

--- a/BitwardenShared/Core/Tools/Services/GeneratorDataStoreTests.swift
+++ b/BitwardenShared/Core/Tools/Services/GeneratorDataStoreTests.swift
@@ -117,6 +117,7 @@ class GeneratorDataStoreTests: BitwardenTestCase {
     }
 
     /// `passwordHistoryPublisher(userId:)` returns a publisher for a user's password history objects.
+    @MainActor
     func test_passwordHistoryPublisher() async throws {
         var publishedValues = [[PasswordHistory]]()
         let publisher = subject.passwordHistoryPublisher(userId: "1")

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -337,7 +337,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
             .fixture(id: "3", name: "Café", type: .login),
             .fixture(id: "4"),
         ]
-        fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send(expectedCiphersInFido2Section)
+        await fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send(expectedCiphersInFido2Section)
 
         let expectedRpID = "myApp.com"
         var iterator = try await subject.ciphersAutofillPublisher(
@@ -1352,7 +1352,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         cipherService.ciphersSubject.value = ciphers
         let cipherView = try CipherView(cipher: XCTUnwrap(cipherService.ciphersSubject.value.last))
 
-        fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([
+        await fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([
             .fixture(id: "2", name: "qwe", type: .login),
             .fixture(id: "3", name: "Café", type: .login),
             .fixture(id: "4"),
@@ -1405,7 +1405,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         setupDefaultDecryptFido2AutofillCredentialsMocker(expectedCredentialId: expectedCredentialId)
         cipherService.ciphersSubject.value = []
 
-        fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([
+        await fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([
             .fixture(id: "2", name: "qwe", type: .login),
             .fixture(id: "3", name: "Café", type: .login),
             .fixture(id: "4"),
@@ -1440,7 +1440,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         cipherService.ciphersSubject.value = ciphers
         let cipherView = try CipherView(cipher: XCTUnwrap(cipherService.ciphersSubject.value.last))
 
-        fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([])
+        await fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([])
         var iterator = try await subject
             .searchCipherAutofillPublisher(
                 availableFido2CredentialsPublisher: fido2UserInterfaceHelper
@@ -1480,7 +1480,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         ]
         cipherService.ciphersSubject.value = ciphers
 
-        fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([
+        await fido2UserInterfaceHelper.credentialsForAuthenticationSubject.send([
             .fixture(id: "2", name: "qwe", type: .login),
             .fixture(id: "3", name: "Café", type: .login),
             .fixture(id: "4"),

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -267,7 +267,7 @@ extension DefaultSyncService {
         }
 
         if let organizations = response.profile?.organizations {
-            if !vaultTimeoutService.isLocked(userId: userId) {
+            if await !vaultTimeoutService.isLocked(userId: userId) {
                 try await organizationService.initializeOrganizationCrypto(
                     organizations: organizations.compactMap(Organization.init)
                 )

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -588,6 +588,7 @@ class SyncServiceTests: BitwardenTestCase {
 
     /// `fetchSync()` replaces the list of the user's organizations but doesn't initialize
     /// organization crypto if the user's vault is locked.
+    @MainActor
     func test_fetchSync_organizations_vaultLocked() async throws {
         client.result = .httpSuccess(testData: .syncWithProfileOrganizations)
         stateService.activeAccount = .fixture()

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
@@ -21,6 +21,8 @@ class MockVaultTimeoutService: VaultTimeoutService {
     /// Whether or not a user's client is locked.
     var isClientLocked = [String: Bool]()
 
+    nonisolated init() {}
+
     func isLocked(userId: String) -> Bool {
         isClientLocked[userId] == true
     }

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -15,6 +15,7 @@ enum VaultTimeoutServiceError: Error {
 
 /// A protocol for handling vault access.
 ///
+@MainActor
 protocol VaultTimeoutService: AnyObject {
     // MARK: Methods
 

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @testable import BitwardenShared
 
+@MainActor
 final class VaultTimeoutServiceTests: BitwardenTestCase {
     // MARK: Properties
 
@@ -37,8 +38,8 @@ final class VaultTimeoutServiceTests: BitwardenTestCase {
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         cancellables = nil
         clientService = nil

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 @testable import BitwardenShared
 
+@MainActor
 final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
@@ -44,8 +45,8 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         authRepository = nil
         biometricsRepository = nil
@@ -190,7 +191,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.landing` and doesn't set the
     /// carousel shown flag if the carousel feature flag is off.
-    @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselNotShown() async {
         authRepository.activeAccount = .fixture()
         configService.featureFlagsBool[.nativeCarouselFlow] = false
@@ -203,7 +203,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.landing` and sets the carousel shown
     /// flag if the carousel feature flag is on and the carousel hasn't been shown yet.
-    @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselShown() async {
         authRepository.activeAccount = .fixture()
         configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
@@ -216,7 +215,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects `.didCompleteAuth` to `.vaultUnlockSetup` and sets the
     /// carousel shown flag if the carousel feature flag is on and the carousel hasn't been shown yet.
-    @MainActor
     func test_handleAndRoute_didCompleteAuth_carouselShown_vaultUnlockSetup() async {
         authRepository.activeAccount = .fixture()
         configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
@@ -259,7 +257,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to complete the auth flow if the account
     /// doesn't require an updated password and there's a rehydratable target saved
     /// but it's in the app extension context.
-    @MainActor
     func test_handleAndRoute_didCompleteAuth_completeWithRehydrationNotCalledAppExtension() async {
         subject = AuthRouter(
             isInAppExtension: true,
@@ -292,7 +289,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.complete` if the user still
     /// needs to set up autofill but is within the app extension.
-    @MainActor
     func test_handleAndRoute_didCompleteAuth_incompleteAutofill_withinAppExtension() async {
         subject = AuthRouter(
             isInAppExtension: true,
@@ -319,7 +315,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_:)` redirects `.didCompleteAuth` to `.complete` if the user still
     /// needs to set up a vault unlock method but is within the app extension.
-    @MainActor
     func test_handleAndRoute_didCompleteAuth_incomplete_withinAppExtension() async {
         subject = AuthRouter(
             isInAppExtension: true,
@@ -352,7 +347,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects`.didDeleteAccount` to another account
     ///     when there are more accounts.
-    @MainActor
     func test_handleAndRoute_didDeleteAccount_alternateAccount() async {
         let activeAccount = Account.fixture()
         stateService.activeAccount = activeAccount
@@ -906,7 +900,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `handleAndRoute(_ :)` redirects `.didLogout()` to `.vaultUnlock`
     ///     by way of an account switch when the logout is user initiated
     ///     and a locked alternate is available.
-    @MainActor
     func test_handleAndRoute_didLogout_userInitiated_alternateAccount() {
         let alt = Account.fixtureAccountLogin()
         stateService.accounts = [
@@ -961,7 +954,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.introCarousel` if there's no accounts and
     /// the carousel flow is enabled.
-    @MainActor
     func test_handleAndRoute_didStart_carouselFlow() async {
         configService.featureFlagsBoolPreAuth[.nativeCarouselFlow] = true
 
@@ -972,7 +964,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.landing` if there's no accounts, the
     /// carousel flow is enabled, but the carousel has already been shown.
-    @MainActor
     func test_handleAndRoute_didStart_carouselFlow_carouselShown() async {
         configService.featureFlagsBool[.nativeCarouselFlow] = true
         stateService.introCarouselShown = true
@@ -983,7 +974,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     }
 
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.landing` if it's running in an extension.
-    @MainActor
     func test_handleAndRoute_didStart_carouselFlow_extension() async {
         configService.featureFlagsBool[.nativeCarouselFlow] = true
 
@@ -1005,7 +995,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
 
     /// `handleAndRoute(_ :)` redirects `.didStart` to `.completeWithNeverUnlockKey` if there's an
     /// existing account with never lock enabled and sets the intro carousel as shown.
-    @MainActor
     func test_handleAndRoute_didStart_carouselFlow_existingAccountNeverLock() async {
         let account = Account.fixture()
         authRepository.activeAccount = .fixture()
@@ -1147,7 +1136,6 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// `handleAndRoute(_ :)` in app extension redirects `.didTimeout` to `.vaultUnlock`
     /// if the account session has timed out and the action is lock but doesn't save
     /// rehydration state.
-    @MainActor
     func test_handleAndRoute_didTimeout_sessionExpired_lock_inAppExtension() async {
         subject = AuthRouter(
             isInAppExtension: true,

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
@@ -24,6 +24,7 @@ protocol Fido2UserInterfaceHelperDelegate: Fido2UserVerificationMediatorDelegate
 
 /// A helper to extend `Fido2UserInterface` protocol capabilities for Fido2 flows
 /// depending on user interaction.
+@MainActor
 protocol Fido2UserInterfaceHelper: Fido2UserInterface {
     /// The `BitwardenSdk.CheckUserOptions` the SDK provides while in Fido2 creation flow.
     var fido2CreationOptions: BitwardenSdk.CheckUserOptions? { get }
@@ -74,7 +75,7 @@ protocol Fido2UserInterfaceHelper: Fido2UserInterface {
 
 // MARK: - DefaultFido2UserInterfaceHelper
 
-/// Default implemenation of `Fido2UserInterfaceHelper`.
+/// Default implementation of `Fido2UserInterfaceHelper`.
 class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
     /// Mediator which manages user verification on Fido2 flows.
     private var fido2UserVerificationMediator: Fido2UserVerificationMediator
@@ -155,7 +156,7 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
             throw Fido2Error.noDelegateSetup
         }
 
-        guard await fido2UserInterfaceHelperDelegate.isAutofillingFromList else {
+        guard fido2UserInterfaceHelperDelegate.isAutofillingFromList else {
             guard availableCredentials.count == 1 else {
                 throw Fido2Error.invalidOperationError
             }

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelperTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelperTests.swift
@@ -6,6 +6,7 @@ import XCTest
 
 // MARK: - Fido2UserInterfaceHelperTests
 
+@MainActor
 class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
@@ -23,8 +24,8 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
         subject = DefaultFido2UserInterfaceHelper(fido2UserVerificationMediator: fido2UserVerificationMediator)
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         fido2UserInterfaceHelperDelegate = nil
         fido2UserVerificationMediator = nil
@@ -35,7 +36,6 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
 
     /// `checkUser(options:hint:)` with hint `informExcludedCredentialFound` informs the delegate
     /// of the situation and returns that user has not been verified.
-    @MainActor
     func test_checkUser_informExcludedCredentialFoundHint() async throws {
         subject.setupDelegate(fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate)
         let cipher = CipherView.fixture()
@@ -213,7 +213,7 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
     }
 
     /// `checkUserAndPickCredentialForCreation(options:newCredential:)` returns picked cipher
-    /// after succesfully calling `pickedCredentialForCreation(cipherResult:)`.
+    /// after successfully calling `pickedCredentialForCreation(cipherResult:)`.
     func test_checkUserAndPickCredentialForCreation_returnsPickedCipher() async throws {
         let expectedOptions = CheckUserOptions(
             requirePresence: true,
@@ -278,7 +278,6 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
 
     /// `pickCredentialForAuthentication(availableCredentials:)` not autofilling from list succeeds
     /// with first available credential.
-    @MainActor
     func test_pickCredentialForAuthentication_notAutofillingFromListSucceeds() async throws {
         subject.setupDelegate(fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate)
         fido2UserInterfaceHelperDelegate.isAutofillingFromList = false
@@ -291,7 +290,6 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
 
     /// `pickCredentialForAuthentication(availableCredentials:)` autofilling from list succeeds
     /// with picked credential.
-    @MainActor
     func test_pickCredentialForAuthentication_autofillingFromListSucceeds() async throws {
         subject.setupDelegate(fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate)
         fido2UserInterfaceHelperDelegate.isAutofillingFromList = true
@@ -322,7 +320,6 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
 
     /// `pickCredentialForAuthentication(availableCredentials:)` autofilling from list throws
     /// when picking credential.
-    @MainActor
     func test_pickCredentialForAuthentication_autofillingFromListThrowsPickingCredential() async throws {
         subject.setupDelegate(fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate)
         fido2UserInterfaceHelperDelegate.isAutofillingFromList = true
@@ -346,7 +343,6 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
 
     /// `pickCredentialForAuthentication(availableCredentials:)` not autofilling from list throws
     /// invalid operation error when available credentials is different from 1.
-    @MainActor
     func test_pickCredentialForAuthentication_throwsNotAutofillingFromListNoAvailableCredentials() async throws {
         subject.setupDelegate(fido2UserInterfaceHelperDelegate: fido2UserInterfaceHelperDelegate)
         fido2UserInterfaceHelperDelegate.isAutofillingFromList = false
@@ -382,8 +378,7 @@ class Fido2UserInterfaceHelperTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertFalse(resultPreferredFalse)
     }
 
-    /// `setupDelegate(fido2UserVerificationMediatorDelegate:)`  sets up deleagte in inner mediator.
-    @MainActor
+    /// `setupDelegate(fido2UserVerificationMediatorDelegate:)`  sets up delegate in inner mediator.
     func test_setupDelegate() async throws {
         subject.setupDelegate(fido2UserInterfaceHelperDelegate: MockFido2UserInterfaceHelperDelegate())
         XCTAssertTrue(fido2UserVerificationMediator.setupDelegateCalled)

--- a/BitwardenShared/UI/Autofill/Utilities/TestHelpers/MockFido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/TestHelpers/MockFido2UserInterfaceHelper.swift
@@ -37,6 +37,8 @@ class MockFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
     var fido2UserInterfaceHelperDelegate: Fido2UserInterfaceHelperDelegate?
     var userVerificationPreferenceSetup: Uv?
 
+    nonisolated init() {}
+
     func availableCredentialsForAuthenticationPublisher() -> AnyPublisher<[BitwardenSdk.CipherView]?, Error> {
         credentialsForAuthenticationSubject.eraseToAnyPublisher()
     }

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -119,6 +119,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
     /// `init()` subscribes to app background events and logs an error if one occurs when
     /// setting the last active time.
+    @MainActor
     func test_appBackgrounded_error() {
         stateService.activeAccount = .fixture()
         vaultTimeoutService.setLastActiveTimeError = BitwardenTestError.example
@@ -130,6 +131,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
     }
 
     /// The user's last active time is updated when the app is backgrounded.
+    @MainActor
     func test_appBackgrounded_setLastActiveTime() {
         let account: Account = .fixture()
         stateService.activeAccount = account

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -685,6 +685,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
     /// `vaultItemTapped(_:)` with Fido2 credential doesn't call the `Fido2UserInterfaceHelper`
     /// that a cipher has been picked for creation when there is no creation request.
     @available(iOSApplicationExtension 17.0, *)
+    @MainActor
     func test_perform_vaultItemTapped_fido2PickedWhenNotInCreation() async {
         let vaultListItem = VaultListItem(
             cipherView: CipherView.fixture(),

--- a/TestHelpers/Support/BaseBitwardenTestCase.swift
+++ b/TestHelpers/Support/BaseBitwardenTestCase.swift
@@ -194,6 +194,7 @@ open class BaseBitwardenTestCase: XCTestCase {
     ///     - line: The line number in which the failure occurred. Defaults to the line number on
     ///         which this function was called from.
     ///
+    @MainActor
     open func waitForAsync(
         _ condition: @escaping () -> Bool,
         timeout: TimeInterval = 10.0,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18439](https://bitwarden.atlassian.net/browse/PM-18439)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a few tests that have been intermittently failing on test runs. Most of these failures stem from concurrency issues where mocks or internal variables are accessed or mutated from separate threads. Moving mocks or tests or some protocols to the main actor to prevent these issues was the general theme around the fixes.

- `AppProcessorTests.test_appBackgrounded_setLastActiveTime`
  - Caused by `MockVaultTimeoutService.lastActiveTime` being accessed from multiple threads.
  - Fixed by moving `VaultTimeoutService` to the main actor.
- `Fido2UserInterfaceHelperTests.test_checkUserAndPickCredentialForCreation_errors`
  - Caused by accessing the continuation from multiple threads?
  - Fixed by moving `Fido2UserInterfaceHelper` to the main actor.
- `StateServiceTests.test_didAccountSwitchInExtension_noActiveUser_cachedActiveUserId`
  - I think this was a race condition caused by lazy init in the mock. Removing the lazy init seemed to fix it.
- `AuthenticatorSyncServiceTests.test_determineSyncForUserId_syncTurnedOff`
  - I moved `waitForAsync` to the main actor and I wasn't able to get this to fail afterwards.
- `PublisherAsyncTests test_asyncMap`
  - I wasn't able to get this one to fail.
- `AuthenticatorSyncServiceTests.test_decryptTOTPs_filtersOutDeleted()`
  - Fixed by swapping `waitFor` with `waitForAsync`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18439]: https://bitwarden.atlassian.net/browse/PM-18439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ