### PR TITLE
[QA-1170]  Send UI update - Adding missing accessibilityIDs

### DIFF
--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
@@ -47,6 +47,7 @@ struct ViewSendItemView: View {
             Label(Localizations.deleteSend, image: Asset.Images.trash16.swiftUIImage, scaleImageDimension: 16)
         }
         .buttonStyle(.secondary(isDestructive: true, size: .medium))
+        .accessibilityIdentifier("ViewSendDeleteButton")
     }
 
     /// The main content of the view.
@@ -94,6 +95,7 @@ struct ViewSendItemView: View {
                             store.send(.copyNotes)
                         }
                     )
+                    .accessibilityIdentifier("ViewSendNotes")
                 }
             }
         }
@@ -112,6 +114,7 @@ struct ViewSendItemView: View {
                         .styleGuide(.subheadline)
                         .foregroundStyle(Asset.Colors.textSecondary.swiftUIColor)
                         .lineLimit(1)
+                        .accessibilityIdentifier("ViewSendShareLinkText")
                 }
             }
             .padding(16)
@@ -123,6 +126,7 @@ struct ViewSendItemView: View {
                     Label(Localizations.copy, image: Asset.Images.copy16.swiftUIImage, scaleImageDimension: 16)
                 }
                 .buttonStyle(.primary(size: .medium))
+                .accessibilityIdentifier("ViewSendCopyButton")
 
                 Button {
                     store.send(.shareSend)
@@ -130,6 +134,7 @@ struct ViewSendItemView: View {
                     Label(Localizations.share, image: Asset.Images.share16.swiftUIImage, scaleImageDimension: 16)
                 }
                 .buttonStyle(.secondary(size: .medium))
+                .accessibilityIdentifier("ViewSendShareButton")
             }
             .padding(16)
         }
@@ -138,7 +143,8 @@ struct ViewSendItemView: View {
     /// The send details section, containing the send's name, content, and deletion date.
     @ViewBuilder private var sendDetailsSection: some View {
         SectionView(Localizations.sendDetails, contentSpacing: 8) {
-            BitwardenTextValueField(title: Localizations.sendNameRequired, value: store.state.sendView.name)
+            // swiftlint:disable:next line_length
+            BitwardenTextValueField(title: Localizations.sendNameRequired, value: store.state.sendView.name, valueAccessibilityIdentifier: "ViewSendNameField")
 
             switch store.state.sendView.type {
             case .file:
@@ -148,6 +154,7 @@ struct ViewSendItemView: View {
                             Text(file.fileName)
                                 .styleGuide(.body)
                                 .foregroundStyle(Asset.Colors.textPrimary.swiftUIColor)
+                                .accessibilityIdentifier("ViewSendFileNameText")
 
                             if let fileSize = file.sizeName {
                                 Text(fileSize)
@@ -155,19 +162,22 @@ struct ViewSendItemView: View {
                                     .foregroundStyle(Asset.Colors.textSecondary.swiftUIColor)
                                     .frame(maxWidth: .infinity, alignment: .trailing)
                                     .multilineTextAlignment(.trailing)
+                                    .accessibilityIdentifier("ViewSendFileSizeText")
                             }
                         }
                     }
                 }
             case .text:
                 if let text = store.state.sendView.text?.text {
-                    BitwardenTextValueField(title: Localizations.textToShare, value: text)
+                    // swiftlint:disable:next line_length
+                    BitwardenTextValueField(title: Localizations.textToShare, value: text, valueAccessibilityIdentifier: "ViewSendContentText")
                 }
             }
 
             BitwardenTextValueField(
                 title: Localizations.deletionDate,
-                value: store.state.sendView.deletionDate.formatted(date: .abbreviated, time: .shortened)
+                value: store.state.sendView.deletionDate.formatted(date: .abbreviated, time: .shortened),
+                valueAccessibilityIdentifier: "ViewSendDeletionDateField"
             )
         }
     }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
@@ -143,8 +143,10 @@ struct ViewSendItemView: View {
     /// The send details section, containing the send's name, content, and deletion date.
     @ViewBuilder private var sendDetailsSection: some View {
         SectionView(Localizations.sendDetails, contentSpacing: 8) {
-            // swiftlint:disable:next line_length
-            BitwardenTextValueField(title: Localizations.sendNameRequired, value: store.state.sendView.name, valueAccessibilityIdentifier: "ViewSendNameField")
+            BitwardenTextValueField(
+                title: Localizations.sendNameRequired,
+                value: store.state.sendView.name,
+                valueAccessibilityIdentifier: "ViewSendNameField")
 
             switch store.state.sendView.type {
             case .file:
@@ -169,8 +171,10 @@ struct ViewSendItemView: View {
                 }
             case .text:
                 if let text = store.state.sendView.text?.text {
-                    // swiftlint:disable:next line_length
-                    BitwardenTextValueField(title: Localizations.textToShare, value: text, valueAccessibilityIdentifier: "ViewSendContentText")
+                    BitwardenTextValueField(
+                        title: Localizations.textToShare,
+                        value: text,
+                        valueAccessibilityIdentifier: "ViewSendContentText")
                 }
             }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/QA-1170

## 📔 Objective

This work is a subtask of [QA-947](https://bitwarden.atlassian.net/browse/QA-947), a story created to group all the native app views that contain elements without Automation IDs.
NOTE: Not all the elements will require an AutomationID. We are adding the ones we currently need so we can reduce the flakiness on some critical Mobile e2e tests

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[QA-947]: https://bitwarden.atlassian.net/browse/QA-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ