### PR TITLE
[PM-18223] Update processors to use showErrorAlert

### DIFF
--- a/BitwardenShared/Core/Platform/Extensions/Task+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/Task+Extensions.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 extension Task where Success == Never, Failure == Never {
-    static func sleep(forSeconds delay: Int, tolerance: Int = 1) async throws {
+    static func sleep(forSeconds delay: Double, tolerance: Double = 1) async throws {
         if #available(iOS 16.0, *) {
             try await sleep(for: .seconds(delay), tolerance: .seconds(tolerance))
         } else {
-            try await sleep(nanoseconds: UInt64(delay) * NSEC_PER_SEC)
+            try await sleep(nanoseconds: UInt64(delay * Double(NSEC_PER_SEC)))
         }
     }
 }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -258,9 +258,9 @@ class CompleteRegistrationProcessor: StateProcessor<
                 return
             }
 
-            coordinator.showAlert(.networkResponseError(error) {
+            await coordinator.showErrorAlert(error: error) {
                 await self.completeRegistration(captchaToken: captchaToken)
-            })
+            }
         }
     }
 
@@ -351,9 +351,9 @@ class CompleteRegistrationProcessor: StateProcessor<
             } catch VerifyEmailTokenRequestError.tokenExpired {
                 coordinator.navigate(to: .expiredLink)
             } catch {
-                coordinator.showAlert(.networkResponseError(error) {
+                await coordinator.showErrorAlert(error: error) {
                     await self.verifyUserEmail()
-                })
+                }
             }
         }
     }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -160,17 +160,15 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         subject.state = .fixture()
         subject.state.fromEmail = true
 
-        let urlError = URLError(.notConnectedToInternet) as Error
+        let urlError = URLError(.notConnectedToInternet)
         client.results = [.httpFailure(urlError), .httpSuccess(testData: .emptyResponse)]
 
         await subject.perform(.appeared)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, Alert.networkResponseError(urlError) {
-            await self.subject.perform(.appeared)
-        })
+        let alertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(alertWithRetry.error as? URLError, urlError)
 
-        try await alert.tapAction(title: Localizations.tryAgain)
+        await alertWithRetry.retry()
 
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.emailVerified))
         XCTAssertEqual(client.requests.count, 2)
@@ -412,21 +410,13 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         )
 
         guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-
-        client.result = .httpFailure(
-            ServerError.error(errorResponse: errorResponse)
-        )
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
 
         await subject.perform(.completeRegistration)
 
         XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "Email 'j@a.com' is already taken."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
@@ -460,21 +450,13 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         )
 
         guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-
-        client.result = .httpFailure(
-            ServerError.error(errorResponse: errorResponse)
-        )
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
 
         await subject.perform(.completeRegistration)
 
         XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "The field MasterPasswordHint must be a string with a maximum length of 50."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
@@ -491,21 +473,13 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         )
 
         guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-
-        client.result = .httpFailure(
-            ServerError.error(errorResponse: errorResponse)
-        )
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
 
         await subject.perform(.completeRegistration)
 
         XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "The Email field is not a supported e-mail address format."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
@@ -580,17 +554,15 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         authService.loginWithMasterPasswordResult = .success(())
         subject.state = .fixture()
 
-        let urlError = URLError(.notConnectedToInternet) as Error
+        let urlError = URLError(.notConnectedToInternet)
         client.results = [.httpFailure(urlError), .httpSuccess(testData: .createAccountRequest)]
 
         await subject.perform(.completeRegistration)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, Alert.networkResponseError(urlError) {
-            await self.subject.perform(.completeRegistration)
-        })
+        let alertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(alertWithRetry.error as? URLError, urlError)
 
-        try await alert.tapAction(title: Localizations.tryAgain)
+        await alertWithRetry.retry()
 
         XCTAssertEqual(authService.loginWithMasterPasswordPassword, "password1234")
         XCTAssertNil(authService.loginWithMasterPasswordCaptchaToken)
@@ -646,15 +618,15 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         authService.loginWithMasterPasswordResult = .success(())
         subject.state = .fixture()
 
-        let urlError = URLError(.timedOut) as Error
+        let urlError = URLError(.timedOut)
         client.results = [.httpFailure(urlError), .httpSuccess(testData: .createAccountRequest)]
 
         await subject.perform(.completeRegistration)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.message, urlError.localizedDescription)
+        let alertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(alertWithRetry.error as? URLError, urlError)
 
-        try await alert.tapAction(title: Localizations.tryAgain)
+        await alertWithRetry.retry()
 
         XCTAssertEqual(authService.loginWithMasterPasswordPassword, "password1234")
         XCTAssertNil(authService.loginWithMasterPasswordCaptchaToken)

--- a/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginWithDevice/LoginWithDeviceProcessor.swift
@@ -16,6 +16,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
     typealias Services = HasAuthRepository
         & HasAuthService
         & HasCaptchaService
+        & HasConfigService
         & HasErrorReporter
 
     // MARK: Properties
@@ -95,7 +96,9 @@ final class LoginWithDeviceProcessor: StateProcessor<
             // Start checking for a response every few seconds.
             setCheckTimer()
         } catch {
-            coordinator.showAlert(.networkResponseError(error) { await self.sendLoginWithDeviceRequest() })
+            await coordinator.showErrorAlert(error: error) {
+                await self.sendLoginWithDeviceRequest()
+            }
             services.errorReporter.log(error: error)
         }
     }
@@ -127,59 +130,57 @@ final class LoginWithDeviceProcessor: StateProcessor<
             coordinator.hideLoadingOverlay()
             await coordinator.handleEvent(.didCompleteAuth)
         } catch {
-            handleError(error) { await self.attemptLogin(with: request) }
+            await handleError(error) { await self.attemptLogin(with: request) }
         }
     }
 
     /// Check for a response to the login request.
-    private func checkForResponse() {
-        Task {
-            do {
-                // Get the updated request.
-                guard let requestId = self.state.requestId else { throw AuthError.missingData }
-                let request = try await self.services.authService.checkPendingLoginRequest(withId: requestId)
+    private func checkForResponse() async {
+        do {
+            // Get the updated request.
+            guard let requestId = state.requestId else { throw AuthError.missingData }
+            let request = try await services.authService.checkPendingLoginRequest(withId: requestId)
 
-                guard request.requestApproved == true else {
-                    if !request.isAnswered {
-                        // Keep waiting and schedule the next timer if the request hasn't been
-                        // answered and approved yet.
-                        setCheckTimer()
-                    }
-                    return
+            guard request.requestApproved == true else {
+                if !request.isAnswered {
+                    // Keep waiting and schedule the next timer if the request hasn't been
+                    // answered and approved yet.
+                    setCheckTimer()
                 }
-
-                // Remove admin pending login request if exists
-                try? await services.authService.setPendingAdminLoginRequest(nil, userId: nil)
-
-                // Otherwise, if the request has been approved, stop the update timer
-                // and attempt to authenticate.
-                self.checkTimer?.invalidate()
-                await self.attemptLogin(with: request)
-            } catch CheckLoginRequestError.expired {
-                // If the request has expired, stop the timer but don't alert the user and remain
-                // on the view.
-                self.checkTimer?.invalidate()
-            } catch {
-                // For any other errors, stop the timer while the alert is being shown and resume it
-                // when it's dismissed.
-                self.checkTimer?.invalidate()
-                self.coordinator.showAlert(.networkResponseError(error)) {
-                    self.setCheckTimer()
-                }
-                self.services.errorReporter.log(error: error)
+                return
             }
+
+            // Remove admin pending login request if exists
+            try? await services.authService.setPendingAdminLoginRequest(nil, userId: nil)
+
+            // Otherwise, if the request has been approved, stop the update timer
+            // and attempt to authenticate.
+            checkTimer?.invalidate()
+            await attemptLogin(with: request)
+        } catch CheckLoginRequestError.expired {
+            // If the request has expired, stop the timer but don't alert the user and remain
+            // on the view.
+            checkTimer?.invalidate()
+        } catch {
+            // For any other errors, stop the timer while the alert is being shown and resume it
+            // when it's dismissed.
+            checkTimer?.invalidate()
+            await coordinator.showErrorAlert(error: error, onDismissed: {
+                self.setCheckTimer()
+            })
+            services.errorReporter.log(error: error)
         }
     }
 
     /// Generically handle an error on the view.
-    private func handleError(_ error: Error, _ tryAgain: (() async -> Void)? = nil) {
+    private func handleError(_ error: Error, _ tryAgain: (() async -> Void)? = nil) async {
         coordinator.hideLoadingOverlay()
 
         // Handle a captcha or two-factor error.
         if let identityTokenError = error as? IdentityTokenRequestError {
             switch identityTokenError {
             case let .captchaRequired(token):
-                launchCaptchaFlow(with: token)
+                await launchCaptchaFlow(with: token)
             case let .twoFactorRequired(authMethodsData, _, _, _):
                 let unlockMethod: TwoFactorUnlockMethod? = if let key = approvedRequest?.key, let authRequestResponse {
                     TwoFactorUnlockMethod.loginWithDevice(
@@ -199,7 +200,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
             return
         }
 
-        coordinator.showAlert(.networkResponseError(error, tryAgain: tryAgain))
+        await coordinator.showErrorAlert(error: error, tryAgain: tryAgain)
         services.errorReporter.log(error: error)
     }
 
@@ -208,7 +209,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
     /// - Parameter siteKey: The site key that was returned with a captcha error. The token used to authenticate
     ///   with hCaptcha.
     ///
-    private func launchCaptchaFlow(with siteKey: String) {
+    private func launchCaptchaFlow(with siteKey: String) async {
         do {
             let url = try services.captchaService.generateCaptchaUrl(with: siteKey)
             coordinator.navigate(
@@ -219,7 +220,7 @@ final class LoginWithDeviceProcessor: StateProcessor<
                 context: self
             )
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -230,7 +231,9 @@ final class LoginWithDeviceProcessor: StateProcessor<
 
         // Set the timer to auto-check for a response every four seconds.
         checkTimer = Timer.scheduledTimer(withTimeInterval: UI.duration(4), repeats: false) { [weak self] _ in
-            self?.checkForResponse()
+            Task { @MainActor [weak self] in
+                await self?.checkForResponse()
+            }
         }
     }
 }
@@ -251,8 +254,9 @@ extension LoginWithDeviceProcessor: CaptchaFlowDelegate {
 
         // Show the alert after a delay to ensure it doesn't try to display over the
         // closing captcha view.
-        DispatchQueue.main.asyncAfter(deadline: UI.after(0.6)) {
-            self.coordinator.showAlert(.networkResponseError(error))
+        Task { @MainActor in
+            try await Task.sleep(forSeconds: UI.duration(0.6))
+            await coordinator.showErrorAlert(error: error)
         }
     }
 }

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
@@ -195,7 +195,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(authService.generateSingleSignOnOrgIdentifier, "BestOrganization")
         XCTAssertEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(URLError(.timedOut)) {})
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? URLError, URLError(.timedOut))
         XCTAssertEqual(errorReporter.errors.last as? URLError, URLError(.timedOut))
     }
 
@@ -247,7 +247,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         // Verify the results.
         XCTAssertEqual(authService.loginWithSingleSignOnCode, "super_cool_secret_code")
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
         XCTAssertNil(stateService.rememberedOrgIdentifier)
     }
@@ -391,7 +391,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         waitFor(!errorReporter.errors.isEmpty)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -117,7 +117,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
     /// - Parameter siteKey: The site key that was returned with a captcha error. The token used to authenticate
     ///   with hCaptcha.
     ///
-    private func launchCaptchaFlow(with siteKey: String) {
+    private func launchCaptchaFlow(with siteKey: String) async {
         do {
             let url = try services.captchaService.generateCaptchaUrl(with: siteKey)
             coordinator.navigate(
@@ -128,7 +128,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
                 context: self
             )
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -145,7 +145,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
             }
         } catch {
             services.errorReporter.log(error: error)
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
         }
     }
 
@@ -178,7 +178,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
         } catch let error as InputValidationError {
             coordinator.showAlert(Alert.inputValidationAlert(error: error))
         } catch let IdentityTokenRequestError.captchaRequired(hCaptchaSiteCode) {
-            launchCaptchaFlow(with: hCaptchaSiteCode)
+            await launchCaptchaFlow(with: hCaptchaSiteCode)
         } catch IdentityTokenRequestError.newDeviceNotVerified {
             coordinator.showAlert(.defaultAlert(title: Localizations.invalidVerificationCode))
         } catch let authError as AuthError {
@@ -194,7 +194,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
                 coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             }
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -314,8 +314,9 @@ extension TwoFactorAuthProcessor: CaptchaFlowDelegate {
 
         // Show the alert after a delay to ensure it doesn't try to display over the
         // closing captcha view.
-        DispatchQueue.main.asyncAfter(deadline: UI.after(0.6)) {
-            self.coordinator.showAlert(.networkResponseError(error))
+        Task { @MainActor in
+            try await Task.sleep(forSeconds: UI.duration(0.6))
+            await coordinator.showErrorAlert(error: error)
         }
     }
 }
@@ -348,8 +349,9 @@ extension TwoFactorAuthProcessor: DuoAuthenticationFlowDelegate {
 
     func duoErrored(error: Error) {
         // The delay is necessary in order to ensure the alert displays over the WebAuth view.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.handleError(error) {
+        Task { @MainActor in
+            try await Task.sleep(forSeconds: UI.duration(0.5))
+            await self.handleError(error) {
                 self.authenticateWithDuo()
             }
         }
@@ -387,7 +389,7 @@ extension TwoFactorAuthProcessor: DuoAuthenticationFlowDelegate {
     }
 
     /// Generically handle an error on the view.
-    private func handleError(_ error: Error, _ tryAgain: (() async -> Void)? = nil) {
+    private func handleError(_ error: Error, _ tryAgain: (() async -> Void)? = nil) async {
         // First, hide the loading overlay.
         coordinator.hideLoadingOverlay()
 
@@ -395,7 +397,7 @@ extension TwoFactorAuthProcessor: DuoAuthenticationFlowDelegate {
         if case ASWebAuthenticationSessionError.canceledLogin = error { return }
 
         // Otherwise, show the alert and log the error.
-        coordinator.showAlert(.networkResponseError(error, tryAgain: tryAgain))
+        await coordinator.showErrorAlert(error: error, tryAgain: tryAgain)
         services.errorReporter.log(error: error)
     }
 }
@@ -456,8 +458,9 @@ extension TwoFactorAuthProcessor: WebAuthnFlowDelegate {
 
     func webAuthnErrored(error: Error) {
         // The delay is necessary in order to ensure the alert displays over the WebAuthn view.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-            self.handleError(error) {
+        Task { @MainActor in
+            try await Task.sleep(forSeconds: UI.duration(0.5))
+            await self.handleError(error) {
                 self.authenticateWithWebAuthn()
             }
         }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -80,8 +80,8 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
     func test_captchaErrored() {
         subject.captchaErrored(error: BitwardenTestError.example)
 
-        waitFor(!coordinator.alertShown.isEmpty)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        waitFor(!coordinator.errorAlertsShown.isEmpty)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -379,7 +379,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertEqual(authService.loginWithTwoFactorCodeCode, "Test")
         XCTAssertEqual(captchaService.generateCaptchaSiteKey, "token")
 
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -395,7 +395,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.verifying)])
         XCTAssertEqual(authService.loginWithTwoFactorCodeCode, "Test")
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -502,7 +502,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.continueTapped)
 
         XCTAssertFalse(authRepository.unlockVaultWithKeyConnectorKeyCalled)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(TwoFactorAuthError.missingOrgIdentifier))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? TwoFactorAuthError, .missingOrgIdentifier)
         XCTAssertEqual(coordinator.routes, [])
         XCTAssertEqual(errorReporter.errors as? [TwoFactorAuthError], [.missingOrgIdentifier])
     }
@@ -517,7 +517,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.continueTapped)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(error))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? IdentityTokenRequestError, error)
     }
 
     /// `perform(_:)` with `.listenForNFC` starts listening for NFC tags and attempts login if one is read.
@@ -550,7 +550,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.listenForNFC)
 
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-        XCTAssertEqual(coordinator.alertShown, [.networkResponseError(BitwardenTestError.example)])
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
     }
 
     /// `perform(_:)` with `.receivedDuoToken` handles an error correctly.
@@ -563,7 +563,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.receivedDuoToken("DuoToken"))
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
     }
 
     /// `perform(_:)` with `.receivedDuoToken` handles a two-factor error correctly.

--- a/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessor.swift
+++ b/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessor.swift
@@ -6,6 +6,7 @@ class PasswordHintProcessor: StateProcessor<PasswordHintState, PasswordHintActio
     // MARK: Types
 
     typealias Services = HasAccountAPIService
+        & HasConfigService
         & HasErrorReporter
 
     // MARK: Private Properties
@@ -77,7 +78,7 @@ class PasswordHintProcessor: StateProcessor<PasswordHintState, PasswordHintActio
             coordinator.hideLoadingOverlay()
             coordinator.showAlert(alert)
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/PasswordHint/PasswordHintProcessorTests.swift
@@ -49,7 +49,7 @@ class PasswordHintProcessorTests: BitwardenTestCase {
         await subject.perform(.submitPressed)
 
         let responseError = ResponseValidationError(response: errorResponse)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(responseError))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [ResponseValidationError], [responseError])
         XCTAssertEqual(errorReporter.errors.last as? ResponseValidationError, responseError)
     }
 

--- a/BitwardenShared/UI/Auth/RemoveMasterPassword/RemoveMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/RemoveMasterPassword/RemoveMasterPasswordProcessor.swift
@@ -12,6 +12,7 @@ class RemoveMasterPasswordProcessor: StateProcessor<
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasConfigService
         & HasErrorReporter
 
     // MARK: Private Properties
@@ -84,7 +85,7 @@ class RemoveMasterPasswordProcessor: StateProcessor<
             ))
         } catch {
             services.errorReporter.log(error: error)
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
         }
     }
 }

--- a/BitwardenShared/UI/Auth/RemoveMasterPassword/RemoveMasterPasswordProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/RemoveMasterPassword/RemoveMasterPasswordProcessorTests.swift
@@ -102,8 +102,7 @@ class RemoveMasterPasswordProcessorTests: BitwardenTestCase {
 
         await subject.perform(.continueFlow)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .defaultAlert(title: Localizations.anErrorHasOccurred))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 

--- a/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessor.swift
@@ -14,6 +14,7 @@ class SetMasterPasswordProcessor: StateProcessor<
 
     typealias Services = HasAuthRepository
         & HasAuthService
+        & HasConfigService
         & HasErrorReporter
         & HasOrganizationAPIService
         & HasPolicyService
@@ -101,7 +102,7 @@ class SetMasterPasswordProcessor: StateProcessor<
                 state.masterPasswordPolicy = policy
             }
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -156,7 +157,7 @@ class SetMasterPasswordProcessor: StateProcessor<
         } catch let error as InputValidationError {
             coordinator.showAlert(.inputValidationAlert(error: error))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/SetMasterPassword/SetMasterPasswordProcessorTests.swift
@@ -126,7 +126,7 @@ class SetMasterPasswordProcessorTests: BitwardenTestCase {
 
         await subject.perform(.appeared)
 
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [BitwardenTestError.example])
     }
 
@@ -150,7 +150,7 @@ class SetMasterPasswordProcessorTests: BitwardenTestCase {
 
         await subject.perform(.saveTapped)
 
-        XCTAssertEqual(coordinator.alertShown, [.networkResponseError(BitwardenTestError.example)])
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessor.swift
@@ -189,9 +189,9 @@ class StartRegistrationProcessor: StateProcessor<
         } catch let error as StartRegistrationError {
             showStartRegistrationErrorAlert(error)
         } catch {
-            coordinator.showAlert(.networkResponseError(error) {
+            await coordinator.showErrorAlert(error: error) {
                 await self.startRegistration()
-            })
+            }
         }
     }
 

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -194,21 +194,13 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         )
 
         guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-
-        client.result = .httpFailure(
-            ServerError.error(errorResponse: errorResponse)
-        )
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
 
         await subject.perform(.startRegistration)
 
         XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "Email 'j@a.com' is already taken."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
@@ -234,21 +226,13 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         )
 
         guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-
-        client.result = .httpFailure(
-            ServerError.error(errorResponse: errorResponse)
-        )
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
 
         await subject.perform(.startRegistration)
 
         XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "The field Email must be a string with a maximum length of 256."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
@@ -299,21 +283,13 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         )
 
         guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-
-        client.result = .httpFailure(
-            ServerError.error(errorResponse: errorResponse)
-        )
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
 
         await subject.perform(.startRegistration)
 
         XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "The Email field is not a supported e-mail address format."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
@@ -325,17 +301,15 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
     func test_perform_startRegistration_noInternetConnection() async throws {
         subject.state = .fixture()
 
-        let urlError = URLError(.notConnectedToInternet) as Error
+        let urlError = URLError(.notConnectedToInternet)
         client.results = [.httpFailure(urlError), .httpSuccess(testData: .startRegistrationSuccess)]
 
         await subject.perform(.startRegistration)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, Alert.networkResponseError(urlError) {
-            await self.subject.perform(.startRegistration)
-        })
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, urlError)
 
-        try await alert.tapAction(title: Localizations.tryAgain)
+        await errorAlertWithRetry.retry()
 
         XCTAssertEqual(client.requests.count, 2)
         XCTAssertEqual(
@@ -367,15 +341,15 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
     func test_perform_startRegistration_timeout() async throws {
         subject.state = .fixture()
 
-        let urlError = URLError(.timedOut) as Error
+        let urlError = URLError(.timedOut)
         client.results = [.httpFailure(urlError), .httpSuccess(testData: .startRegistrationSuccess)]
 
         await subject.perform(.startRegistration)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.message, urlError.localizedDescription)
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, urlError)
 
-        try await alert.tapAction(title: Localizations.tryAgain)
+        await errorAlertWithRetry.retry()
 
         XCTAssertEqual(client.requests.count, 2)
         XCTAssertEqual(

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
@@ -14,6 +14,7 @@ class UpdateMasterPasswordProcessor: StateProcessor<
 
     typealias Services = HasAuthRepository
         & HasAuthService
+        & HasConfigService
         & HasErrorReporter
         & HasPolicyService
         & HasSettingsRepository
@@ -116,9 +117,9 @@ class UpdateMasterPasswordProcessor: StateProcessor<
                 await coordinator.handleEvent(.didCompleteAuth)
             }
         } catch {
-            coordinator.showAlert(.networkResponseError(error) {
+            await coordinator.showErrorAlert(error: error) {
                 await self.syncVault()
-            })
+            }
             services.errorReporter.log(error: error)
         }
     }
@@ -174,7 +175,7 @@ class UpdateMasterPasswordProcessor: StateProcessor<
         } catch let error as InputValidationError {
             coordinator.showAlert(.inputValidationAlert(error: error))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessorTests.swift
@@ -163,7 +163,7 @@ class UpdateMasterPasswordProcessorTests: BitwardenTestCase {
 
         await subject.perform(.saveTapped)
 
-        XCTAssertEqual(coordinator.alertShown, [.networkResponseError(BitwardenTestError.example)])
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinator.swift
@@ -19,8 +19,8 @@ open class AnyCoordinator<Route, Event>: Coordinator {
     /// A closure that wraps the `showAlert(_:)` method.
     private let doShowAlert: (Alert, (() -> Void)?) -> Void
 
-    /// A closure that wraps the `showErrorAlert(error:tryAgain:)` method.
-    private let doShowErrorAlert: (Error, (() async -> Void)?) async -> Void
+    /// A closure that wraps the `showErrorAlert(error:tryAgain:onDismissed:)` method.
+    private let doShowErrorAlert: (Error, (() async -> Void)?, (() -> Void)?) async -> Void
 
     /// A closure that wraps the `showLoadingOverlay(_:)` method.
     private let doShowLoadingOverlay: (LoadingOverlayState) -> Void
@@ -48,7 +48,7 @@ open class AnyCoordinator<Route, Event>: Coordinator {
             coordinator.navigate(to: route, context: context)
         }
         doShowAlert = { coordinator.showAlert($0, onDismissed: $1) }
-        doShowErrorAlert = { await coordinator.showErrorAlert(error: $0, tryAgain: $1) }
+        doShowErrorAlert = { await coordinator.showErrorAlert(error: $0, tryAgain: $1, onDismissed: $2) }
         doShowLoadingOverlay = { coordinator.showLoadingOverlay($0) }
         doShowToast = { coordinator.showToast($0, subtitle: $1, additionalBottomPadding: $2) }
         doStart = { coordinator.start() }
@@ -69,11 +69,15 @@ open class AnyCoordinator<Route, Event>: Coordinator {
     }
 
     func showErrorAlert(error: Error) async {
-        await doShowErrorAlert(error, nil)
+        await doShowErrorAlert(error, nil, nil)
     }
 
-    func showErrorAlert(error: Error, tryAgain: (() async -> Void)?) async {
-        await doShowErrorAlert(error, tryAgain)
+    func showErrorAlert(
+        error: Error,
+        tryAgain: (() async -> Void)? = nil,
+        onDismissed: (() -> Void)? = nil
+    ) async {
+        await doShowErrorAlert(error, tryAgain, onDismissed)
     }
 
     open func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/AnyCoordinatorTests.swift
@@ -42,9 +42,9 @@ class AnyCoordinatorTests: BitwardenTestCase {
     func test_showErrorAlert_withTryAgain() async {
         let error = BitwardenTestError.example
         var tryAgainCalled = false
-        await subject.showErrorAlert(error: error) {
+        await subject.showErrorAlert(error: error, tryAgain: {
             tryAgainCalled = true
-        }
+        })
         XCTAssertEqual(coordinator.errorAlertsWithRetryShown.map(\.error) as? [BitwardenTestError], [error])
 
         let errorAlertWithRetry = coordinator.errorAlertsWithRetryShown[0]

--- a/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
@@ -49,8 +49,13 @@ protocol Coordinator<Route, Event>: AnyObject {
     /// - Parameters:
     ///   - error: The error that occurred, used to customize the details of the alert.
     ///   - tryAgain: An optional closure allowing the user to retry whatever triggered the error.
+    ///   - onDismissed: An optional closure that is called when the alert is dismissed.
     ///
-    func showErrorAlert(error: Error, tryAgain: (() async -> Void)?) async
+    func showErrorAlert(
+        error: Error,
+        tryAgain: (() async -> Void)?,
+        onDismissed: (() -> Void)?
+    ) async
 
     /// Shows the loading overlay view.
     ///
@@ -170,7 +175,7 @@ extension Coordinator {
     ///   - error: The error that occurred, used to customize the details of the alert.
     ///
     func showErrorAlert(error: Error) async {
-        await showErrorAlert(error: error, tryAgain: nil)
+        await showErrorAlert(error: error, tryAgain: nil, onDismissed: nil)
     }
 }
 
@@ -188,8 +193,9 @@ extension Coordinator where Self: HasErrorAlertServices, Self: HasNavigator {
     /// - Parameters:
     ///   - error: The error that occurred, used to customize the details of the alert.
     ///   - tryAgain: An optional closure allowing the user to retry whatever triggered the error.
+    ///   - onDismissed: An optional closure that is called when the alert is dismissed.
     ///
-    func showErrorAlert(error: Error, tryAgain: (() async -> Void)?) async {
+    func showErrorAlert(error: Error, tryAgain: (() async -> Void)?, onDismissed: (() -> Void)?) async {
         let alert = if await errorAlertServices.configService.getFeatureFlag(.mobileErrorReporting) {
             Alert.networkResponseError(error, shareErrorDetails: {
                 // TODO: PM-18224 Show share sheet to export error details
@@ -197,7 +203,7 @@ extension Coordinator where Self: HasErrorAlertServices, Self: HasNavigator {
         } else {
             Alert.networkResponseError(error, tryAgain: tryAgain)
         }
-        showAlert(alert)
+        showAlert(alert, onDismissed: onDismissed)
     }
 }
 

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessor.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessor.swift
@@ -21,6 +21,7 @@ final class LoginRequestProcessor: StateProcessor<LoginRequestState, LoginReques
     // MARK: Types
 
     typealias Services = HasAuthService
+        & HasConfigService
         & HasErrorReporter
         & HasStateService
 
@@ -110,7 +111,7 @@ final class LoginRequestProcessor: StateProcessor<LoginRequestState, LoginReques
             coordinator.navigate(to: .dismiss(dismissAction))
         } catch {
             coordinator.hideLoadingOverlay()
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -120,7 +121,7 @@ final class LoginRequestProcessor: StateProcessor<LoginRequestState, LoginReques
         do {
             state.email = try await services.stateService.getActiveAccount().profile.email
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessorTests.swift
@@ -75,7 +75,7 @@ class LoginRequestProcessorTests: BitwardenTestCase {
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.loading)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
@@ -64,7 +64,8 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
     /// error with deleting the account, an alert is shown and the error is logged.
     @MainActor
     func test_perform_deleteAccount_error() async throws {
-        authRepository.deleteAccountResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        authRepository.deleteAccountResult = .failure(error)
 
         await subject.perform(.deleteAccount)
 
@@ -74,15 +75,14 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
 
         XCTAssertTrue(authRepository.deleteAccountCalled)
 
-        let errorAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(errorAlert, .networkResponseError(URLError(.timedOut)))
-        XCTAssertEqual(errorReporter.errors as? [URLError], [URLError(.timedOut)])
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
 
         authRepository.deleteAccountCalled = false
         errorReporter.errors.removeAll()
 
         authRepository.deleteAccountResult = .success(())
-        try await errorAlert.tapAction(title: Localizations.tryAgain)
+        await errorAlertWithRetry.retry()
         XCTAssertTrue(authRepository.deleteAccountCalled)
         XCTAssertTrue(errorReporter.errors.isEmpty)
     }
@@ -270,7 +270,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
 
         await subject.perform(.deleteAccount)
 
-        XCTAssertEqual(coordinator.alertShown, [.networkResponseError(BitwardenTestError.example)])
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
@@ -299,10 +299,8 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
         await subject.perform(.loadData)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.alertActions.count, 1)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
 
-        try await alert.tapAction(title: Localizations.ok)
         coordinator.alertOnDismissed?()
 
         XCTAssertEqual(coordinator.routes.last, .dismiss)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessor.swift
@@ -12,6 +12,7 @@ final class PendingRequestsProcessor: StateProcessor<
     // MARK: Types
 
     typealias Services = HasAuthService
+        & HasConfigService
         & HasErrorReporter
 
     // MARK: Properties
@@ -94,7 +95,7 @@ final class PendingRequestsProcessor: StateProcessor<
             // Show the success toast.
             state.toast = Toast(title: Localizations.requestsDeclined)
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -110,7 +111,7 @@ final class PendingRequestsProcessor: StateProcessor<
             setUpdateTimer()
         } catch {
             state.loadingState = .data([])
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessorTests.swift
@@ -73,7 +73,7 @@ class PendingRequestsProcessorTests: BitwardenTestCase {
 
         XCTAssertTrue(authService.getPendingLoginRequestCalled)
         XCTAssertEqual(subject.state.loadingState, .data([]))
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -111,7 +111,7 @@ class PendingRequestsProcessorTests: BitwardenTestCase {
         // Verify the results.
         XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.loading)
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessor.swift
@@ -8,7 +8,8 @@ import WatchConnectivity
 final class OtherSettingsProcessor: StateProcessor<OtherSettingsState, OtherSettingsAction, OtherSettingsEffect> {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasSettingsRepository
         & HasSystemDevice
         & HasWatchService
@@ -103,9 +104,9 @@ final class OtherSettingsProcessor: StateProcessor<OtherSettingsState, OtherSett
             try await services.settingsRepository.fetchSync()
             state.toast = Toast(title: Localizations.syncingComplete)
         } catch {
-            coordinator.showAlert(.networkResponseError(error) {
+            await coordinator.showErrorAlert(error: error) {
                 await self.syncVault()
-            })
+            }
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessorTests.swift
@@ -111,7 +111,8 @@ class OtherSettingsProcessorTests: BitwardenTestCase {
     /// syncing fails.
     @MainActor
     func test_perform_syncNow_error() async throws {
-        settingsRepository.fetchSyncResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        settingsRepository.fetchSyncResult = .failure(error)
 
         await subject.perform(.syncNow)
 
@@ -119,13 +120,12 @@ class OtherSettingsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.syncing)])
         XCTAssertTrue(settingsRepository.fetchSyncCalled)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.first)
-        XCTAssertEqual(alert, .networkResponseError(URLError(.timedOut)))
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
 
         // Tapping the try again button the alert should attempt the call again.
         settingsRepository.fetchSyncCalled = false
-        let tryAgainAction = try XCTUnwrap(alert.alertActions.first)
-        await tryAgainAction.handler?(tryAgainAction, [])
+        await errorAlertWithRetry.retry()
         XCTAssertTrue(settingsRepository.fetchSyncCalled)
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultAction.swift
@@ -5,9 +5,6 @@ enum ExportVaultAction: Equatable {
     /// Dismiss the sheet.
     case dismiss
 
-    /// The export vault button was tapped.
-    case exportVaultTapped
-
     /// The file format type was changed.
     case fileFormatTypeChanged(ExportFormatType)
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultEffect.swift
@@ -3,6 +3,9 @@
 /// Effects handled by the `ExportVaultProcessor`.
 ///
 enum ExportVaultEffect: Equatable {
+    /// The export vault button was tapped.
+    case exportVaultTapped
+
     /// Any initial data for the view should be loaded.
     case loadData
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
@@ -55,9 +55,10 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         authRepository.validatePasswordResult = .success(false)
         subject.state.masterPasswordOrOtpText = "password"
 
-        subject.receive(.exportVaultTapped)
-        let exportAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
-        await exportAction.handler?(exportAction, [])
+        await subject.perform(.exportVaultTapped)
+
+        let confirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await confirmationAlert.tapAction(title: Localizations.exportVault)
 
         XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.invalidMasterPassword))
     }
@@ -68,11 +69,12 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         authRepository.validatePasswordResult = .failure(BitwardenTestError.example)
         subject.state.masterPasswordOrOtpText = "password"
 
-        subject.receive(.exportVaultTapped)
-        let exportAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
-        await exportAction.handler?(exportAction, [])
+        await subject.perform(.exportVaultTapped)
 
-        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+        let confirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await confirmationAlert.tapAction(title: Localizations.exportVault)
+
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
     }
 
     /// `loadData` loads the initial data for the view.
@@ -106,7 +108,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
         await subject.perform(.sendCodeTapped)
 
-        XCTAssertEqual(coordinator.alertShown, [.networkResponseError(BitwardenTestError.example)])
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
@@ -122,7 +124,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
     /// `.receive()` with  `.exportVaultTapped` shows the confirm alert for encrypted formats and
     /// exports the vault.
     @MainActor
-    func test_receive_exportVaultTapped_encrypted() throws {
+    func test_receive_exportVaultTapped_encrypted() async throws {
         let testURL = URL(string: "www.bitwarden.com")!
         exportService.exportVaultContentResult = .success("")
         exportService.writeToFileResult = .success(testURL)
@@ -130,59 +132,57 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         subject.state.filePasswordText = "file password"
         subject.state.filePasswordConfirmationText = "file password"
         subject.state.masterPasswordOrOtpText = "password"
-        subject.receive(.exportVaultTapped)
+
+        await subject.perform(.exportVaultTapped)
 
         // Confirm that the correct alert is displayed.
-        XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: true, action: {}))
+        let confirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmationAlert, .confirmExportVault(encrypted: true, action: {}))
 
-        let exportAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
-        let task = Task {
-            await exportAction.handler?(exportAction, [])
-        }
-        waitFor(!coordinator.routes.isEmpty)
-        task.cancel()
+        try await confirmationAlert.tapAction(title: Localizations.exportVault)
+
         XCTAssertEqual(exportService.exportVaultContentsFormat, .encryptedJson(password: "file password"))
         XCTAssertEqual(coordinator.routes.last, .shareExportedVault(testURL))
     }
 
     /// `.receive()` with  `.exportVaultTapped` logs an error on export failure.
     @MainActor
-    func test_receive_exportVaultTapped_encrypted_error() throws {
+    func test_receive_exportVaultTapped_encrypted_error() async throws {
         exportService.exportVaultContentResult = .failure(BitwardenTestError.example)
         subject.state.fileFormat = .jsonEncrypted
         subject.state.filePasswordText = "file password"
         subject.state.filePasswordConfirmationText = "file password"
         subject.state.masterPasswordOrOtpText = "password"
-        subject.receive(.exportVaultTapped)
+
+        await subject.perform(.exportVaultTapped)
 
         // Select the alert action to export.
-        let exportAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
-        let task = Task {
-            await exportAction.handler?(exportAction, [])
-        }
-        waitFor(!errorReporter.errors.isEmpty)
-        task.cancel()
+        let confirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmationAlert, .confirmExportVault(encrypted: true, action: {}))
+
+        try await confirmationAlert.tapAction(title: Localizations.exportVault)
+
         XCTAssertEqual(errorReporter.errors.first as? BitwardenTestError, .example)
     }
 
     /// `.receive()` with  `.exportVaultTapped` shows an alert if the file password fields don't match.
     @MainActor
-    func test_receive_exportVaultTapped_encrypted_filePasswordMismatch() {
+    func test_receive_exportVaultTapped_encrypted_filePasswordMismatch() async {
         subject.state.fileFormat = .jsonEncrypted
         subject.state.filePasswordText = "filePassword"
         subject.state.filePasswordConfirmationText = "not the file password"
 
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(coordinator.alertShown.last, .passwordsDontMatch)
     }
 
     /// `.receive()` with  `.exportVaultTapped` shows an alert if the file password is missing.
     @MainActor
-    func test_receive_exportVaultTapped_encrypted_missingFilePassword() {
+    func test_receive_exportVaultTapped_encrypted_missingFilePassword() async {
         subject.state.fileFormat = .jsonEncrypted
 
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(
             coordinator.alertShown.last,
@@ -196,11 +196,11 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
     /// `.receive()` with  `.exportVaultTapped` shows an alert if the file password confirmation is missing.
     @MainActor
-    func test_receive_exportVaultTapped_encrypted_missingFilePasswordConfirmation() {
+    func test_receive_exportVaultTapped_encrypted_missingFilePasswordConfirmation() async {
         subject.state.fileFormat = .jsonEncrypted
         subject.state.filePasswordText = "file password"
 
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(
             coordinator.alertShown.last,
@@ -214,8 +214,8 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
     /// `.receive()` with  `.exportVaultTapped` shows an alert if the master password is missing.
     @MainActor
-    func test_receive_exportVaultTapped_missingMasterPassword() {
-        subject.receive(.exportVaultTapped)
+    func test_receive_exportVaultTapped_missingMasterPassword() async {
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(
             coordinator.alertShown.last,
@@ -229,10 +229,10 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
     /// `.receive()` with `.exportVaultTapped` shows the confirm alert for unencrypted formats.
     @MainActor
-    func test_receive_exportVaultTapped_unencrypted() {
+    func test_receive_exportVaultTapped_unencrypted() async {
         subject.state.fileFormat = .json
         subject.state.masterPasswordOrOtpText = "password"
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         // Confirm that the correct alert is displayed.
         XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: false, action: {}))
@@ -240,39 +240,35 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
     /// `.receive()` with  `.exportVaultTapped` logs an error on export failure.
     @MainActor
-    func test_receive_exportVaultTapped_unencrypted_error() throws {
+    func test_receive_exportVaultTapped_unencrypted_error() async throws {
         exportService.exportVaultContentResult = .failure(BitwardenTestError.example)
         subject.state.fileFormat = .csv
         subject.state.masterPasswordOrOtpText = "password"
-        subject.receive(.exportVaultTapped)
+
+        await subject.perform(.exportVaultTapped)
 
         // Select the alert action to export.
-        let exportAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
-        let task = Task {
-            await exportAction.handler?(exportAction, [])
-        }
-        waitFor(!errorReporter.errors.isEmpty)
-        task.cancel()
+        let confirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await confirmationAlert.tapAction(title: Localizations.exportVault)
+
         XCTAssertEqual(errorReporter.errors.first as? BitwardenTestError, .example)
     }
 
     /// `.receive()` with  `.exportVaultTapped` passes a file url to the coordinator on success.
     @MainActor
-    func test_receive_exportVaultTapped_unencrypted_success() throws {
+    func test_receive_exportVaultTapped_unencrypted_success() async throws {
         let testURL = URL(string: "www.bitwarden.com")!
         exportService.exportVaultContentResult = .success("")
         exportService.writeToFileResult = .success(testURL)
         subject.state.fileFormat = .json
         subject.state.masterPasswordOrOtpText = "password"
-        subject.receive(.exportVaultTapped)
+
+        await subject.perform(.exportVaultTapped)
 
         // Select the alert action to export.
-        let exportAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
-        let task = Task {
-            await exportAction.handler?(exportAction, [])
-        }
-        waitFor(!coordinator.routes.isEmpty)
-        task.cancel()
+        let confirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await confirmationAlert.tapAction(title: Localizations.exportVault)
+
         XCTAssertEqual(coordinator.routes.last, .shareExportedVault(testURL))
     }
 
@@ -288,7 +284,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         subject.state.filePasswordConfirmationText = "file password"
         subject.state.masterPasswordOrOtpText = "password"
 
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: true, action: {}))
         try await coordinator.alertShown.last?.tapAction(title: Localizations.exportVault)
@@ -310,7 +306,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         subject.state.hasMasterPassword = false
         subject.state.masterPasswordOrOtpText = "otp"
 
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: false, action: {}))
         try await coordinator.alertShown.last?.tapAction(title: Localizations.exportVault)
@@ -331,7 +327,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         subject.state.hasMasterPassword = false
         subject.state.masterPasswordOrOtpText = "otp"
 
-        subject.receive(.exportVaultTapped)
+        await subject.perform(.exportVaultTapped)
 
         XCTAssertEqual(coordinator.alertShown.last, .confirmExportVault(encrypted: false, action: {}))
         try await coordinator.alertShown.last?.tapAction(title: Localizations.exportVault)

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultView.swift
@@ -40,7 +40,7 @@ struct ExportVaultView: View {
 
             ToolbarItem(placement: .topBarTrailing) {
                 primaryActionToolbarButton(Localizations.export) {
-                    store.send(.exportVaultTapped)
+                    Task { await store.perform(.exportVaultTapped) }
                 }
                 .accessibilityIdentifier("ExportVaultButton")
                 .disabled(store.state.disableIndividualVaultExport)

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultViewTests.swift
@@ -58,7 +58,9 @@ class ExportVaultViewTests: BitwardenTestCase {
         let button = try subject.inspect().find(button: Localizations.export)
         try button.tap()
 
-        XCTAssertEqual(processor.dispatchedActions.last, .exportVaultTapped)
+        waitFor { !processor.effects.isEmpty }
+
+        XCTAssertEqual(processor.effects.last, .exportVaultTapped)
     }
 
     /// Updating the value of the file format sends the  `.fileFormatTypeChanged()` action.

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolder/AddEditFolderProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolder/AddEditFolderProcessor.swift
@@ -23,7 +23,8 @@ protocol AddEditFolderDelegate: AnyObject {
 final class AddEditFolderProcessor: StateProcessor<AddEditFolderState, AddEditFolderAction, AddEditFolderEffect> {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasSettingsRepository
 
     // MARK: Properties
@@ -99,9 +100,9 @@ final class AddEditFolderProcessor: StateProcessor<AddEditFolderState, AddEditFo
             coordinator.navigate(to: .dismiss)
             delegate?.folderDeleted()
         } catch {
-            coordinator.showAlert(.networkResponseError(error) {
+            await coordinator.showErrorAlert(error: error) {
                 await self.deleteFolder(withID: id)
-            })
+            }
             services.errorReporter.log(error: error)
         }
     }
@@ -133,9 +134,9 @@ final class AddEditFolderProcessor: StateProcessor<AddEditFolderState, AddEditFo
         } catch let error as InputValidationError {
             coordinator.showAlert(Alert.inputValidationAlert(error: error))
         } catch {
-            coordinator.showAlert(.networkResponseError(error) {
+            await coordinator.showErrorAlert(error: error) {
                 await self.handleSaveTapped()
-            })
+            }
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolder/AddEditFolderProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/Folders/AddEditFolder/AddEditFolder/AddEditFolderProcessorTests.swift
@@ -57,16 +57,14 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
         await subject.perform(.deleteTapped)
 
         // Ensure the alert is shown.
-        var alert = coordinator.alertShown.last
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert, .confirmDeleteFolder {})
 
         // Press the "Yes" button on the alert.
-        let action = try XCTUnwrap(alert?.alertActions.first(where: { $0.title == Localizations.yes }))
-        await action.handler?(action, [])
+        try await alert.tapAction(title: Localizations.yes)
 
         // Ensure the error alert is displayed.
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.first as? BitwardenTestError, .example)
     }
 
@@ -76,23 +74,22 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
     func test_perform_deleteTapped_networkError() async throws {
         // Set up the mock data.
         subject.state.mode = .edit(.fixture(id: "testID"))
-        settingsRepository.deleteFolderResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        settingsRepository.deleteFolderResult = .failure(error)
 
         await subject.perform(.deleteTapped)
 
         // Ensure the alert is shown.
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert, .confirmDeleteFolder {})
 
         // Press the "Yes" button on the alert.
-        let action = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.yes }))
-        await action.handler?(action, [])
+        try await alert.tapAction(title: Localizations.yes)
 
         XCTAssertEqual(settingsRepository.deletedFolderId, "testID")
 
         // Ensure the error alert is displayed.
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .networkResponseError(URLError(.timedOut)))
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? URLError, error)
         XCTAssertEqual(errorReporter.errors.first as? URLError, URLError(.timedOut))
 
         // The try again button should retry the call.
@@ -150,8 +147,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
 
         await subject.perform(.saveTapped)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.first)
-        XCTAssertEqual(alert, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.first as? BitwardenTestError, .example)
     }
 
@@ -165,8 +161,7 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
 
         await subject.perform(.saveTapped)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.first)
-        XCTAssertEqual(alert, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors.first as? BitwardenTestError, .example)
     }
 
@@ -175,20 +170,20 @@ class AddEditFolderProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_savePressed_networkError() async throws {
         subject.state.folderName = "Folder Name"
-        settingsRepository.addFolderResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        settingsRepository.addFolderResult = .failure(error)
 
         await subject.perform(.saveTapped)
 
         XCTAssertEqual(settingsRepository.addedFolderName, "Folder Name")
 
-        let alert = try XCTUnwrap(coordinator.alertShown.first)
-        XCTAssertEqual(alert, .networkResponseError(URLError(.timedOut)))
-        XCTAssertEqual(errorReporter.errors.first as? URLError, URLError(.timedOut))
+        let errorAlertsWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertsWithRetry.error as? URLError, error)
+        XCTAssertEqual(errorReporter.errors.first as? URLError, error)
 
         // The try again button should retry the call.
         settingsRepository.addedFolderName = nil
-        let tryAgainAction = try XCTUnwrap(alert.alertActions.first)
-        await tryAgainAction.handler?(tryAgainAction, [])
+        await errorAlertsWithRetry.retry()
         XCTAssertEqual(settingsRepository.addedFolderName, "Folder Name")
     }
 

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -112,10 +112,10 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         vaultCoordinator?.navigate(to: vaultRoute, context: context)
     }
 
-    func showErrorAlert(error: any Error, tryAgain: (() async -> Void)?) async {
+    func showErrorAlert(error: any Error, tryAgain: (() async -> Void)?, onDismissed: (() -> Void)?) async {
         errorReporter.log(error: BitwardenError.generalError(
             type: "TabCoordinator: `showErrorAlert` Not Supported",
-            message: "`showErrorAlert(error:tryAgain:)` is not supported from TabCoordinator."
+            message: "`showErrorAlert(error:tryAgain:onDismissed:)` is not supported from TabCoordinator."
         ))
     }
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -234,7 +234,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
         } catch is CancellationError {
             // No-op: don't log or alert for cancellation errors.
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             Logger.application.error("Generator: error generating password: \(error)")
         }
     }
@@ -256,7 +256,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
         } catch is CancellationError {
             // No-op: don't log or alert for cancellation errors.
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             Logger.application.error("Generator: error generating username: \(error)")
         }
     }
@@ -334,7 +334,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
         do {
             try await saveGeneratedValue(state.generatedValue)
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             Logger.application.error("Generator: error generating username: \(error)")
         }
     }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -199,13 +199,13 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     func test_generatePassword_error() {
         subject.state.generatorType = .password
 
-        struct PasswordGeneratorError: Error {}
+        struct PasswordGeneratorError: Error, Equatable {}
         generatorRepository.passwordResult = .failure(PasswordGeneratorError())
 
         subject.receive(.refreshGeneratedValue)
 
-        waitFor { !coordinator.alertShown.isEmpty }
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.anErrorHasOccurred))
+        waitFor { !coordinator.errorAlertsShown.isEmpty }
+        XCTAssertEqual(coordinator.errorAlertsShown as? [PasswordGeneratorError], [PasswordGeneratorError()])
     }
 
     /// Generating a new password validates the password options before generating the value.
@@ -279,13 +279,13 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         subject.state.generatorType = .username
         subject.state.usernameState.usernameGeneratorType = .plusAddressedEmail
 
-        struct UsernameGeneratorError: Error {}
+        struct UsernameGeneratorError: Error, Equatable {}
         generatorRepository.usernameResult = .failure(UsernameGeneratorError())
 
         subject.receive(.refreshGeneratedValue)
 
-        waitFor { !coordinator.alertShown.isEmpty }
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.anErrorHasOccurred))
+        waitFor { !coordinator.errorAlertsShown.isEmpty }
+        XCTAssertEqual(coordinator.errorAlertsShown as? [UsernameGeneratorError], [UsernameGeneratorError()])
     }
 
     /// If an error occurs loading the generator options, an alert is shown and a new value isn't generated.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -8,7 +8,8 @@ import Foundation
 final class SendListProcessor: StateProcessor<SendListState, SendListAction, SendListEffect> {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasPasteboardService
         & HasPolicyService
         & HasSendRepository
@@ -117,10 +118,9 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
         do {
             try await services.sendRepository.fetchSync(forceSync: false)
         } catch {
-            let alert = Alert.networkResponseError(error) { [weak self] in
-                await self?.refresh()
+            await coordinator.showErrorAlert(error: error) {
+                await self.refresh()
             }
-            coordinator.showAlert(alert)
         }
     }
 
@@ -135,11 +135,10 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
             coordinator.hideLoadingOverlay()
             state.toast = Toast(title: Localizations.sendDeleted)
         } catch {
-            let alert = Alert.networkResponseError(error) { [weak self] in
-                await self?.deleteSend(sendView)
-            }
             coordinator.hideLoadingOverlay()
-            coordinator.showAlert(alert)
+            await coordinator.showErrorAlert(error: error) {
+                await self.deleteSend(sendView)
+            }
         }
     }
 
@@ -160,11 +159,10 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
             coordinator.hideLoadingOverlay()
             state.toast = Toast(title: Localizations.sendPasswordRemoved)
         } catch {
-            let alert = Alert.networkResponseError(error) { [weak self] in
-                await self?.removePassword(sendView)
-            }
             coordinator.hideLoadingOverlay()
-            coordinator.showAlert(alert)
+            await coordinator.showErrorAlert(error: error) {
+                await self.removePassword(sendView)
+            }
         }
     }
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -205,7 +205,8 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     @MainActor
     func test_perform_sendListItemRow_deletePressed_networkError() async throws {
         let sendView = SendView.fixture(id: "SEND_ID")
-        sendRepository.deleteSendResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        sendRepository.deleteSendResult = .failure(error)
         await subject.perform(.sendListItemRow(.deletePressed(sendView)))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
@@ -214,8 +215,9 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(sendRepository.deleteSendSendView, sendView)
 
         sendRepository.deleteSendResult = .success(())
-        let errorAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await errorAlert.tapAction(title: Localizations.tryAgain)
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
+        await errorAlertWithRetry.retry()
 
         XCTAssertEqual(
             coordinator.loadingOverlaysShown.last?.title,
@@ -248,7 +250,8 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     @MainActor
     func test_perform_sendListItemRow_removePassword_networkError() async throws {
         let sendView = SendView.fixture(id: "SEND_ID")
-        sendRepository.removePasswordFromSendResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        sendRepository.removePasswordFromSendResult = .failure(error)
         await subject.perform(.sendListItemRow(.removePassword(sendView)))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
@@ -257,8 +260,9 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(sendRepository.removePasswordFromSendSendView, sendView)
 
         sendRepository.removePasswordFromSendResult = .success(sendView)
-        let errorAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await errorAlert.tapAction(title: Localizations.tryAgain)
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
+        await errorAlertWithRetry.retry()
 
         XCTAssertEqual(
             coordinator.loadingOverlaysShown.last?.title,

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -12,6 +12,7 @@ class AddEditSendItemProcessor:
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasConfigService
         & HasErrorReporter
         & HasPasteboardService
         & HasPolicyService
@@ -27,7 +28,7 @@ class AddEditSendItemProcessor:
     // MARK: Properties
 
     /// The `Coordinator` that handles navigation for this processor.
-    let coordinator: any Coordinator<SendItemRoute, AuthAction>
+    let coordinator: AnyCoordinator<SendItemRoute, AuthAction>
 
     /// The services required by this processor.
     let services: Services
@@ -42,7 +43,7 @@ class AddEditSendItemProcessor:
     ///   - state: The initial state of this processor.
     ///
     init(
-        coordinator: any Coordinator<SendItemRoute, AuthAction>,
+        coordinator: AnyCoordinator<SendItemRoute, AuthAction>,
         services: Services,
         state: AddEditSendItemState
     ) {
@@ -146,11 +147,10 @@ class AddEditSendItemProcessor:
             coordinator.hideLoadingOverlay()
             coordinator.navigate(to: .deleted)
         } catch {
-            let alert = Alert.networkResponseError(error) { [weak self] in
-                await self?.deleteSend(sendView)
-            }
             coordinator.hideLoadingOverlay()
-            coordinator.showAlert(alert)
+            await coordinator.showErrorAlert(error: error) {
+                await self.deleteSend(sendView)
+            }
         }
     }
 
@@ -218,11 +218,10 @@ class AddEditSendItemProcessor:
             coordinator.hideLoadingOverlay()
             state.toast = Toast(title: Localizations.sendPasswordRemoved)
         } catch {
-            let alert = Alert.networkResponseError(error) { [weak self] in
-                await self?.removePassword(sendView)
-            }
             coordinator.hideLoadingOverlay()
-            coordinator.showAlert(alert)
+            await coordinator.showErrorAlert(error: error) {
+                await self.removePassword(sendView)
+            }
         }
     }
 
@@ -261,9 +260,9 @@ class AddEditSendItemProcessor:
                 await copyLink(to: newSendView)
             }
         } catch {
-            coordinator.showAlert(.networkResponseError(error) { [weak self] in
-                await self?.saveSendItem()
-            })
+            await coordinator.showErrorAlert(error: error) {
+                await self.saveSendItem()
+            }
         }
     }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -28,7 +28,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         reviewPromptService = MockReviewPromptService()
         sendRepository = MockSendRepository()
         subject = AddEditSendItemProcessor(
-            coordinator: coordinator,
+            coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 pasteboardService: pasteboardService,
                 policyService: policyService,
@@ -91,7 +91,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     func test_perform_deletePressed_networkError() async throws {
         let sendView = SendView.fixture(id: "SEND_ID")
         subject.state.originalSendView = sendView
-        sendRepository.deleteSendResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        sendRepository.deleteSendResult = .failure(error)
         await subject.perform(.deletePressed)
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
@@ -100,8 +101,9 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(sendRepository.deleteSendSendView, sendView)
 
         sendRepository.deleteSendResult = .success(())
-        let errorAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await errorAlert.tapAction(title: Localizations.tryAgain)
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
+        await errorAlertWithRetry.retry()
 
         XCTAssertEqual(
             coordinator.loadingOverlaysShown.last?.title,
@@ -167,7 +169,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     func test_perform_sendListItemRow_removePassword_networkError() async throws {
         let sendView = SendView.fixture(id: "SEND_ID")
         subject.state.originalSendView = sendView
-        sendRepository.removePasswordFromSendResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        sendRepository.removePasswordFromSendResult = .failure(error)
         await subject.perform(.removePassword)
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
@@ -176,8 +179,9 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(sendRepository.removePasswordFromSendSendView, sendView)
 
         sendRepository.removePasswordFromSendResult = .success(sendView)
-        let errorAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await errorAlert.tapAction(title: Localizations.tryAgain)
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
+        await errorAlertWithRetry.retry()
 
         XCTAssertEqual(
             coordinator.loadingOverlaysShown.last?.title,
@@ -241,7 +245,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.state.text = "Text"
         subject.state.deletionDate = .custom(deletionDate)
         subject.state.customDeletionDate = deletionDate
-        sendRepository.addTextSendResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        sendRepository.addTextSendResult = .failure(error)
 
         await subject.perform(.savePressed)
 
@@ -254,12 +259,13 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .networkResponseError(URLError(.timedOut)))
-
         let sendView = SendView.fixture(id: "SEND_ID", name: "Name")
         sendRepository.addTextSendResult = .success(sendView)
-        try await alert.tapAction(title: Localizations.tryAgain)
+
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
+        await errorAlertWithRetry.retry()
+
         XCTAssertEqual(coordinator.routes.last, .complete(sendView))
     }
 
@@ -446,7 +452,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.state.text = "Text"
         subject.state.deletionDate = .custom(deletionDate)
         subject.state.customDeletionDate = deletionDate
-        sendRepository.updateSendResult = .failure(URLError(.timedOut))
+        let error = URLError(.timedOut)
+        sendRepository.updateSendResult = .failure(error)
 
         await subject.perform(.savePressed)
 
@@ -459,12 +466,13 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .networkResponseError(URLError(.timedOut)))
-
         let sendView = SendView.fixture(id: "SEND_ID", name: "Name")
         sendRepository.updateSendResult = .success(sendView)
-        try await alert.tapAction(title: Localizations.tryAgain)
+
+        let errorAlertWithRetry = try XCTUnwrap(coordinator.errorAlertsWithRetryShown.last)
+        XCTAssertEqual(errorAlertWithRetry.error as? URLError, error)
+        await errorAlertWithRetry.retry()
+
         XCTAssertEqual(coordinator.routes.last, .complete(sendView))
     }
 

--- a/BitwardenShared/UI/Vault/ImportLogins/ImportLogins/ImportLoginsProcessor.swift
+++ b/BitwardenShared/UI/Vault/ImportLogins/ImportLogins/ImportLoginsProcessor.swift
@@ -149,7 +149,7 @@ class ImportLoginsProcessor: StateProcessor<ImportLoginsState, ImportLoginsActio
 
             coordinator.navigate(to: .importLoginsSuccess)
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/ImportLogins/ImportLogins/ImportLoginsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/ImportLogins/ImportLogins/ImportLoginsProcessorTests.swift
@@ -155,7 +155,7 @@ class ImportLoginsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.syncingLogins)])
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.alertShown, [.networkResponseError(BitwardenTestError.example)])
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertTrue(coordinator.routes.isEmpty)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [BitwardenTestError.example])
         XCTAssertTrue(settingsRepository.fetchSyncCalled)

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -207,7 +207,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
         waitFor(!errorReporter.errors.isEmpty)
 
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
@@ -652,7 +652,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
 
         waitFor(!errorReporter.errors.isEmpty)
 
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -15,6 +15,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
     typealias Services = HasAuthRepository
         & HasAutofillCredentialService
         & HasClientService
+        & HasConfigService
         & HasErrorReporter
         & HasEventService
         & HasFido2CredentialStore
@@ -713,7 +714,7 @@ extension VaultAutofillListProcessor {
         } catch UserVerificationError.cancelled {
             return
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -12,6 +12,7 @@ final class VaultGroupProcessor: StateProcessor<
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasConfigService
         & HasErrorReporter
         & HasEventService
         & HasPasteboardService
@@ -206,7 +207,7 @@ final class VaultGroupProcessor: StateProcessor<
         do {
             try await services.vaultRepository.fetchSync(forceSync: true, filter: state.vaultFilterType)
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -220,7 +220,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         await subject.perform(.refresh)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -621,7 +621,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
         } catch UserVerificationError.cancelled {
             return
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -675,7 +675,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
                 self?.delegate?.itemSoftDeleted()
             })))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -898,7 +898,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         vaultRepository.softDeleteCipherResult = .failure(TestError())
         await subject.perform(.deletePressed)
         // Ensure the alert is shown.
-        var alert = coordinator.alertShown.last
+        let alert = coordinator.alertShown.last
         XCTAssertEqual(alert, .deleteCipherConfirmation(isSoftDelete: true) {})
 
         // Tap the "Yes" button on the alert.
@@ -906,11 +906,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         await action.handler?(action, [])
 
         // Ensure the generic error alert is displayed.
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(
-            alert,
-            .networkResponseError(TestError())
-        )
+        XCTAssertEqual(coordinator.errorAlertsShown as? [TestError], [TestError()])
         XCTAssertEqual(errorReporter.errors.first as? TestError, TestError())
     }
 
@@ -1176,11 +1172,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 
         await subject.perform(.savePressed)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.first)
-        XCTAssertEqual(
-            alert,
-            Alert.defaultAlert(title: Localizations.anErrorHasOccurred)
-        )
+        XCTAssertEqual(coordinator.errorAlertsShown as? [EncryptError], [EncryptError()])
     }
 
     /// `perform(_:)` with `.savePressed` shows an error if an organization but no collections have been selected.
@@ -1219,20 +1211,12 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_savePressed_serverErrorAlert() async throws {
         let response = HTTPResponse.failure(statusCode: 400, body: APITestData.bitwardenErrorMessage.data)
-        try vaultRepository.addCipherResult = .failure(
-            ServerError.error(errorResponse: ErrorResponseModel(response: response))
-        )
+        let error = try ServerError.error(errorResponse: ErrorResponseModel(response: response))
+        vaultRepository.addCipherResult = .failure(error)
         subject.state.name = "vault item"
         await subject.perform(.savePressed)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.first)
-        XCTAssertEqual(
-            alert,
-            Alert.defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: "You do not have permissions to edit this."
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsShown as? [ServerError], [error])
     }
 
     /// `perform(_:)` with `.savePressed` saves the item.

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -8,7 +8,8 @@ import Foundation
 class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, AttachmentsEffect> {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -91,7 +92,7 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
             state.cipher = updatedCipher
             state.toast = Toast(title: Localizations.attachmentDeleted)
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -107,7 +108,7 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
                 coordinator.showAlert(.defaultAlert(title: Localizations.premiumRequired))
             }
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -163,7 +164,7 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
         } catch let error as InputValidationError {
             coordinator.showAlert(.inputValidationAlert(error: error))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -69,7 +69,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         await subject.perform(.loadPremiumStatus)
 
         XCTAssertFalse(subject.state.hasPremium)
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.anErrorHasOccurred))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -101,7 +101,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.save)
 
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -201,7 +201,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         await confirmAction.handler?(confirmAction, [])
 
         // Verify the results.
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
@@ -217,7 +217,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         await confirmAction.handler?(confirmAction, [])
 
         // Verify the results.
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(CipherAPIServiceError.updateMissingId))
+        XCTAssertEqual(coordinator.errorAlertsShown as? [CipherAPIServiceError], [.updateMissingId])
         XCTAssertEqual(errorReporter.errors.last as? CipherAPIServiceError, .updateMissingId)
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessor.swift
@@ -21,7 +21,8 @@ class EditCollectionsProcessor: StateProcessor<
 > {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -114,7 +115,7 @@ class EditCollectionsProcessor: StateProcessor<
                 self.delegate?.didUpdateCipher()
             }))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessorTests.swift
@@ -103,12 +103,7 @@ class EditCollectionsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.save)
 
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsShown as? [UpdateCipherError], [UpdateCipherError()])
         XCTAssertEqual(errorReporter.errors.last as? UpdateCipherError, UpdateCipherError())
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessor.swift
@@ -23,7 +23,8 @@ class MoveToOrganizationProcessor: StateProcessor<
 > {
     // MARK: Types
 
-    typealias Services = HasErrorReporter
+    typealias Services = HasConfigService
+        & HasErrorReporter
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -122,7 +123,7 @@ class MoveToOrganizationProcessor: StateProcessor<
                 self.delegate?.didMoveCipher(self.state.cipher, to: owner)
             }))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/MoveToOrganization/MoveToOrganizationProcessorTests.swift
@@ -106,12 +106,7 @@ class MoveToOrganizationProcessorTests: BitwardenTestCase {
 
         await subject.perform(.moveCipher)
 
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred
-            )
-        )
+        XCTAssertEqual(coordinator.errorAlertsShown as? [ShareCipherError], [ShareCipherError()])
         XCTAssertEqual(errorReporter.errors.last as? ShareCipherError, ShareCipherError())
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -10,6 +10,7 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
 
     typealias Services = HasAPIService
         & HasAuthRepository
+        & HasConfigService
         & HasErrorReporter
         & HasEventService
         & HasPasteboardService
@@ -307,7 +308,7 @@ private extension ViewItemProcessor {
                 self?.delegate?.itemDeleted()
             })))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -324,7 +325,7 @@ private extension ViewItemProcessor {
                 self?.delegate?.itemSoftDeleted()
             })))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }
@@ -461,7 +462,7 @@ private extension ViewItemProcessor {
                 self?.delegate?.itemRestored()
             })))
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -591,7 +591,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         vaultRepository.softDeleteCipherResult = .failure(TestError())
         await subject.perform(.deletePressed)
         // Ensure the alert is shown.
-        var alert = coordinator.alertShown.last
+        let alert = coordinator.alertShown.last
         XCTAssertEqual(alert, .deleteCipherConfirmation(isSoftDelete: true) {})
 
         // Tap the "Yes" button on the alert.
@@ -599,11 +599,8 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await action.handler?(action, [])
 
         // Ensure the generic error alert is displayed.
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(
-            alert,
-            .networkResponseError(TestError())
-        )
+        let errorAlert = try XCTUnwrap(coordinator.errorAlertsShown.last)
+        XCTAssertEqual(errorAlert as? TestError, TestError())
         XCTAssertEqual(errorReporter.errors.first as? TestError, TestError())
     }
 
@@ -624,7 +621,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         vaultRepository.deleteCipherResult = .failure(TestError())
         await subject.perform(.deletePressed)
         // Ensure the alert is shown.
-        var alert = coordinator.alertShown.last
+        let alert = coordinator.alertShown.last
         XCTAssertEqual(alert, .deleteCipherConfirmation(isSoftDelete: false) {})
 
         // Tap the "Yes" button on the alert.
@@ -632,11 +629,8 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await action.handler?(action, [])
 
         // Ensure the generic error alert is displayed.
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(
-            alert,
-            .networkResponseError(TestError())
-        )
+        let errorAlert = try XCTUnwrap(coordinator.errorAlertsShown.last)
+        XCTAssertEqual(errorAlert as? TestError, TestError())
         XCTAssertEqual(errorReporter.errors.first as? TestError, TestError())
     }
 
@@ -791,7 +785,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         vaultRepository.restoreCipherResult = .failure(TestError())
         await subject.perform(.restorePressed)
         // Ensure the alert is shown.
-        var alert = coordinator.alertShown.last
+        let alert = coordinator.alertShown.last
         XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToRestoreCipher)
         XCTAssertNil(alert?.message)
 
@@ -800,11 +794,8 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await action.handler?(action, [])
 
         // Ensure the generic error alert is displayed.
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(
-            alert,
-            .networkResponseError(TestError())
-        )
+        let errorAlert = try XCTUnwrap(coordinator.errorAlertsShown.last)
+        XCTAssertEqual(errorAlert as? TestError, TestError())
         XCTAssertEqual(errorReporter.errors.first as? TestError, TestError())
     }
 

--- a/GlobalTestHelpers/MockCoordinator.swift
+++ b/GlobalTestHelpers/MockCoordinator.swift
@@ -42,12 +42,17 @@ class MockCoordinator<Route, Event>: Coordinator {
         errorAlertsShown.append(error)
     }
 
-    func showErrorAlert(error: any Error, tryAgain: (() async -> Void)?) async {
+    func showErrorAlert(
+        error: any Error,
+        tryAgain: (() async -> Void)?,
+        onDismissed: (() -> Void)?
+    ) async {
         if let tryAgain {
             errorAlertsWithRetryShown.append((error, tryAgain))
         } else {
             errorAlertsShown.append(error)
         }
+        alertOnDismissed = onDismissed
     }
 
     func showLoadingOverlay(_ state: LoadingOverlayState) {

--- a/GlobalTestHelpers/MockStackNavigator.swift
+++ b/GlobalTestHelpers/MockStackNavigator.swift
@@ -22,6 +22,7 @@ final class MockStackNavigator: StackNavigator {
     }
 
     var actions: [NavigationAction] = []
+    var alertOnDismissed: (() -> Void)?
     var alerts: [BitwardenShared.Alert] = []
     var isEmpty = true
     var isNavigationBarHidden = false
@@ -74,6 +75,7 @@ final class MockStackNavigator: StackNavigator {
 
     func present(_ alert: BitwardenShared.Alert, onDismissed: (() -> Void)?) {
         alerts.append(alert)
+        alertOnDismissed = onDismissed
     }
 
     func present<Content: View>(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18223](https://bitwarden.atlassian.net/browse/PM-18223)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Follow up to https://github.com/bitwarden/ios/pull/1438, this updates the rest of the processors to use `coordinator.showErrorAlert(error:)` when an error occurs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18223]: https://bitwarden.atlassian.net/browse/PM-18223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ