### PR TITLE
[PM-21125] Stream send updates when viewing a send

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -345,6 +345,49 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         }
     }
 
+    /// `sendListPublisher()` returns a publisher for a single send.
+    func test_sendPublisher() async throws {
+        let send1 = Send.fixture(name: "Initial")
+        sendService.sendSubject.send(send1)
+
+        var iterator = try await subject.sendPublisher(id: "1").makeAsyncIterator()
+
+        var sendView = try await iterator.next()
+        XCTAssertEqual(sendView, SendView(send: send1))
+        XCTAssertEqual(clientService.mockSends.decryptedSends, [send1])
+
+        let send2 = Send.fixture(name: "Updated")
+        sendService.sendSubject.send(send2)
+        sendView = try await iterator.next()
+        XCTAssertEqual(sendView, SendView(send: send2))
+        XCTAssertEqual(clientService.mockSends.decryptedSends, [send1, send2])
+    }
+
+    /// `sendListPublisher()` throws an error if underlying publisher returns an error.
+    func test_sendPublisher_error() async throws {
+        sendService.sendSubject.send(completion: .failure(BitwardenTestError.example))
+
+        var iterator = try await subject.sendPublisher(id: "1").makeAsyncIterator()
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await iterator.next()
+        }
+    }
+
+    /// `sendListPublisher()` passes along a `nil` send.
+    func test_sendPublisher_nilSend() async throws {
+        sendService.sendSubject.send(nil)
+
+        var iterator = try await subject.sendPublisher(id: "1").makeAsyncIterator()
+
+        var sendView = try await iterator.next()
+        XCTAssertEqual(sendView, Optional(Optional(nil)))
+
+        let send = Send.fixture()
+        sendService.sendSubject.send(send)
+        sendView = try await iterator.next()
+        XCTAssertEqual(sendView, SendView(send: send))
+    }
+
     /// `shareURL()` successfully generates a share url for the send view.
     func test_shareURL() async throws {
         let sendView = SendView.fixture(accessId: "ACCESS_ID", key: "KEY")

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -24,6 +24,8 @@ class MockSendRepository: SendRepository {
 
     var sendListSubject = CurrentValueSubject<[SendListSection], Error>([])
 
+    var sendSubject = CurrentValueSubject<SendView?, Error>(nil)
+
     var sendTypeListPublisherType: BitwardenShared.SendType?
     var sendTypeListSubject = CurrentValueSubject<[SendListItem], Error>([])
 
@@ -100,6 +102,12 @@ class MockSendRepository: SendRepository {
 
     func sendListPublisher() -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>> {
         sendListSubject
+            .eraseToAnyPublisher()
+            .values
+    }
+
+    func sendPublisher(id: String) async throws -> AsyncThrowingPublisher<AnyPublisher<SendView?, Error>> {
+        sendSubject
             .eraseToAnyPublisher()
             .values
     }

--- a/BitwardenShared/Core/Tools/Services/SendService.swift
+++ b/BitwardenShared/Core/Tools/Services/SendService.swift
@@ -70,6 +70,13 @@ protocol SendService {
 
     // MARK: Publishers
 
+    /// A publisher for a `Send`.
+    ///
+    /// - Parameter id: The ID of the `Send` to publish updates for.
+    /// - Returns: A publisher containing the encrypted send.
+    ///
+    func sendPublisher(id: String) async throws -> AnyPublisher<Send?, Error>
+
     /// A publisher for the list of sends.
     ///
     /// - Returns: The list of encrypted sends.
@@ -206,8 +213,13 @@ extension DefaultSendService {
         try await sendDataStore.replaceSends(sends.map(Send.init), userId: userId)
     }
 
+    func sendPublisher(id: String) async throws -> AnyPublisher<Send?, Error> {
+        let userId = try await stateService.getActiveAccountId()
+        return sendDataStore.sendPublisher(id: id, userId: userId)
+    }
+
     func sendsPublisher() async throws -> AnyPublisher<[Send], Error> {
         let userId = try await stateService.getActiveAccountId()
-        return sendDataStore.sendPublisher(userId: userId)
+        return sendDataStore.sendsPublisher(userId: userId)
     }
 }

--- a/BitwardenShared/Core/Tools/Services/SendServiceTests.swift
+++ b/BitwardenShared/Core/Tools/Services/SendServiceTests.swift
@@ -347,11 +347,29 @@ class SendServiceTests: BitwardenTestCase {
         XCTAssertEqual(sendDataStore.replaceSendsUserId, "1")
     }
 
+    /// `sendPublisher()` throws an error if one occurs.
+    func test_sendPublisher_error() async {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
+            _ = try await subject.sendPublisher(id: "1")
+        }
+    }
+
+    /// `sendPublisher()` returns a publisher for a send.
+    func test_sendPublisher_withValues() async throws {
+        stateService.activeAccount = .fixtureAccountLogin()
+        sendDataStore.sendSubject.send(.fixture())
+
+        var iterator = try await subject.sendPublisher(id: "1").values.makeAsyncIterator()
+        let publisherValue = try await iterator.next()
+
+        try XCTAssertEqual(XCTUnwrap(publisherValue), .fixture())
+    }
+
     /// `sendsPublisher()` returns a publisher for the list of sections and items that are
     /// displayed in the sends tab.
     func test_sendsPublisher_withValues() async throws {
         stateService.activeAccount = .fixtureAccountLogin()
-        sendDataStore.sendSubject.send([.fixture()])
+        sendDataStore.sendsSubject.send([.fixture()])
 
         var iterator = try await subject.sendsPublisher().values.makeAsyncIterator()
         let publisherValue = try await iterator.next()

--- a/BitwardenShared/Core/Tools/Services/Stores/SendDataStoreTests.swift
+++ b/BitwardenShared/Core/Tools/Services/Stores/SendDataStoreTests.swift
@@ -55,10 +55,29 @@ class SendDataStoreTests: BitwardenTestCase {
         )
     }
 
-    /// `sendPublisher(userId:)` returns a publisher for a user's send objects.
+    /// `sendPublisher(userId:)` returns a publisher for a single send.
     func test_sendPublisher() async throws {
+        var publishedValues = [Send?]()
+        let publisher = subject.sendPublisher(id: "1", userId: "1")
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { value in
+                    publishedValues.append(value)
+                }
+            )
+        defer { publisher.cancel() }
+
+        try await subject.replaceSends(sends, userId: "1")
+
+        waitFor { publishedValues.count == 2 }
+        XCTAssertNil(publishedValues[0])
+        XCTAssertEqual(publishedValues[1], Send.fixture(id: "1", name: "SEND1"))
+    }
+
+    /// `sendsPublisher(userId:)` returns a publisher for a user's send objects.
+    func test_sendsPublisher() async throws {
         var publishedValues = [[Send]]()
-        let publisher = subject.sendPublisher(userId: "1")
+        let publisher = subject.sendsPublisher(userId: "1")
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { values in

--- a/BitwardenShared/Core/Tools/Services/Stores/TestHelpers/MockSendDataStore.swift
+++ b/BitwardenShared/Core/Tools/Services/Stores/TestHelpers/MockSendDataStore.swift
@@ -13,7 +13,9 @@ class MockSendDataStore: SendDataStore {
     var fetchSendUserId: String?
     var fetchSendResult: Result<Send?, Error> = .success(nil)
 
-    var sendSubject = CurrentValueSubject<[Send], Error>([])
+    var sendSubject = CurrentValueSubject<Send?, Error>(nil)
+
+    var sendsSubject = CurrentValueSubject<[Send], Error>([])
 
     var replaceSendsValue: [Send]?
     var replaceSendsUserId: String?
@@ -36,8 +38,12 @@ class MockSendDataStore: SendDataStore {
         return try fetchSendResult.get()
     }
 
-    func sendPublisher(userId: String) -> AnyPublisher<[Send], Error> {
+    func sendPublisher(id: String, userId: String) -> AnyPublisher<Send?, Error> {
         sendSubject.eraseToAnyPublisher()
+    }
+
+    func sendsPublisher(userId: String) -> AnyPublisher<[Send], Error> {
+        sendsSubject.eraseToAnyPublisher()
     }
 
     func replaceSends(_ sends: [Send], userId: String) async throws {

--- a/BitwardenShared/Core/Tools/Services/TestHelpers/MockSendService.swift
+++ b/BitwardenShared/Core/Tools/Services/TestHelpers/MockSendService.swift
@@ -37,6 +37,8 @@ class MockSendService: SendService {
     var syncSendWithServerId: String?
     var syncSendWithServerResult: Result<Void, Error> = .success(())
 
+    var sendSubject = CurrentValueSubject<Send?, Error>(nil)
+
     var sendsSubject = CurrentValueSubject<[Send], Error>([])
 
     // MARK: Methods
@@ -85,6 +87,10 @@ class MockSendService: SendService {
     func syncSendWithServer(id: String) async throws {
         syncSendWithServerId = id
         return try syncSendWithServerResult.get()
+    }
+
+    func sendPublisher(id: String) async throws -> AnyPublisher<Send?, Error> {
+        sendSubject.eraseToAnyPublisher()
     }
 
     func sendsPublisher() async throws -> AnyPublisher<[Send], Error> {

--- a/BitwardenShared/UI/Tools/PreviewContent/SendView+Fixtures.swift
+++ b/BitwardenShared/UI/Tools/PreviewContent/SendView+Fixtures.swift
@@ -5,7 +5,7 @@ import Foundation
 #if DEBUG
 extension SendView {
     static func fixture(
-        id: String = "id",
+        id: String? = "id",
         accessId: String = "accessId",
         name: String = "name",
         notes: String? = nil,

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -1,6 +1,8 @@
 import BitwardenSdk
 import SwiftUI
 
+// swiftlint:disable file_length
+
 // MARK: - MainSendListView
 
 /// The main content of the `SendListView`. Broken out into it's own view so that the

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -2,8 +2,6 @@ import BitwardenKit
 @preconcurrency import BitwardenSdk
 import Foundation
 
-// swiftlint:disable file_length
-
 // MARK: - AddEditSendItemProcessor
 
 /// The processor used to manage state and handle actions for the add/edit send item screen.

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemEffect.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemEffect.swift
@@ -8,4 +8,7 @@ enum ViewSendItemEffect: Equatable {
 
     /// Any initial data for the view should be loaded.
     case loadData
+
+    /// Stream the details of the send.
+    case streamSend
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
@@ -12,7 +12,7 @@ struct ViewSendItemState: Equatable {
     var isAdditionalOptionsExpanded = false
 
     /// The send to show the details of.
-    let sendView: SendView
+    var sendView: SendView
 
     /// A URL for sharing the send.
     var shareURL: URL?

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
@@ -22,6 +22,7 @@ struct ViewSendItemView: View {
                 }
             }
             .task { await store.perform(.loadData) }
+            .task { await store.perform(.streamSend) }
             .toast(
                 store.binding(
                     get: \.toast,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-21125](https://bitwarden.atlassian.net/browse/PM-21125)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The view send screen previously contained a static send instance. If you navigated to edit send from the screen and saved changes, the view send screen would still be showing the outdated send details. This subscribes the view send screen to updates for the send to ensure the latest update of the send is always shown.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/d6dbb2cf-6f2f-41cd-abdf-e5c1aa7d757a


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
