### PR TITLE
[PM-19577] Flight recorder network request and response logging

### DIFF
--- a/BitwardenKit/Core/Platform/Services/API/HTTPServiceBuilder.swift
+++ b/BitwardenKit/Core/Platform/Services/API/HTTPServiceBuilder.swift
@@ -1,0 +1,65 @@
+import Foundation
+import Networking
+
+/// A helper object to build `HTTPService`s with a common set of loggers and request and response handlers.
+///
+public class HTTPServiceBuilder {
+    // MARK: Properties
+
+    /// The underlying `HTTPClient` that performs the network request.
+    private let client: HTTPClient
+
+    /// A `RequestHandler` that applies default headers (user agent, client type & name, etc) to requests.
+    private let defaultHeadersRequestHandler: DefaultHeadersRequestHandler
+
+    /// The loggers used to log HTTP requests and responses.
+    private let loggers: [HTTPLogger]
+
+    /// A `ResponseHandler` that validates that HTTP responses contain successful (2XX) HTTP status
+    /// codes or tries to parse the error otherwise.
+    private let responseValidationHandler = ResponseValidationHandler()
+
+    // MARK: Initialization
+
+    /// Initialize an `HTTPServiceBuilder`.
+    ///
+    /// - Parameters:
+    ///   - client: The underlying `HTTPClient` that performs the network request.
+    ///   - defaultHeadersRequestHandler: A `RequestHandler` that applies default headers
+    ///     (user agent, client type & name, etc) to requests.
+    ///   - loggers: The loggers used to log HTTP requests and responses.
+    ///
+    public init(
+        client: HTTPClient,
+        defaultHeadersRequestHandler: DefaultHeadersRequestHandler,
+        loggers: [HTTPLogger]
+    ) {
+        self.client = client
+        self.defaultHeadersRequestHandler = defaultHeadersRequestHandler
+        self.loggers = loggers
+    }
+
+    // MARK: Methods
+
+    /// Builds an `HTTPService`.
+    ///
+    /// - Parameters:
+    ///   - baseURLGetter: A getter function for dynamically retrieving the base url against which
+    ///     requests are resolved.
+    ///   - tokenProvider: An object used to get an access token and refresh it when necessary.
+    /// - Returns: An `HTTPService` with common loggers and handlers applied.
+    ///
+    public func makeService(
+        baseURLGetter: @escaping @Sendable () -> URL,
+        tokenProvider: TokenProvider? = nil
+    ) -> HTTPService {
+        HTTPService(
+            baseURLGetter: baseURLGetter,
+            client: client,
+            loggers: loggers,
+            requestHandlers: [defaultHeadersRequestHandler],
+            responseHandlers: [responseValidationHandler],
+            tokenProvider: tokenProvider
+        )
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/APIService.swift
+++ b/BitwardenShared/Core/Platform/Services/API/APIService.swift
@@ -31,15 +31,8 @@ class APIService {
     /// necessary.
     private let accountTokenProvider: AccountTokenProvider
 
-    /// The underlying `HTTPClient` that performs the network request.
-    private let client: HTTPClient
-
-    /// A `RequestHandler` that applies default headers (user agent, client type & name, etc) to requests.
-    private let defaultHeadersRequestHandler: DefaultHeadersRequestHandler
-
-    /// A `ResponseHandler` that validates that HTTP responses contain successful (2XX) HTTP status
-    /// codes or tries to parse the error otherwise.
-    private let responseValidationHandler = ResponseValidationHandler()
+    /// A builder for building an `HTTPService`.
+    private let httpServiceBuilder: HTTPServiceBuilder
 
     // MARK: Initialization
 
@@ -49,6 +42,7 @@ class APIService {
     ///   - client: The underlying `HTTPClient` that performs the network request. Defaults
     ///     to `URLSession.shared`.
     ///   - environmentService: The service used by the application to retrieve the environment settings.
+    ///   - flightRecorder: The service used by the application for recording temporary debug logs.
     ///   - stateService: The service used by the application to manage account state.
     ///   - tokenService: The `TokenService` which manages accessing and updating the active
     ///     account's tokens.
@@ -56,60 +50,47 @@ class APIService {
     init(
         client: HTTPClient = URLSession.shared,
         environmentService: EnvironmentService,
+        flightRecorder: FlightRecorder,
         stateService: StateService,
         tokenService: TokenService
     ) {
-        self.client = client
         self.stateService = stateService
 
-        defaultHeadersRequestHandler = DefaultHeadersRequestHandler(
-            appName: "Bitwarden_Mobile",
-            appVersion: Bundle.main.appVersion,
-            buildNumber: Bundle.main.buildNumber,
-            systemDevice: UIDevice.current
+        httpServiceBuilder = HTTPServiceBuilder(
+            client: client,
+            defaultHeadersRequestHandler: DefaultHeadersRequestHandler(
+                appName: "Bitwarden_Mobile",
+                appVersion: Bundle.main.appVersion,
+                buildNumber: Bundle.main.buildNumber,
+                systemDevice: UIDevice.current
+            ),
+            loggers: [
+                FlightRecorderHTTPLogger(flightRecorder: flightRecorder),
+                OSLogHTTPLogger(),
+            ]
         )
 
         accountTokenProvider = AccountTokenProvider(
-            httpService: HTTPService(
-                baseURLGetter: { environmentService.identityURL },
-                client: client,
-                requestHandlers: [defaultHeadersRequestHandler],
-                responseHandlers: [responseValidationHandler]
-            ),
+            httpService: httpServiceBuilder.makeService(baseURLGetter: { environmentService.identityURL }),
             tokenService: tokenService
         )
 
-        apiService = HTTPService(
+        apiService = httpServiceBuilder.makeService(
             baseURLGetter: { environmentService.apiURL },
-            client: client,
-            requestHandlers: [defaultHeadersRequestHandler],
-            responseHandlers: [responseValidationHandler],
             tokenProvider: accountTokenProvider
         )
-        apiUnauthenticatedService = HTTPService(
-            baseURLGetter: { environmentService.apiURL },
-            client: client,
-            requestHandlers: [defaultHeadersRequestHandler],
-            responseHandlers: [responseValidationHandler]
+        apiUnauthenticatedService = httpServiceBuilder.makeService(
+            baseURLGetter: { environmentService.apiURL }
         )
-        eventsService = HTTPService(
+        eventsService = httpServiceBuilder.makeService(
             baseURLGetter: { environmentService.eventsURL },
-            client: client,
-            requestHandlers: [defaultHeadersRequestHandler],
-            responseHandlers: [responseValidationHandler],
             tokenProvider: accountTokenProvider
         )
-        hibpService = HTTPService(
-            baseURL: URL(string: "https://api.pwnedpasswords.com")!,
-            client: client,
-            requestHandlers: [defaultHeadersRequestHandler],
-            responseHandlers: [responseValidationHandler]
+        hibpService = httpServiceBuilder.makeService(
+            baseURLGetter: { URL(string: "https://api.pwnedpasswords.com")! }
         )
-        identityService = HTTPService(
-            baseURLGetter: { environmentService.identityURL },
-            client: client,
-            requestHandlers: [defaultHeadersRequestHandler],
-            responseHandlers: [responseValidationHandler]
+        identityService = httpServiceBuilder.makeService(
+            baseURLGetter: { environmentService.identityURL }
         )
     }
 
@@ -121,11 +102,8 @@ class APIService {
     /// - Returns: A `HTTPService` to communicate with the key connector API.
     ///
     func buildKeyConnectorService(baseURL: URL) -> HTTPService {
-        HTTPService(
-            baseURL: baseURL,
-            client: client,
-            requestHandlers: [defaultHeadersRequestHandler],
-            responseHandlers: [responseValidationHandler],
+        httpServiceBuilder.makeService(
+            baseURLGetter: { baseURL },
             tokenProvider: accountTokenProvider
         )
     }

--- a/BitwardenShared/Core/Platform/Services/API/FlightRecorderHTTPLogger.swift
+++ b/BitwardenShared/Core/Platform/Services/API/FlightRecorderHTTPLogger.swift
@@ -1,0 +1,36 @@
+import Networking
+
+// MARK: FlightRecorderHTTPLogger
+
+/// An `HTTPLogger` that logs HTTP requests and responses to the flight recorder.
+///
+final class FlightRecorderHTTPLogger: HTTPLogger {
+    // MARK: Properties
+
+    /// The service used by the application for recording temporary debug logs.
+    private let flightRecorder: FlightRecorder
+
+    // MARK: Initialization
+
+    /// Initialize a `FlightRecorderHTTPLogger`.
+    ///
+    /// - Parameter flightRecorder: The service used by the application for recording temporary debug logs.
+    ///
+    init(flightRecorder: FlightRecorder) {
+        self.flightRecorder = flightRecorder
+    }
+
+    // MARK: HTTPLogger
+
+    func logRequest(_ httpRequest: HTTPRequest) async {
+        await flightRecorder.log(
+            "Request \(httpRequest.requestID): \(httpRequest.method.rawValue) \(httpRequest.url)"
+        )
+    }
+
+    func logResponse(_ httpResponse: HTTPResponse) async {
+        await flightRecorder.log(
+            "Response \(httpResponse.requestID): \(httpResponse.url) \(httpResponse.statusCode)"
+        )
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/FlightRecorderHTTPLoggerTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/FlightRecorderHTTPLoggerTests.swift
@@ -1,0 +1,89 @@
+import Networking
+import TestHelpers
+import XCTest
+
+@testable import BitwardenShared
+
+class FlightRecorderHTTPLoggerTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var flightRecorder: MockFlightRecorder!
+    var subject: FlightRecorderHTTPLogger!
+
+    let requestID = UUID(uuidString: "773CC135-A878-4851-A28D-180FD7D945FA")!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        flightRecorder = MockFlightRecorder()
+
+        subject = FlightRecorderHTTPLogger(flightRecorder: flightRecorder)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        flightRecorder = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `logRequest(_:)` logs a GET request to the flight recorder.
+    @MainActor
+    func test_logRequest_get() async {
+        let request = HTTPRequest(url: .example, method: .get, requestID: requestID)
+        await subject.logRequest(request)
+        XCTAssertEqual(
+            flightRecorder.logMessages,
+            ["Request 773CC135-A878-4851-A28D-180FD7D945FA: GET https://example.com"]
+        )
+    }
+
+    /// `logRequest(_:)` logs a POST request to the flight recorder.
+    @MainActor
+    func test_logRequest_post() async {
+        let request = HTTPRequest(url: .example, method: .post, requestID: requestID)
+        await subject.logRequest(request)
+        XCTAssertEqual(
+            flightRecorder.logMessages,
+            ["Request 773CC135-A878-4851-A28D-180FD7D945FA: POST https://example.com"]
+        )
+    }
+
+    /// `logResponse(_:)` logs a 200 response to the flight recorder.
+    @MainActor
+    func test_logResponse_200() async {
+        let response = HTTPResponse(
+            url: .example,
+            statusCode: 200,
+            headers: [:],
+            body: Data(),
+            requestID: requestID
+        )
+        await subject.logResponse(response)
+        XCTAssertEqual(
+            flightRecorder.logMessages,
+            ["Response 773CC135-A878-4851-A28D-180FD7D945FA: https://example.com 200"]
+        )
+    }
+
+    /// `logResponse(_:)` logs a 400 response to the flight recorder.
+    @MainActor
+    func test_logResponse_400() async {
+        let response = HTTPResponse(
+            url: .example,
+            statusCode: 400,
+            headers: [:],
+            body: Data(),
+            requestID: requestID
+        )
+        await subject.logResponse(response)
+        XCTAssertEqual(
+            flightRecorder.logMessages,
+            ["Response 773CC135-A878-4851-A28D-180FD7D945FA: https://example.com 400"]
+        )
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/TestHelpers/APIService+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/API/TestHelpers/APIService+Mocks.swift
@@ -8,11 +8,13 @@ extension APIService {
     convenience init(
         client: HTTPClient,
         environmentService: EnvironmentService = MockEnvironmentService(),
+        flightRecorder: FlightRecorder = MockFlightRecorder(),
         stateService: StateService = MockStateService()
     ) {
         self.init(
             client: client,
             environmentService: environmentService,
+            flightRecorder: flightRecorder,
             stateService: stateService,
             tokenService: MockTokenService()
         )

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -392,6 +392,13 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             keychainRepository: keychainRepository
         )
 
+        let flightRecorder = DefaultFlightRecorder(
+            appInfoService: appInfoService,
+            errorReporter: errorReporter,
+            stateService: stateService,
+            timeProvider: timeProvider
+        )
+
         let rehydrationHelper = DefaultRehydrationHelper(
             errorReporter: errorReporter,
             stateService: stateService,
@@ -404,6 +411,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         let tokenService = DefaultTokenService(keychainRepository: keychainRepository, stateService: stateService)
         let apiService = APIService(
             environmentService: environmentService,
+            flightRecorder: flightRecorder,
             stateService: stateService,
             tokenService: tokenService
         )
@@ -480,13 +488,6 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             clientService: clientService,
             errorReporter: errorReporter,
             folderService: folderService,
-            stateService: stateService,
-            timeProvider: timeProvider
-        )
-
-        let flightRecorder = DefaultFlightRecorder(
-            appInfoService: appInfoService,
-            errorReporter: errorReporter,
             stateService: stateService,
             timeProvider: timeProvider
         )

--- a/Networking/Sources/Networking/HTTPLogger.swift
+++ b/Networking/Sources/Networking/HTTPLogger.swift
@@ -1,13 +1,35 @@
 import OSLog
 
-/// An object that handles logging HTTP requests and responses.
+// MARK: - HTTPLogger
+
+/// A protocol for an object that can log HTTP request and responses.
 ///
-final class HTTPLogger: Sendable {
+public protocol HTTPLogger: Sendable {
     /// Logs the details of a `HTTPRequest`.
     ///
     /// - Parameter httpRequest: The `HTTPRequest` to log the details of.
     ///
-    func logRequest(_ httpRequest: HTTPRequest) {
+    func logRequest(_ httpRequest: HTTPRequest) async
+
+    /// Logs the details of a `HTTPResponse`.
+    ///
+    /// - Parameter httpResponse: The `HTTPResponse` to log the details of.
+    ///
+    func logResponse(_ httpResponse: HTTPResponse) async
+}
+
+// MARK: - OSLogHTTPLogger
+
+/// An object that handles logging HTTP requests and responses to OSLog.
+///
+public final class OSLogHTTPLogger: HTTPLogger {
+    // MARK: Initialization
+
+    public init() {}
+
+    // MARK: HTTPLogger
+
+    public func logRequest(_ httpRequest: HTTPRequest) async {
         let formattedBody = formattedBody(httpRequest.body)
         let formattedHeaders = formattedHeaders(httpRequest.headers)
         Logger.networking.info("""
@@ -18,11 +40,7 @@ final class HTTPLogger: Sendable {
         )
     }
 
-    /// Logs the details of a `HTTPResponse`.
-    ///
-    /// - Parameter httpResponse: The `HTTPResponse` to log the details of.
-    ///
-    func logResponse(_ httpResponse: HTTPResponse) {
+    public func logResponse(_ httpResponse: HTTPResponse) async {
         let formattedBody = formattedBody(httpResponse.body)
         let formattedHeaders = formattedHeaders(httpResponse.headers)
         Logger.networking.info("""

--- a/Networking/Sources/Networking/HTTPMethod.swift
+++ b/Networking/Sources/Networking/HTTPMethod.swift
@@ -2,7 +2,7 @@
 ///
 public struct HTTPMethod: Equatable, Sendable {
     /// The string value of the method.
-    let rawValue: String
+    public let rawValue: String
 }
 
 public extension HTTPMethod {

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -136,6 +136,7 @@ targets:
           - "**/Mocks/*"
     dependencies:
       - target: BitwardenKit
+      - target: TestHelpers
   BitwardenKitTests:
     type: bundle.unit-test
     platform: iOS


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19577](https://bitwarden.atlassian.net/browse/PM-19577)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds flight recorder network request and response logging. This logs the method, URL, and status code without any headers or bodies.

Sample logs:

```
2025-04-25T14:17:43-05:00: Request 78674DB1-8166-40C6-9470-000A4B4F6A86: POST https://identity.bitwarden.com/connect/token
2025-04-25T14:17:43-05:00: Response 78674DB1-8166-40C6-9470-000A4B4F6A86: https://identity.bitwarden.com/connect/token 200
2025-04-25T14:17:43-05:00: Request 61B57E6F-B48C-4A9A-931A-2726A5B346AC: GET https://api.bitwarden.com/config
2025-04-25T14:17:43-05:00: Response 61B57E6F-B48C-4A9A-931A-2726A5B346AC: https://api.bitwarden.com/config 200
2025-04-25T14:17:44-05:00: Request E7A8151A-EE1B-4F3A-899D-2A83544FCADA: GET https://api.bitwarden.com/sync
2025-04-25T14:17:44-05:00: Response E7A8151A-EE1B-4F3A-899D-2A83544FCADA: https://api.bitwarden.com/sync 200
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19577]: https://bitwarden.atlassian.net/browse/PM-19577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ