### PR TITLE
[PM-22549] Update CXP related code to work with new iOS 26 beta API

### DIFF
--- a/Bitwarden/Application/SceneDelegate.swift
+++ b/Bitwarden/Application/SceneDelegate.swift
@@ -75,7 +75,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
             #if SUPPORTS_CXP
 
-            if #available(iOS 18.2, *),
+            if #available(iOS 26.0, *),
                let userActivity = connectionOptions.userActivities.first {
                 await checkAndHandleCredentialExchangeActivity(appProcessor: appProcessor, userActivity: userActivity)
             }
@@ -99,7 +99,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         #if SUPPORTS_CXP
 
-        if #available(iOS 18.2, *) {
+        if #available(iOS 26.0, *) {
             Task {
                 await checkAndHandleCredentialExchangeActivity(appProcessor: appProcessor, userActivity: userActivity)
             }
@@ -184,7 +184,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 #if SUPPORTS_CXP
 
-@available(iOS 18.2, *)
+@available(iOS 26.0, *)
 extension SceneDelegate {
     /// Checks  whether there is an `ASCredentialExchangeActivity` in the `userActivity` and handles it.
     /// - Parameters:

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
@@ -15,7 +15,7 @@ protocol ExportCXFCiphersRepository {
     /// Export the credentials using the Credential Exchange flow.
     ///
     /// - Parameter data: Data to export.
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func exportCredentials(data: ASImportableAccount, presentationAnchor: () -> ASPresentationAnchor) async throws
     #endif
 
@@ -28,7 +28,7 @@ protocol ExportCXFCiphersRepository {
     /// Exports the vault creating the `ASImportableAccount` to be used in Credential Exchange Protocol.
     ///
     /// - Returns: An `ASImportableAccount`
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func getExportVaultDataForCXF() async throws -> ASImportableAccount
     #endif
 }
@@ -93,10 +93,21 @@ class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
 
     #if SUPPORTS_CXP
 
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func exportCredentials(data: ASImportableAccount, presentationAnchor: () -> ASPresentationAnchor) async throws {
-        try await credentialManagerFactory.createExportManager(presentationAnchor: presentationAnchor())
-            .exportCredentials(ASExportedCredentialData(accounts: [data]))
+        let manager = credentialManagerFactory.createExportManager(presentationAnchor: presentationAnchor())
+
+        let options = try await manager.requestExport(for: nil)
+
+        try await manager.exportCredentials(
+            ASExportedCredentialData(
+                accounts: [data],
+                formatVersion: options.formatVersion,
+                exporterRelyingPartyIdentifier: Bundle.main.appIdentifier,
+                exporterDisplayName: "Bitwarden",
+                timestamp: Date.now
+            )
+        )
     }
 
     #endif
@@ -108,7 +119,7 @@ class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
 
     #if SUPPORTS_CXP
 
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func getExportVaultDataForCXF() async throws -> ASImportableAccount {
         let ciphers = try await getAllCiphersToExportCXF()
 

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepository.swift
@@ -11,7 +11,7 @@ protocol ImportCiphersRepository: AnyObject {
     ///   - onProgress: Closure to update progress.
     /// - Returns: A dictionary containing the localized cipher type (key) and count (value) of that type
     /// that was imported, e.g. ["Passwords": 3, "Cards": 2].
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func importCiphers(
         credentialImportToken: UUID,
         onProgress: @MainActor (Double) -> Void
@@ -69,7 +69,7 @@ class DefaultImportCiphersRepository {
 // MARK: ImportCiphersRepository
 
 extension DefaultImportCiphersRepository: ImportCiphersRepository {
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func importCiphers(
         credentialImportToken: UUID,
         onProgress: @MainActor (Double) -> Void

--- a/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactory.swift
+++ b/BitwardenShared/Core/Tools/Utilities/CredentialManagerFactory.swift
@@ -4,22 +4,22 @@ import Foundation
 // MARK: - CredentialManagerFactory
 
 protocol CredentialManagerFactory {
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func createExportManager(presentationAnchor: ASPresentationAnchor) -> CredentialExportManager
 
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func createImportManager() -> CredentialImportManager
 }
 
 // MARK: - DefaultCredentialManagerFactory
 
 struct DefaultCredentialManagerFactory: CredentialManagerFactory {
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func createExportManager(presentationAnchor: ASPresentationAnchor) -> any CredentialExportManager {
         ASCredentialExportManager(presentationAnchor: presentationAnchor)
     }
 
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func createImportManager() -> any CredentialImportManager {
         ASCredentialImportManager()
     }
@@ -28,14 +28,17 @@ struct DefaultCredentialManagerFactory: CredentialManagerFactory {
 // MARK: - CredentialExportManager
 
 protocol CredentialExportManager: AnyObject {
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func exportCredentials(_ credentialData: ASExportedCredentialData) async throws
+
+    @available(iOS 26.0, *)
+    func requestExport(for extensionBundleIdentifier: String?) async throws -> ASCredentialExportManager.ExportOptions
 }
 
 // MARK: - CredentialImportManager
 
 protocol CredentialImportManager: AnyObject {
-    @available(iOS 18.2, *)
+    @available(iOS 26.0, *)
     func importCredentials(token: UUID) async throws -> ASExportedCredentialData
 }
 
@@ -46,10 +49,10 @@ protocol CredentialImportManager: AnyObject {
 
 #if SUPPORTS_CXP
 
-@available(iOS 18.2, *)
+@available(iOS 26.0, *)
 extension ASCredentialExportManager: CredentialExportManager {}
 
-@available(iOS 18.2, *)
+@available(iOS 26.0, *)
 extension ASCredentialImportManager: CredentialImportManager {}
 
 #else
@@ -61,9 +64,16 @@ class ASCredentialImportManager: CredentialImportManager {
 }
 
 class ASCredentialExportManager: CredentialExportManager {
+    struct ExportOptions {}
+
     init(presentationAnchor: ASPresentationAnchor) {}
 
     func exportCredentials(_ credentialData: ASExportedCredentialData) async throws {}
+
+    @available(iOS 26.0, *)
+    func requestExport(for extensionBundleIdentifier: String?) async throws -> ASCredentialExportManager.ExportOptions {
+        ASCredentialExportManager.ExportOptions()
+    }
 }
 
 struct ASExportedCredentialData {}

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessor.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessor.swift
@@ -101,7 +101,7 @@ class ExportCXFProcessor: StateProcessor<ExportCXFState, ExportCXFAction, Export
     private func startExport() async {
         #if SUPPORTS_CXP
 
-        guard #available(iOS 18.2, *) else {
+        guard #available(iOS 26.0, *) else {
             coordinator.showAlert(
                 .defaultAlert(
                     title: Localizations.exportingFailed

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessor.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessor.swift
@@ -79,7 +79,7 @@ class ImportCXFProcessor: StateProcessor<ImportCXFState, Void, ImportCXFEffect> 
     private func startImport() async {
         #if SUPPORTS_CXP
 
-        guard #available(iOS 18.2, *), let credentialImportToken = state.credentialImportToken else {
+        guard #available(iOS 26.0, *), let credentialImportToken = state.credentialImportToken else {
             coordinator.showAlert(
                 .defaultAlert(
                     title: Localizations.importError,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22549](https://bitwarden.atlassian.net/browse/PM-22549)

## 📔 Objective

Update Credential Exchange implementation to new iOS 26 beta API.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
