### PR TITLE
[PM-18091] Update cipher delete & restore permissions

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -65,6 +65,9 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// A feature flag for the refactor on the SSO details endpoint.
     case refactorSsoDetailsEndpoint = "pm-12337-refactor-sso-details-endpoint"
 
+    /// A feature flag for the use of new cipher permission properties.
+    case restrictItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission"
+
     // MARK: Test Flags
 
     /// A test feature flag that isn't remotely configured and has no initial value.
@@ -140,6 +143,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
              .nativeCarouselFlow,
              .nativeCreateAccountFlow,
              .refactorSsoDetailsEndpoint,
+             .restrictItemDeletion,
              .testRemoteFeatureFlag,
              .testRemoteInitialBoolFlag,
              .testRemoteInitialIntFlag,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -66,7 +66,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
     case refactorSsoDetailsEndpoint = "pm-12337-refactor-sso-details-endpoint"
 
     /// A feature flag for the use of new cipher permission properties.
-    case restrictItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission"
+    case restrictCipherItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission"
 
     // MARK: Test Flags
 
@@ -143,7 +143,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
              .nativeCarouselFlow,
              .nativeCreateAccountFlow,
              .refactorSsoDetailsEndpoint,
-             .restrictItemDeletion,
+             .restrictCipherItemDeletion,
              .testRemoteFeatureFlag,
              .testRemoteInitialBoolFlag,
              .testRemoteInitialIntFlag,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -29,6 +29,7 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertTrue(FeatureFlag.nativeCarouselFlow.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.nativeCreateAccountFlow.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.refactorSsoDetailsEndpoint.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.restrictItemDeletion.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialBoolFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialIntFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialStringFlag.isRemotelyConfigured)

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -29,7 +29,7 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertTrue(FeatureFlag.nativeCarouselFlow.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.nativeCreateAccountFlow.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.refactorSsoDetailsEndpoint.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.restrictItemDeletion.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.restrictCipherItemDeletion.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialBoolFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialIntFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialStringFlag.isRemotelyConfigured)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -127,6 +127,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     override func perform(_ effect: AddEditItemEffect) async {
         switch effect {
         case .appeared:
+            await loadRestrictItemDeletionFlag()
             await showPasswordAutofillAlertIfNeeded()
             await checkIfUserHasMasterPassword()
             await checkLearnNewLoginActionCardEligibility()
@@ -678,6 +679,14 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
+    }
+
+    /// Load the restrict item deletion flag from the config service to state.
+    ///
+    func loadRestrictItemDeletionFlag() async {
+        state.restrictItemDeletionFlagEnabled = await services.configService.getFeatureFlag(
+            FeatureFlag.restrictItemDeletion
+        )
     }
 
     /// Shows the password autofill information alert if it hasn't been shown before and the user

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -684,8 +684,8 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     /// Load the restrict item deletion flag from the config service to state.
     ///
     func loadRestrictItemDeletionFlag() async {
-        state.restrictItemDeletionFlagEnabled = await services.configService.getFeatureFlag(
-            FeatureFlag.restrictItemDeletion
+        state.restrictCipherItemDeletionFlagEnabled = await services.configService.getFeatureFlag(
+            .restrictCipherItemDeletion
         )
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -839,12 +839,12 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.showMasterPasswordReprompt)
     }
 
-    /// `perform(_:)` with `.appeared` checks restrictItemDeletionFlag and sets value to state.
+    /// `perform(_:)` with `.appeared` checks restrictCipherItemDeletionFlag and sets value to state.
     @MainActor
     func test_perform_appeared_loadRestrictItemDeletionFlag() async {
-        configService.featureFlagsBool[.restrictItemDeletion] = true
+        configService.featureFlagsBool[.restrictCipherItemDeletion] = true
         await subject.perform(.appeared)
-        XCTAssertTrue(subject.state.restrictItemDeletionFlagEnabled)
+        XCTAssertTrue(subject.state.restrictCipherItemDeletionFlagEnabled)
     }
 
     /// `perform` with `.checkPasswordPressed` checks the password with the HIBP service.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -839,6 +839,14 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.showMasterPasswordReprompt)
     }
 
+    /// `perform(_:)` with `.appeared` checks restrictItemDeletionFlag and sets value to state.
+    @MainActor
+    func test_perform_appeared_loadRestrictItemDeletionFlag() async {
+        configService.featureFlagsBool[.restrictItemDeletion] = true
+        await subject.perform(.appeared)
+        XCTAssertTrue(subject.state.restrictItemDeletionFlagEnabled)
+    }
+
     /// `perform` with `.checkPasswordPressed` checks the password with the HIBP service.
     @MainActor
     func test_perform_checkPasswordPressed_exposedPassword() async throws {

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
@@ -15,6 +15,10 @@ protocol AddEditItemState: Sendable {
     /// Whether the user is able to delete the item.
     var canBeDeleted: Bool { get }
 
+    /// Whether or not this item can be deleted by the user.
+    /// New permission model from PM-18091
+    var canBeDeletedPermission: Bool { get }
+
     /// The Cipher underpinning the state
     var cipher: CipherView { get }
 
@@ -92,6 +96,9 @@ protocol AddEditItemState: Sendable {
 
     /// A computed property that indicates if we should show the learn new login action card.
     var shouldShowLearnNewLoginActionCard: Bool { get }
+
+    /// A flag indicating if cipher permissions should be used.
+    var restrictItemDeletionFlagEnabled: Bool { get set }
 
     /// The SSH key item state.
     var sshKeyState: SSHKeyItemState { get set }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
@@ -15,10 +15,6 @@ protocol AddEditItemState: Sendable {
     /// Whether the user is able to delete the item.
     var canBeDeleted: Bool { get }
 
-    /// Whether or not this item can be deleted by the user.
-    /// New permission model from PM-18091
-    var canBeDeletedPermission: Bool { get }
-
     /// The Cipher underpinning the state
     var cipher: CipherView { get }
 
@@ -98,7 +94,7 @@ protocol AddEditItemState: Sendable {
     var shouldShowLearnNewLoginActionCard: Bool { get }
 
     /// A flag indicating if cipher permissions should be used.
-    var restrictItemDeletionFlagEnabled: Bool { get set }
+    var restrictCipherItemDeletionFlagEnabled: Bool { get set }
 
     /// The SSH key item state.
     var sshKeyState: SSHKeyItemState { get set }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -115,7 +115,9 @@ struct AddEditItemView: View {
                     VaultItemManagementMenuView(
                         isCloneEnabled: false,
                         isCollectionsEnabled: store.state.canAssignToCollection,
-                        isDeleteEnabled: store.state.canBeDeleted,
+                        isDeleteEnabled: store.state.restrictItemDeletionFlagEnabled
+                            ? store.state.canBeDeletedPermission
+                            : store.state.canBeDeleted,
                         isMoveToOrganizationEnabled: store.state.cipher.organizationId == nil,
                         store: store.child(
                             state: { _ in },

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -115,9 +115,7 @@ struct AddEditItemView: View {
                     VaultItemManagementMenuView(
                         isCloneEnabled: false,
                         isCollectionsEnabled: store.state.canAssignToCollection,
-                        isDeleteEnabled: store.state.restrictItemDeletionFlagEnabled
-                            ? store.state.canBeDeletedPermission
-                            : store.state.canBeDeleted,
+                        isDeleteEnabled: store.state.canBeDeleted,
                         isMoveToOrganizationEnabled: store.state.cipher.organizationId == nil,
                         store: store.child(
                             state: { _ in },

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -97,6 +97,9 @@ struct CipherItemState: Equatable {
     /// The list of ownership options that can be selected for the cipher.
     var ownershipOptions: [CipherOwner]
 
+    /// A flag indicating if cipher permissions should be used.
+    var restrictItemDeletionFlag: Bool = false
+
     /// If master password reprompt toggle should be shown
     var showMasterPasswordReprompt: Bool
 
@@ -140,6 +143,16 @@ struct CipherItemState: Equatable {
         }
     }
 
+    /// Whether or not this item can be deleted by the user.
+    /// New permission model from PM-18091
+    var canBeDeletedPermission: Bool {
+        // backwards capability for old server versions
+        guard let cipherPermissions = cipher.permissions else {
+            return canBeDeleted
+        }
+        return cipherPermissions.delete
+    }
+
     /// The list of collections that can be selected from for the current owner.
     /// These are collections that the user can add items to, so they are non-read-only collections.
     var collectionsForOwner: [CollectionView] {
@@ -175,6 +188,11 @@ struct CipherItemState: Equatable {
             organizationId = newValue?.organizationId
             collectionIds = []
         }
+    }
+
+    var restrictItemDeletionFlagEnabled: Bool {
+        get { restrictItemDeletionFlag }
+        set { restrictItemDeletionFlag = newValue }
     }
 
     /// The flag indicating if we should show the learn new login action card.

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -146,11 +146,21 @@ struct CipherItemState: Equatable {
     /// Whether or not this item can be deleted by the user.
     /// New permission model from PM-18091
     var canBeDeletedPermission: Bool {
-        // backwards capability for old server versions
+        // backwards compatibility for old server versions
         guard let cipherPermissions = cipher.permissions else {
             return canBeDeleted
         }
         return cipherPermissions.delete
+    }
+
+    /// Whether or not this item can be restored by the user.
+    /// New permission model from PM-18091
+    var canBeRestoredPermission: Bool {
+        // backwards compatibility for old server versions
+        guard let cipherPermissions = cipher.permissions else {
+            return isSoftDeleted
+        }
+        return cipherPermissions.restore && isSoftDeleted
     }
 
     /// The list of collections that can be selected from for the current owner.

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -98,7 +98,7 @@ struct CipherItemState: Equatable {
     var ownershipOptions: [CipherOwner]
 
     /// A flag indicating if cipher permissions should be used.
-    var restrictItemDeletionFlag: Bool = false
+    var restrictCipherItemDeletionFlag: Bool = false
 
     /// If master password reprompt toggle should be shown
     var showMasterPasswordReprompt: Bool
@@ -136,21 +136,16 @@ struct CipherItemState: Equatable {
 
     /// Whether or not this item can be deleted by the user.
     var canBeDeleted: Bool {
+        // New permission model from PM-18091
+        if restrictCipherItemDeletionFlagEnabled, let cipherPermissions = cipher.permissions {
+            return cipherPermissions.delete
+        }
+
         guard !collectionIds.isEmpty else { return true }
         return collections.contains { collection in
             guard let id = collection.id else { return false }
             return collection.manage && collectionIds.contains(id)
         }
-    }
-
-    /// Whether or not this item can be deleted by the user.
-    /// New permission model from PM-18091
-    var canBeDeletedPermission: Bool {
-        // backwards compatibility for old server versions
-        guard let cipherPermissions = cipher.permissions else {
-            return canBeDeleted
-        }
-        return cipherPermissions.delete
     }
 
     /// Whether or not this item can be restored by the user.
@@ -200,9 +195,9 @@ struct CipherItemState: Equatable {
         }
     }
 
-    var restrictItemDeletionFlagEnabled: Bool {
-        get { restrictItemDeletionFlag }
-        set { restrictItemDeletionFlag = newValue }
+    var restrictCipherItemDeletionFlagEnabled: Bool {
+        get { restrictCipherItemDeletionFlag }
+        set { restrictCipherItemDeletionFlag = newValue }
     }
 
     /// The flag indicating if we should show the learn new login action card.

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -173,9 +173,60 @@ class CipherItemStateTests: BitwardenTestCase {
         XCTAssertFalse(state.canBeDeletedPermission)
     }
 
+    /// `canBeRestoredPermission` cipher permissions is nil fallback to isSoftDeleted
+    func test_canBeRestoredPermission_permissions_nil() throws {
+        var cipher = CipherView.loginFixture(
+            collectionIds: ["1", "2"],
+            deletedDate: nil,
+            login: .fixture(),
+            permissions: nil
+        )
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertFalse(state.canBeRestoredPermission)
+
+        cipher = CipherView.loginFixture(
+            collectionIds: ["1", "2"],
+            deletedDate: Date(),
+            login: .fixture(),
+            permissions: nil
+        )
+        state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertTrue(state.canBeRestoredPermission)
+    }
+
+    /// `canBeRestoredPermission` returns value from cipher permissions if not nil
+    /// restore value true
+    func test_canBeRestoredPermission_true() throws {
+        let cipher = CipherView.loginFixture(
+            deletedDate: Date(),
+            login: .fixture(),
+            permissions: CipherPermissions(
+                delete: true,
+                restore: true
+            )
+        )
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertTrue(state.canBeRestoredPermission)
+    }
+
+    /// `canBeRestoredPermission` returns value from cipher permissions if not nil
+    /// restore value false
+    func test_canBeRestoredPermission_false() throws {
+        let cipher = CipherView.loginFixture(
+            deletedDate: Date(),
+            login: .fixture(),
+            permissions: CipherPermissions(
+                delete: true,
+                restore: false
+            )
+        )
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertFalse(state.canBeRestoredPermission)
+    }
+
     /// `restrictItemDeletionFlagEnable` default value is false
     func test_restrictItemDeletionFlagValue() throws {
-        var cipher = CipherView.loginFixture(
+        let cipher = CipherView.loginFixture(
             login: .fixture(),
             permissions: CipherPermissions(
                 delete: false,

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -128,24 +128,7 @@ class CipherItemStateTests: BitwardenTestCase {
         XCTAssertTrue(state.canBeDeleted)
     }
 
-    /// `canBeDeletedPermission` cipher permissions is nil fallback to canBeDeleted
-    func test_canBeDeletedPermission_permissions_nil() throws {
-        let cipher = CipherView.loginFixture(
-            collectionIds: ["1", "2"],
-            login: .fixture(),
-            permissions: nil
-        )
-        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        XCTAssertFalse(state.canBeDeletedPermission)
-
-        state.collections = [
-            CollectionView.fixture(id: "1", manage: true),
-            CollectionView.fixture(id: "2", manage: false),
-        ]
-        XCTAssertTrue(state.canBeDeletedPermission)
-    }
-
-    /// `canBeDeletedPermission` returns value from cipher permissions if not nil
+    /// `canBeDeleted` returns value from cipher permissions if not nil
     /// delete value true
     func test_canBeDeletedPermission_true() throws {
         let cipher = CipherView.loginFixture(
@@ -156,10 +139,10 @@ class CipherItemStateTests: BitwardenTestCase {
             )
         )
         let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        XCTAssertTrue(state.canBeDeletedPermission)
+        XCTAssertTrue(state.canBeDeleted)
     }
 
-    /// `canBeDeletedPermission` returns value from cipher permissions if not nil
+    /// `canBeDeleted` returns value from cipher permissions if not nil
     /// delete value false
     func test_canBeDeletedPermission_false() throws {
         let cipher = CipherView.loginFixture(
@@ -169,8 +152,9 @@ class CipherItemStateTests: BitwardenTestCase {
                 restore: true
             )
         )
-        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        XCTAssertFalse(state.canBeDeletedPermission)
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        state.restrictCipherItemDeletionFlagEnabled = true
+        XCTAssertFalse(state.canBeDeleted)
     }
 
     /// `canBeRestoredPermission` cipher permissions is nil fallback to isSoftDeleted
@@ -182,6 +166,7 @@ class CipherItemStateTests: BitwardenTestCase {
             permissions: nil
         )
         var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        state.restrictCipherItemDeletionFlagEnabled = true
         XCTAssertFalse(state.canBeRestoredPermission)
 
         cipher = CipherView.loginFixture(
@@ -205,7 +190,8 @@ class CipherItemStateTests: BitwardenTestCase {
                 restore: true
             )
         )
-        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        state.restrictCipherItemDeletionFlagEnabled = true
         XCTAssertTrue(state.canBeRestoredPermission)
     }
 
@@ -220,12 +206,13 @@ class CipherItemStateTests: BitwardenTestCase {
                 restore: false
             )
         )
-        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        state.restrictCipherItemDeletionFlagEnabled = true
         XCTAssertFalse(state.canBeRestoredPermission)
     }
 
-    /// `restrictItemDeletionFlagEnable` default value is false
-    func test_restrictItemDeletionFlagValue() throws {
+    /// `restrictCipherItemDeletionFlagEnable` default value is false
+    func test_restrictCipherItemDeletionFlagValue() throws {
         let cipher = CipherView.loginFixture(
             login: .fixture(),
             permissions: CipherPermissions(
@@ -235,9 +222,9 @@ class CipherItemStateTests: BitwardenTestCase {
         )
 
         var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        XCTAssertFalse(state.restrictItemDeletionFlagEnabled)
-        state.restrictItemDeletionFlagEnabled = true
-        XCTAssertTrue(state.restrictItemDeletionFlagEnabled)
+        XCTAssertFalse(state.restrictCipherItemDeletionFlagEnabled)
+        state.restrictCipherItemDeletionFlagEnabled = true
+        XCTAssertTrue(state.restrictCipherItemDeletionFlagEnabled)
     }
 
     /// `collectionsForOwner` contains collections that are not read-only

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -128,6 +128,67 @@ class CipherItemStateTests: BitwardenTestCase {
         XCTAssertTrue(state.canBeDeleted)
     }
 
+    /// `canBeDeletedPermission` cipher permissions is nil fallback to canBeDeleted
+    func test_canBeDeletedPermission_permissions_nil() throws {
+        let cipher = CipherView.loginFixture(
+            collectionIds: ["1", "2"],
+            login: .fixture(),
+            permissions: nil
+        )
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertFalse(state.canBeDeletedPermission)
+
+        state.collections = [
+            CollectionView.fixture(id: "1", manage: true),
+            CollectionView.fixture(id: "2", manage: false),
+        ]
+        XCTAssertTrue(state.canBeDeletedPermission)
+    }
+
+    /// `canBeDeletedPermission` returns value from cipher permissions if not nil
+    /// delete value true
+    func test_canBeDeletedPermission_true() throws {
+        let cipher = CipherView.loginFixture(
+            login: .fixture(),
+            permissions: CipherPermissions(
+                delete: true,
+                restore: true
+            )
+        )
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertTrue(state.canBeDeletedPermission)
+    }
+
+    /// `canBeDeletedPermission` returns value from cipher permissions if not nil
+    /// delete value false
+    func test_canBeDeletedPermission_false() throws {
+        let cipher = CipherView.loginFixture(
+            login: .fixture(),
+            permissions: CipherPermissions(
+                delete: false,
+                restore: true
+            )
+        )
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertFalse(state.canBeDeletedPermission)
+    }
+
+    /// `restrictItemDeletionFlagEnable` default value is false
+    func test_restrictItemDeletionFlagValue() throws {
+        var cipher = CipherView.loginFixture(
+            login: .fixture(),
+            permissions: CipherPermissions(
+                delete: false,
+                restore: true
+            )
+        )
+
+        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
+        XCTAssertFalse(state.restrictItemDeletionFlagEnabled)
+        state.restrictItemDeletionFlagEnabled = true
+        XCTAssertTrue(state.restrictItemDeletionFlagEnabled)
+    }
+
     /// `collectionsForOwner` contains collections that are not read-only
     func test_collectionsForOwner() throws {
         let cipher = CipherView.loginFixture(

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -520,8 +520,8 @@ private extension ViewItemProcessor {
                 let hasPremium = await (try? services.vaultRepository.doesActiveAccountHavePremium()) ?? false
                 let hasMasterPassword = try await services.stateService.getUserHasMasterPassword()
                 let collections = try await services.vaultRepository.fetchCollections(includeReadOnly: true)
-                let restrictItemDeletionFlagEnabled: Bool = await services.configService.getFeatureFlag(
-                    FeatureFlag.restrictItemDeletion
+                let restrictCipherItemDeletionFlagEnabled: Bool = await services.configService.getFeatureFlag(
+                    .restrictCipherItemDeletion
                 )
                 var totpState = LoginTOTPState(cipher.login?.totp)
                 if let key = totpState.authKeyModel,
@@ -533,7 +533,7 @@ private extension ViewItemProcessor {
                     cipherView: cipher,
                     hasMasterPassword: hasMasterPassword,
                     hasPremium: hasPremium,
-                    restrictItemDeletionFlagEnabled: restrictItemDeletionFlagEnabled
+                    restrictCipherItemDeletionFlagEnabled: restrictCipherItemDeletionFlagEnabled
                 ) else { continue }
 
                 if case var .data(itemState) = newState.loadingState {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -171,7 +171,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         XCTAssertTrue(subject.state.hasPremiumFeatures)
         XCTAssertTrue(subject.state.hasMasterPassword)
-        XCTAssertFalse(subject.state.restrictItemDeletionFlagEnabled)
+        XCTAssertFalse(subject.state.restrictCipherItemDeletionFlagEnabled)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -300,13 +300,13 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
 
-    /// `perform(_:)` with `.appeared` loads feature flag value for .restrictItemDeletion.
+    /// `perform(_:)` with `.appeared` loads feature flag value for .restrictCipherItemDeletion.
     @MainActor
     func test_perform_appeared_restrictItemDeletion() {
         let account = Account.fixture()
         stateService.activeAccount = account
         configService.featureFlagsBool = [
-            .restrictItemDeletion: true,
+            .restrictCipherItemDeletion: true,
         ]
 
         let cipherItem = CipherView.loginFixture(
@@ -325,7 +325,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             hasPremium: false
         )!
 
-        XCTAssertTrue(subject.state.restrictItemDeletionFlagEnabled)
+        XCTAssertTrue(subject.state.restrictCipherItemDeletionFlagEnabled)
     }
 
     /// `perform` with `.checkPasswordPressed` records any errors.
@@ -675,7 +675,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
                 cipherView: .fixture(reprompt: .password),
                 hasMasterPassword: true,
                 hasPremium: false,
-                restrictItemDeletionFlagEnabled: true
+                restrictCipherItemDeletionFlagEnabled: true
             )
         )
         await subject.perform(.deletePressed)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -11,6 +11,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
     var authRepository: MockAuthRepository!
     var client: MockHTTPClient!
+    var configService: MockConfigService!
     var coordinator: MockCoordinator<VaultItemRoute, VaultItemEvent>!
     var delegate: MockCipherItemOperationDelegate!
     var errorReporter: MockErrorReporter!
@@ -27,6 +28,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         super.setUp()
         authRepository = MockAuthRepository()
         client = MockHTTPClient()
+        configService = MockConfigService()
         coordinator = MockCoordinator<VaultItemRoute, VaultItemEvent>()
         delegate = MockCipherItemOperationDelegate()
         errorReporter = MockErrorReporter()
@@ -37,6 +39,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         vaultRepository = MockVaultRepository()
         let services = ServiceContainer.withMocks(
             authRepository: authRepository,
+            configService: configService,
             errorReporter: errorReporter,
             eventService: eventService,
             httpClient: client,
@@ -168,6 +171,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         XCTAssertTrue(subject.state.hasPremiumFeatures)
         XCTAssertTrue(subject.state.hasMasterPassword)
+        XCTAssertFalse(subject.state.restrictItemDeletionFlagEnabled)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -294,6 +298,34 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
+    }
+
+    /// `perform(_:)` with `.appeared` loads feature flag value for .restrictItemDeletion.
+    @MainActor
+    func test_perform_appeared_restrictItemDeletion() {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        configService.featureFlagsBool = [
+            .restrictItemDeletion: true,
+        ]
+
+        let cipherItem = CipherView.loginFixture(
+            id: "id"
+        )
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        let expectedState = CipherItemState(
+            existing: cipherItem,
+            hasPremium: false
+        )!
+
+        XCTAssertTrue(subject.state.restrictItemDeletionFlagEnabled)
     }
 
     /// `perform` with `.checkPasswordPressed` records any errors.
@@ -642,7 +674,8 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             ViewItemState(
                 cipherView: .fixture(reprompt: .password),
                 hasMasterPassword: true,
-                hasPremium: false
+                hasPremium: false,
+                restrictItemDeletionFlagEnabled: true
             )
         )
         await subject.perform(.deletePressed)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -56,6 +56,9 @@ struct ViewItemState: Equatable, Sendable {
     /// The password history of the item.
     var passwordHistory: [PasswordHistoryView]?
 
+    /// A flag indicating if cipher permissions should be used.
+    var restrictItemDeletionFlagEnabled = false
+
     /// A toast message to show in the view.
     var toast: Toast?
 }
@@ -73,7 +76,8 @@ extension ViewItemState {
     init?(
         cipherView: CipherView,
         hasMasterPassword: Bool,
-        hasPremium: Bool
+        hasPremium: Bool,
+        restrictItemDeletionFlagEnabled: Bool
     ) {
         guard let cipherItemState = CipherItemState(
             existing: cipherView,
@@ -84,5 +88,6 @@ extension ViewItemState {
         self.hasMasterPassword = hasMasterPassword
         hasPremiumFeatures = cipherItemState.accountHasPremium
         passwordHistory = cipherView.passwordHistory
+        self.restrictItemDeletionFlagEnabled = restrictItemDeletionFlagEnabled
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -57,7 +57,7 @@ struct ViewItemState: Equatable, Sendable {
     var passwordHistory: [PasswordHistoryView]?
 
     /// A flag indicating if cipher permissions should be used.
-    var restrictItemDeletionFlagEnabled = false
+    var restrictCipherItemDeletionFlagEnabled = false
 
     /// A toast message to show in the view.
     var toast: Toast?
@@ -77,7 +77,7 @@ extension ViewItemState {
         cipherView: CipherView,
         hasMasterPassword: Bool,
         hasPremium: Bool,
-        restrictItemDeletionFlagEnabled: Bool
+        restrictCipherItemDeletionFlagEnabled: Bool
     ) {
         guard let cipherItemState = CipherItemState(
             existing: cipherView,
@@ -88,6 +88,6 @@ extension ViewItemState {
         self.hasMasterPassword = hasMasterPassword
         hasPremiumFeatures = cipherItemState.accountHasPremium
         passwordHistory = cipherView.passwordHistory
-        self.restrictItemDeletionFlagEnabled = restrictItemDeletionFlagEnabled
+        self.restrictCipherItemDeletionFlagEnabled = restrictCipherItemDeletionFlagEnabled
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
@@ -166,8 +166,8 @@ class ViewItemStateTests: BitwardenTestCase {
         XCTAssertEqual(subject.navigationTitle, "")
     }
 
-    /// `restrictItemDeletionFlagEnabled` default value is false.
-    func test_restrictItemDeletionFlagEnabled() {
+    /// `restrictCipherItemDeletionFlagEnabled` default value is false.
+    func test_restrictCipherItemDeletionFlagEnabled() {
         let subject = ViewItemState(
             loadingState: .data(
                 CipherItemState(
@@ -180,11 +180,11 @@ class ViewItemStateTests: BitwardenTestCase {
             ),
             hasVerifiedMasterPassword: false
         )
-        XCTAssertFalse(subject.restrictItemDeletionFlagEnabled)
+        XCTAssertFalse(subject.restrictCipherItemDeletionFlagEnabled)
     }
 
-    /// `restrictItemDeletionFlagEnabled` is correctly initialized.
-    func test_restrictItemDeletionFlagEnabled_value() {
+    /// `restrictCipherItemDeletionFlagEnabled` is correctly initialized.
+    func test_restrictCipherItemDeletionFlagEnabled_value() {
         let subject = ViewItemState(
             loadingState: .data(
                 CipherItemState(
@@ -196,8 +196,8 @@ class ViewItemStateTests: BitwardenTestCase {
                 )!
             ),
             hasVerifiedMasterPassword: false,
-            restrictItemDeletionFlagEnabled: true
+            restrictCipherItemDeletionFlagEnabled: true
         )
-        XCTAssertTrue(subject.restrictItemDeletionFlagEnabled)
+        XCTAssertTrue(subject.restrictCipherItemDeletionFlagEnabled)
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
@@ -165,4 +165,39 @@ class ViewItemStateTests: BitwardenTestCase {
         let subject = ViewItemState()
         XCTAssertEqual(subject.navigationTitle, "")
     }
+
+    /// `restrictItemDeletionFlagEnabled` default value is false.
+    func test_restrictItemDeletionFlagEnabled() {
+        let subject = ViewItemState(
+            loadingState: .data(
+                CipherItemState(
+                    existing: .fixture(
+                        id: "id",
+                        reprompt: .password
+                    ),
+                    hasPremium: true
+                )!
+            ),
+            hasVerifiedMasterPassword: false
+        )
+        XCTAssertFalse(subject.restrictItemDeletionFlagEnabled)
+    }
+
+    /// `restrictItemDeletionFlagEnabled` is correctly initialized.
+    func test_restrictItemDeletionFlagEnabled_value() {
+        let subject = ViewItemState(
+            loadingState: .data(
+                CipherItemState(
+                    existing: .fixture(
+                        id: "id",
+                        reprompt: .password
+                    ),
+                    hasPremium: true
+                )!
+            ),
+            hasVerifiedMasterPassword: false,
+            restrictItemDeletionFlagEnabled: true
+        )
+        XCTAssertTrue(subject.restrictItemDeletionFlagEnabled)
+    }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -77,7 +77,7 @@ struct ViewItemView: View {
                     let restoreButtonVisible = store.state.restrictItemDeletionFlagEnabled
                         ? isRestoredPermissionEnabled
                         : state.isSoftDeleted
-                    if  restoreButtonVisible {
+                    if restoreButtonVisible {
                         toolbarButton(Localizations.restore) {
                             await store.perform(.restorePressed)
                         }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -23,12 +23,6 @@ struct ViewItemView: View {
         store.state.loadingState.data?.canBeDeleted ?? false
     }
 
-    /// Whether to show the delete option in the toolbar menu.
-    /// New permission model from PM-18091
-    var isDeletePermissionEnabled: Bool {
-        store.state.loadingState.data?.canBeDeletedPermission ?? false
-    }
-
     /// Whether the restore option is available.
     /// New permission model from PM-18091
     var isRestoredPermissionEnabled: Bool {
@@ -74,7 +68,7 @@ struct ViewItemView: View {
 
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 if let state = store.state.loadingState.data {
-                    let restoreButtonVisible = store.state.restrictItemDeletionFlagEnabled
+                    let restoreButtonVisible = store.state.restrictCipherItemDeletionFlagEnabled
                         ? isRestoredPermissionEnabled
                         : state.isSoftDeleted
                     if restoreButtonVisible {
@@ -92,9 +86,7 @@ struct ViewItemView: View {
                 VaultItemManagementMenuView(
                     isCloneEnabled: store.state.canClone,
                     isCollectionsEnabled: isCollectionsEnabled,
-                    isDeleteEnabled: store.state.restrictItemDeletionFlagEnabled
-                        ? isDeletePermissionEnabled
-                        : isDeleteEnabled,
+                    isDeleteEnabled: isDeleteEnabled,
                     isMoveToOrganizationEnabled: isMoveToOrganizationEnabled,
                     store: store.child(
                         state: { _ in },

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -29,6 +29,12 @@ struct ViewItemView: View {
         store.state.loadingState.data?.canBeDeletedPermission ?? false
     }
 
+    /// Whether the restore option is available.
+    /// New permission model from PM-18091
+    var isRestoredPermissionEnabled: Bool {
+        store.state.loadingState.data?.canBeRestoredPermission ?? false
+    }
+
     /// Whether to show the move to organization option in the toolbar menu.
     var isMoveToOrganizationEnabled: Bool {
         guard let cipher = store.state.loadingState.data?.cipher else { return false }
@@ -68,7 +74,10 @@ struct ViewItemView: View {
 
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 if let state = store.state.loadingState.data {
-                    if state.isSoftDeleted {
+                    let restoreButtonVisible = store.state.restrictItemDeletionFlagEnabled
+                        ? isRestoredPermissionEnabled
+                        : state.isSoftDeleted
+                    if  restoreButtonVisible {
                         toolbarButton(Localizations.restore) {
                             await store.perform(.restorePressed)
                         }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -23,6 +23,12 @@ struct ViewItemView: View {
         store.state.loadingState.data?.canBeDeleted ?? false
     }
 
+    /// Whether to show the delete option in the toolbar menu.
+    /// New permission model from PM-18091
+    var isDeletePermissionEnabled: Bool {
+        store.state.loadingState.data?.canBeDeletedPermission ?? false
+    }
+
     /// Whether to show the move to organization option in the toolbar menu.
     var isMoveToOrganizationEnabled: Bool {
         guard let cipher = store.state.loadingState.data?.cipher else { return false }
@@ -77,7 +83,9 @@ struct ViewItemView: View {
                 VaultItemManagementMenuView(
                     isCloneEnabled: store.state.canClone,
                     isCollectionsEnabled: isCollectionsEnabled,
-                    isDeleteEnabled: isDeleteEnabled,
+                    isDeleteEnabled: store.state.restrictItemDeletionFlagEnabled
+                        ? isDeletePermissionEnabled
+                        : isDeleteEnabled,
                     isMoveToOrganizationEnabled: isMoveToOrganizationEnabled,
                     store: store.child(
                         state: { _ in },


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-18091

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Use new cipher permissions properties to show or hide the delete and restore buttons on the UI.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/1598475b-303a-4f49-8914-b02fb75ea440


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
