### PR TITLE
[BWA-155] refactor: Adjust scopes of Date extension to avoid conflicts

### DIFF
--- a/AuthenticatorShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
+++ b/AuthenticatorShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
@@ -569,7 +569,7 @@ extension PasswordHistoryView {
     }
 }
 
-extension Date {
+fileprivate extension Date {
     init(
         year: Int,
         month: Int,

--- a/BitwardenShared/UI/Auth/PreviewContent/LoginRequest+Fixtures.swift
+++ b/BitwardenShared/UI/Auth/PreviewContent/LoginRequest+Fixtures.swift
@@ -32,4 +32,31 @@ extension LoginRequest {
         )
     }
 }
+
+fileprivate extension Date {
+    init(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0,
+        second: Int = 0,
+        nanosecond: Int = 0,
+        timeZone: TimeZone = TimeZone(secondsFromGMT: 0)!
+    ) {
+        let calendar = Calendar(identifier: .gregorian)
+        let dateComponents = DateComponents(
+            calendar: calendar,
+            timeZone: timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second,
+            nanosecond: nanosecond
+        )
+        self = dateComponents.date!
+    }
+}
 #endif

--- a/BitwardenShared/UI/Tools/PreviewContent/SendView+Fixtures.swift
+++ b/BitwardenShared/UI/Tools/PreviewContent/SendView+Fixtures.swift
@@ -71,4 +71,31 @@ extension SendTextView {
         )
     }
 }
+
+fileprivate extension Date {
+    init(
+        year: Int,
+        month: Int,
+        day: Int,
+        hour: Int = 0,
+        minute: Int = 0,
+        second: Int = 0,
+        nanosecond: Int = 0,
+        timeZone: TimeZone = TimeZone(secondsFromGMT: 0)!
+    ) {
+        let calendar = Calendar(identifier: .gregorian)
+        let dateComponents = DateComponents(
+            calendar: calendar,
+            timeZone: timeZone,
+            year: year,
+            month: month,
+            day: day,
+            hour: hour,
+            minute: minute,
+            second: second,
+            nanosecond: nanosecond
+        )
+        self = dateComponents.date!
+    }
+}
 #endif

--- a/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
+++ b/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
@@ -569,7 +569,7 @@ extension PasswordHistoryView {
     }
 }
 
-extension Date {
+fileprivate extension Date {
     init(
         year: Int,
         month: Int,

--- a/TestHelpers/Extensions/Date.swift
+++ b/TestHelpers/Extensions/Date.swift
@@ -1,6 +1,8 @@
 import Foundation
 
-extension Date {
+public extension Date {
+    /// A convenience initializer for `Date` to specify a specific point in time.
+    /// Useful in tests and previews.
     init(
         year: Int,
         month: Int,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-155

## 📔 Objective

We have a `Date` extension that adds a new initializer that makes it easier to specify an exact `Date` object for use in tests and previews. Historically, this was defined in two locations: one in `GlobalTestHelpers` and the other in `BitwardenSdk+VaultFixtures` behind an `if #DEBUG` flag. Because one definition was in the test target module, it was picked when running tests, and the one in `BitwardenShared` was ignored.

However, as a result of https://github.com/bitwarden/ios/pull/1424 the `GlobalTestHelpers` version was pulled into `TestHelpers`; but it was still an `internal` visibility level, as it was only needed inside of the `TestHelpers` module. But with needing to bring more things into `BitwardenKit`, tests in `BitwardenKitTests` will need to have access to it, necessitating making it `public`.

As a result, there are issues. Namely, because there are copies of the extension in both `TestHelpers` and in `BitwardenShared`, tests now wouldn't have a way to prioritize one over the other, and provide an error of `Ambiguous use of 'init(year:month:day:hour:minute:second:nanosecond:timeZone:)'`.

To solve this, I have made the extensions inside of `BitwardenShared` and `AuthenticatorShared` be `fileprivate`, which has necessitated further duplication because it exists across multiple files.

The alternate solution would be to simply make it a public extension in `BitwardenKit` itself, allowing tests and fixtures to have one singular location for the function—but also making it available to the rest of the code, which seems unideal.

It is also possible there is some aspect of module configuration here that I missed; but the fact still remains that we had two separate public copies of the extension that could be surfaced, and that seems unideal to begin with.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
