### PR TITLE
[PM-20504] Turn off smart quotes in password fields

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -167,6 +167,7 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
                     .id(title)
                     .introspect(.textField, on: .iOS(.v15, .v16, .v17, .v18)) { textField in
                         textField.smartDashesType = isPassword ? .no : .default
+                        textField.smartQuotesType = isPassword ? .no : .default
                     }
                     .accessibilityLabel(title ?? "")
                     .foregroundStyle(


### PR DESCRIPTION
## 🎟️ Tracking

PM-20504

## 📔 Objective

Smart punctuation should be turned off in password fields, this was being done for smart dashes and now the same is applied to smart quotes.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
