### PR TITLE
[PM-19577] Display logging end date on flight recorder toggle

### DIFF
--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -22,6 +22,9 @@ enum ExternalLinksConstants {
     /// A link to Bitwarden's help page for learning more about the account fingerprint phrase.
     static let fingerprintPhrase = URL(string: "https://bitwarden.com/help/fingerprint-phrase/")!
 
+    /// A link the Bitwarden's help page for the flight recorder.
+    static let flightRecorderHelp = URL(string: "https://bitwarden.com/help/flight-recorder")!
+
     /// A link to Bitwarden's help page for generating username types.
     static let generatorUsernameTypes = URL(string: "https://bitwarden.com/help/generator/#username-types")!
 

--- a/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1194,3 +1194,4 @@
 "EditTextSend" = "Edit text Send";
 "LogDeleted" = "Log deleted";
 "AllLogsDeleted" = "All logs deleted";
+"LoggingEndsOnDateAtTime" = "Logging ends on %1$@ at %2$@";

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutEffect.swift
@@ -6,8 +6,8 @@ enum AboutEffect: Equatable {
     /// The view appeared so the initial data should be loaded.
     case loadData
 
-    /// Stream the enabled status of the flight recorder.
-    case streamFlightRecorderEnabled
+    /// Stream the active flight recorder log.
+    case streamFlightRecorderLog
 
     /// The flight recorder toggle value changed.
     case toggleFlightRecorder(Bool)

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
@@ -53,8 +53,8 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
         switch effect {
         case .loadData:
             await loadData()
-        case .streamFlightRecorderEnabled:
-            await streamFlightRecorderEnabled()
+        case .streamFlightRecorderLog:
+            await streamFlightRecorderLog()
         case let .toggleFlightRecorder(isOn):
             if isOn {
                 coordinator.navigate(to: .enableFlightRecorder)
@@ -113,10 +113,10 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
         state.isFlightRecorderFeatureFlagEnabled = await services.configService.getFeatureFlag(.flightRecorder)
     }
 
-    /// Streams the enabled status of the flight recorder.
-    private func streamFlightRecorderEnabled() async {
-        for await isEnabled in await services.flightRecorder.isEnabledPublisher().values {
-            state.isFlightRecorderToggleOn = isEnabled
+    /// Streams the flight recorder's active log metadata.
+    private func streamFlightRecorderLog() async {
+        for await activeLog in await services.flightRecorder.activeLogPublisher().values {
+            state.flightRecorderActiveLog = activeLog
         }
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutState.swift
@@ -5,17 +5,19 @@ import Foundation
 /// An object that defines the current state of the `AboutView`.
 ///
 struct AboutState {
+    // MARK: Properties
+
     /// The URL for Bitwarden's app review page in the app store.
     var appReviewUrl: URL?
 
     /// The copyright text.
     var copyrightText = ""
 
+    /// The flight recorder's active log metadata, if logging is enabled.
+    var flightRecorderActiveLog: FlightRecorderData.LogMetadata?
+
     /// Whether the flight recorder feature is enabled.
     var isFlightRecorderFeatureFlagEnabled = false
-
-    /// Whether the toggle for enabling flight recorder is on.
-    var isFlightRecorderToggleOn = false
 
     /// Whether the submit crash logs toggle is on.
     var isSubmitCrashLogsToggleOn: Bool = false
@@ -28,4 +30,22 @@ struct AboutState {
 
     /// The version of the app.
     var version = ""
+
+    // MARK: Computed Properties
+
+    /// The accessibility label for the flight recorder toggle.
+    var flightRecorderToggleAccessibilityLabel: String {
+        var accessibilityLabelComponents = [Localizations.flightRecorder]
+        if let log = flightRecorderActiveLog {
+            // VoiceOver doesn't read the short date style correctly so use the medium style instead.
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .medium
+
+            accessibilityLabelComponents.append(Localizations.loggingEndsOnDateAtTime(
+                dateFormatter.string(from: log.endDate),
+                log.formattedEndTime
+            ))
+        }
+        return accessibilityLabelComponents.joined(separator: ", ")
+    }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutViewTests.swift
@@ -60,7 +60,7 @@ class AboutViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.effects, [.toggleFlightRecorder(true)])
         processor.effects.removeAll()
 
-        processor.state.isFlightRecorderToggleOn = true
+        processor.state.flightRecorderActiveLog = FlightRecorderData.LogMetadata(duration: .eightHours, startDate: .now)
         try toggle.tap()
         try await waitForAsync { !self.processor.effects.isEmpty }
         XCTAssertEqual(processor.effects, [.toggleFlightRecorder(false)])

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/AboutStateTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/FlightRecorderLogs/AboutStateTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class AboutStateTests: BitwardenTestCase {
+    /// `flightRecorderToggleAccessibilityLabel` returns the flight recorder toggle's accessibility
+    /// label when the flight recorder is off.
+    func test_flightRecorderToggleAccessibilityLabel_flightRecorderOff() {
+        let subject = AboutState(flightRecorderActiveLog: nil)
+        XCTAssertEqual(subject.flightRecorderToggleAccessibilityLabel, Localizations.flightRecorder)
+    }
+
+    /// `flightRecorderToggleAccessibilityLabel` returns the flight recorder toggle's accessibility
+    /// label when the flight recorder is on.
+    func test_flightRecorderToggleAccessibilityLabel_flightRecorderOn() {
+        let subject = AboutState(
+            flightRecorderActiveLog: FlightRecorderData.LogMetadata(
+                duration: .eightHours,
+                startDate: Date(year: 2025, month: 5, day: 1)
+            )
+        )
+        XCTAssertEqual(
+            subject.flightRecorderToggleAccessibilityLabel,
+            Localizations.flightRecorder + ", Logging ends on May 1, 2025 at 8:00 AM"
+        )
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19577](https://bitwarden.atlassian.net/browse/PM-19577)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When the flight recorder is enabled, display the date in which logging will end in the flight recorder toggle component. This also adds the help link to the toggle.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="557" alt="Screenshot 2025-05-28 at 4 47 51 PM" src="https://github.com/user-attachments/assets/ab4e751a-c1e1-41c3-876e-e13a8e3668f4" /> | <img width="557" alt="Screenshot 2025-05-28 at 4 46 46 PM" src="https://github.com/user-attachments/assets/ea9a192a-7831-4cd2-b67e-f5335fe28fcc" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
