### PR TITLE
[PM-8952] Implemented minimum length for pin

### DIFF
--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -70,6 +70,9 @@ extension Constants {
     /// A default value for the minimum number of characters required when creating a password.
     static let minimumPasswordCharacters = 12
 
+    /// The minimum length when setting a pin.
+    static let minimumPinLength = 4
+
     /// The minimum number of minutes before allowing the vault to sync again.
     static let minimumSyncInterval: TimeInterval = 30 * 60 // 30 minutes
 

--- a/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
+++ b/BitwardenShared/UI/Auth/Extensions/Alert+Auth.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 // MARK: - Alert+Auth
@@ -322,7 +323,9 @@ extension Alert {
     ) -> Alert {
         Alert(
             title: Localizations.enterPIN,
-            message: settingUp ? Localizations.setPINDescription : Localizations.verifyPIN,
+            message: settingUp
+                ? Localizations.yourPINMustBeAtLeastXCharactersDescriptionLong(Constants.minimumPinLength)
+                : Localizations.verifyPIN,
             alertActions: [
                 AlertAction(
                     title: Localizations.submit,
@@ -330,6 +333,10 @@ extension Alert {
                     handler: { _, alertTextFields in
                         guard let pin = alertTextFields.first(where: { $0.id == "pin" })?.text else { return }
                         await completion(pin)
+                    },
+                    shouldEnableAction: { textFields in
+                        guard let pin = textFields.first(where: { $0.id == "pin" })?.text else { return false }
+                        return pin.count >= Constants.minimumPinLength
                     }
                 ),
                 AlertAction(title: Localizations.cancel, style: .cancel, handler: { _, _ in

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -435,7 +435,6 @@
 "Unlock" = "Unlock";
 "UnlockVault" = "Unlock vault";
 "ThirtyMinutes" = "30 minutes";
-"SetPINDescription" = "Set your PIN code for unlocking Bitwarden. Your PIN settings will be reset if you ever fully log out of the application.";
 "LoggedInAsOn" = "Logged in as %1$@ on %2$@.";
 "VaultLockedMasterPassword" = "Your vault is locked. Verify your master password to continue.";
 "VaultLockedPIN" = "Your vault is locked. Verify your PIN code to continue.";
@@ -1167,3 +1166,4 @@
 "ExpiresInXDays" = "Expires in %1$@ days";
 "DateRangeXToY" = "%1$@ to %2$@";
 "SelfHostServerURL" = "Self-host server URL";
+"YourPINMustBeAtLeastXCharactersDescriptionLong" = "Your PIN must be at least %1$@ characters. Your PIN settings will be reset if you ever fully log out of the application.";


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-8952](https://bitwarden.atlassian.net/browse/PM-8952)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
From now on, pin must have a minimum length of 4.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
| Before | After |
| --- | --- |
|![image](https://github.com/user-attachments/assets/e61ec15c-27d4-4e6d-b7e8-99e29706b206)|![image](https://github.com/user-attachments/assets/18dc3bce-b0fe-4d8a-8fb4-51a55fb01413) |


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-8952]: https://bitwarden.atlassian.net/browse/PM-8952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ