### PR TITLE
[PM-18414] CI restructuring #3 - Add Brewfile with version pinning

### DIFF
--- a/.github/workflows/build-bwa.yml
+++ b/.github/workflows/build-bwa.yml
@@ -131,9 +131,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Install Mint, protobuf, xcbeautify, and yq
+      - name: Install Homebrew Dependencies
         run: |
-          brew install mint swift-protobuf xcbeautify yq
+          brew update
+          brew bundle
 
       - name: Install Mint packages
         if: steps.mint-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,18 +333,10 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Update homebrew
+      - name: Install Homebrew Dependencies
         run: |
           brew update
-
-      - name: Install Fastlane
-        if: env._BUILD_MODE == 'Device'
-        run: |
-          brew install fastlane
-
-      - name: Install Mint
-        run: |
-          brew install mint
+          brew bundle
 
       - name: Install Mint packages
         if: steps.mint-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -119,9 +119,10 @@ jobs:
         run: |
           ./Scripts-bwa/update_test_local_config.sh "${{ env._COMPILER_FLAGS }}"
 
-      - name: Install Mint, protobuf, and xcresultparser
+      - name: Install Homebrew Dependencies and run bootstrap.sh
         run: |
-          brew install mint swift-protobuf xcresultparser
+          brew update
+          brew bundle
           ./Scripts/bootstrap.sh
 
       - name: Build and test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,9 +114,10 @@ jobs:
         run: |
           ./Scripts/update_test_local_config.sh "${{ env._COMPILER_FLAGS }}"
 
-      - name: Install Mint and xcresultparser
+      - name: Install Homebrew Dependencies and run bootstrap.sh
         run: |
-          brew install mint xcresultparser
+          brew update
+          brew bundle
           ./Scripts/bootstrap.sh
 
       - name: Build and test

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,8 @@
+brew "fastlane"
+brew "mint"
+brew "swift-protobuf" # used by Bitwarden Authenticator
+
+if ENV["CI"]
+    brew "yq"
+    brew "xcresultparser"
+end

--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+brew bundle check # use --verbose to list missing dependencies
+
 mint bootstrap
 
 # Handle script being called from repo root or Scripts folder


### PR DESCRIPTION
## 🎟️ Tracking

PM-18414

## 📔 Objective

_Splitting this change from the bigger CI restructuring branch._

Address a recurring dev experience gap by having a list of homebrew dependencies that can be used by our devs locally and in our CI - dependencies were regularly missed while setting up local dev environments. 

Also looked into pinning dependency versions, we would need to create our own tap. References: 

* [Homebrew - Brewfile](https://docs.brew.sh/Brew-Bundle-and-Brewfile#versions): "Homebrew is a [rolling release](https://en.wikipedia.org/wiki/Rolling_release) package manager so it does not support installing arbitrary older versions of software."
* [Homebrew - Versions](https://docs.brew.sh/Versions): "Homebrew’s versions should not be used to “pin” formulae to your personal requirements. You should instead [create your own tap](https://docs.brew.sh/How-to-Create-and-Maintain-a-Tap) for formulae you or your organisation wish to control the versioning of, or those that do not meet the above standards."


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
