### PR TITLE
[PM-21393] Sync when BWA sync turned on

### DIFF
--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepository.swift
@@ -34,7 +34,7 @@ protocol SettingsRepository: AnyObject {
 
     /// Updates the user's vault by syncing it with the API.
     ///
-    func fetchSync() async throws
+    func fetchSync(forceSync: Bool) async throws
 
     /// Get the current value of the allow sync on refresh value.
     func getAllowSyncOnRefresh() async throws -> Bool
@@ -94,6 +94,12 @@ protocol SettingsRepository: AnyObject {
 
     /// The publisher to keep track of the list of the user's current folders.
     func foldersListPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[FolderView], Error>>
+}
+
+extension SettingsRepository {
+    func fetchSync() async throws {
+        try await fetchSync(forceSync: true)
+    }
 }
 
 // MARK: - DefaultSettingsRepository
@@ -181,8 +187,8 @@ extension DefaultSettingsRepository: SettingsRepository {
         try await folderService.editFolderWithServer(id: id, name: folder.name)
     }
 
-    func fetchSync() async throws {
-        try await syncService.fetchSync(forceSync: true)
+    func fetchSync(forceSync: Bool) async throws {
+        try await syncService.fetchSync(forceSync: forceSync)
     }
 
     func getAllowSyncOnRefresh() async throws -> Bool {

--- a/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
+++ b/BitwardenShared/Core/Platform/Repositories/TestHelpers/MockSettingsRepository.swift
@@ -17,6 +17,7 @@ class MockSettingsRepository: SettingsRepository {
     var editedFolderName: String?
     var editFolderResult: Result<Void, Error> = .success(())
     var fetchSyncCalled = false
+    var fetchSyncForceSync: Bool?
     var fetchSyncResult: Result<Void, Error> = .success(())
     var foldersListError: Error?
     var getDefaultUriMatchTypeResult: Result<BitwardenShared.UriMatchType, Error> = .success(.domain)
@@ -50,8 +51,9 @@ class MockSettingsRepository: SettingsRepository {
         try editFolderResult.get()
     }
 
-    func fetchSync() async throws {
+    func fetchSync(forceSync: Bool) async throws {
         fetchSyncCalled = true
+        fetchSyncForceSync = forceSync
         try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -215,8 +215,10 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
     ///
     private func setSyncToAuthenticator(_ enabled: Bool) async {
         do {
-            Task {
-                try await services.settingsRepository.fetchSync(forceSync: false)
+            if enabled {
+                Task {
+                    try await services.settingsRepository.fetchSync(forceSync: false)
+                }
             }
             try await services.stateService.setSyncToAuthenticator(enabled)
             state.isAuthenticatorSyncEnabled = enabled

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -215,6 +215,9 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
     ///
     private func setSyncToAuthenticator(_ enabled: Bool) async {
         do {
+            Task {
+                try await services.settingsRepository.fetchSync(forceSync: false)
+            }
             try await services.stateService.setSyncToAuthenticator(enabled)
             state.isAuthenticatorSyncEnabled = enabled
         } catch {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -427,7 +427,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertFalse(syncEnabled)
     }
 
-    /// `perform(_:)` with `.toggleSyncWithAuthenticator` enables authenticator sync and updates the state.
+    /// `perform(_:)` with `.toggleSyncWithAuthenticator` enables authenticator sync, updates the state, and attempts a sync.
     @MainActor
     func test_perform_toggleSyncWithAuthenticator_enable() async throws {
         configService.featureFlagsBool[.enableAuthenticatorSync] = true
@@ -439,6 +439,9 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         let syncEnabled = try await stateService.getSyncToAuthenticator()
         XCTAssertTrue(syncEnabled)
+
+        waitFor { settingsRepository.fetchSyncCalled }
+        XCTAssertEqual(settingsRepository.fetchSyncForceSync, false)
     }
 
     /// `perform(_:)` with `.toggleSyncWithAuthenticator` correctly handles and logs errors.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -427,7 +427,8 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertFalse(syncEnabled)
     }
 
-    /// `perform(_:)` with `.toggleSyncWithAuthenticator` enables authenticator sync, updates the state, and attempts a sync.
+    /// `perform(_:)` with `.toggleSyncWithAuthenticator` enables authenticator sync,
+    /// updates the state, and attempts a sync.
     @MainActor
     func test_perform_toggleSyncWithAuthenticator_enable() async throws {
         configService.featureFlagsBool[.enableAuthenticatorSync] = true


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21393

## 📔 Objective

This kicks off a background sync when a PM user turns on syncing TOTP codes with BWA. This covers the edge case where someone in BWA taps the button to set up PM, logs in to PM, and goes directly to the settings screen (thus bypassing the sync on viewing the vault screen).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
