### PR TITLE
[PM-3503] Add AnonAddy self-hosted server URL support

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -8,6 +8,9 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// A feature flag to enable/disable account deprovisioning.
     case accountDeprovisioning = "pm-10308-account-deprovisioning"
 
+    /// A feature flag to enable/disable the ability to add a custom domain for anonAddy users.
+    case anonAddySelfHostAlias = "anon-addy-self-host-alias"
+
     /// A feature flag to enable/disable the app review prompt.
     case appReviewPrompt = "app-review-prompt"
 
@@ -133,6 +136,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
              .testLocalInitialStringFlag:
             false
         case .accountDeprovisioning,
+             .anonAddySelfHostAlias,
              .appReviewPrompt,
              .cipherKeyEncryption,
              .cxpExportMobile,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -19,6 +19,7 @@ final class FeatureFlagTests: BitwardenTestCase {
 
     /// `getter:isRemotelyConfigured` returns the correct value for each flag.
     func test_isRemotelyConfigured() {
+        XCTAssertTrue(FeatureFlag.anonAddySelfHostAlias.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.appReviewPrompt.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.cipherKeyEncryption.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.cxpExportMobile.isRemotelyConfigured)

--- a/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptions.swift
@@ -10,6 +10,9 @@ struct UsernameGenerationOptions: Codable, Equatable {
     /// The domain name used to generate a forwarded email alias with addy.io.
     var anonAddyDomainName: String?
 
+    /// The base URL for the addy.io api.
+    var anonAddyBaseUrl: String?
+
     /// Whether to capitalize the random word.
     var capitalizeRandomWordUsername: Bool?
 

--- a/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptionsTests.swift
@@ -11,6 +11,7 @@ class UsernameGenerationOptionsTests: BitwardenTestCase {
         {
           "anonAddyApiAccessToken": "ADDYIO_API_TOKEN",
           "anonAddyDomainName": "bitwarden.com",
+          "anonAddyBaseUrl": "bitwarden.com",
           "capitalizeRandomWordUsername": true,
           "catchAllEmailDomain": "bitwarden.com",
           "catchAllEmailType": 0,
@@ -34,6 +35,7 @@ class UsernameGenerationOptionsTests: BitwardenTestCase {
             UsernameGenerationOptions(
                 anonAddyApiAccessToken: "ADDYIO_API_TOKEN",
                 anonAddyDomainName: "bitwarden.com",
+                anonAddyBaseUrl: "bitwarden.com",
                 capitalizeRandomWordUsername: true,
                 catchAllEmailDomain: "bitwarden.com",
                 catchAllEmailType: .random,

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1167,3 +1167,4 @@
 "ExpiresToday" = "Expires today";
 "ExpiresInXDays" = "Expires in %1$@ days";
 "DateRangeXToY" = "%1$@ to %2$@";
+"SelfHostServerURL" = "Self-host server URL";

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -82,10 +82,10 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     override func perform(_ effect: GeneratorEffect) async {
         switch effect {
         case .appeared:
+            await loadAddyIOFeatureFlag()
             await reloadGeneratorOptions()
             await generateValue(shouldSavePassword: true)
             await checkLearnGeneratorActionCardEligibility()
-            await checkAddyIOFeatureFlag()
         case .dismissLearnGeneratorActionCard:
             await services.stateService.setLearnGeneratorActionCardStatus(.complete)
             state.isLearnGeneratorActionCardEligible = false
@@ -195,7 +195,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
 
     /// Checks if the Addy.io feature flag is enabled and updates the state accordingly.
     ///
-    private func checkAddyIOFeatureFlag() async {
+    private func loadAddyIOFeatureFlag() async {
         state.usernameState.addyIOSelfHostServerUrlEnabled = await services.configService
             .getFeatureFlag(.anonAddySelfHostAlias)
     }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -85,6 +85,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
             await reloadGeneratorOptions()
             await generateValue(shouldSavePassword: true)
             await checkLearnGeneratorActionCardEligibility()
+            await checkAddyIOFeatureFlag()
         case .dismissLearnGeneratorActionCard:
             await services.stateService.setLearnGeneratorActionCardStatus(.complete)
             state.isLearnGeneratorActionCardEligible = false
@@ -191,6 +192,13 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     }
 
     // MARK: Private
+
+    /// Checks if the Addy.io feature flag is enabled and updates the state accordingly.
+    ///
+    private func checkAddyIOFeatureFlag() async {
+        state.usernameState.addyIOSelfHostServerUrlEnabled = await services.configService
+            .getFeatureFlag(.anonAddySelfHostAlias)
+    }
 
     /// Checks the eligibility of the generator Login action card.
     ///

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -485,6 +485,15 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertFalse(subject.state.isLearnGeneratorActionCardEligible)
     }
 
+    /// `perform(:)` with `.appeared` should set the `addyIOSelfHostServerUrlEnabled` to
+    /// feature flag `anonAddySelfHostAlias` value.
+    @MainActor
+    func test_perform_checkAddyIOFeatureFlag_true() async {
+        configService.featureFlagsBool[.anonAddySelfHostAlias] = true
+        await subject.perform(.appeared)
+        XCTAssertTrue(subject.state.usernameState.addyIOSelfHostServerUrlEnabled)
+    }
+
     /// `receive(_:)` with `.copyGeneratedValØue` copies the generated password to the system
     /// pasteboard and shows a toast.
     @MainActor

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -99,6 +99,7 @@ extension GeneratorState {
             // Forwarded Email Properties
             addyIOAPIAccessToken = options.anonAddyApiAccessToken ?? addyIOAPIAccessToken
             addyIODomainName = options.anonAddyDomainName ?? addyIODomainName
+            addyIOSelfHostServerUrl = options.anonAddyBaseUrl ?? addyIOSelfHostServerUrl
             duckDuckGoAPIKey = options.duckDuckGoApiKey ?? duckDuckGoAPIKey
             fastmailAPIKey = options.fastMailApiKey ?? fastmailAPIKey
             firefoxRelayAPIAccessToken = options.firefoxRelayApiAccessToken ?? firefoxRelayAPIAccessToken

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -37,6 +37,9 @@ extension GeneratorState {
         /// The domain name used to generate a forwarded email alias with addy.io.
         var addyIODomainName: String = ""
 
+        /// The base URL for the addy.io api.
+        var addyIOSelfHostServerUrl: String = ""
+
         /// The DuckDuckGo API key used to generate a forwarded email alias.
         var duckDuckGoAPIKey: String = ""
 
@@ -162,6 +165,7 @@ extension GeneratorState.UsernameState {
         UsernameGenerationOptions(
             anonAddyApiAccessToken: addyIOAPIAccessToken.nilIfEmpty,
             anonAddyDomainName: addyIODomainName.nilIfEmpty,
+            anonAddyBaseUrl: addyIOSelfHostServerUrl.nilIfEmpty,
             capitalizeRandomWordUsername: capitalize,
             catchAllEmailDomain: domain.nilIfEmpty,
             catchAllEmailType: catchAllEmailType,
@@ -221,7 +225,7 @@ extension GeneratorState.UsernameState {
             ForwarderServiceType.addyIo(
                 apiToken: addyIOAPIAccessToken,
                 domain: addyIODomainName,
-                baseUrl: "https://app.addy.io"
+                baseUrl: addyIOSelfHostServerUrl.nilIfEmpty ?? "https://app.addy.io"
             )
         case .duckDuckGo:
             ForwarderServiceType.duckDuckGo(token: duckDuckGoAPIKey)

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -15,6 +15,9 @@ extension GeneratorState {
 
         // MARK: Properties
 
+        /// A flag indicating if the addy IO selfhost is enabled.
+        var addyIOSelfHostServerUrlEnabled = false
+
         /// An optional website host used to generate usernames (either plus addressed or catch all).
         var emailWebsite: String?
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -415,14 +415,13 @@ extension GeneratorState {
                 ])
                 if usernameState.addyIOSelfHostServerUrlEnabled {
                     fields.append(contentsOf: [
-                    textField(
-                        accessibilityId: "AnonAddySelfHosteUrlEntry",
-                        keyPath: \.usernameState.addyIOSelfHostServerUrl,
-                        title: Localizations.selfHostServerURL
-                    ),
+                        textField(
+                            accessibilityId: "AnonAddySelfHosteUrlEntry",
+                            keyPath: \.usernameState.addyIOSelfHostServerUrl,
+                            title: Localizations.selfHostServerURL
+                        ),
                     ])
                 }
-
             case .duckDuckGo:
                 fields.append(
                     textField(

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -413,6 +413,16 @@ extension GeneratorState {
                         title: Localizations.domainNameRequiredParenthesis
                     ),
                 ])
+                if usernameState.addyIOSelfHostServerUrlEnabled {
+                    fields.append(contentsOf: [
+                    textField(
+                        accessibilityId: "AnonAddySelfHosteUrlEntry",
+                        keyPath: \.usernameState.addyIOSelfHostServerUrl,
+                        title: Localizations.selfHostServerURL
+                    ),
+                    ])
+                }
+
             case .duckDuckGo:
                 fields.append(
                     textField(

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -100,6 +100,7 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.generatorType = .username
         subject.usernameState.usernameGeneratorType = .forwardedEmail
         subject.usernameState.forwardedEmailService = .addyIO
+        subject.usernameState.addyIOSelfHostServerUrlEnabled = true
 
         assertInlineSnapshot(of: dumpFormSections(subject.formSections), as: .lines) {
             """
@@ -115,6 +116,7 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 Options: addy.io, DuckDuckGo, Fastmail, Firefox Relay, ForwardEmail, SimpleLogin
               Text: API access token Value: (empty)
               Text: Domain name (required) Value: (empty)
+              Text: Self-host server URL Value: (empty)
             """
         }
     }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -553,6 +553,9 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.addyIOAPIAccessToken = "token"
         XCTAssertTrue(subject.canGenerateUsername)
 
+        subject.addyIOSelfHostServerUrl = "bitwarden.com"
+        XCTAssertTrue(subject.canGenerateUsername)
+
         subject.forwardedEmailService = .duckDuckGo
         XCTAssertFalse(subject.canGenerateUsername)
         subject.duckDuckGoAPIKey = "apiKey"
@@ -587,6 +590,19 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertEqual(subject.catchAllEmailType, .random)
         XCTAssertEqual(subject.plusAddressedEmailType, .random)
+    }
+
+    /// `usernameState.update(with:)` sets addy io base url if exists.
+    func test_usernameState_updateWithOptions_addyIOBaseUrl() {
+        var subject = GeneratorState().usernameState
+        subject.update(with: UsernameGenerationOptions(anonAddyBaseUrl: "bitwarden.com"))
+
+        XCTAssertEqual(subject.usernameGenerationOptions.anonAddyBaseUrl, "bitwarden.com")
+
+        subject.addyIOSelfHostServerUrl = "bitwarden2.com"
+        subject.update(with: UsernameGenerationOptions())
+
+        XCTAssertEqual(subject.usernameGenerationOptions.anonAddyBaseUrl, "bitwarden2.com")
     }
 
     /// `usernameState.update(with:)` sets the email type to website if an email website exists.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-3503

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Support self-hosted AnonAddy server URLs in the username generator.

When the feature flag, AnonAddySelfHostAlias, is enabled users can enter the server URL for their self-hosted AnonAddy instance. When disabled, the default cloud URL is used.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
![Simulator Screenshot - iPhone 16 Pro - 2025-04-14 at 20 57 08](https://github.com/user-attachments/assets/b6ce33da-7f05-459a-a34a-07a8e9f0a580)


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
