### PR TITLE
[PM-21825] Update CI-main.yml permissions

### DIFF
--- a/.github/workflows/CI-main.yml
+++ b/.github/workflows/CI-main.yml
@@ -24,13 +24,12 @@ env:
 
 permissions:
   contents: read
+  actions: write #required for dispatch-and-download.yml
 
 jobs:
   resolve-values:
     name: "Resolve values"
     runs-on: ubuntu-22.04
-    permissions:
-      actions: write #required for dispatch-and-download.yml
     outputs:
       version_name: ${{ steps.version_info.outputs.version_name }}
       version_number: ${{ steps.version_info.outputs.version_number }}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-21825](https://bitwarden.atlassian.net/browse/PM-21825)

## 📔 Objective

The `action: write` permission needs to be set for all jobs calling `build.yml` even when the step that requires it is skipped. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-21825]: https://bitwarden.atlassian.net/browse/PM-21825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ