### PR TITLE
[PM-21125] Add navigation setup for view send item

### DIFF
--- a/BitwardenShareExtension/ShareViewController.swift
+++ b/BitwardenShareExtension/ShareViewController.swift
@@ -14,7 +14,7 @@ class ShareViewController: UIViewController {
     /// The app's theme.
     var appTheme: AppTheme = .default
 
-    var authCompletionRoute: AppRoute? = .sendItem(.add(content: nil, hasPremium: false))
+    var authCompletionRoute: AppRoute? = .sendItem(.add(content: nil))
 
     /// The processor that manages application level logic.
     private var appProcessor: AppProcessor?
@@ -58,9 +58,7 @@ class ShareViewController: UIViewController {
         let appProcessor = AppProcessor(appModule: appModule, services: services)
         self.appProcessor = appProcessor
 
-        let hasPremium = try? await services.sendRepository.doesActiveAccountHavePremium()
-
-        authCompletionRoute = .sendItem(.add(content: content, hasPremium: hasPremium ?? false))
+        authCompletionRoute = .sendItem(.add(content: content))
 
         Task {
             await appProcessor.start(

--- a/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -383,16 +383,16 @@ class AppCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(module.loginRequestCoordinator.routes.last, .loginRequest(.fixture()))
     }
 
-    /// `navigate(to:)` with `.sendItem(.add(content:hasPremium:))` starts the send item coordinator
+    /// `navigate(to:)` with `.sendItem(.add(content:))` starts the send item coordinator
     /// and navigates to the proper route.
     @MainActor
     func test_navigateTo_sendItem() {
-        subject.navigate(to: .sendItem(.add(content: nil, hasPremium: false)))
+        subject.navigate(to: .sendItem(.add(content: nil)))
 
         XCTAssertTrue(module.sendItemCoordinator.isStarted)
         XCTAssertEqual(
             module.sendItemCoordinator.routes,
-            [.add(content: nil, hasPremium: false)]
+            [.add(content: nil)]
         )
     }
 
@@ -400,15 +400,15 @@ class AppCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// creating a new one.
     @MainActor
     func test_navigateTo_sendItem_twice() {
-        subject.navigate(to: .sendItem(.add(content: nil, hasPremium: false)))
-        subject.navigate(to: .sendItem(.add(content: .text("test"), hasPremium: true)))
+        subject.navigate(to: .sendItem(.add(content: nil)))
+        subject.navigate(to: .sendItem(.add(content: .text("test"))))
 
         XCTAssertTrue(module.sendItemCoordinator.isStarted)
         XCTAssertEqual(
             module.sendItemCoordinator.routes,
             [
-                .add(content: nil, hasPremium: false),
-                .add(content: .text("test"), hasPremium: true),
+                .add(content: nil),
+                .add(content: .text("test")),
             ]
         )
     }

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1182,3 +1182,5 @@
 "DoYouReallyWantToDeleteAllRecordedLogs" = "Do you really want to delete all recorded logs?";
 "ThisAccountWillSoonBeDeletedLogInAtXToContinueUsingBitwarden" = "This account will soon be deleted. Log in at %1$@ to continue using Bitwarden.";
 "AppSettings" = "App settings";
+"ViewFileSend" = "View file Send";
+"ViewTextSend" = "View text Send";

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -64,24 +64,17 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
         switch route {
         case let .addItem(type):
             guard let delegate = context as? SendItemDelegate else { return }
-            Task {
-                let hasPremium = try? await services.sendRepository.doesActiveAccountHavePremium()
-                let route: SendItemRoute
-                if let type {
-                    route = .add(content: .type(type), hasPremium: hasPremium ?? false)
-                } else {
-                    route = .add(content: nil, hasPremium: hasPremium ?? false)
-                }
-                showItem(route: route, delegate: delegate)
+            let route: SendItemRoute = if let type {
+                .add(content: .type(type))
+            } else {
+                .add(content: nil)
             }
+            showItem(route: route, delegate: delegate)
         case let .dismiss(dismissAction):
             stackNavigator?.dismiss(completion: dismissAction?.action)
         case let .editItem(sendView):
             guard let delegate = context as? SendItemDelegate else { return }
-            Task {
-                let hasPremium = try? await services.sendRepository.doesActiveAccountHavePremium()
-                showItem(route: .edit(sendView, hasPremium: hasPremium ?? false), delegate: delegate)
-            }
+            showItem(route: .edit(sendView), delegate: delegate)
         case let .group(type):
             showGroup(type)
         case .list:

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -88,6 +88,9 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
             showList()
         case let .share(url):
             showShareSheet(for: [url])
+        case let .viewItem(sendView):
+            guard let delegate = context as? SendItemDelegate else { return }
+            showItem(route: .view(sendView), delegate: delegate)
         }
     }
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
@@ -263,6 +263,20 @@ class SendCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(action.view is UIActivityViewController)
     }
 
+    /// `navigate(to:)` with `.viewItem` presents the view send item screen
+    @MainActor
+    func test_navigateTo_viewItem() throws {
+        let sendView = SendView.fixture()
+        subject.navigate(to: .viewItem(sendView), context: sendItemDelegate)
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is UINavigationController)
+
+        XCTAssertTrue(module.sendItemCoordinator.isStarted)
+        XCTAssertEqual(module.sendItemCoordinator.routes.last, .view(sendView))
+    }
+
     /// `start()` initializes the coordinator's state correctly.
     @MainActor
     func test_start() throws {

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
@@ -49,8 +49,7 @@ class SendCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.addItem` presents the add send item screen.
     @MainActor
-    func test_navigateTo_addItem_hasPremium_withDelegate() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+    func test_navigateTo_addItem_withDelegate() throws {
         subject.navigate(to: .addItem(), context: sendItemDelegate)
 
         waitFor(!stackNavigator.actions.isEmpty)
@@ -59,14 +58,13 @@ class SendCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(action.view is UINavigationController)
 
         XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: nil, hasPremium: true))
+        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: nil))
     }
 
     /// `navigate(to:)` with `.addItem` and without a delegate does not present the add send item
     /// screen.
     @MainActor
-    func test_navigateTo_addItem_hasPremium_withoutDelegate() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+    func test_navigateTo_addItem_withoutDelegate() throws {
         subject.navigate(to: .addItem(), context: nil)
 
         XCTAssertFalse(module.sendItemCoordinator.isStarted)
@@ -75,38 +73,7 @@ class SendCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.addItem` presents the add send item screen.
     @MainActor
-    func test_navigateTo_addItem_notHasPremium() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(false)
-        subject.navigate(to: .addItem(), context: sendItemDelegate)
-
-        waitFor(!stackNavigator.actions.isEmpty)
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .presented)
-        XCTAssertTrue(action.view is UINavigationController)
-
-        XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: nil, hasPremium: false))
-    }
-
-    /// `navigate(to:)` with `.addItem` presents the add send item screen.
-    @MainActor
-    func test_navigateTo_addItem_hasPremiumError() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .failure(BitwardenTestError.example)
-        subject.navigate(to: .addItem(), context: sendItemDelegate)
-
-        waitFor(!stackNavigator.actions.isEmpty)
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .presented)
-        XCTAssertTrue(action.view is UINavigationController)
-
-        XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: nil, hasPremium: false))
-    }
-
-    /// `navigate(to:)` with `.addItem` presents the add send item screen.
-    @MainActor
-    func test_navigateTo_addItem_fileType_hasPremium_withDelegate() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+    func test_navigateTo_addItem_fileType_withDelegate() throws {
         subject.navigate(to: .addItem(type: .file), context: sendItemDelegate)
 
         waitFor(!stackNavigator.actions.isEmpty)
@@ -115,48 +82,17 @@ class SendCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(action.view is UINavigationController)
 
         XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: .type(.file), hasPremium: true))
+        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: .type(.file)))
     }
 
     /// `navigate(to:)` with `.addItem` and without a delegate does not present the add send item
     /// screen.
     @MainActor
-    func test_navigateTo_addItem_fileType_hasPremium_withoutDelegate() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+    func test_navigateTo_addItem_fileType_withoutDelegate() throws {
         subject.navigate(to: .addItem(type: .file), context: nil)
 
         XCTAssertFalse(module.sendItemCoordinator.isStarted)
         XCTAssertTrue(module.sendItemCoordinator.routes.isEmpty)
-    }
-
-    /// `navigate(to:)` with `.addItem` presents the add send item screen.
-    @MainActor
-    func test_navigateTo_addItem_fileType_notHasPremium() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(false)
-        subject.navigate(to: .addItem(type: .file), context: sendItemDelegate)
-
-        waitFor(!stackNavigator.actions.isEmpty)
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .presented)
-        XCTAssertTrue(action.view is UINavigationController)
-
-        XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: .type(.file), hasPremium: false))
-    }
-
-    /// `navigate(to:)` with `.addItem` presents the add send item screen.
-    @MainActor
-    func test_navigateTo_addItem_fileType_hasPremiumError() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .failure(BitwardenTestError.example)
-        subject.navigate(to: .addItem(type: .file), context: sendItemDelegate)
-
-        waitFor(!stackNavigator.actions.isEmpty)
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .presented)
-        XCTAssertTrue(action.view is UINavigationController)
-
-        XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .add(content: .type(.file), hasPremium: false))
     }
 
     /// `navigate(to:)` with `.dismiss` dismisses the current modally presented screen.
@@ -170,8 +106,7 @@ class SendCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.editItem` presents the add send item screen.
     @MainActor
-    func test_navigateTo_editItem_hasPremium_withDelegate() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+    func test_navigateTo_editItem_withDelegate() throws {
         let sendView = SendView.fixture()
         subject.navigate(to: .editItem(sendView), context: sendItemDelegate)
 
@@ -181,51 +116,18 @@ class SendCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(action.view is UINavigationController)
 
         XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .edit(sendView, hasPremium: true))
+        XCTAssertEqual(module.sendItemCoordinator.routes.last, .edit(sendView))
     }
 
     /// `navigate(to:)` with `.editItem` and without a delegate does not present the add send item
     /// screen.
     @MainActor
-    func test_navigateTo_editItem_hasPremium_withoutDelegate() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+    func test_navigateTo_editItem_withoutDelegate() throws {
         let sendView = SendView.fixture()
         subject.navigate(to: .editItem(sendView), context: nil)
 
         XCTAssertFalse(module.sendItemCoordinator.isStarted)
         XCTAssertTrue(module.sendItemCoordinator.routes.isEmpty)
-    }
-
-    /// `navigate(to:)` with `.editItem` presents the add send item screen.
-    @MainActor
-    func test_navigateTo_editItem_notHasPremium() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(false)
-        let sendView = SendView.fixture()
-        subject.navigate(to: .editItem(sendView), context: sendItemDelegate)
-
-        waitFor(!stackNavigator.actions.isEmpty)
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .presented)
-        XCTAssertTrue(action.view is UINavigationController)
-
-        XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .edit(sendView, hasPremium: false))
-    }
-
-    /// `navigate(to:)` with `.editItem` presents the add send item screen.
-    @MainActor
-    func test_navigateTo_editItem_hasPremiumError() throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .failure(BitwardenTestError.example)
-        let sendView = SendView.fixture()
-        subject.navigate(to: .editItem(sendView), context: sendItemDelegate)
-
-        waitFor(!stackNavigator.actions.isEmpty)
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .presented)
-        XCTAssertTrue(action.view is UINavigationController)
-
-        XCTAssertTrue(module.sendItemCoordinator.isStarted)
-        XCTAssertEqual(module.sendItemCoordinator.routes.last, .edit(sendView, hasPremium: false))
     }
 
     /// `navigate(to:)` with `.group` pushes the send list screen for the type onto the stack.

--- a/BitwardenShared/UI/Tools/Send/Send/SendRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendRoute.swift
@@ -33,4 +33,10 @@ public enum SendRoute: Equatable {
     /// - Parameter url: The `URL` to share.
     ///
     case share(url: URL)
+
+    /// A route to view send item screen.
+    ///
+    /// - Parameter sendView: The `SendView` to view the details of.
+    ///
+    case viewItem(_ sendView: SendView)
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -165,6 +165,12 @@ class AddEditSendItemProcessor:
         if state.maximumAccessCount != 0 {
             state.maximumAccessCountText = "\(state.maximumAccessCount)"
         }
+
+        do {
+            state.hasPremium = try await services.sendRepository.doesActiveAccountHavePremium()
+        } catch {
+            services.errorReporter.log(error: error)
+        }
     }
 
     /// A method to respond to a `ProfileSwitcherAction`

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -139,7 +139,7 @@ extension AddEditSendItemState {
     ///   - sendView: The `SendView` to use to instantiate this state.
     ///   - hasPremium: A flag indicating if the active account has premium access.
     ///
-    init(sendView: SendView, hasPremium: Bool) {
+    init(sendView: SendView, hasPremium: Bool = false) {
         self.init(
             accessId: sendView.accessId,
             currentAccessCount: Int(sendView.accessCount),

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
@@ -86,6 +86,8 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
             showFileSelection(route: route, delegate: delegate)
         case let .share(url):
             showShareSheet(for: [url])
+        case let .view(sendView):
+            showViewItem(for: sendView)
         }
     }
 
@@ -178,6 +180,20 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
             applicationActivities: nil
         )
         stackNavigator?.present(viewController)
+    }
+
+    /// Shows the view item screen.
+    ///
+    /// - Parameter sendView: The send to view.
+    ///
+    private func showViewItem(for sendView: SendView) {
+        let state = ViewSendItemState(sendView: sendView)
+        let processor = ViewSendItemProcessor(
+            coordinator: asAnyCoordinator(),
+            services: services,
+            state: state
+        )
+        stackNavigator?.replace(ViewSendItemView(store: Store(processor: processor)))
     }
 }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
@@ -71,16 +71,16 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
 
     func navigate(to route: SendItemRoute, context: AnyObject?) {
         switch route {
-        case let .add(content, hasPremium):
-            showAddItem(content: content, hasPremium: hasPremium)
+        case let .add(content):
+            showAddItem(content: content)
         case .cancel:
             delegate?.sendItemCancelled()
         case .deleted:
             delegate?.sendItemDeleted()
         case let .complete(sendView):
             delegate?.sendItemCompleted(with: sendView)
-        case let .edit(sendView, hasPremium):
-            showEditItem(for: sendView, hasPremium: hasPremium)
+        case let .edit(sendView):
+            showEditItem(for: sendView)
         case let .fileSelection(route):
             guard let delegate = context as? FileSelectionDelegate else { return }
             showFileSelection(route: route, delegate: delegate)
@@ -97,14 +97,10 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
 
     /// Shows the add item screen.
     ///
-    /// - Parameters:
-    ///   - content: Optional content to pre-fill the add item screen.
-    ///   - hasPremium: A flag indicating if the active account has premium access.
+    /// - Parameter content: Optional content to pre-fill the add item screen.
     ///
-    private func showAddItem(content: AddSendContentType?, hasPremium: Bool) {
-        var state = AddEditSendItemState(
-            hasPremium: hasPremium
-        )
+    private func showAddItem(content: AddSendContentType?) {
+        var state = AddEditSendItemState()
         switch content {
         case let .file(fileName, fileData):
             state.fileName = fileName
@@ -132,15 +128,10 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator {
 
     /// Shows the edit item screen.
     ///
-    /// - Parameters:
-    ///   - sendView: The send to edit.
-    ///   - hasPremium: A flag indicating if the active account has premium access.
+    /// - Parameter sendView: The send to edit.
     ///
-    private func showEditItem(for sendView: SendView, hasPremium: Bool) {
-        let state = AddEditSendItemState(
-            sendView: sendView,
-            hasPremium: hasPremium
-        )
+    private func showEditItem(for sendView: SendView) {
+        let state = AddEditSendItemState(sendView: sendView)
         let processor = AddEditSendItemProcessor(
             coordinator: asAnyCoordinator(),
             services: services,

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinatorTests.swift
@@ -199,4 +199,16 @@ class SendItemCoordinatorTests: BitwardenTestCase {
         subject.navigate(to: .fileSelection(.camera), context: nil)
         XCTAssertNil(stackNavigator.actions.last)
     }
+
+    /// `navigate(to:)` with `.view` shows the view send screen.
+    @MainActor
+    func test_navigateTo_view() throws {
+        let sendView = SendView.fixture()
+        subject.navigate(to: .view(sendView))
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .replaced)
+        let view = try XCTUnwrap(action.view as? ViewSendItemView)
+        XCTAssertEqual(view.store.state.sendView, sendView)
+    }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinatorTests.swift
@@ -43,25 +43,12 @@ class SendItemCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.add()` shows the add item screen.
     @MainActor
-    func test_navigateTo_add_noContent_hasPremium() throws {
-        subject.navigate(to: .add(content: nil, hasPremium: true))
+    func test_navigateTo_add_noContent() throws {
+        subject.navigate(to: .add(content: nil))
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .replaced)
         let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertTrue(view.store.state.hasPremium)
-        XCTAssertEqual(view.store.state.mode, .add)
-    }
-
-    /// `navigate(to:)` with `.addItem` shows the add send item screen.
-    @MainActor
-    func test_navigateTo_add_noContent_notHasPremium() throws {
-        subject.navigate(to: .add(content: nil, hasPremium: false))
-
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .replaced)
-        let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertFalse(view.store.state.hasPremium)
         XCTAssertEqual(view.store.state.mode, .add)
     }
 
@@ -73,15 +60,13 @@ class SendItemCoordinatorTests: BitwardenTestCase {
                 content: .file(
                     fileName: "test file",
                     fileData: Data("test data".utf8)
-                ),
-                hasPremium: false
+                )
             )
         )
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .replaced)
         let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertFalse(view.store.state.hasPremium)
         XCTAssertEqual(view.store.state.mode, .shareExtension(.empty()))
         XCTAssertEqual(view.store.state.type, .file)
         XCTAssertEqual(view.store.state.text, "")
@@ -92,17 +77,11 @@ class SendItemCoordinatorTests: BitwardenTestCase {
     /// `navigate(to:)` with `.add()` shows the add item screen with prefilled text content.
     @MainActor
     func test_navigateTo_add_textContent() throws {
-        subject.navigate(
-            to: .add(
-                content: .text("test"),
-                hasPremium: true
-            )
-        )
+        subject.navigate(to: .add(content: .text("test")))
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .replaced)
         let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertTrue(view.store.state.hasPremium)
         XCTAssertEqual(
             view.store.state.mode,
             .shareExtension(.empty())
@@ -116,17 +95,11 @@ class SendItemCoordinatorTests: BitwardenTestCase {
     /// `navigate(to:)` with `.add()` shows the add send item screen with prefilled type content.
     @MainActor
     func test_navigateTo_add_typeContent() throws {
-        subject.navigate(
-            to: .add(
-                content: .type(.file),
-                hasPremium: false
-            )
-        )
+        subject.navigate(to: .add(content: .type(.file)))
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .replaced)
         let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertFalse(view.store.state.hasPremium)
         XCTAssertEqual(view.store.state.mode, .add)
         XCTAssertEqual(view.store.state.type, .file)
         XCTAssertEqual(view.store.state.text, "")
@@ -154,28 +127,13 @@ class SendItemCoordinatorTests: BitwardenTestCase {
 
     /// `navigate(to:)` with `.edit` shows the edit screen.
     @MainActor
-    func test_navigateTo_edit_hasPremium() throws {
+    func test_navigateTo_edit() throws {
         let sendView = SendView.fixture(id: "SEND_ID", name: "Name")
-        subject.navigate(to: .edit(sendView, hasPremium: true))
+        subject.navigate(to: .edit(sendView))
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .replaced)
         let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertTrue(view.store.state.hasPremium)
-        XCTAssertEqual(view.store.state.name, "Name")
-        XCTAssertEqual(view.store.state.mode, .edit)
-    }
-
-    /// `navigate(to:)` with `.edit` shows the edit screen.
-    @MainActor
-    func test_navigateTo_edit_notHasPremium() throws {
-        let sendView = SendView.fixture(id: "SEND_ID", name: "Name")
-        subject.navigate(to: .edit(sendView, hasPremium: false))
-
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .replaced)
-        let view = try XCTUnwrap(action.view as? AddEditSendItemView)
-        XCTAssertFalse(view.store.state.hasPremium)
         XCTAssertEqual(view.store.state.name, "Name")
         XCTAssertEqual(view.store.state.mode, .edit)
     }

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
@@ -23,11 +23,9 @@ public enum AddSendContentType: Equatable, Hashable {
 public enum SendItemRoute: Equatable, Hashable {
     /// A route to the add item screen.
     ///
-    /// - Parameters:
-    ///   - content: Initial content to pre-fill the add send screen with.
-    ///   - hasPremium: A flag indicating if the active account has premium access.
+    /// - Parameter content: Initial content to pre-fill the add send screen with.
     ///
-    case add(content: AddSendContentType?, hasPremium: Bool)
+    case add(content: AddSendContentType?)
 
     /// A route specifying that the send item flow has been cancelled.
     case cancel
@@ -44,11 +42,9 @@ public enum SendItemRoute: Equatable, Hashable {
 
     /// A route to the edit item screen for the provided send.
     ///
-    /// - Parameters:
-    ///   - sendView: The `SendView` to edit.
-    ///   - hasPremium: A flag indicating if the active account has premium access.
+    /// - Parameter sendView: The `SendView` to edit.
     ///
-    case edit(_ sendView: SendView, hasPremium: Bool)
+    case edit(_ sendView: SendView)
 
     /// A route to a file selection route.
     ///

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
@@ -29,17 +29,17 @@ public enum SendItemRoute: Equatable, Hashable {
     ///
     case add(content: AddSendContentType?, hasPremium: Bool)
 
-    /// A route specifing that the send item flow has been cancelled.
+    /// A route specifying that the send item flow has been cancelled.
     case cancel
 
-    /// A route specifing that the send item flow has been completed, along with the new/updated
+    /// A route specifying that the send item flow has been completed, along with the new/updated
     /// send view.
     ///
     /// - Parameter sendView: The new or updated `SendView`.
     ///
     case complete(_ sendView: SendView)
 
-    /// A route specifing that the send item flow completed by deleting a send.
+    /// A route specifying that the send item flow completed by deleting a send.
     case deleted
 
     /// A route to the edit item screen for the provided send.
@@ -61,4 +61,10 @@ public enum SendItemRoute: Equatable, Hashable {
     /// - Parameter url: The `URL` to share.
     ///
     case share(url: URL)
+
+    /// A route to view send item screen.
+    ///
+    /// - Parameter sendView: The `SendView` to view the details of.
+    ///
+    case view(_ sendView: SendView)
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemAction.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemAction.swift
@@ -1,0 +1,11 @@
+// MARK: - ViewSendItemAction
+
+/// Actions that can be processed by a `ViewSendItemProcessor`.
+///
+enum ViewSendItemAction: Equatable {
+    /// The dismiss button was tapped.
+    case dismiss
+
+    /// The edit item button was tapped.
+    case editItem
+}

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemEffect.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemEffect.swift
@@ -1,0 +1,5 @@
+// MARK: - ViewSendItemEffect
+
+/// Effects that can be processed by a `ViewSendItemProcessor`.
+///
+enum ViewSendItemEffect: Equatable {}

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessor.swift
@@ -1,0 +1,49 @@
+// MARK: - ViewSendItemProcessor
+
+/// The processor used to manage state and handle actions for the view send item screen.
+///
+class ViewSendItemProcessor: StateProcessor<ViewSendItemState, ViewSendItemAction, ViewSendItemEffect> {
+    // MARK: Types
+
+    typealias Services = HasErrorReporter
+
+    // MARK: Private Properties
+
+    /// The `Coordinator` that handles navigation for this processor.
+    private let coordinator: AnyCoordinator<SendItemRoute, AuthAction>
+
+    /// The services required by this processor.
+    private let services: Services
+
+    // MARK: Initialization
+
+    /// Creates a new `ViewSendItemProcessor`.
+    ///
+    /// - Parameters:
+    ///   - coordinator: The coordinator that handles navigation for this processor.
+    ///   - services: The services required by this processor.
+    ///   - state: The initial state of this processor.
+    ///
+    init(
+        coordinator: AnyCoordinator<SendItemRoute, AuthAction>,
+        services: Services,
+        state: ViewSendItemState
+    ) {
+        self.coordinator = coordinator
+        self.services = services
+        super.init(state: state)
+    }
+
+    // MARK: Methods
+
+    override func perform(_ effect: ViewSendItemEffect) async {}
+
+    override func receive(_ action: ViewSendItemAction) {
+        switch action {
+        case .dismiss:
+            coordinator.navigate(to: .cancel)
+        case .editItem:
+            break
+        }
+    }
+}

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessor.swift
@@ -43,7 +43,7 @@ class ViewSendItemProcessor: StateProcessor<ViewSendItemState, ViewSendItemActio
         case .dismiss:
             coordinator.navigate(to: .cancel)
         case .editItem:
-            break
+            coordinator.navigate(to: .edit(state.sendView))
         }
     }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessorTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class ViewSendItemProcessorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var coordinator: MockCoordinator<SendItemRoute, AuthAction>!
+    var subject: ViewSendItemProcessor!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        coordinator = MockCoordinator()
+
+        subject = ViewSendItemProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(),
+            state: ViewSendItemState(sendView: .fixture())
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        coordinator = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `receive(_:)` with `.dismiss` navigates to the cancel route.
+    @MainActor
+    func test_receive_dismiss() {
+        subject.receive(.dismiss)
+
+        XCTAssertEqual(coordinator.routes.last, .cancel)
+    }
+
+    /// `receive(_:)` with `.editItem` navigates to the edit send view.
+    @MainActor
+    func test_receive_editItem() {
+        subject.receive(.editItem)
+
+        XCTAssertEqual(coordinator.routes.last, .edit(subject.state.sendView))
+    }
+}

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
@@ -1,0 +1,22 @@
+import BitwardenSdk
+
+// MARK: - ViewSendItemState
+
+/// An object that defines the current state of a `ViewSendItemView`.
+///
+struct ViewSendItemState: Equatable {
+    // MARK: Properties
+
+    /// The send to show the details of.
+    let sendView: SendView
+
+    // MARK: Computed Properties
+
+    /// The navigation title of the view.
+    var navigationTitle: String {
+        switch sendView.type {
+        case .file: Localizations.viewFileSend
+        case .text: Localizations.viewTextSend
+        }
+    }
+}

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+// MARK: - ViewSendItemView
+
+/// A view that allows the user to view the details of a send item.
+///
+struct ViewSendItemView: View {
+    // MARK: Properties
+
+    /// The `Store` for this view.
+    @ObservedObject var store: Store<ViewSendItemState, ViewSendItemAction, ViewSendItemEffect>
+
+    // MARK: View
+
+    var body: some View {
+        EmptyView()
+            .scrollView(padding: 12)
+            .navigationTitle(store.state.navigationTitle)
+            .overlay(alignment: .bottomTrailing) {
+                editItemFloatingActionButton {
+                    store.send(.editItem)
+                }
+            }
+            .toolbar {
+                cancelToolbarItem {
+                    store.send(.dismiss)
+                }
+            }
+    }
+}

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemViewTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemViewTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class ViewSendItemViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var processor: MockProcessor<ViewSendItemState, ViewSendItemAction, ViewSendItemEffect>!
+    var subject: ViewSendItemView!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        processor = MockProcessor(state: ViewSendItemState(sendView: .fixture()))
+
+        subject = ViewSendItemView(store: Store(processor: processor))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        processor = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// Tapping the cancel button sends the `.dismiss` action.
+    @MainActor
+    func test_cancel_tap() throws {
+        let button = try subject.inspect().find(button: Localizations.cancel)
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .dismiss)
+    }
+
+    /// Tapping the edit button sends the `.editItem` action.
+    @MainActor
+    func test_editItemFloatingActionButton_tap() throws {
+        let fab = try subject.inspect().find(viewWithAccessibilityIdentifier: "EditItemFloatingActionButton")
+        try fab.button().tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .editItem)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-21125](https://bitwarden.atlassian.net/browse/PM-21125)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the initial setup for navigating to the view item screen. The actual change for navigating to the view send screen hasn't been implemented yet, and will be coming in a future PR.

As part of this, we were passing `hasPremium` as an associated value in the route to the add/edit item screen. This felt overly complex now that we have multiple routes to the add/edit screen. So that has been refactored so the add/edit processor loads that data when the view appears.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21125]: https://bitwarden.atlassian.net/browse/PM-21125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ