### PR TITLE
[BWA-155] refactor: Change FeatureFlag.initialValues from static to an instance variable

### DIFF
--- a/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -44,19 +44,21 @@ enum FeatureFlag: String, CaseIterable, Codable {
         allCases.filter { !$0.rawValue.hasPrefix("test-") }
     }
 
-    /// The initial values for feature flags.
+    /// The initial value of the feature flag.
     /// If `isRemotelyConfigured` is true for the flag, then this will get overridden by the server;
     /// but if `isRemotelyConfigured` is false for the flag, then the value here will be used.
     /// This is a helpful way to manage local feature flags.
-    static let initialValues: [FeatureFlag: AnyCodable] = [
-        .enablePasswordManagerSync: .bool(false),
-        .testLocalInitialBoolFlag: .bool(true),
-        .testLocalInitialIntFlag: .int(42),
-        .testLocalInitialStringFlag: .string("Test String"),
-        .testRemoteInitialBoolFlag: .bool(true),
-        .testRemoteInitialIntFlag: .int(42),
-        .testRemoteInitialStringFlag: .string("Test String"),
-    ]
+    var initialValue: AnyCodable? {
+        switch self {
+        case .testLocalInitialBoolFlag: .bool(true)
+        case .testLocalInitialIntFlag: .int(42)
+        case .testLocalInitialStringFlag: .string("Test String")
+        case .testRemoteInitialBoolFlag: .bool(true)
+        case .testRemoteInitialIntFlag: .int(42)
+        case .testRemoteInitialStringFlag: .string("Test String")
+        default: nil
+        }
+    }
 
     // MARK: Instance Properties
 

--- a/AuthenticatorShared/Core/Platform/Services/ConfigService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/ConfigService.swift
@@ -191,11 +191,11 @@ class DefaultConfigService: ConfigService {
         #endif
 
         guard flag.isRemotelyConfigured else {
-            return FeatureFlag.initialValues[flag]?.boolValue ?? defaultValue
+            return flag.initialValue?.boolValue ?? defaultValue
         }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag]?.boolValue
-            ?? FeatureFlag.initialValues[flag]?.boolValue
+            ?? flag.initialValue?.boolValue
             ?? defaultValue
     }
 
@@ -206,11 +206,11 @@ class DefaultConfigService: ConfigService {
         isPreAuth: Bool = false
     ) async -> Int {
         guard flag.isRemotelyConfigured else {
-            return FeatureFlag.initialValues[flag]?.intValue ?? defaultValue
+            return flag.initialValue?.intValue ?? defaultValue
         }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag]?.intValue
-            ?? FeatureFlag.initialValues[flag]?.intValue
+            ?? flag.initialValue?.intValue
             ?? defaultValue
     }
 
@@ -221,11 +221,11 @@ class DefaultConfigService: ConfigService {
         isPreAuth: Bool = false
     ) async -> String? {
         guard flag.isRemotelyConfigured else {
-            return FeatureFlag.initialValues[flag]?.stringValue ?? defaultValue
+            return flag.initialValue?.stringValue ?? defaultValue
         }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag]?.stringValue
-            ?? FeatureFlag.initialValues[flag]?.stringValue
+            ?? flag.initialValue?.stringValue
             ?? defaultValue
     }
 
@@ -237,7 +237,7 @@ class DefaultConfigService: ConfigService {
         let flags = FeatureFlag.debugMenuFeatureFlags.map { feature in
             let userDefaultValue = appSettingsStore.debugFeatureFlag(name: feature.rawValue)
             let remoteFlagValue = remoteFeatureFlags[feature]?.boolValue
-                ?? FeatureFlag.initialValues[feature]?.boolValue
+                ?? feature.initialValue?.boolValue
                 ?? false
 
             return DebugMenuFeatureFlag(

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -96,18 +96,21 @@ enum FeatureFlag: String, CaseIterable, Codable {
             .filter { $0 != .enableCipherKeyEncryption }
     }
 
-    /// The initial values for feature flags.
+    /// The initial value of the feature flag.
     /// If `isRemotelyConfigured` is true for the flag, then this will get overridden by the server;
     /// but if `isRemotelyConfigured` is false for the flag, then the value here will be used.
     /// This is a helpful way to manage local feature flags.
-    static let initialValues: [FeatureFlag: AnyCodable] = [
-        .testLocalInitialBoolFlag: .bool(true),
-        .testLocalInitialIntFlag: .int(42),
-        .testLocalInitialStringFlag: .string("Test String"),
-        .testRemoteInitialBoolFlag: .bool(true),
-        .testRemoteInitialIntFlag: .int(42),
-        .testRemoteInitialStringFlag: .string("Test String"),
-    ]
+    var initialValue: AnyCodable? {
+        switch self {
+        case .testLocalInitialBoolFlag: .bool(true)
+        case .testLocalInitialIntFlag: .int(42)
+        case .testLocalInitialStringFlag: .string("Test String")
+        case .testRemoteInitialBoolFlag: .bool(true)
+        case .testRemoteInitialIntFlag: .int(42)
+        case .testRemoteInitialStringFlag: .string("Test String")
+        default: nil
+        }
+    }
 
     // MARK: Instance Properties
 

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -14,7 +14,7 @@ final class FeatureFlagTests: BitwardenTestCase {
 
     /// `initialValues` returns the correct value for each flag.
     func test_initialValues() {
-        XCTAssertNil(FeatureFlag.initialValues[.cipherKeyEncryption]?.boolValue)
+        XCTAssertNil(FeatureFlag.cipherKeyEncryption.initialValue?.boolValue)
     }
 
     /// `getter:isRemotelyConfigured` returns the correct value for each flag.

--- a/BitwardenShared/Core/Platform/Services/ConfigService.swift
+++ b/BitwardenShared/Core/Platform/Services/ConfigService.swift
@@ -191,11 +191,11 @@ class DefaultConfigService: ConfigService {
         #endif
 
         guard flag.isRemotelyConfigured else {
-            return FeatureFlag.initialValues[flag]?.boolValue ?? defaultValue
+            return flag.initialValue?.boolValue ?? defaultValue
         }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag]?.boolValue
-            ?? FeatureFlag.initialValues[flag]?.boolValue
+            ?? flag.initialValue?.boolValue
             ?? defaultValue
     }
 
@@ -206,11 +206,11 @@ class DefaultConfigService: ConfigService {
         isPreAuth: Bool = false
     ) async -> Int {
         guard flag.isRemotelyConfigured else {
-            return FeatureFlag.initialValues[flag]?.intValue ?? defaultValue
+            return flag.initialValue?.intValue ?? defaultValue
         }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag]?.intValue
-            ?? FeatureFlag.initialValues[flag]?.intValue
+            ?? flag.initialValue?.intValue
             ?? defaultValue
     }
 
@@ -221,11 +221,11 @@ class DefaultConfigService: ConfigService {
         isPreAuth: Bool = false
     ) async -> String? {
         guard flag.isRemotelyConfigured else {
-            return FeatureFlag.initialValues[flag]?.stringValue ?? defaultValue
+            return flag.initialValue?.stringValue ?? defaultValue
         }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag]?.stringValue
-            ?? FeatureFlag.initialValues[flag]?.stringValue
+            ?? flag.initialValue?.stringValue
             ?? defaultValue
     }
 
@@ -237,7 +237,7 @@ class DefaultConfigService: ConfigService {
         let flags = FeatureFlag.debugMenuFeatureFlags.map { feature in
             let userDefaultValue = appSettingsStore.debugFeatureFlag(name: feature.rawValue)
             let remoteFlagValue = remoteFeatureFlags[feature]?.boolValue
-                ?? FeatureFlag.initialValues[feature]?.boolValue
+                ?? feature.initialValue?.boolValue
                 ?? false
 
             return DebugMenuFeatureFlag(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-155

## 📔 Objective

This is a small sideways refactor in the process of improving the `ConfigService` behavior between BWA and PM. In particular, this changes the `FeatureFlag.initialValues` variable from static to instance, to match things like `isRemotelyConfigured`. This makes eventually bringing `FeatureFlag` into `BitwardenKit` as a protocol easier, in addition to being more parallel with the other properties on `FeatureFlag`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
