### PR TITLE
[PM-22176] Remove Edit FAB and action for deleted items

### DIFF
--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -74,6 +74,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
                 return
             }
 
+            let canEdit = cipherView.deletedDate == nil
             let hasPremium = try await services.vaultRepository.doesActiveAccountHavePremium()
             let hasMasterPassword = try await services.stateService.getUserHasMasterPassword()
 
@@ -82,7 +83,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
                 cipherView: cipherView,
                 hasMasterPassword: hasMasterPassword,
                 id: item.id,
-                showEdit: true
+                showEdit: canEdit
             ) { action in
                 await self.handleMoreOptionsAction(
                     action,

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -524,6 +524,29 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(coordinator.routes.last, .editItem(.fixture(type: .identity)))
     }
 
+    /// `showMoreOptionsAlert()` shows the appropriate more options alert for a deleted login cipher.
+    @MainActor
+    func test_showMoreOptionsAlert_login_deleted() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.userHasMasterPassword = [account.profile.userId: true]
+
+        vaultRepository.fetchCipherResult = .success(.fixture(deletedDate: .now, type: .login))
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(login: .fixture())))
+
+        await subject.showMoreOptionsAlert(
+            for: item,
+            handleDisplayToast: { _ in },
+            handleOpenURL: { _ in }
+        )
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, "Bitwarden")
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+    }
+
     /// `showMoreOptionsAlert()` shows the appropriate more options alert for a login cipher.
     @MainActor
     func test_showMoreOptionsAlert_login_minimal() async throws {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -17,6 +17,11 @@ struct ViewItemState: Equatable, Sendable {
         }
     }
 
+    /// Whether the cipher can be edited.
+    var canEdit: Bool {
+        loadingState.data?.cipher.deletedDate == nil
+    }
+
     /// The current state. If this state is not `.loading`, this value will contain an associated value with the
     /// appropriate internal state.
     var loadingState: LoadingState<CipherItemState> = .loading(nil)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
@@ -42,6 +42,22 @@ class ViewItemStateTests: BitwardenTestCase {
         XCTAssertFalse(subject.canClone)
     }
 
+    /// `canEdit` returns `true` for a cipher that isn't deleted.
+    func test_canEdit() throws {
+        let subject = try ViewItemState(loadingState: .data(
+            XCTUnwrap(CipherItemState(existing: .fixture(), hasPremium: false))
+        ))
+        XCTAssertTrue(subject.canEdit)
+    }
+
+    /// `canEdit` returns `false` for a cipher that is deleted.
+    func test_canEdit_deleted() throws {
+        let subject = try ViewItemState(loadingState: .data(
+            XCTUnwrap(CipherItemState(existing: .fixture(deletedDate: .now), hasPremium: false))
+        ))
+        XCTAssertFalse(subject.canEdit)
+    }
+
     /// `isMasterPasswordRequired` is false when the user has no password.
     func test_isMasterPasswordRequired_repromptOff_noPassword() {
         let subject = ViewItemState(

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -89,7 +89,7 @@ struct ViewItemView: View {
             }
         }
         .overlay(alignment: .bottomTrailing) {
-            editItemFloatingActionButton {
+            editItemFloatingActionButton(hidden: !store.state.canEdit) {
                 store.send(.editPressed)
             }
         }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemViewTests.swift
@@ -164,6 +164,16 @@ class ViewItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(processor.dispatchedActions.last, .editPressed)
     }
 
+    /// The edit item FAB is hidden if the item has been deleted.
+    @MainActor
+    func test_editItemFloatingActionButton_hidden_cipherDeleted() async throws {
+        processor.state.loadingState = .data(CipherItemState(existing: .fixture(deletedDate: .now), hasPremium: true)!)
+        let fab = try subject.inspect().find(
+            floatingActionButtonWithAccessibilityIdentifier: "EditItemFloatingActionButton"
+        )
+        XCTAssertTrue(fab.isHidden())
+    }
+
     /// Tapping the password history button dispatches the `passwordHistoryPressed` action.
     @MainActor
     func test_passwordHistoryButton_tap() throws {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-22176](https://bitwarden.atlassian.net/browse/PM-22176)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the Edit FAB from the View Item view for deleted items. 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/146c7f9b-d1e3-494c-9435-e0d7d900b81a



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
