### PR TITLE
[PM-21393] fix: Split BitwardenKit configuration into Release and Debug

### DIFF
--- a/Configs/BitwardenKit-Debug.xcconfig
+++ b/Configs/BitwardenKit-Debug.xcconfig
@@ -1,4 +1,6 @@
 #include "./Common-bwpm.xcconfig"
+#include "./Base-Debug.xcconfig"
 #include? "./Local-bwpm.xcconfig"
 
 PRODUCT_BUNDLE_IDENTIFIER = $(ORGANIZATION_IDENTIFIER).bitwarden-kit
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) $(BITWARDEN_FLAGS)

--- a/Configs/BitwardenKit-Release.xcconfig
+++ b/Configs/BitwardenKit-Release.xcconfig
@@ -1,0 +1,6 @@
+#include "./Common-bwpm.xcconfig"
+#include "./Base-Release.xcconfig"
+#include? "./Local-bwpm.xcconfig"
+
+PRODUCT_BUNDLE_IDENTIFIER = $(ORGANIZATION_IDENTIFIER).bitwarden-kit
+SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) $(BITWARDEN_FLAGS)

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -101,8 +101,8 @@ targets:
     type: framework
     platform: iOS
     configFiles:
-      Debug: Configs/BitwardenKit.xcconfig
-      Release: Configs/BitwardenKit.xcconfig
+      Debug: Configs/BitwardenKit-Debug.xcconfig
+      Release: Configs/BitwardenKit-Release.xcconfig
     settings:
       base:
         APPLICATION_EXTENSION_API_ONLY: true


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21393

## 📔 Objective

`BitwardenKit` was not pulling in `BITWARDEN_FLAGS` to add to compilation flags; this had the effect of making changes in the Debug Menu not actually take effect. This splits BWK's configuration into Release and Debug, like our other targets, and properly brings in the `BITWARDEN_FLAGS`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
