### PR TITLE
[PM-19577] Deactivate flight recorder if appending to the log fails

### DIFF
--- a/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
+++ b/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
@@ -142,7 +142,7 @@ actor DefaultFlightRecorder {
 
         if !disableLogLifecycleTimerForTesting {
             Task {
-                await dataSubject.send(stateService.getFlightRecorderData())
+                _ = await getFlightRecorderData() // Load the flight recorder data to the subject.
                 await self.configureLogLifecycleTimer()
             }
         }

--- a/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
+++ b/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
@@ -410,11 +410,17 @@ extension DefaultFlightRecorder: FlightRecorder {
     }
 
     func log(_ message: String, file: String, line: UInt) async {
-        guard let log = await getFlightRecorderData()?.activeLog else { return }
+        guard var data = await getFlightRecorderData(), let log = data.activeLog else { return }
         do {
             let timestampedMessage = "\(dateFormatter.string(from: timeProvider.presentTime)): \(message)\n"
             try await append(message: timestampedMessage, to: log)
         } catch {
+            // If there's an error writing to the file, disable the flight recorder. This prevents
+            // an infinite loop by logging an error to the error reporter which then tries again to
+            // log to the flight recorder, and so on.
+            data.activeLog = nil
+            await setFlightRecorderData(data)
+
             let fileName = URL(fileURLWithPath: file).lastPathComponent
             errorReporter.log(error: BitwardenError.generalError(
                 type: "Flight Recorder Log Error",

--- a/BitwardenShared/Core/Platform/Services/FlightRecorderTests.swift
+++ b/BitwardenShared/Core/Platform/Services/FlightRecorderTests.swift
@@ -572,7 +572,8 @@ class FlightRecorderTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(stateService.flightRecorderData, FlightRecorderData(activeLog: activeLog))
     }
 
-    /// `log(_:)` logs an error if appending the log to the file fails.
+    /// `log(_:)` logs an error and deactivates the flight recorder if appending the log to the file
+    /// fails.
     func test_log_error() async throws {
         fileManager.appendDataResult = .failure(BitwardenTestError.example)
         stateService.flightRecorderData = FlightRecorderData(activeLog: activeLog)
@@ -583,6 +584,7 @@ class FlightRecorderTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let error = try XCTUnwrap(errorReporter.errors.last as? NSError)
         XCTAssertEqual(error.code, BitwardenError.Code.generalError.rawValue)
         XCTAssertEqual(error.domain, "General Error: Flight Recorder Log Error")
+        XCTAssertEqual(stateService.flightRecorderData, FlightRecorderData(inactiveLogs: [activeLog]))
     }
 
     /// `log(_:)` doesn't record the log if there's no active log.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19577](https://bitwarden.atlassian.net/browse/PM-19577)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

If appending to the flight recorder log fails, we record an error with the error reporter. Now that the error reporter also logs errors to the flight recorder, there's a potential infinite loop if writing to the log fails. In this case, it doesn't really make sense to continue logging (since the file could be missing or the device is out of storage or some other unrecoverable error), so in order to prevent looping, this deactivates the flight recorder.

https://github.com/bitwarden/ios/pull/1547#discussion_r2078455240

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19577]: https://bitwarden.atlassian.net/browse/PM-19577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ