### PR TITLE
[PM-19552] Wrap SwiftUI previews in DEBUG #if/#endif to fix release build

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/About/EnableFlightRecorder/EnableFlightRecorderView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/EnableFlightRecorder/EnableFlightRecorderView.swift
@@ -85,7 +85,9 @@ struct EnableFlightRecorderView: View {
 
 // MARK: - Previews
 
+#if DEBUG
 #Preview {
     EnableFlightRecorderView(store: Store(processor: StateProcessor(state: EnableFlightRecorderState())))
         .navStackWrapped
 }
+#endif

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
@@ -74,6 +74,7 @@ struct FlightRecorderLogsView: View {
 
 // MARK: - Previews
 
+#if DEBUG
 #Preview("Empty") {
     FlightRecorderLogsView(
         store: Store(processor: StateProcessor(state: FlightRecorderLogsState())),
@@ -112,3 +113,4 @@ struct FlightRecorderLogsView: View {
     )
     .navStackWrapped
 }
+#endif


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19552](https://bitwarden.atlassian.net/browse/PM-19552)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

#1483 added SwiftUI previews that use `PreviewTimeProvider()` which is behind a DEBUG #if/#endif macro. This fixes the failing release build.

https://github.com/bitwarden/ios/actions/runs/14365865412/job/40278544403#step:34:2186

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19552]: https://bitwarden.atlassian.net/browse/PM-19552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ