### PR TITLE
[BRE-769] Use Fastlane to keep github releases in sync with mobile deploy versions

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -1,0 +1,40 @@
+name: Publish GitHub Release as newest
+
+on:
+  workflow_dispatch:
+#   schedule:
+#     - cron: '0 3 * * *'
+
+jobs:
+  create-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      actions: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+
+      - name: Log in to Azure
+        uses: Azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
+        with:
+          creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
+
+      - name: Download Fastlane credentials
+        env:
+          ACCOUNT_NAME: bitwardenci
+          CONTAINER_NAME: mobile
+          FILE: appstoreconnect-fastlane.json
+        run: |
+          mkdir -p $HOME/secrets
+          az storage blob download --account-name $ACCOUNT_NAME --container-name $CONTAINER_NAME --name $FILE \
+            --file $HOME/secrets/$FILE --output none
+
+      - name: Check released version
+        run: |
+          fastlane get_latest_version \
+            api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json"

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -19,12 +19,32 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get latest pre-release name
+        id: get_latest_prerelease
+        run: |
+          latest_release=$(jq -r 'first' <<< $(curl --silent https://api.github.com/repos/bitwarden/ios/releases))
+          is_latest_prerelease=$(jq -r '.prerelease' <<< $latest_release)
+          echo "is_latest_prerelease=$is_latest_prerelease" >> $GITHUB_OUTPUT
+
+          if [ "$is_latest_prerelease" != "true" ]; then
+              echo "No pre-release found"
+              exit 0
+          fi
+
+          latest_prerelease_version=$(jq -r '.tag_name' <<< $latest_release)
+          echo "latest_prerelease_version=$latest_prerelease_version" >> $GITHUB_OUTPUT
+
+          latest_prerelease_id=$(jq -r '.id' <<< $latest_release)
+          echo "latest_prerelease_id=$latest_prerelease_id" >> $GITHUB_OUTPUT
+
       - name: Log in to Azure
+        if: steps.get_latest_prerelease.outputs.is_latest_prerelease == 'true'
         uses: Azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1.6.1
         with:
           creds: ${{ secrets.AZURE_KV_CI_SERVICE_PRINCIPAL }}
 
       - name: Download Fastlane credentials
+        if: steps.get_latest_prerelease.outputs.is_latest_prerelease == 'true'
         env:
           ACCOUNT_NAME: bitwardenci
           CONTAINER_NAME: mobile
@@ -35,6 +55,38 @@ jobs:
             --file $HOME/secrets/$FILE --output none
 
       - name: Check released version
+        if: steps.get_latest_prerelease.outputs.is_latest_prerelease == 'true'
+        id: appstore_version
         run: |
-          fastlane get_latest_version \
-            api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json"
+          appstore_version=$(fastlane get_latest_version \
+            api_key_path:"$HOME/secrets/appstoreconnect-fastlane.json")
+
+          echo "Latest version on App Store: $appstore_version"
+          echo "appstore_version=$appstore_version" >> $GITHUB_OUTPUT
+
+      - name: Check if version is already released
+        if: steps.get_latest_prerelease.outputs.is_latest_prerelease == 'true'
+        id: check_version
+        run: |
+          latest_prerelease_version=${{ steps.get_latest_prerelease.outputs.latest_prerelease_version }}
+          appstore_version=${{ steps.appstore_version.outputs.appstore_version }}
+
+          if [ "$latest_prerelease_version" == "$appstore_version" ]; then
+              echo "Version $latest_prerelease_version is already released on App Store"
+              echo "version_released=true" >> $GITHUB_OUTPUT
+          else
+              echo "Version $latest_prerelease_version is not released on App Store"
+              echo "version_released=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Make GitHub release latest and non-pre-release
+        if: steps.check_version.outputs.version_released == 'true'
+        id: make_release
+        run: |
+          latest_prerelease_version=${{ steps.get_latest_prerelease.outputs.latest_prerelease_version }}
+          echo "Making release $latest_prerelease_version latest and non-pre-release"
+          curl -X PATCH \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/bitwarden/ios/releases/$latest_prerelease_id \
+            -d '{"prerelease": false, "draft": false, "make_latest": true}'

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -31,4 +31,12 @@ platform :ios do |options|
         }
     )
     end
+
+    desc "Get latest published version"
+    lane :get_latest_version do
+        app_store_build_number(
+            api_key_path: options[:api_key_path]
+        )
+        puts lane_context[SharedValues::LATEST_VERSION]
+    end
 end


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BRE-769

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

Add a workflow to check for new iOS or Android versions submitted to the stores. If a new version exists, publish the GitHub release as the latest and non-pre-release.

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
