### PR TITLE
[PM-21352] Disable Accessibility VoiceOver for "New Send" Button on Sends Screen

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -93,6 +93,8 @@ private struct MainSendListView: View {
                         .padding(.horizontal, 24)
                     }
                     .buttonStyle(.primary(shouldFillWidth: false))
+                    // Disable from VoiceOver in favor of the FAB which provides the same functionality.
+                    .accessibilityHidden(true)
 
                     Spacer()
                 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-21352](https://bitwarden.atlassian.net/browse/PM-21352)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Disables the "New Send" button on the send list empty screen from VoiceOver since the FAB button is also included in VoiceOver and provides the same functionality.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21352]: https://bitwarden.atlassian.net/browse/PM-21352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ