### PR TITLE
[PM-19618] Flight recorder automatic log deletion

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Data/FlightRecorderData.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/FlightRecorderData.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 // MARK: - FlightRecorderData
@@ -26,6 +27,13 @@ struct FlightRecorderData: Codable, Equatable {
     var allLogs: [LogMetadata] {
         ([activeLog] + inactiveLogs).compactMap { $0 }
     }
+
+    /// The upcoming date in which either the active log needs to end logging or an inactive log
+    /// expires and needs to be removed.
+    var nextExpirationDate: Date? {
+        let dates = [activeLog?.endDate].compactMap { $0 } + inactiveLogs.map(\.expirationDate)
+        return dates.min()
+    }
 }
 
 extension FlightRecorderData {
@@ -47,6 +55,15 @@ extension FlightRecorderData {
         let startDate: Date
 
         // MARK: Computed Properties
+
+        /// The date when the flight recorder log will expire and be deleted.
+        var expirationDate: Date {
+            Calendar.current.date(
+                byAdding: .day,
+                value: Constants.flightRecorderLogExpirationDays,
+                to: endDate
+            ) ?? endDate
+        }
 
         var id: String {
             fileName

--- a/BitwardenShared/Core/Platform/Models/Data/FlightRecorderData.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/FlightRecorderData.swift
@@ -30,7 +30,7 @@ struct FlightRecorderData: Codable, Equatable {
 
     /// The upcoming date in which either the active log needs to end logging or an inactive log
     /// expires and needs to be removed.
-    var nextExpirationDate: Date? {
+    var nextLogLifecycleDate: Date? {
         let dates = [activeLog?.endDate].compactMap { $0 } + inactiveLogs.map(\.expirationDate)
         return dates.min()
     }

--- a/BitwardenShared/Core/Platform/Models/Data/FlightRecorderDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/FlightRecorderDataTests.swift
@@ -40,6 +40,44 @@ class FlightRecorderDataTests: BitwardenTestCase {
         XCTAssertEqual(subject.allLogs, logs)
     }
 
+    /// `nextExpirationDate` returns the date in which the active log ends logging if that's before
+    /// any of the inactive logs expire.
+    func test_nextExpirationDate_activeLog() {
+        let subject = FlightRecorderData(
+            activeLog: FlightRecorderData.LogMetadata(
+                duration: .eightHours,
+                startDate: Date(year: 2025, month: 4, day: 1)
+            ),
+            inactiveLogs: [
+                FlightRecorderData.LogMetadata(duration: .eightHours, startDate: Date(year: 2025, month: 3, day: 20)),
+                FlightRecorderData.LogMetadata(duration: .eightHours, startDate: Date(year: 2025, month: 3, day: 25)),
+            ]
+        )
+        XCTAssertEqual(subject.nextExpirationDate, Date(year: 2025, month: 4, day: 1, hour: 8))
+    }
+
+    /// `nextExpirationDate` returns the date in which the first inactive log expires if that's
+    /// before the active log needs to end logging.
+    func test_nextExpirationDate_inactiveLog() {
+        let subject = FlightRecorderData(
+            activeLog: FlightRecorderData.LogMetadata(
+                duration: .eightHours,
+                startDate: Date(year: 2025, month: 4, day: 1)
+            ),
+            inactiveLogs: [
+                FlightRecorderData.LogMetadata(duration: .eightHours, startDate: Date(year: 2025, month: 1, day: 2)),
+                FlightRecorderData.LogMetadata(duration: .eightHours, startDate: Date(year: 2025, month: 3, day: 4)),
+            ]
+        )
+        XCTAssertEqual(subject.nextExpirationDate, Date(year: 2025, month: 2, day: 1, hour: 8))
+    }
+
+    /// `nextExpirationDate` returns an empty array if there's no logs.
+    func test_nextExpirationDate_noLogs() {
+        let subject = FlightRecorderData()
+        XCTAssertNil(subject.nextExpirationDate)
+    }
+
     /// `activeLog` sets the active log.
     func test_setActiveLog() {
         var subject = FlightRecorderData()
@@ -62,6 +100,24 @@ class FlightRecorderDataTests: BitwardenTestCase {
     }
 
     // MARK: FlightRecorderData.LogMetadata Tests
+
+    /// `expirationDate` returns the date when the log will expire and be deleted.
+    func test_logMetadata_expirationData() {
+        XCTAssertEqual(
+            FlightRecorderData.LogMetadata(
+                duration: .oneHour,
+                startDate: Date(year: 2025, month: 4, day: 3, hour: 10, minute: 30)
+            ).expirationDate,
+            Date(year: 2025, month: 5, day: 3, hour: 11, minute: 30)
+        )
+        XCTAssertEqual(
+            FlightRecorderData.LogMetadata(
+                duration: .eightHours,
+                startDate: Date(year: 2025, month: 4, day: 3, hour: 10, minute: 30)
+            ).expirationDate,
+            Date(year: 2025, month: 5, day: 3, hour: 18, minute: 30)
+        )
+    }
 
     /// `id` returns the log's file name as a unique identifier.
     func test_logMetadata_id() {

--- a/BitwardenShared/Core/Platform/Models/Data/FlightRecorderDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/FlightRecorderDataTests.swift
@@ -40,9 +40,9 @@ class FlightRecorderDataTests: BitwardenTestCase {
         XCTAssertEqual(subject.allLogs, logs)
     }
 
-    /// `nextExpirationDate` returns the date in which the active log ends logging if that's before
+    /// `nextLogLifecycleDate` returns the date in which the active log ends logging if that's before
     /// any of the inactive logs expire.
-    func test_nextExpirationDate_activeLog() {
+    func test_nextLogLifecycleDate_activeLog() {
         let subject = FlightRecorderData(
             activeLog: FlightRecorderData.LogMetadata(
                 duration: .eightHours,
@@ -53,12 +53,12 @@ class FlightRecorderDataTests: BitwardenTestCase {
                 FlightRecorderData.LogMetadata(duration: .eightHours, startDate: Date(year: 2025, month: 3, day: 25)),
             ]
         )
-        XCTAssertEqual(subject.nextExpirationDate, Date(year: 2025, month: 4, day: 1, hour: 8))
+        XCTAssertEqual(subject.nextLogLifecycleDate, Date(year: 2025, month: 4, day: 1, hour: 8))
     }
 
-    /// `nextExpirationDate` returns the date in which the first inactive log expires if that's
+    /// `nextLogLifecycleDate` returns the date in which the first inactive log expires if that's
     /// before the active log needs to end logging.
-    func test_nextExpirationDate_inactiveLog() {
+    func test_nextLogLifecycleDate_inactiveLog() {
         let subject = FlightRecorderData(
             activeLog: FlightRecorderData.LogMetadata(
                 duration: .eightHours,
@@ -69,13 +69,13 @@ class FlightRecorderDataTests: BitwardenTestCase {
                 FlightRecorderData.LogMetadata(duration: .eightHours, startDate: Date(year: 2025, month: 3, day: 4)),
             ]
         )
-        XCTAssertEqual(subject.nextExpirationDate, Date(year: 2025, month: 2, day: 1, hour: 8))
+        XCTAssertEqual(subject.nextLogLifecycleDate, Date(year: 2025, month: 2, day: 1, hour: 8))
     }
 
-    /// `nextExpirationDate` returns an empty array if there's no logs.
-    func test_nextExpirationDate_noLogs() {
+    /// `nextLogLifecycleDate` returns an empty array if there's no logs.
+    func test_nextLogLifecycleDate_noLogs() {
         let subject = FlightRecorderData()
-        XCTAssertNil(subject.nextExpirationDate)
+        XCTAssertNil(subject.nextLogLifecycleDate)
     }
 
     /// `activeLog` sets the active log.

--- a/BitwardenShared/Core/Platform/Models/Domain/Fixtures/FlightRecorderLogMetadata+Fixtures.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/Fixtures/FlightRecorderLogMetadata+Fixtures.swift
@@ -5,7 +5,8 @@ import Foundation
 extension FlightRecorderLogMetadata {
     static func fixture(
         duration: FlightRecorderLoggingDuration = .twentyFourHours,
-        endDate: Date = Date(year: 2025, month: 4, day: 3, hour: 1),
+        endDate: Date = Date(year: 2025, month: 4, day: 4),
+        expirationDate: Date = Date(year: 2025, month: 5, day: 4),
         fileSize: String = "8 KB",
         id: String = "1",
         isActiveLog: Bool = false,
@@ -15,6 +16,7 @@ extension FlightRecorderLogMetadata {
         FlightRecorderLogMetadata(
             duration: duration,
             endDate: endDate,
+            expirationDate: expirationDate,
             fileSize: fileSize,
             id: id,
             isActiveLog: isActiveLog,

--- a/BitwardenShared/Core/Platform/Models/Domain/FlightRecorderLogMetadata.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/FlightRecorderLogMetadata.swift
@@ -14,6 +14,9 @@ struct FlightRecorderLogMetadata: Equatable, Identifiable {
     /// The date when the flight recorder for this log stops/stopped logging.
     let endDate: Date
 
+    /// The date when the flight recorder log will expire and be deleted.
+    let expirationDate: Date
+
     /// The size of the log file.
     let fileSize: String
 
@@ -30,15 +33,6 @@ struct FlightRecorderLogMetadata: Equatable, Identifiable {
     let url: URL
 
     // MARK: Computed Properties
-
-    /// The date when the flight recorder log will expire and be deleted.
-    var expirationDate: Date {
-        Calendar.current.date(
-            byAdding: .day,
-            value: Constants.flightRecorderLogExpirationDays,
-            to: endDate
-        ) ?? endDate
-    }
 
     /// The formatted date range for when the flight recorder was enabled for the log.
     var formattedLoggingDateRange: String {

--- a/BitwardenShared/Core/Platform/Models/Domain/FlightRecorderLogMetadataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/FlightRecorderLogMetadataTests.swift
@@ -8,22 +8,18 @@ class FlightRecorderLogMetadataTests: BitwardenTestCase {
     let logOneHour = FlightRecorderLogMetadata.fixture(
         duration: .oneHour,
         endDate: Date(year: 2025, month: 4, day: 3, hour: 11, minute: 30),
+        expirationDate: Date(year: 2025, month: 5, day: 3, hour: 11, minute: 30),
         startDate: Date(year: 2025, month: 4, day: 3, hour: 10, minute: 30)
     )
 
     let logEightHours = FlightRecorderLogMetadata.fixture(
         duration: .eightHours,
         endDate: Date(year: 2025, month: 4, day: 3, hour: 18, minute: 30),
+        expirationDate: Date(year: 2025, month: 5, day: 3, hour: 18, minute: 30),
         startDate: Date(year: 2025, month: 4, day: 3, hour: 10, minute: 30)
     )
 
     // MARK: Tests
-
-    /// `expirationDate` returns the date when the log will expire and be deleted.
-    func test_expirationData() {
-        XCTAssertEqual(logOneHour.expirationDate, Date(year: 2025, month: 5, day: 3, hour: 11, minute: 30))
-        XCTAssertEqual(logEightHours.expirationDate, Date(year: 2025, month: 5, day: 3, hour: 18, minute: 30))
-    }
 
     /// `formattedLoggingDateRange` returns the formatted date range for when the flight recorder was enabled.
     func test_formattedLoggingDateRange() {

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
@@ -132,6 +132,7 @@ struct FlightRecorderLogsView: View {
                     FlightRecorderLogMetadata(
                         duration: .eightHours,
                         endDate: Date(year: 2025, month: 4, day: 1, hour: 8),
+                        expirationDate: Date(year: 2025, month: 5, day: 1, hour: 8),
                         fileSize: "2 KB",
                         id: "1",
                         isActiveLog: true,
@@ -141,6 +142,7 @@ struct FlightRecorderLogsView: View {
                     FlightRecorderLogMetadata(
                         duration: .oneWeek,
                         endDate: Date(year: 2025, month: 3, day: 7),
+                        expirationDate: Date(year: 2025, month: 4, day: 6),
                         fileSize: "12 KB",
                         id: "2",
                         isActiveLog: false,
@@ -150,6 +152,7 @@ struct FlightRecorderLogsView: View {
                     FlightRecorderLogMetadata(
                         duration: .oneHour,
                         endDate: Date(year: 2025, month: 3, day: 3, hour: 13),
+                        expirationDate: Date(year: 2025, month: 4, day: 2, hour: 13),
                         fileSize: "1.5 MB",
                         id: "3",
                         isActiveLog: false,
@@ -159,6 +162,7 @@ struct FlightRecorderLogsView: View {
                     FlightRecorderLogMetadata(
                         duration: .twentyFourHours,
                         endDate: Date(year: 2025, month: 3, day: 2),
+                        expirationDate: Date(year: 2025, month: 4, day: 1),
                         fileSize: "50 KB",
                         id: "4",
                         isActiveLog: false,

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsViewTests.swift
@@ -94,6 +94,7 @@ class FlightRecorderLogsViewTests: BitwardenTestCase {
             FlightRecorderLogMetadata(
                 duration: .eightHours,
                 endDate: Date(year: 2025, month: 4, day: 1, hour: 8),
+                expirationDate: Date(year: 2025, month: 5, day: 1, hour: 8),
                 fileSize: "2 KB",
                 id: "1",
                 isActiveLog: true,
@@ -103,6 +104,7 @@ class FlightRecorderLogsViewTests: BitwardenTestCase {
             FlightRecorderLogMetadata(
                 duration: .oneWeek,
                 endDate: Date(year: 2025, month: 3, day: 7),
+                expirationDate: Date(year: 2025, month: 4, day: 6),
                 fileSize: "12 KB",
                 id: "2",
                 isActiveLog: false,
@@ -112,6 +114,7 @@ class FlightRecorderLogsViewTests: BitwardenTestCase {
             FlightRecorderLogMetadata(
                 duration: .oneHour,
                 endDate: Date(year: 2025, month: 3, day: 3, hour: 13),
+                expirationDate: Date(year: 2025, month: 4, day: 2, hour: 13),
                 fileSize: "1.5 MB",
                 id: "3",
                 isActiveLog: false,
@@ -121,6 +124,7 @@ class FlightRecorderLogsViewTests: BitwardenTestCase {
             FlightRecorderLogMetadata(
                 duration: .twentyFourHours,
                 endDate: Date(year: 2025, month: 3, day: 2),
+                expirationDate: Date(year: 2025, month: 4, day: 1),
                 fileSize: "50 KB",
                 id: "4",
                 isActiveLog: false,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19618](https://bitwarden.atlassian.net/browse/PM-19618)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds automatic flight recorder log deletion. This handles two cases:

- Turning off the active log at its end date.
- Deleting inactive logs when they reach their expiration date (30 days after logging ended).


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19618]: https://bitwarden.atlassian.net/browse/PM-19618?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ