### PR TITLE
[PM-18439] Fix CoreData model warnings during tests

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/Stores/DataStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/DataStore.swift
@@ -19,6 +19,17 @@ enum StoreType {
 /// A data store that manages persisting data across app launches in Core Data.
 ///
 class DataStore {
+    // MARK: Type Properties
+
+    /// The managed object model representing the entities in the database schema. CoreData throws
+    /// warnings if this is instantiated multiple times (e.g. in tests), which is fixed by making
+    /// it static.
+    private static let managedObjectModel: NSManagedObjectModel = {
+        let modelURL = Bundle(for: DataStore.self).url(forResource: "Authenticator", withExtension: "momd")!
+        let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL)!
+        return managedObjectModel
+    }()
+
     // MARK: Properties
 
     /// A managed object context which executes on a background queue.
@@ -45,9 +56,7 @@ class DataStore {
     init(errorReporter: ErrorReporter, storeType: StoreType = .persisted) {
         self.errorReporter = errorReporter
 
-        let modelURL = Bundle(for: type(of: self)).url(forResource: "Authenticator", withExtension: "momd")!
-        let managedObjectModel = NSManagedObjectModel(contentsOf: modelURL)!
-        persistentContainer = NSPersistentContainer(name: "Authenticator", managedObjectModel: managedObjectModel)
+        persistentContainer = NSPersistentContainer(name: "Authenticator", managedObjectModel: Self.managedObjectModel)
         let storeDescription: NSPersistentStoreDescription
         switch storeType {
         case .memory:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18439](https://bitwarden.atlassian.net/browse/PM-18439)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes some CoreData warnings when running tests:

```
⚠️  CoreData: Multiple NSEntityDescriptions claim the NSManagedObject subclass 'AuthenticatorBridgeKit.AuthenticatorBridgeItemData' so +entity is unable to disambiguate.
CoreData: warning: 'AuthenticatorBridgeItemData' from NSManagedObjectModel (claims 'AuthenticatorBridgeKit.AuthenticatorBridgeItemData'.
❌ CoreData: +[AuthenticatorBridgeKit.AuthenticatorBridgeItemData entity] Failed to find a unique match for an NSEntityDescription to a managed object subclass
```

The `BitwardenShared` instance was previously fixed in #1276.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18439]: https://bitwarden.atlassian.net/browse/PM-18439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ