### PR TITLE
[PM-21125] Enable navigation to view send

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -41,6 +41,9 @@ enum SendListItemRowAction: Equatable, Sendable {
 
     /// The item was pressed.
     case sendListItemPressed(SendListItem)
+
+    /// The view send button was tapped.
+    case viewSend(_ sendView: SendView)
 }
 
 // MARK: - SendListItemRowEffect
@@ -155,6 +158,9 @@ struct SendListItemRowView: View {
                     await store.perform(.copyLinkPressed(sendView))
                 }
                 .accessibilityIdentifier("Copy")
+                Button(Localizations.view) {
+                    store.send(.viewSend(sendView))
+                }
                 Button(Localizations.edit) {
                     store.send(.editPressed(sendView))
                 }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -100,10 +100,12 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
             case let .sendListItemPressed(item):
                 switch item.itemType {
                 case let .send(sendView):
-                    coordinator.navigate(to: .editItem(sendView), context: self)
+                    coordinator.navigate(to: .viewItem(sendView), context: self)
                 case let .group(type, _):
                     coordinator.navigate(to: .group(type))
                 }
+            case let .viewSend(sendView):
+                coordinator.navigate(to: .viewItem(sendView), context: self)
             }
         case let .toastShown(toast):
             state.toast = toast

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -476,14 +476,14 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(coordinator.routes.last, .editItem(sendView))
     }
 
-    /// `receive(_:)` with `.sendListItemRow(.sendListItemPressed())` navigates to the edit send route.
+    /// `receive(_:)` with `.sendListItemRow(.sendListItemPressed())` navigates to the view send route.
     @MainActor
     func test_receive_sendListItemRow_sendListItemPressed_withSendView() {
         let sendView = SendView.fixture()
         let item = SendListItem(sendView: sendView)!
         subject.receive(.sendListItemRow(.sendListItemPressed(item)))
 
-        XCTAssertEqual(coordinator.routes.last, .editItem(sendView))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(sendView))
     }
 
     /// `receive(_:)` with `.sendListItemRow(.sendListItemPressed())` navigates to the group send route.
@@ -493,6 +493,15 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         subject.receive(.sendListItemRow(.sendListItemPressed(item)))
 
         XCTAssertEqual(coordinator.routes.last, .group(.file))
+    }
+
+    /// `receive(_:)` with `.sendListItemRow(.viewSend())` navigates to the view send route.
+    @MainActor
+    func test_receive_sendListItemRow_viewSend() {
+        let sendView = SendView.fixture()
+        subject.receive(.sendListItemRow(.viewSend(sendView)))
+
+        XCTAssertEqual(coordinator.routes.last, .viewItem(sendView))
     }
 
     /// `receive(_:)` with `.toastShown` updates the toast value in the state.

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
@@ -40,6 +40,13 @@ public enum SendItemRoute: Equatable, Hashable {
     /// A route specifying that the send item flow completed by deleting a send.
     case deleted
 
+    /// A route that dismisses a presented sheet.
+    ///
+    /// - Parameter action: An optional `DismissAction` that is executed after the sheet has been
+    ///   dismissed.
+    ///
+    case dismiss(_ action: DismissAction? = nil)
+
     /// A route to the edit item screen for the provided send.
     ///
     /// - Parameter sendView: The `SendView` to edit.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-21125](https://bitwarden.atlassian.net/browse/PM-21125)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This enables navigation to the view Send view from the Sends list. This also includes an update for navigating to the edit sends view from viewing a send. Edit send is presented on top of view send and tapping the cancel button from edit send should only dismiss the edit send view (without these changes it would dismiss both).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/38922319-80c7-44cf-a3ee-0fc237e91442

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21125]: https://bitwarden.atlassian.net/browse/PM-21125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ