### PR TITLE
[PM-20147] Remove enable-debug-app-review-prompt feature flag

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -24,9 +24,6 @@ enum FeatureFlag: String, CaseIterable, Codable {
     /// This flag introduces a new flow for account creation
     case emailVerification = "email-verification"
 
-    /// Flag to enable/disable the debug app review prompt.
-    case enableDebugAppReviewPrompt = "enable-debug-app-review-prompt"
-
     /// Flag to enable/disable the ability to sync TOTP codes with the Authenticator app.
     case enableAuthenticatorSync = "enable-pm-bwa-sync"
 
@@ -115,7 +112,6 @@ enum FeatureFlag: String, CaseIterable, Codable {
     var isRemotelyConfigured: Bool {
         switch self {
         case .enableCipherKeyEncryption,
-             .enableDebugAppReviewPrompt,
              .flightRecorder,
              .ignore2FANoticeEnvironmentCheck,
              .mobileErrorReporting,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -34,7 +34,6 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertTrue(FeatureFlag.testRemoteInitialIntFlag.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.testRemoteInitialStringFlag.isRemotelyConfigured)
 
-        XCTAssertFalse(FeatureFlag.enableDebugAppReviewPrompt.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.enableCipherKeyEncryption.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.flightRecorder.isRemotelyConfigured)
         XCTAssertFalse(FeatureFlag.ignore2FANoticeEnvironmentCheck.isRemotelyConfigured)

--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -11,9 +11,6 @@ extension Constants {
     /// The app review prompt delay in nanoseconds.
     static let appReviewPromptDelay: UInt64 = 3_000_000_000
 
-    /// The debug toast message for when the user is eligible for an app review prompt.
-    static let appReviewPromptEligibleDebugMessage = "User is eligible for app review prompt."
-
     /// The minimum server version required to have cipher key encryption on.
     static let cipherKeyEncryptionMinServerVersion = "2024.2.0"
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -369,9 +369,6 @@ extension VaultListProcessor {
             do {
                 try await Task.sleep(nanoseconds: Constants.appReviewPromptDelay)
                 state.isEligibleForAppReview = true
-                if await services.configService.getFeatureFlag(.enableDebugAppReviewPrompt) {
-                    state.toast = Toast(title: Constants.appReviewPromptEligibleDebugMessage)
-                }
             } catch is CancellationError {
                 // Task was cancelled, no need to handle this error
             } catch {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -111,24 +111,15 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     @MainActor
     func test_perform_checkAppReviewEligibility_eligible() async {
         reviewPromptService.isEligibleForReviewPromptResult = true
-        configService.featureFlagsBool = [
-            FeatureFlag.enableDebugAppReviewPrompt: true,
-        ]
-
         await subject.perform(.checkAppReviewEligibility)
         await subject.reviewPromptTask?.value
         XCTAssertTrue(subject.state.isEligibleForAppReview)
-        XCTAssertEqual(subject.state.toast?.title, Constants.appReviewPromptEligibleDebugMessage)
     }
 
     /// `perform(_:)` with `.checkAppReviewEligibility` does not schedule a review prompt if the user is not eligible.
     @MainActor
     func test_perform_checkAppReviewEligibility_notEligible() async {
         reviewPromptService.isEligibleForReviewPromptResult = false
-        configService.featureFlagsBool = [
-            FeatureFlag.enableDebugAppReviewPrompt: true,
-        ]
-
         await subject.perform(.checkAppReviewEligibility)
         await subject.reviewPromptTask?.value
         XCTAssertFalse(subject.state.isEligibleForAppReview)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20147
## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Remove enable-debug-app-review-prompt feature flag from codebase.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
