### PR TITLE
[PM-19553] Update flight recorder banner dismissal tracking

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Data/FlightRecorderData.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/FlightRecorderData.swift
@@ -42,9 +42,6 @@ extension FlightRecorderData {
     struct LogMetadata: Codable, Equatable, Identifiable {
         // MARK: Properties
 
-        /// A list of user IDs that have seen and dismissed the flight recorder toast banner for this log.
-        var bannerDismissedByUserIds: [String]
-
         /// The duration for how long the flight recorder was enabled for the log.
         let duration: FlightRecorderLoggingDuration
 
@@ -53,6 +50,9 @@ extension FlightRecorderData {
 
         /// The file name of the file on disk.
         let fileName: String
+
+        /// Whether the flight recorder toast banner has been dismissed for this log.
+        @DefaultFalse var isBannerDismissed = false
 
         /// The date the logging was started.
         let startDate: Date
@@ -97,7 +97,6 @@ extension FlightRecorderData {
         ///   - startDate: The date the logging was started.
         ///
         init(duration: FlightRecorderLoggingDuration, startDate: Date) {
-            bannerDismissedByUserIds = []
             self.duration = duration
             self.startDate = startDate
 

--- a/BitwardenShared/Core/Platform/Models/Data/FlightRecorderDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Data/FlightRecorderDataTests.swift
@@ -105,10 +105,9 @@ class FlightRecorderDataTests: BitwardenTestCase {
         var log = FlightRecorderData.LogMetadata(duration: .eightHours, startDate: .now)
         subject.activeLog = log
 
-        subject.activeLog?.bannerDismissedByUserIds.append("123")
-        subject.activeLog?.bannerDismissedByUserIds.append("456")
+        subject.activeLog?.isBannerDismissed = true
 
-        log.bannerDismissedByUserIds.append(contentsOf: ["123", "456"])
+        log.isBannerDismissed = true
         XCTAssertEqual(subject, FlightRecorderData(activeLog: log))
     }
 

--- a/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
+++ b/BitwardenShared/Core/Platform/Services/FlightRecorder.swift
@@ -61,9 +61,7 @@ protocol FlightRecorder: Sendable, BitwardenLogger {
     /// Sets a flag indicating that the flight recorder banner for the active log was viewed and
     /// dismissed by the active user.
     ///
-    /// - Parameter userId: The ID of the user who dismissed the banner.
-    ///
-    func setFlightRecorderBannerDismissed(userId: String) async
+    func setFlightRecorderBannerDismissed() async
 }
 
 extension FlightRecorder {
@@ -454,9 +452,9 @@ extension DefaultFlightRecorder: FlightRecorder {
         }
     }
 
-    func setFlightRecorderBannerDismissed(userId: String) async {
+    func setFlightRecorderBannerDismissed() async {
         guard var data = await getFlightRecorderData(), data.activeLog != nil else { return }
-        data.activeLog?.bannerDismissedByUserIds.append(userId)
+        data.activeLog?.isBannerDismissed = true
         await setFlightRecorderData(data)
     }
 }

--- a/BitwardenShared/Core/Platform/Services/FlightRecorderTests.swift
+++ b/BitwardenShared/Core/Platform/Services/FlightRecorderTests.swift
@@ -631,24 +631,24 @@ class FlightRecorderTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertNil(stateService.flightRecorderData)
     }
 
-    /// `setFlightRecorderBannerDismissed(userId:)` sets that the flight recorder banner was
-    /// dismissed by the user.
+    /// `setFlightRecorderBannerDismissed()` sets that the flight recorder banner was dismissed by
+    /// the user.
     func test_setFlightRecorderBannerDismissed() async {
         stateService.flightRecorderData = FlightRecorderData(activeLog: activeLog)
-        await subject.setFlightRecorderBannerDismissed(userId: "123")
+        await subject.setFlightRecorderBannerDismissed()
 
         var activeLogWithDismissedBanner = activeLog
-        activeLogWithDismissedBanner.bannerDismissedByUserIds.append("123")
+        activeLogWithDismissedBanner.isBannerDismissed = true
         XCTAssertEqual(
             stateService.flightRecorderData,
             FlightRecorderData(activeLog: activeLogWithDismissedBanner)
         )
     }
 
-    /// `setFlightRecorderBannerDismissed(userId:)` doesn't modify the flight recorder data if
-    /// there's no flight recorder data.
+    /// `setFlightRecorderBannerDismissed()` doesn't modify the flight recorder data if there's no
+    /// flight recorder data.
     func test_setFlightRecorderBannerDismissed_noFlightRecorderData() async {
-        await subject.setFlightRecorderBannerDismissed(userId: "123")
+        await subject.setFlightRecorderBannerDismissed()
         XCTAssertNil(stateService.flightRecorderData)
     }
 

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockFlightRecorder.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockFlightRecorder.swift
@@ -17,7 +17,7 @@ final class MockFlightRecorder: FlightRecorder {
     var fetchLogsResult: Result<[FlightRecorderLogMetadata], Error> = .success([])
     var isEnabledSubject = CurrentValueSubject<Bool, Never>(false)
     var logMessages = [String]()
-    var setFlightRecorderBannerDismissedUserIds = [String]()
+    var setFlightRecorderBannerDismissedCalled = false
 
     nonisolated init() {}
 
@@ -58,7 +58,7 @@ final class MockFlightRecorder: FlightRecorder {
         logMessages.append(message)
     }
 
-    func setFlightRecorderBannerDismissed(userId: String) async {
-        setFlightRecorderBannerDismissedUserIds.append(userId)
+    func setFlightRecorderBannerDismissed() async {
+        setFlightRecorderBannerDismissedCalled = true
     }
 }

--- a/BitwardenShared/Core/Platform/Utilities/DefaultFalse.swift
+++ b/BitwardenShared/Core/Platform/Utilities/DefaultFalse.swift
@@ -6,7 +6,7 @@ struct DefaultFalse: Codable, Hashable {
     // MARK: Properties
 
     /// The wrapped value.
-    let wrappedValue: Bool
+    var wrappedValue: Bool
 
     // MARK: Initialization
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -239,13 +239,7 @@ extension VaultListProcessor {
     ///
     private func dismissFlightRecorderToastBanner() async {
         state.isFlightRecorderToastBannerVisible = false
-
-        do {
-            let userId = try await services.stateService.getActiveAccountId()
-            await services.flightRecorder.setFlightRecorderBannerDismissed(userId: userId)
-        } catch {
-            services.errorReporter.log(error: error)
-        }
+        await services.flightRecorder.setFlightRecorderBannerDismissed()
     }
 
     /// Entry point to handling things around push notifications.
@@ -413,14 +407,9 @@ extension VaultListProcessor {
     /// Streams the flight recorder enabled status.
     ///
     private func streamFlightRecorderLog() async {
-        do {
-            let userId = try await services.stateService.getActiveAccountId()
-            for await log in await services.flightRecorder.activeLogPublisher().values {
-                state.activeFlightRecorderLog = log
-                state.isFlightRecorderToastBannerVisible = !(log?.bannerDismissedByUserIds.contains(userId) ?? true)
-            }
-        } catch {
-            services.errorReporter.log(error: error)
+        for await log in await services.flightRecorder.activeLogPublisher().values {
+            state.activeFlightRecorderLog = log
+            state.isFlightRecorderToastBannerVisible = !(log?.isBannerDismissed ?? true)
         }
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -433,19 +433,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await subject.perform(.dismissFlightRecorderToastBanner)
 
         XCTAssertFalse(subject.state.isFlightRecorderToastBannerVisible)
-        XCTAssertEqual(flightRecorder.setFlightRecorderBannerDismissedUserIds, ["1"])
-    }
-
-    /// `perform(_:)` with `.dismissFlightRecorderToastBanner` logs an error if one occurs.
-    @MainActor
-    func test_perform_dismissFlightRecorderToastBanner_error() async {
-        subject.state.isFlightRecorderToastBannerVisible = true
-
-        await subject.perform(.dismissFlightRecorderToastBanner)
-
-        XCTAssertFalse(subject.state.isFlightRecorderToastBannerVisible)
-        XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
-        XCTAssertTrue(flightRecorder.setFlightRecorderBannerDismissedUserIds.isEmpty)
+        XCTAssertTrue(flightRecorder.setFlightRecorderBannerDismissedCalled)
     }
 
     /// `perform(_:)` with `.dismissImportLoginsActionCard` sets the user's import logins setup
@@ -794,13 +782,6 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.isFlightRecorderToastBannerVisible, false)
     }
 
-    /// `perform(_:)` with `.streamFlightRecorderLog` logs an error if one occurs.
-    @MainActor
-    func test_perform_streamFlightRecorderLog_error() async throws {
-        await subject.perform(.streamFlightRecorderLog)
-        XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
-    }
-
     /// `perform(_:)` with `.streamFlightRecorderLog` streams the flight recorder log but doesn't
     /// display the flight recorder banner if the user has dismissed it previously.
     @MainActor
@@ -813,7 +794,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         defer { task.cancel() }
 
         var log = FlightRecorderData.LogMetadata(duration: .eightHours, startDate: .now)
-        log.bannerDismissedByUserIds = ["1"]
+        log.isBannerDismissed = true
         flightRecorder.activeLogSubject.send(log)
 
         try await waitForAsync { self.subject.state.activeFlightRecorderLog != nil }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-19553](https://bitwarden.atlassian.net/browse/PM-19553)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Previously, the flight recorder banner's dismissal was tracked on a per-user basis. This changes that to track it on an app-wide basis.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-19553]: https://bitwarden.atlassian.net/browse/PM-19553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ