### PR TITLE
fix: Handle SUPPORTS_CXP flag

### DIFF
--- a/BitwardenKit/Core/Platform/Services/API/Extensions/JSONEncoder+Bitwarden.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Extensions/JSONEncoder+Bitwarden.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension JSONEncoder {
+public extension JSONEncoder {
     // MARK: Static Properties
 
     /// The default `JSONEncoder` used to encode JSON payloads throughout the app.

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
@@ -1,6 +1,8 @@
 #if SUPPORTS_CXP
 import AuthenticationServices
+import BitwardenKitMocks
 import InlineSnapshotTesting
+import TestHelpers
 import XCTest
 
 @testable import BitwardenShared

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
@@ -1,5 +1,6 @@
 #if SUPPORTS_CXP
 import AuthenticationServices
+import TestHelpers
 import XCTest
 
 @testable import BitwardenShared

--- a/BitwardenShared/Core/Tools/Utilities/TestHelpers/MockCredentialManagerFactory.swift
+++ b/BitwardenShared/Core/Tools/Utilities/TestHelpers/MockCredentialManagerFactory.swift
@@ -1,6 +1,7 @@
 #if SUPPORTS_CXP
 import AuthenticationServices
 import BitwardenSdk
+import TestHelpers
 
 @testable import BitwardenShared
 


### PR DESCRIPTION
## 📔 Objective

With the `SUPPORTS_CXP` flag off by default, some classes used by the CXP and its testing flows got moved without the CXP code being updated. This fixes that with imports and proper scoping.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
