### PR TITLE
[PM-20538] Display toast on flight recorder log deletion

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1192,3 +1192,5 @@
 "NewTextSend" = "New text Send";
 "EditFileSend" = "Edit file Send";
 "EditTextSend" = "Edit text Send";
+"LogDeleted" = "Log deleted";
+"AllLogsDeleted" = "All logs deleted";

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsAction.swift
@@ -17,4 +17,7 @@ enum FlightRecorderLogsAction: Equatable {
 
     /// Share all flight recorder logs.
     case shareAll
+
+    /// The toast was shown or hidden.
+    case toastShown(Toast?)
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsProcessor.swift
@@ -63,6 +63,8 @@ final class FlightRecorderLogsProcessor: StateProcessor<
         case .shareAll:
             let urls = state.logs.map(\.url)
             coordinator.navigate(to: .shareURLs(urls))
+        case let .toastShown(newValue):
+            state.toast = newValue
         }
     }
 
@@ -85,6 +87,7 @@ final class FlightRecorderLogsProcessor: StateProcessor<
         confirmDeletion(isBulkDeletion: true) {
             do {
                 try await self.services.flightRecorder.deleteInactiveLogs()
+                self.state.toast = Toast(title: Localizations.allLogsDeleted)
                 await self.loadData()
             } catch {
                 self.services.errorReporter.log(error: error)
@@ -99,6 +102,7 @@ final class FlightRecorderLogsProcessor: StateProcessor<
         confirmDeletion(isBulkDeletion: false) {
             do {
                 try await self.services.flightRecorder.deleteLog(log)
+                self.state.toast = Toast(title: Localizations.logDeleted)
                 await self.loadData()
             } catch {
                 self.services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsProcessorTests.swift
@@ -85,6 +85,7 @@ class FlightRecorderLogsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(flightRecorder.deleteLogLogs, [log])
         XCTAssertTrue(flightRecorder.fetchLogsCalled)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.logDeleted))
     }
 
     /// `receive(_:)` with `.delete` logs an error and shows an error alert if an error occurs.
@@ -101,6 +102,7 @@ class FlightRecorderLogsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertNil(subject.state.toast)
     }
 
     /// `receive(_:)` with `.deleteAll` shows a confirmation alert and then deletes the inactive logs.
@@ -118,6 +120,7 @@ class FlightRecorderLogsProcessorTests: BitwardenTestCase {
 
         XCTAssertTrue(flightRecorder.deleteInactiveLogsCalled)
         XCTAssertTrue(flightRecorder.fetchLogsCalled)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.allLogsDeleted))
     }
 
     /// `receive(_:)` with `.deleteAll` logs an error and shows an error alert if an error occurs.
@@ -134,6 +137,7 @@ class FlightRecorderLogsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertNil(subject.state.toast)
     }
 
     /// `receive(_:)` with `.dismiss` dismisses the view.
@@ -168,5 +172,16 @@ class FlightRecorderLogsProcessorTests: BitwardenTestCase {
                 URL(fileURLWithPath: "/FlightRecorderLogs/2.txt"),
             ])
         )
+    }
+
+    /// `receive(_:)` with `.toastShown` updates the state's toast value.
+    @MainActor
+    func test_receive_toastShown() {
+        let toast = Toast(title: "toast!")
+        subject.receive(.toastShown(toast))
+        XCTAssertEqual(subject.state.toast, toast)
+
+        subject.receive(.toastShown(nil))
+        XCTAssertNil(subject.state.toast)
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsState.swift
@@ -8,6 +8,9 @@ struct FlightRecorderLogsState: Equatable {
     /// The list of flight recorder logs on the device.
     var logs = [FlightRecorderLogMetadata]()
 
+    /// A toast message to show in the view.
+    var toast: Toast?
+
     // MARK: Computed Properties
 
     /// Whether the delete all option is enabled.

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/FlightRecorderLogsView.swift
@@ -21,6 +21,10 @@ struct FlightRecorderLogsView: View {
         content
             .navigationBar(title: Localizations.recordedLogs, titleDisplayMode: .inline)
             .task { await store.perform(.loadData) }
+            .toast(store.binding(
+                get: \.toast,
+                send: FlightRecorderLogsAction.toastShown
+            ))
             .toolbar {
                 closeToolbarItem {
                     store.send(.dismiss)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-20538](https://bitwarden.atlassian.net/browse/PM-20538) - Add delete confirmation for individually deleted logs
[PM-20533](https://bitwarden.atlassian.net/browse/PM-20533) - Add deletion confirmation for logs deleted in bulk

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a toast to the flight recorder logs view when a single or all logs have been deleted.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Single log:

https://github.com/user-attachments/assets/bd18b0b5-707d-43c5-a786-355d02ff9e98

All logs:

https://github.com/user-attachments/assets/b8e3f6c3-79a2-4b15-a62f-8f67ada25f8b



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20538]: https://bitwarden.atlassian.net/browse/PM-20538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-20533]: https://bitwarden.atlassian.net/browse/PM-20533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ