### PR TITLE
[PM-18262] feat: Implemented SimpleLogin Self-host server URL

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -71,6 +71,9 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// A feature flag for the use of new cipher permission properties.
     case restrictCipherItemDeletion = "pm-15493-restrict-item-deletion-to-can-manage-permission"
 
+    /// A feature flag to enable SimpleLogin self-host alias generation
+    case simpleLoginSelfHostAlias = "simple-login-self-host-alias"
+
     // MARK: Test Flags
 
     /// A test feature flag that isn't remotely configured and has no initial value.
@@ -148,6 +151,7 @@ enum FeatureFlag: String, CaseIterable, Codable {
              .nativeCreateAccountFlow,
              .refactorSsoDetailsEndpoint,
              .restrictCipherItemDeletion,
+             .simpleLoginSelfHostAlias,
              .testRemoteFeatureFlag,
              .testRemoteInitialBoolFlag,
              .testRemoteInitialIntFlag,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -31,6 +31,7 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertTrue(FeatureFlag.nativeCreateAccountFlow.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.refactorSsoDetailsEndpoint.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.restrictCipherItemDeletion.isRemotelyConfigured)
+        XCTAssertTrue(FeatureFlag.simpleLoginSelfHostAlias.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialBoolFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialIntFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialStringFlag.isRemotelyConfigured)

--- a/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptions.swift
@@ -52,6 +52,9 @@ struct UsernameGenerationOptions: Codable, Equatable {
     /// The simple login API key used to generate a forwarded email alias.
     var simpleLoginApiKey: String?
 
+    /// The base URL for the SimpleLogin API.
+    var simpleLoginBaseUrl: String?
+
     /// The type of username to generate.
     var type: UsernameGeneratorType?
 }

--- a/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/UsernameGenerationOptionsTests.swift
@@ -25,6 +25,7 @@ class UsernameGenerationOptionsTests: BitwardenTestCase {
           "plusAddressedEmailType": 0,
           "serviceType": 2,
           "simpleLoginApiKey": "SIMPLELOGIN_API_KEY",
+          "simpleLoginBaseUrl": "app.simplelogin.io",
           "type": 2
         }
         """
@@ -49,6 +50,7 @@ class UsernameGenerationOptionsTests: BitwardenTestCase {
                 plusAddressedEmailType: .random,
                 serviceType: .simpleLogin,
                 simpleLoginApiKey: "SIMPLELOGIN_API_KEY",
+                simpleLoginBaseUrl: "app.simplelogin.io",
                 type: .forwardedEmail
             )
         )

--- a/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
@@ -1,14 +1,6 @@
 /// The service used to generate a forwarded email alias.
 ///
 enum ForwardedEmailServiceType: Int, CaseIterable, Codable, Equatable, Menuable {
-    // MARK: Static properties
-
-    /// The default base URL for addy.io.
-    static let defaultAddyIOBaseUrl = "https://app.addy.io"
-
-    /// The default base URL for SimpleLogin.
-    static let defaultSimpleLoginBaseUrl = "https://app.simplelogin.io"
-
     // MARK: Cases
 
     /// Generate a forwarded email using addy.io.
@@ -29,8 +21,18 @@ enum ForwardedEmailServiceType: Int, CaseIterable, Codable, Equatable, Menuable 
     /// Generate a forwarded email using ForwardEmail.
     case forwardEmail = 5
 
+    // MARK: Static properties
+
     /// All of the cases to show in the menu.
     static let allCases: [Self] = [.addyIO, .duckDuckGo, .fastmail, .firefoxRelay, .forwardEmail, .simpleLogin]
+
+    /// The default base URL for addy.io.
+    static let defaultAddyIOBaseUrl = "https://app.addy.io"
+
+    /// The default base URL for SimpleLogin.
+    static let defaultSimpleLoginBaseUrl = "https://app.simplelogin.io"
+
+    // MARK: Properties
 
     var localizedName: String {
         switch self {

--- a/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/ForwardedEmailServiceType.swift
@@ -1,6 +1,16 @@
 /// The service used to generate a forwarded email alias.
 ///
 enum ForwardedEmailServiceType: Int, CaseIterable, Codable, Equatable, Menuable {
+    // MARK: Static properties
+
+    /// The default base URL for addy.io.
+    static let defaultAddyIOBaseUrl = "https://app.addy.io"
+
+    /// The default base URL for SimpleLogin.
+    static let defaultSimpleLoginBaseUrl = "https://app.simplelogin.io"
+
+    // MARK: Cases
+
     /// Generate a forwarded email using addy.io.
     case addyIO = 0
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -82,7 +82,7 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     override func perform(_ effect: GeneratorEffect) async {
         switch effect {
         case .appeared:
-            await loadAddyIOFeatureFlag()
+            await loadFlags()
             await reloadGeneratorOptions()
             await generateValue(shouldSavePassword: true)
             await checkLearnGeneratorActionCardEligibility()
@@ -193,11 +193,13 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
 
     // MARK: Private
 
-    /// Checks if the Addy.io feature flag is enabled and updates the state accordingly.
+    /// Loads feature flags and updates state accordingly.
     ///
-    private func loadAddyIOFeatureFlag() async {
+    private func loadFlags() async {
         state.usernameState.addyIOSelfHostServerUrlEnabled = await services.configService
             .getFeatureFlag(.anonAddySelfHostAlias)
+        state.usernameState.simpleLoginSelfHostServerUrlEnabled = await services.configService
+            .getFeatureFlag(.simpleLoginSelfHostAlias)
     }
 
     /// Checks the eligibility of the generator Login action card.

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -486,12 +486,15 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     }
 
     /// `perform(:)` with `.appeared` should set the `addyIOSelfHostServerUrlEnabled` to
-    /// feature flag `anonAddySelfHostAlias` value.
+    /// feature flag `anonAddySelfHostAlias` value and `simpleLoginSelfHostServerUrlEnabled`
+    /// to feature flag `simpleLoginSelfHostAlias` value.
     @MainActor
-    func test_perform_checkAddyIOFeatureFlag_true() async {
+    func test_perform_loadFlags() async {
         configService.featureFlagsBool[.anonAddySelfHostAlias] = true
+        configService.featureFlagsBool[.simpleLoginSelfHostAlias] = true
         await subject.perform(.appeared)
         XCTAssertTrue(subject.state.usernameState.addyIOSelfHostServerUrlEnabled)
+        XCTAssertTrue(subject.state.usernameState.simpleLoginSelfHostServerUrlEnabled)
     }
 
     /// `receive(_:)` with `.copyGeneratedValØue` copies the generated password to the system

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -67,6 +67,12 @@ extension GeneratorState {
         /// The simple login API key used to generate a forwarded email alias.
         var simpleLoginAPIKey: String = ""
 
+        /// The base URL for the SimpleLogin api.
+        var simpleLoginSelfHostServerUrl: String = ""
+
+        /// A flag indicating if the SimpleLogin selfhost is enabled.
+        var simpleLoginSelfHostServerUrlEnabled = false
+
         // MARK: Plus Addressed Email Properties
 
         /// The user's email for generating plus addressed emails.
@@ -107,6 +113,7 @@ extension GeneratorState {
             forwardEmailAPIToken = options.forwardEmailApiToken ?? forwardEmailAPIToken
             forwardEmailDomainName = options.forwardEmailDomainName ?? forwardEmailDomainName
             simpleLoginAPIKey = options.simpleLoginApiKey ?? simpleLoginAPIKey
+            simpleLoginSelfHostServerUrl = options.simpleLoginBaseUrl ?? simpleLoginSelfHostServerUrl
 
             // Plus Address Email Properties
             email = options.plusAddressedEmail ?? email
@@ -183,6 +190,7 @@ extension GeneratorState.UsernameState {
             plusAddressedEmailType: plusAddressedEmailType,
             serviceType: forwardedEmailService,
             simpleLoginApiKey: simpleLoginAPIKey.nilIfEmpty,
+            simpleLoginBaseUrl: simpleLoginSelfHostServerUrl.nilIfEmpty,
             type: usernameGeneratorType
         )
     }
@@ -229,7 +237,7 @@ extension GeneratorState.UsernameState {
             ForwarderServiceType.addyIo(
                 apiToken: addyIOAPIAccessToken,
                 domain: addyIODomainName,
-                baseUrl: addyIOSelfHostServerUrl.nilIfEmpty ?? "https://app.addy.io"
+                baseUrl: addyIOSelfHostServerUrl.nilIfEmpty ?? ForwardedEmailServiceType.defaultAddyIOBaseUrl
             )
         case .duckDuckGo:
             ForwarderServiceType.duckDuckGo(token: duckDuckGoAPIKey)
@@ -243,8 +251,11 @@ extension GeneratorState.UsernameState {
                 domain: forwardEmailDomainName
             )
         case .simpleLogin:
-            // TODO: PM-18262 Add baseUrl support for self-hosted SimpleLogin.
-            ForwarderServiceType.simpleLogin(apiKey: simpleLoginAPIKey, baseUrl: "")
+            ForwarderServiceType.simpleLogin(
+                apiKey: simpleLoginAPIKey,
+                baseUrl: simpleLoginSelfHostServerUrl.nilIfEmpty
+                    ?? ForwardedEmailServiceType.defaultSimpleLoginBaseUrl
+            )
         }
         return UsernameGeneratorRequest.forwarded(service: service, website: emailWebsite)
     }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -469,6 +469,15 @@ extension GeneratorState {
                         title: Localizations.apiKeyRequiredParenthesis
                     )
                 )
+                if usernameState.simpleLoginSelfHostServerUrlEnabled {
+                    fields.append(contentsOf: [
+                        textField(
+                            accessibilityId: "SimpleLoginSelfHosteUrlEntry",
+                            keyPath: \.usernameState.simpleLoginSelfHostServerUrl,
+                            title: Localizations.selfHostServerURL
+                        ),
+                    ])
+                }
             }
 
             groups.append(FormSectionGroup(fields: fields, id: "ForwardedEmailGroup"))

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -710,7 +710,13 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.forwardedEmailService = .simpleLogin
         try XCTAssertEqual(
             subject.usernameGeneratorRequest(),
-            .forwarded(service: .simpleLogin(apiKey: "SIMPLE LOGIN TOKEN", baseUrl: ""), website: "example.com")
+            .forwarded(
+                service: .simpleLogin(
+                    apiKey: "SIMPLE LOGIN TOKEN",
+                    baseUrl: "https://app.simplelogin.io"
+                ),
+                website: "example.com"
+            )
         )
     }
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -224,6 +224,7 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.generatorType = .username
         subject.usernameState.usernameGeneratorType = .forwardedEmail
         subject.usernameState.forwardedEmailService = .simpleLogin
+        subject.usernameState.simpleLoginSelfHostServerUrlEnabled = true
 
         assertInlineSnapshot(of: dumpFormSections(subject.formSections), as: .lines) {
             """
@@ -238,6 +239,7 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 Selection: SimpleLogin
                 Options: addy.io, DuckDuckGo, Fastmail, Firefox Relay, ForwardEmail, SimpleLogin
               Text: API key (required) Value: (empty)
+              Text: Self-host server URL Value: (empty)
             """
         }
     }
@@ -603,6 +605,19 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.update(with: UsernameGenerationOptions())
 
         XCTAssertEqual(subject.usernameGenerationOptions.anonAddyBaseUrl, "bitwarden2.com")
+    }
+
+    /// `usernameState.update(with:)` sets SimpleLogin base url if exists.
+    func test_usernameState_updateWithOptions_simpleLoginBaseUrl() {
+        var subject = GeneratorState().usernameState
+        subject.update(with: UsernameGenerationOptions(simpleLoginBaseUrl: "bitwarden.com"))
+
+        XCTAssertEqual(subject.usernameGenerationOptions.simpleLoginBaseUrl, "bitwarden.com")
+
+        subject.simpleLoginSelfHostServerUrl = "bitwarden2.com"
+        subject.update(with: UsernameGenerationOptions())
+
+        XCTAssertEqual(subject.usernameGenerationOptions.simpleLoginBaseUrl, "bitwarden2.com")
     }
 
     /// `usernameState.update(with:)` sets the email type to website if an email website exists.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18262](https://bitwarden.atlassian.net/browse/PM-18262)

## 📔 Objective

Add support for SimpleLogin Self-host server URL.
This also fixes an issue for SimpleLogin where the default URL to use for the service was not being passed and that's why the generation wasn't working.

## 📸 Screenshots

### SimpleLogin Self-host
<img width="314" alt="SimpleLogin Self-host" src="https://github.com/user-attachments/assets/b1f8590b-4d6e-4567-ae93-0e65ceaa5c56">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18262]: https://bitwarden.atlassian.net/browse/PM-18262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ