### PR TITLE
[PM-21681] Stop syncing TOTP codes with BWA on PM logout

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -760,6 +760,7 @@ extension DefaultAuthRepository: AuthRepository {
         let userId = try await stateService.getAccountIdOrActiveId(userId: userId)
 
         // Clear all user data.
+        try await stateService.setSyncToAuthenticator(false, userId: userId)
         try await biometricsRepository.setBiometricUnlockKey(authKey: nil)
         try await keychainService.deleteItems(for: userId)
         await vaultTimeoutService.remove(userId: userId)

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -2085,6 +2085,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         biometricsRepository.setBiometricUnlockKeyError = nil
         stateService.pinProtectedUserKeyValue["1"] = "1"
         stateService.encryptedPinByUserId["1"] = "1"
+        stateService.syncToAuthenticatorByUserId["1"] = true
 
         try await subject.logout(userInitiated: true)
 
@@ -2095,6 +2096,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(vaultTimeoutService.removedIds, [anneAccount.profile.userId])
         XCTAssertEqual(stateService.pinProtectedUserKeyValue["1"], "1")
         XCTAssertEqual(stateService.encryptedPinByUserId["1"], "1")
+        XCTAssertEqual(stateService.syncToAuthenticatorByUserId["1"], false)
     }
 
     /// `logout` successfully logs out a user clearing pins because of policy Remove unlock with pin being enabled.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21681

## 📔 Objective

This turns off syncing for a user between PM and BWA when that user logs out of PM. This change will then be picked up by the `AuthenticatorSyncService`, which will do the necessary things to delete data out of the shared storage.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
