### PR TITLE
chore/SRE-583 Deprecate usage of Auth-Email Header

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequest.swift
@@ -51,10 +51,8 @@ struct IdentityTokenRequest: Request {
 
     /// HTTP headers to be sent in the request.
     var headers: [String: String] {
-        guard case let .password(email, _) = requestModel.authenticationMethod else {
-            return [:]
-        }
-        return ["Auth-Email": Data(email.utf8).base64EncodedString().urlEncoded()]
+        // Auth-Email header is deprecated and no longer needed
+        return [:]
     }
 
     /// The HTTP method for this request.

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
@@ -73,9 +73,9 @@ class IdentityTokenRequestTests: BitwardenTestCase {
         XCTAssertTrue(subjectAuthorizationCode.headers.isEmpty)
     }
 
-    /// `headers` returns the headers needed for a password request.
+    /// `headers` returns empty headers for a password request as Auth-Email is deprecated.
     func test_headers_password() {
-        XCTAssertEqual(subjectPassword.headers, ["Auth-Email": "dXNlckBleGFtcGxlLmNvbQ"])
+        XCTAssertTrue(subjectPassword.headers.isEmpty)
     }
 
     /// `method` returns the method of the request.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/SRE-583

## 📔 Objective

Deprecate usage of Auth-Email Header

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
