### PR TITLE
[PM-20171] Fix ViewItemView retain cycle

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -18,6 +18,9 @@ enum ViewItemAction: Equatable, Sendable {
     /// The visibility button was pressed for the specified custom field.
     case customFieldVisibilityPressed(CustomFieldState)
 
+    /// The view item disappeared from the screen.
+    case disappeared
+
     /// The dismiss button was pressed.
     case dismissPressed
 
@@ -57,7 +60,8 @@ enum ViewItemAction: Equatable, Sendable {
             true
         case let .copyPressed(_, field):
             field.requiresMasterPasswordReprompt
-        case .dismissPressed,
+        case .disappeared,
+             .dismissPressed,
              .passwordHistoryPressed,
              .toastShown:
             false

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
@@ -73,6 +73,7 @@ class ViewItemActionTests: BitwardenTestCase {
                 .requiresMasterPasswordReprompt
         )
 
+        XCTAssertFalse(ViewItemAction.disappeared.requiresMasterPasswordReprompt)
         XCTAssertFalse(ViewItemAction.dismissPressed.requiresMasterPasswordReprompt)
 
         XCTAssertTrue(ViewItemAction.downloadAttachment(.fixture()).requiresMasterPasswordReprompt)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -783,7 +783,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(coordinator.routes.last, .dismiss())
     }
 
-    /// `receive` with `.disappeared` should clear streamCipherDetailsTask and call deinit.
+    /// `receive` with `.disappeared` should clear streamCipherDetailsTask.
     @MainActor
     func test_receive_disappearPressed() {
         let account = Account.fixture()

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -157,6 +157,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         )
         vaultRepository.cipherDetailsSubject.send(cipherItem)
 
+        XCTAssertNil(subject.streamCipherDetailsTask)
         let task = Task {
             await subject.perform(.appeared)
         }
@@ -172,6 +173,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         expectedState.allUserCollections = collections
 
+        XCTAssertNotNil(subject.streamCipherDetailsTask)
         XCTAssertTrue(subject.state.hasPremiumFeatures)
         XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertFalse(subject.state.restrictCipherItemDeletionFlagEnabled)
@@ -779,6 +781,25 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_receive_dismissPressed() {
         subject.receive(.dismissPressed)
         XCTAssertEqual(coordinator.routes.last, .dismiss())
+    }
+
+    /// `receive` with `.disappeared` should clear streamCipherDetailsTask and call deinit.
+    @MainActor
+    func test_receive_disappearPressed() {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+
+        XCTAssertNil(subject.streamCipherDetailsTask)
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertNotNil(subject.streamCipherDetailsTask)
+        subject.receive(.disappeared)
+        XCTAssertNil(subject.streamCipherDetailsTask)
     }
 
     /// `perform(_:)` with `.deletePressed` presents the confirmation alert before delete the item and displays

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -107,6 +107,9 @@ struct ViewItemView: View {
                 await store.perform(.appeared)
             }
         }
+        .onDisappear {
+            store.send(.disappeared)
+        }
     }
 
     // MARK: Private Views


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-20171

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
In the `ViewItemView`, create a task reference for `.appeared`. This enables us to cancel it when the view is closed and free the memory.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
