### PR TITLE
[PM-19621] Disable flight recorder delete and share all buttons if there's no logs

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsState.swift
@@ -7,4 +7,16 @@ struct FlightRecorderLogsState: Equatable {
 
     /// The list of flight recorder logs on the device.
     var logs = [FlightRecorderLogMetadata]()
+
+    // MARK: Computed Properties
+
+    /// Whether the delete all option is enabled.
+    var isDeleteAllEnabled: Bool {
+        logs.contains { !$0.isActiveLog }
+    }
+
+    /// Whether the share all option is enabled.
+    var isShareAllEnabled: Bool {
+        !logs.isEmpty
+    }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
@@ -29,10 +29,12 @@ struct FlightRecorderLogsView: View {
                     Button(Localizations.shareAll) {
                         store.send(.shareAll)
                     }
+                    .disabled(!store.state.isShareAllEnabled)
 
                     Button(Localizations.deleteAll, role: .destructive) {
                         store.send(.deleteAll)
                     }
+                    .disabled(!store.state.isDeleteAllEnabled)
                 }
             }
     }
@@ -95,11 +97,10 @@ struct FlightRecorderLogsView: View {
                     store.send(.share(log))
                 }
 
-                if !log.isActiveLog {
-                    Button(Localizations.delete, role: .destructive) {
-                        store.send(.delete(log))
-                    }
+                Button(Localizations.delete, role: .destructive) {
+                    store.send(.delete(log))
                 }
+                .disabled(log.isActiveLog)
             } label: {
                 Asset.Images.ellipsisHorizontal24.swiftUIImage
                     .foregroundStyle(Asset.Colors.textSecondary.swiftUIColor)

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsViewTests.swift
@@ -50,12 +50,47 @@ class FlightRecorderLogsViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .delete(log))
     }
 
+    /// The delete button is disabled for the active log.
+    @MainActor
+    func test_delete_disabledForActiveLog() throws {
+        processor.state.logs = [.fixture(isActiveLog: true)]
+        let button = try subject.inspect().find(button: Localizations.delete)
+        XCTAssertTrue(button.isDisabled())
+    }
+
+    /// The delete all button is disabled when there's no logs or only an active log.
+    @MainActor
+    func test_deleteAll_disabledWhenNoLogs() throws {
+        var button = try subject.inspect().find(button: Localizations.deleteAll)
+        XCTAssertTrue(button.isDisabled())
+
+        processor.state.logs = [.fixture(isActiveLog: true)]
+        button = try subject.inspect().find(button: Localizations.deleteAll)
+        XCTAssertTrue(button.isDisabled())
+
+        processor.state.logs = [.fixture()]
+        button = try subject.inspect().find(button: Localizations.deleteAll)
+        XCTAssertFalse(button.isDisabled())
+    }
+
     /// Tapping the delete all toolbar button dispatches the `.deleteAll` action.
     @MainActor
     func test_deleteAll_tap() throws {
+        processor.state.logs = [.fixture()]
         let button = try subject.inspect().find(button: Localizations.deleteAll)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .deleteAll)
+    }
+
+    /// The share all button is disabled when there's no logs.
+    @MainActor
+    func test_shareAll_disabledWhenNoLogs() throws {
+        var button = try subject.inspect().find(button: Localizations.shareAll)
+        XCTAssertTrue(button.isDisabled())
+
+        processor.state.logs = [.fixture()]
+        button = try subject.inspect().find(button: Localizations.shareAll)
+        XCTAssertFalse(button.isDisabled())
     }
 
     /// Tapping the share log menu button dispatches the `.share(_:)` action.
@@ -71,6 +106,7 @@ class FlightRecorderLogsViewTests: BitwardenTestCase {
     /// Tapping the share all toolbar button dispatches the `.shareAll` action.
     @MainActor
     func test_shareAll_tap() throws {
+        processor.state.logs = [.fixture()]
         let button = try subject.inspect().find(button: Localizations.shareAll)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .shareAll)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19621](https://bitwarden.atlassian.net/browse/PM-21119)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If there's no logs in the flight recorder logs view, the delete and share all buttons in the options menu should be disabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="557" alt="Screenshot 2025-05-05 at 12 19 51 PM" src="https://github.com/user-attachments/assets/e161dfcb-a072-42d9-9af7-905c8cb9db39" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
