### PR TITLE
[PM-21681] Consolidate SessionTimeout into BitwardenKit

### DIFF
--- a/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValue.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValue.swift
@@ -1,37 +1,11 @@
+import BitwardenKit
+
 // MARK: - SessionTimeoutValue
 
 /// An enumeration of session timeout values to choose from.
+/// BWA does not use the custom value.
 ///
-/// Note: This is imported from the PM app, but the `custom` case has been removed.
-///
-public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menuable, Sendable {
-    /// Timeout immediately.
-    case immediately
-
-    /// Timeout after 1 minute.
-    case oneMinute
-
-    /// Timeout after 5 minutes.
-    case fiveMinutes
-
-    /// Timeout after 15 minutes.
-    case fifteenMinutes
-
-    /// Timeout after 30 minutes.
-    case thirtyMinutes
-
-    /// Timeout after 1 hour.
-    case oneHour
-
-    /// Timeout after 4 hours.
-    case fourHours
-
-    /// Timeout on app restart.
-    case onAppRestart
-
-    /// Never timeout the session.
-    case never
-
+extension SessionTimeoutValue: @retroactive CaseIterable, Menuable {
     /// All of the cases to show in the menu.
     public static let allCases: [Self] = [
         .immediately,
@@ -66,51 +40,8 @@ public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menu
             Localizations.onRestart
         case .never:
             Localizations.never
-        }
-    }
-
-    /// The session timeout value in seconds.
-    var seconds: Int {
-        rawValue * 60
-    }
-
-    /// The session timeout value in minutes.
-    public var rawValue: Int {
-        switch self {
-        case .immediately: 0
-        case .oneMinute: 1
-        case .fiveMinutes: 5
-        case .fifteenMinutes: 15
-        case .thirtyMinutes: 30
-        case .oneHour: 60
-        case .fourHours: 240
-        case .onAppRestart: -1
-        case .never: -2
-        }
-    }
-
-    public init(rawValue: Int) {
-        switch rawValue {
-        case 0:
-            self = .immediately
-        case 1:
-            self = .oneMinute
-        case 5:
-            self = .fiveMinutes
-        case 15:
-            self = .fifteenMinutes
-        case 30:
-            self = .thirtyMinutes
-        case 60:
-            self = .oneHour
-        case 240:
-            self = .fourHours
-        case -1:
-            self = .onAppRestart
-        case -2:
-            self = .never
-        default:
-            self = .never
+        case .custom:
+            Localizations.custom
         }
     }
 }

--- a/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import XCTest
 
 @testable import AuthenticatorShared
@@ -23,20 +24,6 @@ final class SessionTimeoutValueTests: BitwardenTestCase {
         )
     }
 
-    /// `init` returns the correct case for the given raw value.
-    func test_initFromRawValue() {
-        XCTAssertEqual(SessionTimeoutValue.immediately, SessionTimeoutValue(rawValue: 0))
-        XCTAssertEqual(SessionTimeoutValue.oneMinute, SessionTimeoutValue(rawValue: 1))
-        XCTAssertEqual(SessionTimeoutValue.fiveMinutes, SessionTimeoutValue(rawValue: 5))
-        XCTAssertEqual(SessionTimeoutValue.fifteenMinutes, SessionTimeoutValue(rawValue: 15))
-        XCTAssertEqual(SessionTimeoutValue.thirtyMinutes, SessionTimeoutValue(rawValue: 30))
-        XCTAssertEqual(SessionTimeoutValue.oneHour, SessionTimeoutValue(rawValue: 60))
-        XCTAssertEqual(SessionTimeoutValue.fourHours, SessionTimeoutValue(rawValue: 240))
-        XCTAssertEqual(SessionTimeoutValue.onAppRestart, SessionTimeoutValue(rawValue: -1))
-        XCTAssertEqual(SessionTimeoutValue.never, SessionTimeoutValue(rawValue: -2))
-        XCTAssertEqual(SessionTimeoutValue.never, SessionTimeoutValue(rawValue: 12345))
-    }
-
     /// `localizedName` returns the correct values.
     func test_localizedName() {
         XCTAssertEqual(SessionTimeoutValue.immediately.localizedName, Localizations.immediately)
@@ -48,18 +35,6 @@ final class SessionTimeoutValueTests: BitwardenTestCase {
         XCTAssertEqual(SessionTimeoutValue.fourHours.localizedName, Localizations.fourHours)
         XCTAssertEqual(SessionTimeoutValue.onAppRestart.localizedName, Localizations.onRestart)
         XCTAssertEqual(SessionTimeoutValue.never.localizedName, Localizations.never)
-    }
-
-    /// `rawValue` returns the correct values.
-    func test_rawValues() {
-        XCTAssertEqual(SessionTimeoutValue.immediately.rawValue, 0)
-        XCTAssertEqual(SessionTimeoutValue.oneMinute.rawValue, 1)
-        XCTAssertEqual(SessionTimeoutValue.fiveMinutes.rawValue, 5)
-        XCTAssertEqual(SessionTimeoutValue.fifteenMinutes.rawValue, 15)
-        XCTAssertEqual(SessionTimeoutValue.thirtyMinutes.rawValue, 30)
-        XCTAssertEqual(SessionTimeoutValue.oneHour.rawValue, 60)
-        XCTAssertEqual(SessionTimeoutValue.fourHours.rawValue, 240)
-        XCTAssertEqual(SessionTimeoutValue.onAppRestart.rawValue, -1)
-        XCTAssertEqual(SessionTimeoutValue.never.rawValue, -2)
+        XCTAssertEqual(SessionTimeoutValue.custom(123).localizedName, Localizations.custom)
     }
 }

--- a/AuthenticatorShared/UI/Platform/Application/AppProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Combine
 import Foundation
 import UIKit

--- a/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import Foundation
 import XCTest

--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -150,6 +150,7 @@
 "VaultTimeout" = "Vault timeout";
 "ThirtyMinutes" = "30 minutes";
 "OnRestart" = "On app restart";
+"Custom" = "Custom";
 "SessionTimeout" = "Session timeout";
 "FileCouldNotBeProcessed" = "File could not be processed";
 "EnsureItsValidJsonAndTryAgain" = "Ensure it’s valid JSON and try again.";

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsEffect.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsEffect.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 // MARK: - SettingsEffect
 
 /// Effects that can be processed by an `SettingsProcessor`.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import OSLog
 
 // MARK: - SettingsProcessor

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 /// An object that defines the current state of a `SettingsView`.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import SwiftUI
 
 // MARK: - SettingsView

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import SnapshotTesting
 import XCTest
 

--- a/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValue.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValue.swift
@@ -1,0 +1,79 @@
+// MARK: - SessionTimeoutValue
+
+/// An enumeration of session timeout values to choose from.
+///
+/// Note: This is imported from the PM app, but the `custom` case has been removed.
+///
+public enum SessionTimeoutValue: RawRepresentable, Equatable, Hashable, Sendable {
+    /// Timeout immediately.
+    case immediately
+
+    /// Timeout after 1 minute.
+    case oneMinute
+
+    /// Timeout after 5 minutes.
+    case fiveMinutes
+
+    /// Timeout after 15 minutes.
+    case fifteenMinutes
+
+    /// Timeout after 30 minutes.
+    case thirtyMinutes
+
+    /// Timeout after 1 hour.
+    case oneHour
+
+    /// Timeout after 4 hours.
+    case fourHours
+
+    /// Timeout on app restart.
+    case onAppRestart
+
+    /// Never timeout the session.
+    case never
+
+    /// The session timeout value in seconds.
+    public var seconds: Int {
+        rawValue * 60
+    }
+
+    /// The session timeout value in minutes.
+    public var rawValue: Int {
+        switch self {
+        case .immediately: 0
+        case .oneMinute: 1
+        case .fiveMinutes: 5
+        case .fifteenMinutes: 15
+        case .thirtyMinutes: 30
+        case .oneHour: 60
+        case .fourHours: 240
+        case .onAppRestart: -1
+        case .never: -2
+        }
+    }
+
+    public init(rawValue: Int) {
+        switch rawValue {
+        case 0:
+            self = .immediately
+        case 1:
+            self = .oneMinute
+        case 5:
+            self = .fiveMinutes
+        case 15:
+            self = .fifteenMinutes
+        case 30:
+            self = .thirtyMinutes
+        case 60:
+            self = .oneHour
+        case 240:
+            self = .fourHours
+        case -1:
+            self = .onAppRestart
+        case -2:
+            self = .never
+        default:
+            self = .never
+        }
+    }
+}

--- a/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValue.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValue.swift
@@ -2,35 +2,36 @@
 
 /// An enumeration of session timeout values to choose from.
 ///
-/// Note: This is imported from the PM app, but the `custom` case has been removed.
-///
 public enum SessionTimeoutValue: RawRepresentable, Equatable, Hashable, Sendable {
-    /// Timeout immediately.
+    /// Time out immediately.
     case immediately
 
-    /// Timeout after 1 minute.
+    /// Time out after 1 minute.
     case oneMinute
 
-    /// Timeout after 5 minutes.
+    /// Time out after 5 minutes.
     case fiveMinutes
 
-    /// Timeout after 15 minutes.
+    /// Time out after 15 minutes.
     case fifteenMinutes
 
-    /// Timeout after 30 minutes.
+    /// Time out after 30 minutes.
     case thirtyMinutes
 
-    /// Timeout after 1 hour.
+    /// Time out after 1 hour.
     case oneHour
 
-    /// Timeout after 4 hours.
+    /// Time out after 4 hours.
     case fourHours
 
-    /// Timeout on app restart.
+    /// Time out on app restart.
     case onAppRestart
 
-    /// Never timeout the session.
+    /// Never time out the session.
     case never
+
+    /// A custom timeout value.
+    case custom(Int)
 
     /// The session timeout value in seconds.
     public var seconds: Int {
@@ -49,6 +50,7 @@ public enum SessionTimeoutValue: RawRepresentable, Equatable, Hashable, Sendable
         case .fourHours: 240
         case .onAppRestart: -1
         case .never: -2
+        case let .custom(customValue): customValue
         }
     }
 
@@ -73,7 +75,7 @@ public enum SessionTimeoutValue: RawRepresentable, Equatable, Hashable, Sendable
         case -2:
             self = .never
         default:
-            self = .never
+            self = .custom(rawValue)
         }
     }
 }

--- a/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
@@ -1,0 +1,33 @@
+import BitwardenKit
+import XCTest
+
+final class SessionTimeoutValueTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `init` returns the correct case for the given raw value.
+    func test_initFromRawValue() {
+        XCTAssertEqual(SessionTimeoutValue.immediately, SessionTimeoutValue(rawValue: 0))
+        XCTAssertEqual(SessionTimeoutValue.oneMinute, SessionTimeoutValue(rawValue: 1))
+        XCTAssertEqual(SessionTimeoutValue.fiveMinutes, SessionTimeoutValue(rawValue: 5))
+        XCTAssertEqual(SessionTimeoutValue.fifteenMinutes, SessionTimeoutValue(rawValue: 15))
+        XCTAssertEqual(SessionTimeoutValue.thirtyMinutes, SessionTimeoutValue(rawValue: 30))
+        XCTAssertEqual(SessionTimeoutValue.oneHour, SessionTimeoutValue(rawValue: 60))
+        XCTAssertEqual(SessionTimeoutValue.fourHours, SessionTimeoutValue(rawValue: 240))
+        XCTAssertEqual(SessionTimeoutValue.onAppRestart, SessionTimeoutValue(rawValue: -1))
+        XCTAssertEqual(SessionTimeoutValue.never, SessionTimeoutValue(rawValue: -2))
+        XCTAssertEqual(SessionTimeoutValue.never, SessionTimeoutValue(rawValue: 12345))
+    }
+
+    /// `rawValue` returns the correct values.
+    func test_rawValues() {
+        XCTAssertEqual(SessionTimeoutValue.immediately.rawValue, 0)
+        XCTAssertEqual(SessionTimeoutValue.oneMinute.rawValue, 1)
+        XCTAssertEqual(SessionTimeoutValue.fiveMinutes.rawValue, 5)
+        XCTAssertEqual(SessionTimeoutValue.fifteenMinutes.rawValue, 15)
+        XCTAssertEqual(SessionTimeoutValue.thirtyMinutes.rawValue, 30)
+        XCTAssertEqual(SessionTimeoutValue.oneHour.rawValue, 60)
+        XCTAssertEqual(SessionTimeoutValue.fourHours.rawValue, 240)
+        XCTAssertEqual(SessionTimeoutValue.onAppRestart.rawValue, -1)
+        XCTAssertEqual(SessionTimeoutValue.never.rawValue, -2)
+    }
+}

--- a/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
@@ -15,7 +15,7 @@ final class SessionTimeoutValueTests: BitwardenTestCase {
         XCTAssertEqual(SessionTimeoutValue.fourHours, SessionTimeoutValue(rawValue: 240))
         XCTAssertEqual(SessionTimeoutValue.onAppRestart, SessionTimeoutValue(rawValue: -1))
         XCTAssertEqual(SessionTimeoutValue.never, SessionTimeoutValue(rawValue: -2))
-        XCTAssertEqual(SessionTimeoutValue.never, SessionTimeoutValue(rawValue: 12345))
+        XCTAssertEqual(SessionTimeoutValue.custom(12345), SessionTimeoutValue(rawValue: 12345))
     }
 
     /// `rawValue` returns the correct values.
@@ -29,5 +29,6 @@ final class SessionTimeoutValueTests: BitwardenTestCase {
         XCTAssertEqual(SessionTimeoutValue.fourHours.rawValue, 240)
         XCTAssertEqual(SessionTimeoutValue.onAppRestart.rawValue, -1)
         XCTAssertEqual(SessionTimeoutValue.never.rawValue, -2)
+        XCTAssertEqual(SessionTimeoutValue.custom(12345).rawValue, 12345)
     }
 }

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 @testable import BitwardenShared
@@ -304,7 +305,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
         return sessionTimeoutAction[userId] ?? .lock
     }
 
-    func sessionTimeoutValue(userId: String?) async throws -> BitwardenShared.SessionTimeoutValue {
+    func sessionTimeoutValue(userId: String?) async throws -> SessionTimeoutValue {
         guard let value = try vaultTimeout[unwrapUserId(userId)] else {
             throw (userId == nil)
                 ? StateServiceError.noActiveAccount
@@ -328,7 +329,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
         try setMasterPasswordResult.get()
     }
 
-    func setVaultTimeout(value: BitwardenShared.SessionTimeoutValue, userId: String?) async throws {
+    func setVaultTimeout(value: SessionTimeoutValue, userId: String?) async throws {
         try vaultTimeout[unwrapUserId(userId)] = value
         if let setVaultTimeoutError {
             throw setVaultTimeoutError

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialServiceTests.swift
@@ -1,4 +1,5 @@
 import AuthenticationServices
+import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
 import TestHelpers

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import Combine
 import Foundation
@@ -61,7 +62,7 @@ class MockVaultTimeoutService: VaultTimeoutService {
         removedIds.append(userId)
     }
 
-    func sessionTimeoutValue(userId: String?) async throws -> BitwardenShared.SessionTimeoutValue {
+    func sessionTimeoutValue(userId: String?) async throws -> SessionTimeoutValue {
         if let sessionTimeoutValueError {
             throw sessionTimeoutValueError
         }

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import TestHelpers
 import XCTest

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityAction.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 // MARK: AccountSecurityAction

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 import OSLog
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import TestHelpers
 import XCTest

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 // MARK: - UnlockMethod
@@ -19,37 +20,7 @@ public enum UnlockMethod {
 
 /// An enumeration of session timeout values to choose from.
 ///
-public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menuable, Sendable {
-    /// Timeout immediately.
-    case immediately
-
-    /// Timeout after 1 minute.
-    case oneMinute
-
-    /// Timeout after 5 minutes.
-    case fiveMinutes
-
-    /// Timeout after 15 minutes.
-    case fifteenMinutes
-
-    /// Timeout after 30 minutes.
-    case thirtyMinutes
-
-    /// Timeout after 1 hour.
-    case oneHour
-
-    /// Timeout after 4 hours.
-    case fourHours
-
-    /// Timeout on app restart.
-    case onAppRestart
-
-    /// Never timeout the session.
-    case never
-
-    /// A custom timeout value.
-    case custom(Int)
-
+extension SessionTimeoutValue: @retroactive CaseIterable, Menuable {
     /// All of the cases to show in the menu.
     public static let allCases: [Self] = [
         .immediately,
@@ -87,52 +58,6 @@ public enum SessionTimeoutValue: RawRepresentable, CaseIterable, Equatable, Menu
             Localizations.never
         case .custom:
             Localizations.custom
-        }
-    }
-
-    /// The session timeout value in seconds.
-    var seconds: Int {
-        rawValue * 60
-    }
-
-    /// The session timeout value in minutes.
-    public var rawValue: Int {
-        switch self {
-        case .immediately: 0
-        case .oneMinute: 1
-        case .fiveMinutes: 5
-        case .fifteenMinutes: 15
-        case .thirtyMinutes: 30
-        case .oneHour: 60
-        case .fourHours: 240
-        case .onAppRestart: -1
-        case .never: -2
-        case let .custom(customValue): customValue
-        }
-    }
-
-    public init(rawValue: Int) {
-        switch rawValue {
-        case 0:
-            self = .immediately
-        case 1:
-            self = .oneMinute
-        case 5:
-            self = .fiveMinutes
-        case 15:
-            self = .fifteenMinutes
-        case 30:
-            self = .thirtyMinutes
-        case 60:
-            self = .oneHour
-        case 240:
-            self = .fourHours
-        case -1:
-            self = .onAppRestart
-        case -2:
-            self = .never
-        default:
-            self = .custom(rawValue)
         }
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
 import TestHelpers

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
 import TestHelpers


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-21681

## 📔 Objective

Because both PM and BWA will need to know each other's session timeout information (particularly, BWA knowing PM), it makes sense for them to have a shared object for tracking it. This pulls that object into `BitwardenKit`, as a separate PR to cut down on noise in future PRs.

Some things are left in the PM and BWA applications. Notably, `allCases` is different between the two currently (as BWA doesn't handle a custom timeout); and localizations are kept separate because we haven't yet decided how to handle localizations in `BitwardenKit` objects. The lack of bringing `Menuable` into `BitwardenKit` similarly is because we haven't yet decided how to handle assets and colors in `BitwardenKit` objects, or I would have brought that over, too.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
