### PR TITLE
[PM-19577] Log navigation changes to the flight recorder

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/Mocks/MockBitwardenLogger.swift
+++ b/BitwardenKit/Core/Platform/Utilities/Mocks/MockBitwardenLogger.swift
@@ -1,0 +1,11 @@
+@testable import BitwardenKit
+
+public class MockBitwardenLogger: BitwardenLogger {
+    public var logs = [String]()
+
+    public init() {}
+
+    public func log(_ message: String, file: String, line: UInt) {
+        logs.append(message)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
+++ b/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
@@ -10,7 +10,7 @@ import OSLog
 /// A protocol for a service which can temporarily be enabled to collect logs for debugging to a
 /// local file.
 ///
-protocol FlightRecorder: Sendable {
+protocol FlightRecorder: Sendable, BitwardenLogger {
     /// Deletes all inactive flight recorder logs. This will not delete the currently active log.
     ///
     func deleteInactiveLogs() async throws
@@ -56,6 +56,12 @@ protocol FlightRecorder: Sendable {
 extension FlightRecorder {
     func log(_ message: String, file: String = #file, line: UInt = #line) async {
         await log(message, file: file, line: line)
+    }
+
+    nonisolated func log(_ message: String, file: String, line: UInt) {
+        Task {
+            await log(message, file: file, line: line)
+        }
     }
 }
 
@@ -421,16 +427,6 @@ extension DefaultFlightRecorder: FlightRecorder {
                 message: "\(fileName):\(line) Unable to write message to log: \(message)",
                 error: error
             ))
-        }
-    }
-}
-
-// MARK: DefaultFlightRecorder + BitwardenLogger
-
-extension DefaultFlightRecorder: BitwardenLogger {
-    nonisolated func log(_ message: String, file: String, line: UInt) {
-        Task {
-            await log(message, file: file, line: line)
         }
     }
 }

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -355,8 +355,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 )
             )
         )
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the create account screen.
@@ -371,8 +370,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 )
             )
         )
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the complete registration screen.
@@ -395,8 +393,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 )
             )
         )
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the Duo 2FA screen.
@@ -453,9 +450,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 )
             )
         )
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        navController.isModalInPresentation = true
-        stackNavigator?.present(navController)
+        stackNavigator?.present(view, isModalInPresentation: true)
     }
 
     /// Shows the enterprise single sign-on screen.
@@ -470,9 +465,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         )
         let store = Store(processor: processor)
         let view = SingleSignOnView(store: store)
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the intro carousel screen.
@@ -563,9 +556,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         )
         let store = Store(processor: processor)
         let view = LoginWithDeviceView(store: store)
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the login decryption options screen.
@@ -621,9 +612,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         )
         let store = Store(processor: processor)
         let view = MasterPasswordGuidanceView(store: store)
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the master password hint screen for the provided username.
@@ -638,9 +627,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         )
         let store = Store(processor: processor)
         let view = PasswordHintView(store: store)
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the prevent account lock screen.
@@ -649,9 +636,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         let processor = PreventAccountLockProcessor(coordinator: asAnyCoordinator())
         let store = Store(processor: processor)
         let view = PreventAccountLockView(store: store)
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the remove master password screen.
@@ -699,8 +684,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             state: state
         )
         let view = SelfHostedView(store: Store(processor: processor))
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the set master password view.
@@ -714,11 +698,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             state: SetMasterPasswordState(organizationIdentifier: organizationIdentifier)
         )
         let view = SetMasterPasswordView(store: Store(processor: processor))
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        navigationController.isModalInPresentation = true
-
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view, isModalInPresentation: true)
     }
 
     /// Shows the single sign on screen.
@@ -783,8 +763,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
                 processor: processor
             )
         )
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the start registration screen from expired link screen.
@@ -834,9 +813,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         )
 
         let view = TwoFactorAuthView(store: Store(processor: processor))
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view)
     }
 
     /// Shows the update master password view.
@@ -847,14 +824,8 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             state: .init()
         )
         let store = Store(processor: processor)
-        let view = UpdateMasterPasswordView(
-            store: store
-        )
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        navigationController.isModalInPresentation = true
-
-        stackNavigator?.present(navigationController)
+        let view = UpdateMasterPasswordView(store: store)
+        stackNavigator?.present(view, isModalInPresentation: true)
     }
 
     /// Shows the vault unlock view.

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -123,9 +123,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_checkEmail() throws {
         subject.navigate(to: .checkEmail(email: "email@example.com"))
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<CheckEmailView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is CheckEmailView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.completeWithNeverUnlockKey` notifies the delegate that auth has completed.
@@ -161,9 +162,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_createAccount() throws {
         subject.navigate(to: .createAccount)
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<CreateAccountView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is CreateAccountView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.completeRegistration` pushes the create account view onto the stack navigator.
@@ -174,9 +176,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
             userEmail: "email@example.com"
         ))
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<CompleteRegistrationView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is CompleteRegistrationView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.completeRegistrationFromAppLink` pushes the create account view onto the stack navigator.
@@ -190,16 +193,11 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         let landingAction = try XCTUnwrap(stackNavigator.actions[1])
         let completeRegistrationAction = try XCTUnwrap(stackNavigator.actions[2])
-        let completeRegistrationNavigationController = try XCTUnwrap(
-            completeRegistrationAction.view as? UINavigationController
-        )
         let lastAction = try XCTUnwrap(stackNavigator.actions.last)
 
-        XCTAssertTrue(
-            completeRegistrationNavigationController.viewControllers.first
-                is UIHostingController<CompleteRegistrationView>
-        )
         XCTAssertTrue(landingAction.view is LandingView)
+        XCTAssertTrue(completeRegistrationAction.view is CompleteRegistrationView)
+        XCTAssertEqual(completeRegistrationAction.embedInNavigationController, true)
         XCTAssertEqual(lastAction.type, .dismissedWithCompletionHandler)
     }
 
@@ -208,9 +206,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_startRegistration() throws {
         subject.navigate(to: .startRegistration, context: MockStartRegistrationDelegate())
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<StartRegistrationView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is StartRegistrationView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.startRegistrationFromExpiredLink` pushes the start registration view
@@ -226,18 +225,13 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
         subject.navigate(to: .startRegistrationFromExpiredLink)
 
         let landingAction = try XCTUnwrap(stackNavigator.actions[5])
-        let startRegistration = try XCTUnwrap(stackNavigator.actions[6])
-        let startRegistrationNavigationController = try XCTUnwrap(
-            startRegistration.view as? UINavigationController
-        )
+        let startRegistrationAction = try XCTUnwrap(stackNavigator.actions[6])
         let lastAction = try XCTUnwrap(stackNavigator.actions.last)
 
-        XCTAssertTrue(
-            startRegistrationNavigationController.viewControllers.first
-                is UIHostingController<StartRegistrationView>
-        )
         XCTAssertTrue(landingAction.view is LandingView)
         XCTAssertEqual(landingAction.type, .replaced)
+        XCTAssertTrue(startRegistrationAction.view is StartRegistrationView)
+        XCTAssertEqual(startRegistrationAction.embedInNavigationController, true)
         XCTAssertEqual(lastAction.type, .dismissedWithCompletionHandler)
     }
 
@@ -283,9 +277,11 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_expiredLink() throws {
         subject.navigate(to: .expiredLink)
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ExpiredLinkView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is ExpiredLinkView)
+        XCTAssertEqual(action.embedInNavigationController, true)
+        XCTAssertEqual(action.isModalInPresentation, true)
     }
 
     /// `navigate(to:)` with `.enterpriseSingleSignOn` pushes the enterprise single sign-on view onto the stack
@@ -294,9 +290,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_enterpriseSingleSignOn() throws {
         subject.navigate(to: .enterpriseSingleSignOn(email: "email@example.com"))
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<SingleSignOnView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is SingleSignOnView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.introCarousel` replaces the navigation stack with the intro carousel.
@@ -401,9 +398,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
             isAuthenticated: false
         ))
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<LoginWithDeviceView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is LoginWithDeviceView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.masterPasswordGuidance` presents the master password guidance view.
@@ -411,9 +409,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_masterPasswordGuidance() throws {
         subject.navigate(to: .masterPasswordGuidance)
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<MasterPasswordGuidanceView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is MasterPasswordGuidanceView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.masterPasswordGenerator` presents the generate master password view.
@@ -434,9 +433,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_masterPasswordHint() throws {
         subject.navigate(to: .masterPasswordHint(username: "email@example.com"))
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<PasswordHintView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is PasswordHintView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.preventAccountLock` presents the prevent account lock view.
@@ -444,9 +444,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_preventAccountLock() throws {
         subject.navigate(to: .preventAccountLock)
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<PreventAccountLockView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is PreventAccountLockView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.selfHosted` pushes the self-hosted view onto the stack navigator.
@@ -454,9 +455,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_selfHosted() throws {
         subject.navigate(to: .selfHosted(currentRegion: .unitedStates))
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<SelfHostedView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is SelfHostedView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.removeMasterPassword` pushes the remove master password view onto the stack navigator.
@@ -478,9 +480,11 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_setMasterPassword() throws {
         subject.navigate(to: .setMasterPassword(organizationIdentifier: "ORG_ID"))
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<SetMasterPasswordView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is SetMasterPasswordView)
+        XCTAssertEqual(action.embedInNavigationController, true)
+        XCTAssertEqual(action.isModalInPresentation, true)
     }
 
     /// `handleEvent()` with `.switchAccount` with an locked account navigates to vault unlock
@@ -553,9 +557,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_twoFactor() throws {
         subject.navigate(to: .twoFactor("", .password(""), AuthMethodsData.fixture(), nil))
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<TwoFactorAuthView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is TwoFactorAuthView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.twoFactor` shows the two factor auth view with device verification.
@@ -563,9 +568,10 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_twoFactor_deviceVerification() throws {
         subject.navigate(to: .twoFactor("", .password(""), AuthMethodsData.fixture(), nil, true))
 
-        XCTAssertEqual(stackNavigator.actions.last?.type, .presented)
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<TwoFactorAuthView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is TwoFactorAuthView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.updateMasterPassword` pushes the update master password view onto the stack navigator.
@@ -573,9 +579,11 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_navigate_updateMasterPassword() throws {
         subject.navigate(to: .updateMasterPassword)
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<UpdateMasterPasswordView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is UpdateMasterPasswordView)
+        XCTAssertEqual(action.embedInNavigationController, true)
+        XCTAssertEqual(action.isModalInPresentation, true)
     }
 
     /// `navigate(to:)` with `.vaultUnlock` replaces the current view with the vault unlock view.

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -15,6 +15,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
         & ExtensionSetupModule
         & FileSelectionModule
         & LoginRequestModule
+        & NavigatorBuilderModule
         & SendItemModule
         & TabModule
         & VaultModule
@@ -172,7 +173,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             coordinator.navigate(to: authRoute)
         } else {
             guard let rootNavigator else { return }
-            let navigationController = UINavigationController()
+            let navigationController = module.makeNavigationController()
             let coordinator = module.makeAuthCoordinator(
                 delegate: self,
                 rootNavigator: rootNavigator,
@@ -193,7 +194,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
         if let coordinator = childCoordinator as? AnyCoordinator<ExtensionSetupRoute, Void> {
             coordinator.navigate(to: route)
         } else {
-            let stackNavigator = UINavigationController()
+            let stackNavigator = module.makeNavigationController()
             let coordinator = module.makeExtensionSetupCoordinator(
                 stackNavigator: stackNavigator
             )
@@ -212,7 +213,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
         if let coordinator = childCoordinator as? AnyCoordinator<SendItemRoute, Void> {
             coordinator.navigate(to: route)
         } else {
-            let stackNavigator = UINavigationController()
+            let stackNavigator = module.makeNavigationController()
             let coordinator = module.makeSendItemCoordinator(
                 delegate: self,
                 stackNavigator: stackNavigator
@@ -260,7 +261,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             guard !(currentView is UIHostingController<LoginRequestView>) else { return }
 
             // Create the login request view.
-            let navigationController = UINavigationController()
+            let navigationController = self.module.makeNavigationController()
             let coordinator = self.module.makeLoginRequestCoordinator(stackNavigator: navigationController)
             coordinator.start()
             coordinator.navigate(to: .loginRequest(loginRequest), context: self)
@@ -292,7 +293,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
         if let coordinator = childCoordinator as? AnyCoordinator<VaultRoute, AuthAction> {
             coordinator.navigate(to: route)
         } else {
-            let stackNavigator = UINavigationController()
+            let stackNavigator = module.makeNavigationController()
             let coordinator = module.makeVaultCoordinator(
                 delegate: self,
                 stackNavigator: stackNavigator

--- a/BitwardenShared/UI/Platform/Application/NavigatorBuilderModule.swift
+++ b/BitwardenShared/UI/Platform/Application/NavigatorBuilderModule.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+// MARK: - NavigatorBuilderModule
+
+/// An object that builds navigators for the application.
+///
+@MainActor
+public protocol NavigatorBuilderModule: AnyObject {
+    /// Builds a navigation controller for use in the application.
+    ///
+    /// - Returns: A navigation controller for use in the application.
+    ///
+    func makeNavigationController() -> UINavigationController
+}
+
+extension DefaultAppModule: NavigatorBuilderModule {
+    public func makeNavigationController() -> UINavigationController {
+        ViewLoggingNavigationController(logger: services.flightRecorder)
+    }
+}

--- a/BitwardenShared/UI/Platform/Application/NavigatorBuilderModuleTests.swift
+++ b/BitwardenShared/UI/Platform/Application/NavigatorBuilderModuleTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class NavigatorBuilderModuleTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DefaultAppModule!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = DefaultAppModule(services: .withMocks())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `makeNavigationController()` builds a navigation controller.
+    @MainActor
+    func test_makeNavigationController() {
+        let navigationController = subject.makeNavigationController()
+        XCTAssertTrue(navigationController is ViewLoggingNavigationController)
+    }
+}

--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
@@ -325,11 +325,6 @@ extension UINavigationController: StackNavigator {
         overFullscreen: Bool = false,
         onCompletion: (() -> Void)? = nil
     ) {
-        if let navigationController = viewController as? UINavigationController {
-            // Pass along the existing delegates to propagate view logging to new navigation controllers.
-            navigationController.delegate = delegate
-            navigationController.presentationController?.delegate = presentationController?.delegate
-        }
         var presentedChild = presentedViewController
         var availablePresenter: UIViewController? = self
         while presentedChild != nil {

--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
@@ -64,13 +64,16 @@ public protocol StackNavigator: Navigator {
     ///   - animated: Whether the transition should be animated.
     ///   - embedInNavigationController: Whether the presented view should be embedded in a
     ///     navigation controller.
+    ///   - isModalInPresentation: Whether the presented view controller enforces a modal behavior.
+    ///     This prevents interactive dismissal.
     ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
     ///   - onCompletion: A closure to call on completion.
     ///
-    func present<Content: View>(
+    func present<Content: View>( // swiftlint:disable:this function_parameter_count
         _ view: Content,
         animated: Bool,
         embedInNavigationController: Bool,
+        isModalInPresentation: Bool,
         overFullscreen: Bool,
         onCompletion: (() -> Void)?
     )
@@ -199,6 +202,8 @@ extension StackNavigator {
     ///   - animated: Whether the transition should be animated. Defaults to `UI.animated`.
     ///   - embedInNavigationController: Whether the presented view should be embedded in a
     ///     navigation controller.
+    ///   - isModalInPresentation: Whether the presented view controller enforces a modal behavior.
+    ///     This prevents interactive dismissal.
     ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
     ///   - onCompletion: The closure to call after presenting.
     ///
@@ -206,6 +211,7 @@ extension StackNavigator {
         _ view: Content,
         animated: Bool = UI.animated,
         embedInNavigationController: Bool = true,
+        isModalInPresentation: Bool = false,
         overFullscreen: Bool = false,
         onCompletion _: (() -> Void)? = nil
     ) {
@@ -213,6 +219,7 @@ extension StackNavigator {
             view,
             animated: animated,
             embedInNavigationController: embedInNavigationController,
+            isModalInPresentation: isModalInPresentation,
             overFullscreen: overFullscreen,
             onCompletion: nil
         )
@@ -289,6 +296,7 @@ extension UINavigationController: StackNavigator {
         _ view: Content,
         animated: Bool,
         embedInNavigationController: Bool,
+        isModalInPresentation: Bool,
         overFullscreen: Bool,
         onCompletion: (() -> Void)? = nil
     ) {
@@ -302,7 +310,7 @@ extension UINavigationController: StackNavigator {
         } else {
             controller = UIHostingController(rootView: view)
         }
-        controller.isModalInPresentation = true
+        controller.isModalInPresentation = isModalInPresentation
         if overFullscreen {
             controller.modalPresentationStyle = .overFullScreen
             controller.view.backgroundColor = .clear

--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigatorTests.swift
@@ -43,15 +43,18 @@ class StackNavigatorTests: BitwardenTestCase {
 
     /// `present(_:animated:)` presents the hosted view.
     @MainActor
-    func test_present() {
+    func test_present() throws {
         subject.present(EmptyView(), animated: false)
-        XCTAssertTrue(subject.presentedViewController is UIHostingController<EmptyView>)
+        XCTAssertTrue(subject.presentedViewController is UINavigationController)
+        let navigationController = try XCTUnwrap(subject.presentedViewController as? UINavigationController)
+        XCTAssertEqual(navigationController.viewControllers.count, 1)
+        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<EmptyView>)
     }
 
     /// `present(_:animated:)` presents the hosted view.
     @MainActor
     func test_present_overFullscreen() {
-        subject.present(EmptyView(), animated: false, overFullscreen: true)
+        subject.present(EmptyView(), animated: false, embedInNavigationController: false, overFullscreen: true)
         XCTAssertEqual(subject.presentedViewController?.modalPresentationStyle, .overFullScreen)
         XCTAssertEqual(subject.presentedViewController?.view.backgroundColor, .clear)
         XCTAssertTrue(subject.presentedViewController is UIHostingController<EmptyView>)
@@ -60,8 +63,8 @@ class StackNavigatorTests: BitwardenTestCase {
     /// `present(_:animated:)` presents the hosted view on existing presented views.
     @MainActor
     func test_present_onPresentedView() {
-        subject.present(EmptyView(), animated: false)
-        subject.present(ScrollView<EmptyView> {}, animated: false)
+        subject.present(EmptyView(), animated: false, embedInNavigationController: false)
+        subject.present(ScrollView<EmptyView> {}, animated: false, embedInNavigationController: false)
         XCTAssertTrue(subject.presentedViewController is UIHostingController<EmptyView>)
         waitFor(subject.presentedViewController?.presentedViewController != nil)
         XCTAssertTrue(

--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigatorTests.swift
@@ -41,14 +41,14 @@ class StackNavigatorTests: BitwardenTestCase {
         XCTAssertTrue(subject.isPresenting)
     }
 
-    /// `present(_:animated:)` presents the hosted view.
+    /// `present(_:animated:)` presents the hosted view in a navigation controller.
     @MainActor
     func test_present() throws {
         subject.present(EmptyView(), animated: false)
         XCTAssertTrue(subject.presentedViewController is UINavigationController)
         let navigationController = try XCTUnwrap(subject.presentedViewController as? UINavigationController)
         XCTAssertEqual(navigationController.viewControllers.count, 1)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<EmptyView>)
+        XCTAssertTrue(navigationController.viewControllers[0] is UIHostingController<EmptyView>)
     }
 
     /// `present(_:animated:)` presents the hosted view.
@@ -71,6 +71,13 @@ class StackNavigatorTests: BitwardenTestCase {
             subject.presentedViewController?.presentedViewController
                 is UIHostingController<ScrollView<EmptyView>>
         )
+    }
+
+    /// `present(_:animated:)` presents the hosted view without embedding it in a navigation controller.
+    @MainActor
+    func test_present_withoutEmbedInNavigationController() {
+        subject.present(EmptyView(), animated: false, embedInNavigationController: false)
+        XCTAssertTrue(subject.presentedViewController is UIHostingController<EmptyView>)
     }
 
     /// `dismiss(animated:)` dismisses the hosted view.

--- a/BitwardenShared/UI/Platform/Application/ViewLoggingNavigationController.swift
+++ b/BitwardenShared/UI/Platform/Application/ViewLoggingNavigationController.swift
@@ -1,0 +1,96 @@
+import BitwardenKit
+import UIKit
+
+// MARK: - ViewLoggingNavigationController
+
+/// A `UINavigationController` which logs when views appear and are dismissed as a user is
+/// navigating throughout the app.
+///
+/// For this to work throughout the application, this needs to be consistently used in place of
+/// `UINavigationController` *or* the `delegate` and `presentationController?.delegate` need to be
+/// passed from an existing navigation controller to any newly created `UINavigationController`.
+///
+class ViewLoggingNavigationController: UINavigationController,
+    UINavigationControllerDelegate,
+    UIAdaptivePresentationControllerDelegate {
+    // MARK: Properties
+
+    /// The logger instance used to log when views appear and are dismissed.
+    let logger: BitwardenLogger
+
+    // MARK: Initialization
+
+    /// Initialize a `ViewLoggingNavigationController`.
+    ///
+    /// - Parameter logger: The logger instance used to log when views appear and are dismissed.
+    ///
+    init(logger: BitwardenLogger) {
+        self.logger = logger
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        delegate = self
+        presentationController?.delegate = self
+    }
+
+    // MARK: UINavigationController
+
+    override func dismiss(animated: Bool, completion: (() -> Void)? = nil) {
+        super.dismiss(animated: animated, completion: completion)
+        logger.log("[Navigation] View dismissed: \(resolveLoggingViewName(for: self))")
+    }
+
+    // MARK: UINavigationControllerDelegate
+
+    func navigationController(
+        _ navigationController: UINavigationController,
+        didShow viewController: UIViewController,
+        animated: Bool
+    ) {
+        logger.log("[Navigation] View appeared: \(resolveLoggingViewName(for: viewController))")
+    }
+
+    // MARK: UIAdaptivePresentationControllerDelegate
+
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        let viewController = presentationController.presentedViewController
+        logger.log("[Navigation] View dismissed interactively: \(resolveLoggingViewName(for: viewController))")
+    }
+
+    // MARK: Private
+
+    /// Returns the view's name for the purpose of logging. This attempts to unwrap
+    /// `UIHostingController`s and `UINavigationController`s to log a more descriptive name of the
+    /// view contained within these container view controllers.
+    ///
+    /// - Parameter viewController: The view controller for which to determine the name of the view
+    ///     for logging purposes.
+    /// - Returns: The view's name for logging purposes.
+    ///
+    private func resolveLoggingViewName(for viewController: UIViewController) -> String {
+        let viewType = String(describing: type(of: viewController))
+        if viewType.contains("HostingController") {
+            guard let start = viewType.firstIndex(of: "<"),
+                  let end = viewType.firstIndex(of: ">"),
+                  start < end else {
+                return viewType
+            }
+            let innerType = viewType[viewType.index(after: start) ..< end]
+            return String(innerType)
+        } else if let navigationController = viewController as? UINavigationController,
+                  let visibleViewController = navigationController.visibleViewController {
+            return resolveLoggingViewName(for: visibleViewController)
+        } else {
+            return viewType
+        }
+    }
+}

--- a/BitwardenShared/UI/Platform/Application/ViewLoggingNavigationControllerTests.swift
+++ b/BitwardenShared/UI/Platform/Application/ViewLoggingNavigationControllerTests.swift
@@ -1,0 +1,94 @@
+import BitwardenKitMocks
+import SwiftUI
+import XCTest
+
+@testable import BitwardenShared
+
+class ViewLoggingNavigationControllerTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var logger: MockBitwardenLogger!
+    var subject: ViewLoggingNavigationController!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        logger = MockBitwardenLogger()
+
+        subject = ViewLoggingNavigationController(logger: logger)
+        setKeyWindowRoot(viewController: subject)
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        logger = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `viewDidLoad()` sets the navigation and presentation controller delegates.
+    func test_viewDidLoad_setsDelegates() {
+        XCTAssertIdentical(subject.delegate, subject)
+        XCTAssertIdentical(subject.presentationController?.delegate, subject)
+    }
+
+    /// `dismiss(animated:completion:)` logs the dismissed view.
+    @MainActor
+    func test_dismiss() {
+        let presentedViewController = UIHostingController(rootView: EmptyView())
+        subject.present(presentedViewController, animated: false)
+        subject.dismiss(animated: false)
+        XCTAssertEqual(logger.logs, ["[Navigation] View dismissed: EmptyView"])
+    }
+
+    /// `navigationController(_:didShow:animated:)` logs the shown hosting controller's view.
+    @MainActor
+    func test_navigationControllerDidShow_hostingController() {
+        subject.navigationController(
+            subject,
+            didShow: UIHostingController(rootView: EmptyView()),
+            animated: false
+        )
+        XCTAssertEqual(logger.logs, ["[Navigation] View appeared: EmptyView"])
+    }
+
+    /// `navigationController(_:didShow:animated:)` logs the shown view when the view is a hosting
+    /// controller that isn't a generic UIHostingController.
+    @MainActor
+    func test_navigationControllerDidShow_hostingControllerNotGeneric() {
+        class HostingController: UIViewController {}
+        subject.navigationController(subject, didShow: HostingController(), animated: false)
+        XCTAssertEqual(logger.logs, ["[Navigation] View appeared: HostingController"])
+    }
+
+    /// `navigationController(_:didShow:animated:)` logs the shown navigation controller's view.
+    @MainActor
+    func test_navigationControllerDidShow_navigationController() {
+        let viewController = UINavigationController(rootViewController: UIHostingController(rootView: EmptyView()))
+        subject.navigationController(subject, didShow: viewController, animated: false)
+        XCTAssertEqual(logger.logs, ["[Navigation] View appeared: EmptyView"])
+    }
+
+    /// `navigationController(_:didShow:animated:)` logs the shown view controller.
+    @MainActor
+    func test_navigationControllerDidShow_viewController() {
+        class TestViewController: UIViewController {}
+        subject.navigationController(subject, didShow: TestViewController(), animated: false)
+        XCTAssertEqual(logger.logs, ["[Navigation] View appeared: TestViewController"])
+    }
+
+    /// `presentationControllerDidDismiss(_:)` logs the interactively dismissed view.
+    @MainActor
+    func test_presentationControllerDidDismiss() {
+        let presentationController = UIPresentationController(
+            presentedViewController: UIHostingController(rootView: EmptyView()),
+            presenting: subject
+        )
+        subject.presentationControllerDidDismiss(presentationController)
+        XCTAssertEqual(logger.logs, ["[Navigation] View dismissed interactively: EmptyView"])
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -56,6 +56,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & ExportCXFModule
         & ImportLoginsModule
         & LoginRequestModule
+        & NavigatorBuilderModule
         & PasswordAutoFillModule
 
     typealias Services = HasAccountAPIService
@@ -242,7 +243,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     /// - Parameter folder: The existing folder to edit, if applicable.
     ///
     private func showAddEditFolder(_ folder: FolderView?, delegate: AddEditFolderDelegate?) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeAddEditFolderCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .addEditFolder(folder: folder), context: delegate)
@@ -395,7 +396,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     /// Shows the export vault to another app screen (Credential Exchange flow).
     ///
     private func showExportVaultToApp() {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeExportCXFCoordinator(
             stackNavigator: navigationController
         )
@@ -432,7 +433,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     /// Shows the import login items screen.
     ///
     private func showImportLogins() {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         navigationController.modalPresentationStyle = .overFullScreen
         let coordinator = module.makeImportLoginsCoordinator(
             delegate: self,
@@ -451,7 +452,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     ///   - delegate: The delegate.
     ///
     private func showLoginRequest(_ loginRequest: LoginRequest, delegate: LoginRequestDelegate?) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeLoginRequestCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .loginRequest(loginRequest), context: delegate)

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -337,9 +337,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             services: services,
             state: DeleteAccountState()
         )
-        let view = DeleteAccountView(store: Store(processor: processor))
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(DeleteAccountView(store: Store(processor: processor)))
     }
 
     /// Shows the enable flight recorder screen.
@@ -350,9 +348,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             services: services,
             state: EnableFlightRecorderState()
         )
-        let view = EnableFlightRecorderView(store: Store(processor: processor))
-        let viewController = UIHostingController(rootView: view)
-        stackNavigator?.present(UINavigationController(rootViewController: viewController))
+        stackNavigator?.present(EnableFlightRecorderView(store: Store(processor: processor)))
     }
 
     /// Shows the share sheet to share one or more items.
@@ -393,9 +389,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             coordinator: asAnyCoordinator(),
             services: services
         )
-        let view = ExportVaultView(store: Store(processor: processor))
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(ExportVaultView(store: Store(processor: processor)))
     }
 
     /// Shows the export vault to another app screen (Credential Exchange flow).
@@ -418,8 +412,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             state: FlightRecorderLogsState()
         )
         let view = FlightRecorderLogsView(store: Store(processor: processor), timeProvider: services.timeProvider)
-        let viewController = UIHostingController(rootView: view)
-        stackNavigator?.present(UINavigationController(rootViewController: viewController))
+        stackNavigator?.present(view)
     }
 
     /// Shows the folders screen.
@@ -499,9 +492,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             services: services,
             state: PendingRequestsState()
         )
-        let view = PendingRequestsView(store: Store(processor: processor))
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(PendingRequestsView(store: Store(processor: processor)))
     }
 
     /// Shows the select language screen.
@@ -513,9 +504,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             services: services,
             state: SelectLanguageState(currentLanguage: currentLanguage)
         )
-        let view = SelectLanguageView(store: Store(processor: processor))
-        let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
-        stackNavigator?.present(navController)
+        stackNavigator?.present(SelectLanguageView(store: Store(processor: processor)))
     }
 
     /// Shows the settings screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -142,9 +142,10 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_navigateTo_deleteAccount() throws {
         subject.navigate(to: .deleteAccount)
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<DeleteAccountView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is DeleteAccountView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.didDeleteAccount(otherAccounts:)` calls the delegate method
@@ -178,9 +179,8 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<EnableFlightRecorderView>)
+        XCTAssertTrue(action.view is EnableFlightRecorderView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.exportVault` presents the export vault to file view when
@@ -195,12 +195,13 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         try await waitForAsync { [weak self] in
             guard let self else { return true }
-            return stackNavigator.actions.last?.view is UINavigationController
+            return stackNavigator.actions.last?.view is ExportVaultView
         }
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ExportVaultView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is ExportVaultView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.exportVault` presents the export settings view when
@@ -228,12 +229,13 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         try await waitForAsync { [weak self] in
             guard let self else { return true }
-            return stackNavigator.actions.last?.view is UINavigationController
+            return stackNavigator.actions.last?.view is ExportVaultView
         }
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ExportVaultView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is ExportVaultView)
+        XCTAssertEqual(action.embedInNavigationController, true)
 
         #endif
     }
@@ -243,9 +245,10 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_navigateTo_exportVaultToFile() throws {
         subject.navigate(to: .exportVaultToFile)
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ExportVaultView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is ExportVaultView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.exportVaultToApp` presents the export vault
@@ -279,9 +282,8 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<FlightRecorderLogsView>)
+        XCTAssertTrue(action.view is FlightRecorderLogsView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.lockVault` navigates the user to the login view.
@@ -378,9 +380,10 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_navigateTo_pendingLoginRequests() throws {
         subject.navigate(to: .pendingLoginRequests)
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<PendingRequestsView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is PendingRequestsView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.selectLanguage()` presents the select language view.
@@ -388,9 +391,10 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_navigateTo_selectLanguage() throws {
         subject.navigate(to: .selectLanguage(currentLanguage: .default))
 
-        let navigationController = try XCTUnwrap(stackNavigator.actions.last?.view as? UINavigationController)
-        XCTAssertTrue(stackNavigator.actions.last?.view is UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<SelectLanguageView>)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is SelectLanguageView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.settings` pushes the settings view onto the stack navigator.

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -11,6 +11,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
 
     /// The module types required by this coordinator for creating child coordinators.
     typealias Module = GeneratorModule
+        & NavigatorBuilderModule
         & SendModule
         & SettingsModule
         & VaultModule
@@ -125,7 +126,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
 
         rootNavigator.show(child: tabNavigator)
 
-        let vaultNavigator = UINavigationController()
+        let vaultNavigator = module.makeNavigationController()
         vaultNavigator.navigationBar.prefersLargeTitles = true
         vaultNavigator.navigationBar.accessibilityIdentifier = "MainHeaderBar"
         vaultCoordinator = module.makeVaultCoordinator(
@@ -133,7 +134,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
             stackNavigator: vaultNavigator
         )
 
-        let sendNavigator = UINavigationController()
+        let sendNavigator = module.makeNavigationController()
         sendNavigator.navigationBar.prefersLargeTitles = true
         sendNavigator.navigationBar.accessibilityIdentifier = "MainHeaderBar"
         sendCoordinator = module.makeSendCoordinator(
@@ -141,7 +142,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         )
         sendCoordinator?.start()
 
-        let generatorNavigator = UINavigationController()
+        let generatorNavigator = module.makeNavigationController()
         generatorNavigator.navigationBar.prefersLargeTitles = true
         generatorNavigator.navigationBar.accessibilityIdentifier = "MainHeaderBar"
         // Remove the hairline divider under the navigation bar to make it appear that the segmented
@@ -153,7 +154,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         )
         generatorCoordinator?.start()
 
-        let settingsNavigator = UINavigationController()
+        let settingsNavigator = module.makeNavigationController()
         settingsNavigator.navigationBar.prefersLargeTitles = true
         settingsNavigator.navigationBar.accessibilityIdentifier = "MainHeaderBar"
         let settingsCoordinator = module.makeSettingsCoordinator(

--- a/BitwardenShared/UI/Tools/Generator/GeneratorCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Generator/GeneratorCoordinator.swift
@@ -27,7 +27,8 @@ protocol GeneratorCoordinatorDelegate: AnyObject {
 final class GeneratorCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
-    typealias Module = PasswordHistoryModule
+    typealias Module = NavigatorBuilderModule
+        & PasswordHistoryModule
 
     typealias Services = HasConfigService
         & HasErrorAlertServices.ErrorAlertServices
@@ -123,7 +124,7 @@ final class GeneratorCoordinator: Coordinator, HasStackNavigator {
     /// Shows the generator password history screen.
     ///
     private func showGeneratorHistory() {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makePasswordHistoryCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .passwordHistoryList(.generator))

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -11,7 +11,8 @@ import SwiftUI
 final class SendCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
-    typealias Module = SendItemCoordinator.Module
+    typealias Module = NavigatorBuilderModule
+        & SendItemCoordinator.Module
         & SendItemModule
 
     typealias Services = HasErrorAlertServices.ErrorAlertServices
@@ -132,7 +133,7 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
     ///   - delegate: The delegate for this navigation.
     ///
     private func showItem(route: SendItemRoute, delegate: SendItemDelegate) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         if case .add = route {
             navigationController.removeHairlineDivider()
         }

--- a/BitwardenShared/UI/Vault/ImportLogins/ImportLoginsCoordinator.swift
+++ b/BitwardenShared/UI/Vault/ImportLogins/ImportLoginsCoordinator.swift
@@ -101,10 +101,7 @@ class ImportLoginsCoordinator: NSObject, Coordinator, HasStackNavigator {
     private func showImportLoginsSuccess() {
         let processor = ImportLoginsSuccessProcessor(coordinator: asAnyCoordinator())
         let view = ImportLoginsSuccessView(store: Store(processor: processor))
-        let viewController = UIHostingController(rootView: view)
-        let navigationController = UINavigationController(rootViewController: viewController)
-        navigationController.isModalInPresentation = true
-        stackNavigator?.present(navigationController)
+        stackNavigator?.present(view, isModalInPresentation: true)
     }
 }
 

--- a/BitwardenShared/UI/Vault/ImportLogins/ImportLoginsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/ImportLogins/ImportLoginsCoordinatorTests.swift
@@ -73,8 +73,8 @@ class ImportLoginsCoordinatorTests: BitwardenTestCase {
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ImportLoginsSuccessView>)
+        XCTAssertTrue(action.view is ImportLoginsSuccessView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `start()` has no effect.

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -410,9 +410,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
             )
         )
 
-        let view = VaultItemSelectionView(store: Store(processor: processor))
-        let viewController = UIHostingController(rootView: view)
-        stackNavigator?.present(UINavigationController(rootViewController: viewController))
+        stackNavigator?.present(VaultItemSelectionView(store: Store(processor: processor)))
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -61,6 +61,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
         & GeneratorModule
         & ImportCXFModule
         & ImportLoginsModule
+        & NavigatorBuilderModule
         & VaultItemModule
 
     typealias Services = HasApplication
@@ -222,7 +223,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     /// Shows the add folder screen.
     ///
     private func showAddFolder() {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeAddEditFolderCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .addEditFolder(folder: nil))
@@ -321,7 +322,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     /// - Parameter route: The `ImportCXFRoute` to show.
     ///
     private func showImportCXF(route: ImportCXFRoute) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeImportCXFCoordinator(
             stackNavigator: navigationController
         )
@@ -333,7 +334,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     /// Shows the import login items screen.
     ///
     private func showImportLogins() {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         navigationController.modalPresentationStyle = .fullScreen
         let coordinator = module.makeImportLoginsCoordinator(
             delegate: self,
@@ -376,7 +377,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     /// - Parameter route: The route to navigate to in the coordinator.
     ///
     private func showVaultItem(route: VaultItemRoute, delegate: CipherItemOperationDelegate?) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeVaultItemCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: route, context: delegate)

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -327,8 +327,8 @@ class VaultCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(navigationController.topViewController is UIHostingController<VaultItemSelectionView>)
+        XCTAssertTrue(action.view is VaultItemSelectionView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `.navigate(to:)` with `.viewItem` presents the view item screen.

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
@@ -13,6 +13,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     typealias Module = AddEditFolderModule
         & FileSelectionModule
         & GeneratorModule
+        & NavigatorBuilderModule
         & PasswordHistoryModule
         & VaultItemModule
 
@@ -146,7 +147,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     /// - Parameter route: The route to navigate to in the presented coordinator.
     ///
     private func presentChildVaultItemCoordinator(route: VaultItemRoute, context: AnyObject?) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeVaultItemCoordinator(stackNavigator: navigationController)
         coordinator.navigate(to: route, context: context)
         coordinator.start()
@@ -159,7 +160,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     ///     change to folders.
     ///
     private func showAddFolder(delegate: AddEditFolderDelegate?) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makeAddEditFolderCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .addEditFolder(folder: nil), context: delegate)
@@ -226,7 +227,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     /// Shows the totp camera setup screen.
     ///
     private func showCamera(delegate: AuthenticatorKeyCaptureDelegate) async {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = AuthenticatorKeyCaptureCoordinator(
             appExtensionDelegate: appExtensionDelegate,
             delegate: delegate,
@@ -350,7 +351,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
         emailWebsite: String?,
         delegate: GeneratorCoordinatorDelegate
     ) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         if type != .username {
             // Username doesn't show the segmented control so the divider should show. Otherwise,
             // remove it to make the segmented control appear to be part of the navigation controller.
@@ -368,7 +369,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     /// Shows the totp manual setup screen.
     ///
     private func showManualTotp(delegate: AuthenticatorKeyCaptureDelegate) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = AuthenticatorKeyCaptureCoordinator(
             appExtensionDelegate: appExtensionDelegate,
             delegate: delegate,
@@ -397,7 +398,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     /// - Parameter passwordHistory: The password history to view.
     ///
     private func showPasswordHistory(_ passwordHistory: [PasswordHistoryView]) {
-        let navigationController = UINavigationController()
+        let navigationController = module.makeNavigationController()
         let coordinator = module.makePasswordHistoryCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .passwordHistoryList(.item(passwordHistory)))

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
@@ -220,9 +220,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
             services: services,
             state: AttachmentsState(cipher: cipher)
         )
-        let view = AttachmentsView(store: Store(processor: processor))
-        let hostingController = UIHostingController(rootView: view)
-        stackNavigator?.present(UINavigationController(rootViewController: hostingController))
+        stackNavigator?.present(AttachmentsView(store: Store(processor: processor)))
     }
 
     /// Shows the totp camera setup screen.
@@ -287,9 +285,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
             services: services,
             state: EditCollectionsState(cipher: cipher)
         )
-        let view = EditCollectionsView(store: Store(processor: processor))
-        let hostingController = UIHostingController(rootView: view)
-        stackNavigator?.present(UINavigationController(rootViewController: hostingController))
+        stackNavigator?.present(EditCollectionsView(store: Store(processor: processor)))
     }
 
     /// Shows the edit item screen.
@@ -393,9 +389,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
             services: services,
             state: MoveToOrganizationState(cipher: cipher)
         )
-        let view = MoveToOrganizationView(store: Store(processor: processor))
-        let hostingController = UIHostingController(rootView: view)
-        stackNavigator?.present(UINavigationController(rootViewController: hostingController))
+        stackNavigator?.present(MoveToOrganizationView(store: Store(processor: processor)))
     }
 
     /// A route to view the password history view.

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
@@ -255,8 +255,8 @@ class VaultItemCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this t
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(navigationController.topViewController is UIHostingController<EditCollectionsView>)
+        XCTAssertTrue(action.view is EditCollectionsView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.attachments()` navigates to the attachments view..
@@ -266,8 +266,8 @@ class VaultItemCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this t
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(navigationController.topViewController is UIHostingController<AttachmentsView>)
+        XCTAssertTrue(action.view is AttachmentsView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.generator`, `.password`, and a delegate presents the generator
@@ -446,8 +446,8 @@ class VaultItemCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this t
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
-        let navigationController = try XCTUnwrap(action.view as? UINavigationController)
-        XCTAssertTrue(navigationController.topViewController is UIHostingController<MoveToOrganizationView>)
+        XCTAssertTrue(action.view is MoveToOrganizationView)
+        XCTAssertEqual(action.embedInNavigationController, true)
     }
 
     /// `navigate(to:)` with `.passwordHistory` presents the password history view.

--- a/GlobalTestHelpers/MockAppModule.swift
+++ b/GlobalTestHelpers/MockAppModule.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import UIKit
 
 @testable import BitwardenShared
 
@@ -16,6 +17,7 @@ class MockAppModule:
     ImportCXFModule,
     ImportLoginsModule,
     LoginRequestModule,
+    NavigatorBuilderModule,
     PasswordAutoFillModule,
     PasswordHistoryModule,
     SendModule,
@@ -128,6 +130,10 @@ class MockAppModule:
         stackNavigator _: StackNavigator
     ) -> AnyCoordinator<LoginRequestRoute, Void> {
         loginRequestCoordinator.asAnyCoordinator()
+    }
+
+    func makeNavigationController() -> UINavigationController {
+        UINavigationController()
     }
 
     func makePasswordAutoFillCoordinator(

--- a/GlobalTestHelpers/MockStackNavigator.swift
+++ b/GlobalTestHelpers/MockStackNavigator.swift
@@ -8,6 +8,7 @@ final class MockStackNavigator: StackNavigator {
         var animated: Bool
         var embedInNavigationController: Bool?
         var hidesBottomBar: Bool?
+        var isModalInPresentation: Bool?
         var overFullscreen: Bool?
     }
 
@@ -79,10 +80,11 @@ final class MockStackNavigator: StackNavigator {
         alertOnDismissed = onDismissed
     }
 
-    func present<Content: View>(
+    func present<Content: View>( // swiftlint:disable:this function_parameter_count
         _ view: Content,
         animated: Bool,
         embedInNavigationController: Bool,
+        isModalInPresentation: Bool,
         overFullscreen: Bool,
         onCompletion: (() -> Void)?
     ) {
@@ -93,6 +95,7 @@ final class MockStackNavigator: StackNavigator {
                 view: view,
                 animated: animated,
                 embedInNavigationController: embedInNavigationController,
+                isModalInPresentation: isModalInPresentation,
                 overFullscreen: overFullscreen
             )
         )

--- a/GlobalTestHelpers/MockStackNavigator.swift
+++ b/GlobalTestHelpers/MockStackNavigator.swift
@@ -6,6 +6,7 @@ final class MockStackNavigator: StackNavigator {
         var type: NavigationType
         var view: Any?
         var animated: Bool
+        var embedInNavigationController: Bool?
         var hidesBottomBar: Bool?
         var overFullscreen: Bool?
     }
@@ -81,6 +82,7 @@ final class MockStackNavigator: StackNavigator {
     func present<Content: View>(
         _ view: Content,
         animated: Bool,
+        embedInNavigationController: Bool,
         overFullscreen: Bool,
         onCompletion: (() -> Void)?
     ) {
@@ -90,6 +92,7 @@ final class MockStackNavigator: StackNavigator {
                 type: .presented,
                 view: view,
                 animated: animated,
+                embedInNavigationController: embedInNavigationController,
                 overFullscreen: overFullscreen
             )
         )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19577](https://bitwarden.atlassian.net/browse/PM-19577)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds logging for navigation changes to the flight recorder. 

I originally considered adding this logging to the coordinators whenever `navigate(to:)` is called. This only captures forward navigation though (and some dismissals), since navigating back within an existing navigation controller happens outside of the coordinator.

I settled on logging from a `UINavigationController` subclass which can log pushes, pops, presentations, and dismisses. This ends up being fairly easy to inject into the navigation stack, but does rely on using `NavigatorBuilderModule.makeNavigationController()` to build navigation controllers instead of creating `UINavigationController`s directly. Related to this, we had a bunch of places where we were adding a SwiftUI view to a hosting controller in a navigation controller and then presenting that from a coordinator. I simplified this by allowing a stack navigator to present a SwiftUI view embedded in a navigation controller.

Sample logs:

```
2025-05-07T15:07:13-05:00: [Navigation] View appeared: SettingsView
2025-05-07T15:07:14-05:00: [Navigation] View appeared: VaultListView
2025-05-07T15:07:15-05:00: [Navigation] View appeared: VaultGroupView
2025-05-07T15:07:16-05:00: [Navigation] View appeared: ViewItemView
2025-05-07T15:07:18-05:00: [Navigation] View appeared: AddEditItemView
2025-05-07T15:07:22-05:00: [Navigation] View appeared: AttachmentsView
2025-05-07T15:07:25-05:00: [Navigation] View dismissed: AttachmentsView
2025-05-07T15:07:26-05:00: [Navigation] View dismissed: AddEditItemView
2025-05-07T15:07:27-05:00: [Navigation] View dismissed: ViewItemView
2025-05-07T15:07:29-05:00: [Navigation] View appeared: SendListView
2025-05-07T15:07:30-05:00: [Navigation] View appeared: AddEditSendItemView
2025-05-07T15:07:32-05:00: [Navigation] View dismissed: AddEditSendItemView
2025-05-07T15:07:34-05:00: [Navigation] View appeared: GeneratorView
2025-05-07T15:07:35-05:00: [Navigation] View appeared: PasswordHistoryListView
2025-05-07T15:07:37-05:00: [Navigation] View dismissed: PasswordHistoryListView
2025-05-07T15:07:44-05:00: [Navigation] View appeared: SettingsView
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19577]: https://bitwarden.atlassian.net/browse/PM-19577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ