### PR TITLE
[PM-22347] Improved Open generator intent error alert behavior

### DIFF
--- a/Bitwarden/Application/AppIntents/OpenGeneratorIntent.swift
+++ b/Bitwarden/Application/AppIntents/OpenGeneratorIntent.swift
@@ -2,13 +2,13 @@ import AppIntents
 import BitwardenShared
 
 /// App intent that opens the generator view.
-@available(iOS 16.0, *)
-struct OpenGeneratorIntent: AppIntent {
+@available(iOS 16.4, *)
+struct OpenGeneratorIntent: ForegroundContinuableIntent {
     static var title: LocalizedStringResource = "OpenGenerator"
 
     static var description = IntentDescription("OpenGenerator")
 
-    static var openAppWhenRun: Bool = true
+    static var openAppWhenRun: Bool = false
 
     @MainActor
     func perform() async throws -> some IntentResult {
@@ -18,10 +18,12 @@ struct OpenGeneratorIntent: AppIntent {
         let appIntentMediator = services.getAppIntentMediator()
 
         guard try await appIntentMediator.canRunAppIntents() else {
-            return .result()
+            throw BitwardenShared.AppIntentError.notAllowed
         }
 
         await appIntentMediator.openGenerator()
+
+        try await requestToContinueInForeground()
 
         return .result()
     }

--- a/Bitwarden/Application/AppIntents/ShortcutsProvider.swift
+++ b/Bitwarden/Application/AppIntents/ShortcutsProvider.swift
@@ -1,7 +1,7 @@
 import AppIntents
 
 /// The app shortcuts provider.
-@available(iOS 16.0, *)
+@available(iOS 16.4, *)
 struct ShortcutsProvider: AppShortcutsProvider {
     /// The app shortcuts.
     static var appShortcuts: [AppShortcut] {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22347](https://bitwarden.atlassian.net/browse/PM-22347)

## 📔 Objective

Open generator intent error alert was being left behind the app because the intent was automatically opening the Bitwarden app. So this changes the intent to be a `ForegroundContinuableIntent` so it can decide whether to open the app or display the error alert.

This comes with an added step to the user where they need to accept continuing into the app.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22347]: https://bitwarden.atlassian.net/browse/PM-22347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ