### PR TITLE
[PM-10285] Update master password reprompt to protect item view

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Domain/Fixtures/VaultListItem+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Fixtures/VaultListItem+Fixtures.swift
@@ -88,4 +88,22 @@ extension VaultListTOTP {
             totpCode: totpCode
         )
     }
+
+    static func fixture(
+        id: String = "123",
+        cipherListView: CipherListView,
+        requiresMasterPassword: Bool = false,
+        totpCode: TOTPCodeModel = .init(
+            code: "123456",
+            codeGenerationDate: Date(),
+            period: 30
+        )
+    ) -> VaultListTOTP {
+        VaultListTOTP(
+            id: id,
+            cipherListView: cipherListView,
+            requiresMasterPassword: requiresMasterPassword,
+            totpCode: totpCode
+        )
+    }
 }

--- a/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Alert/Alert/AlertTests.swift
@@ -90,7 +90,7 @@ class AlertTests: BitwardenTestCase {
     }
 
     @MainActor
-    func test_vault_moreOptions_login_canViewPassowrd() async throws { // swiftlint:disable:this function_body_length
+    func test_vault_moreOptions_login_canViewPassword() async throws { // swiftlint:disable:this function_body_length
         var capturedAction: MoreOptionsAction?
         let action: (MoreOptionsAction) -> Void = { action in
             capturedAction = action
@@ -109,7 +109,6 @@ class AlertTests: BitwardenTestCase {
         let alert = Alert.moreOptions(
             canCopyTotp: false,
             cipherView: cipher,
-            hasMasterPassword: false,
             id: cipher.id!,
             showEdit: true,
             action: action
@@ -131,7 +130,7 @@ class AlertTests: BitwardenTestCase {
         await second.handler?(second, [])
         XCTAssertEqual(
             capturedAction,
-            .edit(cipherView: cipher, requiresMasterPasswordReprompt: false)
+            .edit(cipherView: cipher)
         )
         capturedAction = nil
 
@@ -160,7 +159,7 @@ class AlertTests: BitwardenTestCase {
             .copy(
                 toast: Localizations.password,
                 value: "password",
-                requiresMasterPasswordReprompt: false,
+                requiresMasterPasswordReprompt: true,
                 logEvent: .cipherClientCopiedPassword,
                 cipherId: "123"
             )
@@ -194,7 +193,6 @@ class AlertTests: BitwardenTestCase {
         let alert = Alert.moreOptions(
             canCopyTotp: false,
             cipherView: cipher,
-            hasMasterPassword: false,
             id: cipher.id!,
             showEdit: true,
             action: action
@@ -216,7 +214,7 @@ class AlertTests: BitwardenTestCase {
         await second.handler?(second, [])
         XCTAssertEqual(
             capturedAction,
-            .edit(cipherView: cipher, requiresMasterPasswordReprompt: false)
+            .edit(cipherView: cipher)
         )
         capturedAction = nil
 

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -182,33 +182,30 @@ extension Alert {
     ///   - canCopyTotp: Whether the user can copy the TOTP code (because they have premium or the
     ///     organization uses TOTP).
     ///   - cipherView: The cipher view to show.
-    ///   - hasMasterPassword: Whether the user has a master password.
     ///   - id: The id of the item.
     ///   - showEdit: Whether to show the edit option (should be `false` for items in the trash).
     ///   - action: The action to perform after selecting an option.
     ///
     /// - Returns: An alert presenting the user with options to select an attachment type.
     @MainActor
-    static func moreOptions( // swiftlint:disable:this function_body_length function_parameter_count
+    static func moreOptions( // swiftlint:disable:this function_body_length
         canCopyTotp: Bool,
         cipherView: CipherView,
-        hasMasterPassword: Bool,
         id: String,
         showEdit: Bool,
         action: @escaping (_ action: MoreOptionsAction) async -> Void
     ) -> Alert {
         // All the cipher types have the option to view the cipher.
         var alertActions = [
-            AlertAction(title: Localizations.view, style: .default) { _, _ in await action(.view(id: id)) },
+            AlertAction(title: Localizations.view, style: .default) { _, _ in
+                await action(.view(id: id))
+            },
         ]
 
         // Add the option to edit the cipher if desired.
         if showEdit {
             alertActions.append(AlertAction(title: Localizations.edit, style: .default) { _, _ in
-                await action(.edit(
-                    cipherView: cipherView,
-                    requiresMasterPasswordReprompt: cipherView.reprompt == .password && hasMasterPassword
-                ))
+                await action(.edit(cipherView: cipherView))
             })
         }
 
@@ -220,7 +217,7 @@ extension Alert {
                     await action(.copy(
                         toast: Localizations.number,
                         value: number,
-                        requiresMasterPasswordReprompt: cipherView.reprompt == .password && hasMasterPassword,
+                        requiresMasterPasswordReprompt: true,
                         logEvent: nil,
                         cipherId: nil
                     ))
@@ -231,7 +228,7 @@ extension Alert {
                     await action(.copy(
                         toast: Localizations.securityCode,
                         value: code,
-                        requiresMasterPasswordReprompt: cipherView.reprompt == .password && hasMasterPassword,
+                        requiresMasterPasswordReprompt: true,
                         logEvent: .cipherClientCopiedCardCode,
                         cipherId: cipherView.id
                     ))
@@ -255,7 +252,7 @@ extension Alert {
                     await action(.copy(
                         toast: Localizations.password,
                         value: password,
-                        requiresMasterPasswordReprompt: cipherView.reprompt == .password && hasMasterPassword,
+                        requiresMasterPasswordReprompt: true,
                         logEvent: .cipherClientCopiedPassword,
                         cipherId: cipherView.id
                     ))
@@ -263,10 +260,7 @@ extension Alert {
             }
             if canCopyTotp, let totp = cipherView.login?.totp {
                 alertActions.append(AlertAction(title: Localizations.copyTotp, style: .default) { _, _ in
-                    await action(.copyTotp(
-                        totpKey: TOTPKeyModel(authenticatorKey: totp),
-                        requiresMasterPasswordReprompt: cipherView.reprompt == .password && hasMasterPassword
-                    ))
+                    await action(.copyTotp(totpKey: TOTPKeyModel(authenticatorKey: totp)))
                 })
             }
             if let uri = cipherView.login?.uris?.first?.uri,
@@ -307,7 +301,7 @@ extension Alert {
                         await action(.copy(
                             toast: Localizations.privateKey,
                             value: sshKey.privateKey,
-                            requiresMasterPasswordReprompt: cipherView.reprompt == .password && hasMasterPassword,
+                            requiresMasterPasswordReprompt: true,
                             logEvent: nil,
                             cipherId: cipherView.id
                         ))

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -141,7 +141,6 @@ class AlertVaultTests: BitwardenTestCase {
         let alert = Alert.moreOptions(
             canCopyTotp: false,
             cipherView: cipher,
-            hasMasterPassword: false,
             id: cipher.id!,
             showEdit: true,
             action: action
@@ -157,7 +156,7 @@ class AlertVaultTests: BitwardenTestCase {
         try await alert.tapAction(byIndex: 1, withTitle: Localizations.edit)
         XCTAssertEqual(
             capturedAction,
-            .edit(cipherView: cipher, requiresMasterPasswordReprompt: false)
+            .edit(cipherView: cipher)
         )
         capturedAction = nil
 
@@ -180,7 +179,7 @@ class AlertVaultTests: BitwardenTestCase {
             .copy(
                 toast: Localizations.privateKey,
                 value: "privateKey",
-                requiresMasterPasswordReprompt: false,
+                requiresMasterPasswordReprompt: true,
                 logEvent: nil,
                 cipherId: "123"
             )

--- a/BitwardenShared/UI/Vault/Helpers/MasterPasswordRepromptHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/MasterPasswordRepromptHelper.swift
@@ -1,0 +1,134 @@
+import BitwardenSdk
+
+// MARK: - MasterPasswordRepromptHelper
+
+/// A protocol for a helper that's used to present the master password reprompt alert if a cipher
+/// has master password reprompt enabled and the user has a master password.
+///
+protocol MasterPasswordRepromptHelper {
+    /// Reprompts the user for their master password if the cipher has master password reprompt
+    /// enabled and the user has a master password.
+    ///
+    /// - Parameters:
+    ///   - cipherView: The `CipherView` used to determine if master password reprompt is enabled.
+    ///   - completion: A closure that is called if master password reprompt is successful or it
+    ///     wasn't required. This *isn't* called if master password reprompt is unsuccessful.
+    ///
+    func repromptForMasterPasswordIfNeeded(
+        cipherView: CipherView,
+        completion: @escaping @MainActor () async -> Void
+    ) async
+
+    /// Reprompts the user for their master password if the cipher has master password reprompt
+    /// enabled and the user has a master password.
+    ///
+    /// - Parameters:
+    ///   - cipherListView: The `cipherListView` used to determine if master password reprompt is enabled.
+    ///   - completion: A closure that is called if master password reprompt is successful or it
+    ///     wasn't required. This *isn't* called if master password reprompt is unsuccessful.
+    ///
+    func repromptForMasterPasswordIfNeeded(
+        cipherListView: CipherListView,
+        completion: @escaping @MainActor () async -> Void
+    ) async
+}
+
+// MARK: - DefaultMasterPasswordRepromptHelper
+
+/// A default implementation of `MasterPasswordRepromptHelper`.
+///
+@MainActor
+class DefaultMasterPasswordRepromptHelper<Route, Event>: MasterPasswordRepromptHelper {
+    // MARK: Types
+
+    typealias Services = HasAuthRepository
+        & HasErrorReporter
+
+    // MARK: Properties
+
+    /// The `Coordinator` that handles navigation.
+    private let coordinator: AnyCoordinator<Route, Event>
+
+    /// The services used by this helper.
+    private let services: Services
+
+    // MARK: Initialization
+
+    /// Initialize a `DefaultMasterPasswordRepromptHelper`.
+    ///
+    /// - Parameters:
+    ///   - coordinator: The `Coordinator` that handles navigation.
+    ///   - services: The services used by this helper.
+    init(
+        coordinator: AnyCoordinator<Route, Event>,
+        services: Services
+    ) {
+        self.coordinator = coordinator
+        self.services = services
+    }
+
+    // MARK: Methods
+
+    func repromptForMasterPasswordIfNeeded(
+        cipherListView: CipherListView,
+        completion: @escaping @MainActor () async -> Void
+    ) async {
+        await repromptForMasterPasswordIfNeeded(reprompt: cipherListView.reprompt, completion: completion)
+    }
+
+    func repromptForMasterPasswordIfNeeded(
+        cipherView: CipherView,
+        completion: @escaping @MainActor () async -> Void
+    ) async {
+        await repromptForMasterPasswordIfNeeded(reprompt: cipherView.reprompt, completion: completion)
+    }
+
+    // MARK: Private
+
+    /// Presents the master password reprompt alert and calls the completion handler when the user's
+    /// master password has been confirmed.
+    ///
+    /// - Parameter completion: A completion handler that is called when the user's master password
+    ///     has been confirmed.
+    ///
+    private func presentMasterPasswordRepromptAlert(completion: @escaping () async -> Void) async {
+        let alert = Alert.masterPasswordPrompt { password in
+            do {
+                let isValid = try await self.services.authRepository.validatePassword(password)
+                guard isValid else {
+                    self.coordinator.showAlert(.defaultAlert(title: Localizations.invalidMasterPassword))
+                    return
+                }
+                await completion()
+            } catch {
+                self.services.errorReporter.log(error: error)
+                await self.coordinator.showErrorAlert(error: error)
+            }
+        }
+        coordinator.showAlert(alert)
+    }
+
+    /// Reprompts the user for their master password if the reprompt type enables master password
+    /// reprompt and the user has a master password.
+    ///
+    /// - Parameters:
+    ///   - reprompt: The `CipherRepromptType` used to determine if master password reprompt is enabled.
+    ///   - completion: A closure that is called if master password reprompt is successful or it
+    ///     wasn't required. This *isn't* called if master password reprompt is unsuccessful.
+    ///
+    private func repromptForMasterPasswordIfNeeded(
+        reprompt: BitwardenSdk.CipherRepromptType,
+        completion: @escaping @MainActor () async -> Void
+    ) async {
+        do {
+            guard try await services.authRepository.shouldPerformMasterPasswordReprompt(reprompt: reprompt) else {
+                await completion()
+                return
+            }
+            await presentMasterPasswordRepromptAlert(completion: completion)
+        } catch {
+            services.errorReporter.log(error: error)
+            await coordinator.showErrorAlert(error: error)
+        }
+    }
+}

--- a/BitwardenShared/UI/Vault/Helpers/MasterPasswordRepromptHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/MasterPasswordRepromptHelperTests.swift
@@ -13,6 +13,7 @@ class MasterPasswordRepromptHelperTests: BitwardenTestCase {
     var coordinator: MockCoordinator<VaultRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
     var subject: MasterPasswordRepromptHelper!
+    var vaultRepository: MockVaultRepository!
 
     // MARK: Setup & Teardown
 
@@ -22,12 +23,14 @@ class MasterPasswordRepromptHelperTests: BitwardenTestCase {
         authRepository = MockAuthRepository()
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
+        vaultRepository = MockVaultRepository()
 
         subject = DefaultMasterPasswordRepromptHelper(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 authRepository: authRepository,
-                errorReporter: errorReporter
+                errorReporter: errorReporter,
+                vaultRepository: vaultRepository
             )
         )
     }
@@ -39,9 +42,132 @@ class MasterPasswordRepromptHelperTests: BitwardenTestCase {
         coordinator = nil
         errorReporter = nil
         subject = nil
+        vaultRepository = nil
     }
 
     // MARK: Tests
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` doesn't prompt the user and calls the
+    /// completion closure if master password reprompt isn't required.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_noPasswordReprompt() async throws {
+        vaultRepository.fetchCipherResult = .success(CipherView.fixture())
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        XCTAssertTrue(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` logs an error and shows an alert if
+    /// checking if the master password can be verified fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_passwordReprompt_errorCanVerifyMP() async throws {
+        authRepository.canVerifyMasterPasswordResult = .failure(BitwardenTestError.example)
+        vaultRepository.fetchCipherResult = .success(CipherView.fixture(reprompt: .password))
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` logs an error and shows an alert if fetching
+    /// the cipher fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_passwordReprompt_errorFetchCipher() async throws {
+        vaultRepository.fetchCipherResult = .failure(BitwardenTestError.example)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` logs an error and shows an alert if
+    /// validating the password fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_passwordReprompt_errorValidatePassword() async throws {
+        authRepository.validatePasswordResult = .failure(BitwardenTestError.example)
+        vaultRepository.fetchCipherResult = .success(CipherView.fixture(reprompt: .password))
+
+        let cipherId = CipherListView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` logs an error and shows an alert if the
+    /// cipher with the specified ID wasn't found.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_passwordReprompt_fetchCipherNil() async throws {
+        vaultRepository.fetchCipherResult = .success(nil)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        XCTAssertFalse(completionCalled)
+        let error = try XCTUnwrap(errorReporter.errors.last as? NSError)
+        XCTAssertIdentical(coordinator.errorAlertsShown.last as? NSError, error)
+        XCTAssertEqual(error.userInfo["ErrorMessage"] as? String, "A cipher with the specified ID was not found.")
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` shows an alert if the entered password is invalid.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_passwordReprompt_invalidPassword() async throws {
+        vaultRepository.fetchCipherResult = .success(CipherView.fixture(reprompt: .password))
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+
+        authRepository.validatePasswordResult = .success(false)
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        let invalidMasterPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(invalidMasterPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
+
+        XCTAssertFalse(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherId:)` calls the completion closure if the
+    /// master password reprompt was completed successfully.
+    func test_repromptForMasterPasswordIfNeeded_cipherId_passwordReprompt_success() async throws {
+        vaultRepository.fetchCipherResult = .success(CipherView.fixture(reprompt: .password))
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherId: "1") {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+
+        authRepository.validatePasswordResult = .success(true)
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertTrue(completionCalled)
+    }
 
     /// `repromptForMasterPasswordIfNeeded(cipherListView:)` doesn't prompt the user and calls the
     /// completion closure if master password reprompt isn't required.

--- a/BitwardenShared/UI/Vault/Helpers/MasterPasswordRepromptHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/MasterPasswordRepromptHelperTests.swift
@@ -1,0 +1,227 @@
+import BitwardenKitMocks
+import BitwardenSdk
+import TestHelpers
+import XCTest
+
+@testable import BitwardenShared
+
+@MainActor
+class MasterPasswordRepromptHelperTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var authRepository: MockAuthRepository!
+    var coordinator: MockCoordinator<VaultRoute, AuthAction>!
+    var errorReporter: MockErrorReporter!
+    var subject: MasterPasswordRepromptHelper!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        authRepository = MockAuthRepository()
+        coordinator = MockCoordinator()
+        errorReporter = MockErrorReporter()
+
+        subject = DefaultMasterPasswordRepromptHelper(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                authRepository: authRepository,
+                errorReporter: errorReporter
+            )
+        )
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        authRepository = nil
+        coordinator = nil
+        errorReporter = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `repromptForMasterPasswordIfNeeded(cipherListView:)` doesn't prompt the user and calls the
+    /// completion closure if master password reprompt isn't required.
+    func test_repromptForMasterPasswordIfNeeded_cipherListView_noPasswordReprompt() async throws {
+        let cipherListView = CipherListView.fixture()
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+            completionCalled = true
+        }
+
+        XCTAssertTrue(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherListView:)` logs an error and shows an alert if
+    /// checking if the master password can be verified fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherListView_passwordReprompt_errorCanVerifyMP() async throws {
+        authRepository.canVerifyMasterPasswordResult = .failure(BitwardenTestError.example)
+
+        let cipherListView = CipherListView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+            completionCalled = true
+        }
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherListView:)` logs an error and shows an alert if
+    /// validating the password fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherListView_passwordReprompt_errorValidatePassword() async throws {
+        authRepository.validatePasswordResult = .failure(BitwardenTestError.example)
+
+        let cipherListView = CipherListView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherListView:)` shows an alert if the entered password is invalid.
+    func test_repromptForMasterPasswordIfNeeded_cipherListView_passwordReprompt_invalidPassword() async throws {
+        let cipherListView = CipherListView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+
+        authRepository.validatePasswordResult = .success(false)
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        let invalidMasterPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(invalidMasterPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
+
+        XCTAssertFalse(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherListView:)` calls the completion closure if the
+    /// master password reprompt was completed successfully.
+    func test_repromptForMasterPasswordIfNeeded_cipherListView_passwordReprompt_success() async throws {
+        let cipherListView = CipherListView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+
+        authRepository.validatePasswordResult = .success(true)
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertTrue(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherView:)` doesn't prompt the user and calls the
+    /// completion closure if master password reprompt isn't required.
+    func test_repromptForMasterPasswordIfNeeded_cipherView_noPasswordReprompt() async throws {
+        let cipherView = CipherView.fixture()
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+            completionCalled = true
+        }
+
+        XCTAssertTrue(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherView:)` logs an error and shows an alert if
+    /// checking if the master password can be verified fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherView_passwordReprompt_errorCanVerifyMP() async throws {
+        authRepository.canVerifyMasterPasswordResult = .failure(BitwardenTestError.example)
+
+        let cipherView = CipherView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+            completionCalled = true
+        }
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherView:)` logs an error and shows an alert if
+    /// validating the password fails.
+    func test_repromptForMasterPasswordIfNeeded_cipherView_passwordReprompt_errorValidatePassword() async throws {
+        authRepository.validatePasswordResult = .failure(BitwardenTestError.example)
+
+        let cipherView = CipherView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertFalse(completionCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherView:)` shows an alert if the entered password is invalid.
+    func test_repromptForMasterPasswordIfNeeded_cipherView_passwordReprompt_invalidPassword() async throws {
+        let cipherView = CipherView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+
+        authRepository.validatePasswordResult = .success(false)
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        let invalidMasterPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(invalidMasterPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
+
+        XCTAssertFalse(completionCalled)
+    }
+
+    /// `repromptForMasterPasswordIfNeeded(cipherView:)` calls the completion closure if the
+    /// master password reprompt was completed successfully.
+    func test_repromptForMasterPasswordIfNeeded_cipherView_passwordReprompt_success() async throws {
+        let cipherView = CipherView.fixture(reprompt: .password)
+
+        var completionCalled = false
+        await subject.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+            completionCalled = true
+        }
+
+        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(repromptAlert, .masterPasswordPrompt { _ in })
+
+        authRepository.validatePasswordResult = .success(true)
+        try await repromptAlert.tapAction(title: Localizations.submit)
+
+        XCTAssertTrue(completionCalled)
+    }
+}

--- a/BitwardenShared/UI/Vault/Helpers/TestHelpers/MockMasterPasswordRepromptHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/TestHelpers/MockMasterPasswordRepromptHelper.swift
@@ -1,0 +1,38 @@
+import BitwardenSdk
+
+@testable import BitwardenShared
+
+class MockMasterPasswordRepromptHelper: MasterPasswordRepromptHelper {
+    var repromptForMasterPasswordCipherListView: CipherListView?
+    var repromptForMasterPasswordCipherView: CipherView?
+    var repromptForMasterPasswordCompletion: (@MainActor () async -> Void)?
+
+    /// Set this to false to complete master password reprompt manually by calling the
+    /// `repromptForMasterPasswordCompletion` closure. Otherwise, the completion closure will be
+    /// called automatically.
+    var repromptForMasterPasswordAutoComplete = true
+
+    func repromptForMasterPasswordIfNeeded(
+        cipherListView: CipherListView,
+        completion: @escaping @MainActor () async -> Void
+    ) async {
+        repromptForMasterPasswordCipherListView = cipherListView
+        if repromptForMasterPasswordAutoComplete {
+            await completion()
+        } else {
+            repromptForMasterPasswordCompletion = completion
+        }
+    }
+
+    func repromptForMasterPasswordIfNeeded(
+        cipherView: CipherView,
+        completion: @escaping @MainActor () async -> Void
+    ) async {
+        repromptForMasterPasswordCipherView = cipherView
+        if repromptForMasterPasswordAutoComplete {
+            await completion()
+        } else {
+            repromptForMasterPasswordCompletion = completion
+        }
+    }
+}

--- a/BitwardenShared/UI/Vault/Helpers/TestHelpers/MockMasterPasswordRepromptHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/TestHelpers/MockMasterPasswordRepromptHelper.swift
@@ -3,6 +3,7 @@ import BitwardenSdk
 @testable import BitwardenShared
 
 class MockMasterPasswordRepromptHelper: MasterPasswordRepromptHelper {
+    var repromptForMasterPasswordCipherId: String?
     var repromptForMasterPasswordCipherListView: CipherListView?
     var repromptForMasterPasswordCipherView: CipherView?
     var repromptForMasterPasswordCompletion: (@MainActor () async -> Void)?
@@ -11,6 +12,18 @@ class MockMasterPasswordRepromptHelper: MasterPasswordRepromptHelper {
     /// `repromptForMasterPasswordCompletion` closure. Otherwise, the completion closure will be
     /// called automatically.
     var repromptForMasterPasswordAutoComplete = true
+
+    func repromptForMasterPasswordIfNeeded(
+        cipherId: String,
+        completion: @escaping @MainActor () async -> Void
+    ) async {
+        repromptForMasterPasswordCipherId = cipherId
+        if repromptForMasterPasswordAutoComplete {
+            await completion()
+        } else {
+            repromptForMasterPasswordCompletion = completion
+        }
+    }
 
     func repromptForMasterPasswordIfNeeded(
         cipherListView: CipherListView,

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import Foundation
 
 // MARK: - VaultItemMoreOptionsHelper
@@ -40,6 +41,9 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     /// The `Coordinator` that handles navigation.
     private var coordinator: AnyCoordinator<VaultRoute, AuthAction>
 
+    /// The helper to handle master password reprompts.
+    private let masterPasswordRepromptHelper: MasterPasswordRepromptHelper
+
     /// The services used by this helper.
     private var services: Services
 
@@ -49,13 +53,16 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     ///
     /// - Parameters:
     ///   - coordinator: The coordinator that handles navigation.
+    ///   - masterPasswordRepromptHelper: The helper to handle master password reprompts.
     ///   - services: The services used by this helper.
     ///
     init(
         coordinator: AnyCoordinator<VaultRoute, AuthAction>,
+        masterPasswordRepromptHelper: MasterPasswordRepromptHelper,
         services: Services
     ) {
         self.coordinator = coordinator
+        self.masterPasswordRepromptHelper = masterPasswordRepromptHelper
         self.services = services
     }
 
@@ -76,17 +83,16 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
 
             let canEdit = cipherView.deletedDate == nil
             let hasPremium = try await services.vaultRepository.doesActiveAccountHavePremium()
-            let hasMasterPassword = try await services.stateService.getUserHasMasterPassword()
 
             coordinator.showAlert(.moreOptions(
                 canCopyTotp: hasPremium || cipherView.organizationUseTotp,
                 cipherView: cipherView,
-                hasMasterPassword: hasMasterPassword,
                 id: item.id,
                 showEdit: canEdit
             ) { action in
                 await self.handleMoreOptionsAction(
                     action,
+                    cipherView: cipherView,
                     handleDisplayToast: handleDisplayToast,
                     handleOpenURL: handleOpenURL
                 )
@@ -128,6 +134,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     ///
     private func handleMoreOptionsAction(
         _ action: MoreOptionsAction,
+        cipherView: CipherView,
         handleDisplayToast: @escaping (Toast) -> Void,
         handleOpenURL: (URL) -> Void
     ) async {
@@ -146,53 +153,26 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
                 }
             }
             if requiresMasterPasswordReprompt {
-                presentMasterPasswordRepromptAlert(completion: copyBlock)
+                await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+                    copyBlock()
+                }
             } else {
                 copyBlock()
             }
-        case let .copyTotp(totpKey, requiresMasterPasswordReprompt):
-            if requiresMasterPasswordReprompt {
-                presentMasterPasswordRepromptAlert {
-                    await self.generateAndCopyTotpCode(totpKey: totpKey, handleDisplayToast: handleDisplayToast)
-                }
-            } else {
-                await generateAndCopyTotpCode(totpKey: totpKey, handleDisplayToast: handleDisplayToast)
+        case let .copyTotp(totpKey):
+            await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+                await self.generateAndCopyTotpCode(totpKey: totpKey, handleDisplayToast: handleDisplayToast)
             }
-        case let .edit(cipherView, requiresMasterPasswordReprompt):
-            if requiresMasterPasswordReprompt {
-                presentMasterPasswordRepromptAlert {
-                    self.coordinator.navigate(to: .editItem(cipherView), context: self)
-                }
-            } else {
-                coordinator.navigate(to: .editItem(cipherView), context: self)
+        case let .edit(cipherView):
+            await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+                self.coordinator.navigate(to: .editItem(cipherView), context: self)
             }
         case let .launch(url):
             handleOpenURL(url.sanitized)
         case let .view(id):
-            coordinator.navigate(to: .viewItem(id: id))
-        }
-    }
-
-    /// Presents the master password reprompt alert and calls the completion handler when the user's
-    /// master password has been confirmed.
-    ///
-    /// - Parameter completion: A completion handler that is called when the user's master password
-    ///     has been confirmed.
-    ///
-    private func presentMasterPasswordRepromptAlert(completion: @escaping () async -> Void) {
-        let alert = Alert.masterPasswordPrompt { password in
-            do {
-                let isValid = try await self.services.authRepository.validatePassword(password)
-                guard isValid else {
-                    self.coordinator.showAlert(.defaultAlert(title: Localizations.invalidMasterPassword))
-                    return
-                }
-                await completion()
-            } catch {
-                self.coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
-                self.services.errorReporter.log(error: error)
+            await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+                self.coordinator.navigate(to: .viewItem(id: id))
             }
         }
-        coordinator.showAlert(alert)
     }
 }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -171,7 +171,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             handleOpenURL(url.sanitized)
         case let .view(id):
             await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
-                self.coordinator.navigate(to: .viewItem(id: id))
+                self.coordinator.navigate(to: .viewItem(id: id, masterPasswordRepromptCheckCompleted: true))
             }
         }
     }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -112,7 +112,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         // View navigates to the view item view.
         let viewAction = try XCTUnwrap(alert.alertActions[0])
         await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
 
         // Edit navigates to the edit view.
         let editAction = try XCTUnwrap(alert.alertActions[1])
@@ -392,7 +392,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         // View navigates to the view item view.
         let viewAction = try XCTUnwrap(alert.alertActions[0])
         await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
 
         // Edit navigates to the edit view.
         let editAction = try XCTUnwrap(alert.alertActions[1])
@@ -452,7 +452,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     /// `showMoreOptionsAlert()` shows the appropriate more options alert for a login cipher.
     @MainActor
     func test_showMoreOptionsAlert_morePressed_login_full() async throws {
-        // swiftlint:disable:previous function_body_length
         let account = Account.fixture()
         stateService.activeAccount = account
 
@@ -495,7 +494,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         // View navigates to the view item view.
         let viewAction = try XCTUnwrap(alert.alertActions[0])
         await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
 
         // Edit navigates to the edit view.
         let editAction = try XCTUnwrap(alert.alertActions[1])
@@ -603,7 +602,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         // View navigates to the view item view.
         let viewAction = try XCTUnwrap(alert.alertActions[0])
         await viewAction.handler?(viewAction, [])
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
 
         // Edit navigates to the edit view.
         let editAction = try XCTUnwrap(alert.alertActions[1])

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -13,6 +13,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     var authRepository: MockAuthRepository!
     var coordinator: MockCoordinator<VaultRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
+    var masterPasswordRepromptHelper: MockMasterPasswordRepromptHelper!
     var pasteboardService: MockPasteboardService!
     var stateService: MockStateService!
     var subject: VaultItemMoreOptionsHelper!
@@ -26,12 +27,14 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         authRepository = MockAuthRepository()
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
+        masterPasswordRepromptHelper = MockMasterPasswordRepromptHelper()
         pasteboardService = MockPasteboardService()
         stateService = MockStateService()
         vaultRepository = MockVaultRepository()
 
         subject = DefaultVaultItemMoreOptionsHelper(
             coordinator: coordinator.asAnyCoordinator(),
+            masterPasswordRepromptHelper: masterPasswordRepromptHelper,
             services: ServiceContainer.withMocks(
                 authRepository: authRepository,
                 errorReporter: errorReporter,
@@ -48,6 +51,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         authRepository = nil
         coordinator = nil
         errorReporter = nil
+        masterPasswordRepromptHelper = nil
         pasteboardService = nil
         stateService = nil
         subject = nil
@@ -61,7 +65,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_card() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         var item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(type: .card)))
 
@@ -132,7 +135,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_copyPassword_rePromptMasterPassword() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
+        masterPasswordRepromptHelper.repromptForMasterPasswordAutoComplete = false
 
         // A login with data should show the copy and launch actions.
         let loginWithData = CipherView.loginFixture(
@@ -152,7 +155,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
             handleOpenURL: { _ in }
         )
 
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, "Bitwarden")
         XCTAssertEqual(alert.alertActions.count, 6)
         XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
@@ -163,80 +166,19 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
         await copyUsernameAction.handler?(copyUsernameAction, [])
         XCTAssertEqual(pasteboardService.copiedString, "username")
+        pasteboardService.copiedString = nil
 
         // Copy password copies the user's password.
         let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
         await copyPasswordAction.handler?(copyPasswordAction, [])
 
-        // mock the master password
-        authRepository.validatePasswordResult = .success(true)
+        // Validate master password re-prompt is shown.
+        XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherView, loginWithData)
 
-        // Validate master password re-prompt is shown
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
-        var textField = try XCTUnwrap(alert.alertTextFields.first)
-        textField = AlertTextField(id: "password", text: "password")
-        let submitAction = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
-        await submitAction.handler?(submitAction, [textField])
-
+        // Validate string is copied only if master password reprompt completes successfully.
+        XCTAssertNil(pasteboardService.copiedString)
+        await masterPasswordRepromptHelper.repromptForMasterPasswordCompletion?()
         XCTAssertEqual(pasteboardService.copiedString, "secretPassword")
-    }
-
-    /// `showMoreOptionsAlert()` and press `copyPassword` presents master password re-prompt alert,
-    ///  entering wrong password should not allow to copy password.
-    @MainActor
-    func test_showMoreOptionsAlert_copyPassword_passwordReprompt_invalidPassword() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
-
-        // A login with data should show the copy and launch actions.
-        let loginWithData = CipherView.loginFixture(
-            login: .fixture(
-                password: "password",
-                uris: [.fixture(uri: URL.example.relativeString, match: nil)],
-                username: "username"
-            ),
-            reprompt: .password
-        )
-        vaultRepository.fetchCipherResult = .success(loginWithData)
-        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
-
-        await subject.showMoreOptionsAlert(
-            for: item,
-            handleDisplayToast: { _ in },
-            handleOpenURL: { _ in }
-        )
-
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, "Bitwarden")
-        XCTAssertEqual(alert.alertActions.count, 6)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.copyPassword)
-
-        // Test the functionality of the copy user name and password buttons.
-
-        // Copy username copies the username.
-        let copyUsernameAction = try XCTUnwrap(alert.alertActions[2])
-        await copyUsernameAction.handler?(copyUsernameAction, [])
-        XCTAssertEqual(pasteboardService.copiedString, "username")
-
-        // Copy password copies the user's password.
-        let copyPasswordAction = try XCTUnwrap(alert.alertActions[3])
-        await copyPasswordAction.handler?(copyPasswordAction, [])
-
-        // mock the master password
-        authRepository.validatePasswordResult = .success(false)
-
-        // Validate master password re-prompt is shown
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .masterPasswordPrompt { _ in })
-        try await alert.tapAction(title: Localizations.submit)
-
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert, .defaultAlert(title: Localizations.invalidMasterPassword))
-
-        XCTAssertNotEqual(pasteboardService.copiedString, "secretPassword")
-        XCTAssertEqual(pasteboardService.copiedString, "username")
     }
 
     /// `showMoreOptionsAlert()` and press `copyTotp` presents master password re-prompt
@@ -245,7 +187,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_copyTotp_passwordReprompt() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
+        masterPasswordRepromptHelper.repromptForMasterPasswordAutoComplete = false
 
         vaultRepository.refreshTOTPCodeResult = .success(
             LoginTOTPState(
@@ -253,10 +195,11 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
                 codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
             )
         )
-        vaultRepository.fetchCipherResult = .success(.fixture(
+        let cipherView = CipherView.fixture(
             login: .fixture(totp: "totpKey"),
             reprompt: .password
-        ))
+        )
+        vaultRepository.fetchCipherResult = .success(cipherView)
 
         let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
 
@@ -267,59 +210,20 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
             handleOpenURL: { _ in }
         )
 
-        authRepository.validatePasswordResult = .success(true)
-
         let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
         try await optionsAlert.tapAction(title: Localizations.copyTotp)
 
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
+        // Validate master password re-prompt is shown.
+        XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherView, cipherView)
 
+        // Validate string is copied only if master password reprompt completes successfully.
+        XCTAssertNil(pasteboardService.copiedString)
+        await masterPasswordRepromptHelper.repromptForMasterPasswordCompletion?()
         XCTAssertEqual(pasteboardService.copiedString, "123321")
         XCTAssertEqual(
             toastToDisplay,
             Toast(title: Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp))
         )
-    }
-
-    /// `showMoreOptionsAlert()` and press `copyTotp` presents master password re-prompt
-    /// alert and displays an alert if the entered master password doesn't match.
-    @MainActor
-    func test_showMoreOptionsAlert_copyTotp_passwordReprompt_invalidPassword() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
-
-        vaultRepository.refreshTOTPCodeResult = .success(
-            LoginTOTPState(
-                authKeyModel: TOTPKeyModel(authenticatorKey: .standardTotpKey),
-                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30)
-            )
-        )
-        vaultRepository.fetchCipherResult = .success(.fixture(
-            login: .fixture(totp: "totpKey"),
-            reprompt: .password
-        ))
-        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
-
-        await subject.showMoreOptionsAlert(
-            for: item,
-            handleDisplayToast: { _ in },
-            handleOpenURL: { _ in }
-        )
-
-        authRepository.validatePasswordResult = .success(false)
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.copyTotp)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
     }
 
     /// `showMoreOptionsAlert()` and press `copyTotp` copies the TOTP code if the user
@@ -328,7 +232,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_copyTotp_organizationUseTotp() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
         vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
         vaultRepository.refreshTOTPCodeResult = .success(
             LoginTOTPState(
@@ -433,6 +336,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     @MainActor
     func test_showMoreOptionsAlert_edit_passwordReprompt() async throws {
         stateService.activeAccount = .fixture()
+        masterPasswordRepromptHelper.repromptForMasterPasswordAutoComplete = false
 
         let cipherView = CipherView.fixture(reprompt: .password)
         vaultRepository.fetchCipherResult = .success(cipherView)
@@ -449,40 +353,13 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
         try await optionsAlert.tapAction(title: Localizations.edit)
 
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
+        // Validate master password re-prompt is shown.
+        XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherView, cipherView)
 
+        // Validate string is copied only if master password reprompt completes successfully.
+        XCTAssertTrue(coordinator.routes.isEmpty)
+        await masterPasswordRepromptHelper.repromptForMasterPasswordCompletion?()
         XCTAssertEqual(coordinator.routes, [.editItem(cipherView)])
-    }
-
-    /// `showMoreOptionsAlert()` and press `edit` presents master password re-prompt
-    /// alert and displays an alert if the entered master password doesn't match.
-    @MainActor
-    func test_showMoreOptionsAlert_edit_passwordReprompt_invalidPassword() async throws {
-        stateService.activeAccount = .fixture()
-
-        let cipherView = CipherView.fixture(reprompt: .password)
-        vaultRepository.fetchCipherResult = .success(cipherView)
-        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
-
-        await subject.showMoreOptionsAlert(
-            for: item,
-            handleDisplayToast: { _ in },
-            handleOpenURL: { _ in }
-        )
-
-        authRepository.validatePasswordResult = .success(false)
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.edit)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
     }
 
     /// `showMoreOptionsAlert()` shows the appropriate more options alert for an identity cipher.
@@ -490,7 +367,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_identity() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         vaultRepository.fetchCipherResult = .success(.fixture(type: .identity))
         let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(type: .identity)))
@@ -552,7 +428,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_login_minimal() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         vaultRepository.fetchCipherResult = .success(.fixture(type: .login))
         let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(login: .fixture())))
@@ -580,7 +455,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         // swiftlint:disable:previous function_body_length
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         vaultRepository.refreshTOTPCodeResult = .success(
             LoginTOTPState(
@@ -654,7 +528,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_noPassword() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: false]
 
         // Although the cipher calls for a password reprompt, it won't be shown
         // because the user has no password.
@@ -681,38 +554,11 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(coordinator.routes.last, .editItem(login))
     }
 
-    /// `showMoreOptionsAlert()` logs an error if password validation fails.
-    @MainActor
-    func test_showMoreOptionsAlert_passwordRepromptValidationError() async throws {
-        authRepository.validatePasswordResult = .failure(BitwardenTestError.example)
-        stateService.activeAccount = .fixture()
-
-        let cipherView = CipherView.fixture(login: .fixture(password: "password"), reprompt: .password)
-        vaultRepository.fetchCipherResult = .success(cipherView)
-        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
-        await subject.showMoreOptionsAlert(
-            for: item,
-            handleDisplayToast: { _ in },
-            handleOpenURL: { _ in }
-        )
-
-        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-        try await optionsAlert.tapAction(title: Localizations.copyPassword)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.anErrorHasOccurred))
-        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-    }
-
     /// `showMoreOptionsAlert()` shows the appropriate more options alert for a secure note cipher.
     @MainActor
     func test_showMoreOptionsAlert_secureNote() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         vaultRepository.fetchCipherResult = .success(.fixture(type: .secureNote))
         var item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -117,6 +117,16 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     /// The stack navigator that is managed by this coordinator.
     private(set) weak var stackNavigator: StackNavigator?
 
+    // MARK: Computed Properties
+
+    /// The helper to handle master password reprompts.
+    var masterPasswordRepromptHelper: MasterPasswordRepromptHelper {
+        DefaultMasterPasswordRepromptHelper(
+            coordinator: asAnyCoordinator(),
+            services: services
+        )
+    }
+
     // MARK: Initialization
 
     /// Creates a new `VaultCoordinator`.
@@ -295,6 +305,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     private func showGroup(_ group: VaultListGroup, filter: VaultFilterType) {
         let processor = VaultGroupProcessor(
             coordinator: asAnyCoordinator(),
+            masterPasswordRepromptHelper: masterPasswordRepromptHelper,
             services: services,
             state: VaultGroupState(
                 group: group,
@@ -303,6 +314,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
             ),
             vaultItemMoreOptionsHelper: DefaultVaultItemMoreOptionsHelper(
                 coordinator: asAnyCoordinator(),
+                masterPasswordRepromptHelper: masterPasswordRepromptHelper,
                 services: services
             )
         )
@@ -359,12 +371,14 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
     private func showList() {
         let processor = VaultListProcessor(
             coordinator: asAnyCoordinator(),
+            masterPasswordRepromptHelper: masterPasswordRepromptHelper,
             services: services,
             state: VaultListState(
                 iconBaseURL: services.environmentService.iconsURL
             ),
             vaultItemMoreOptionsHelper: DefaultVaultItemMoreOptionsHelper(
                 coordinator: asAnyCoordinator(),
+                masterPasswordRepromptHelper: masterPasswordRepromptHelper,
                 services: services
             )
         )
@@ -416,6 +430,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
             userVerificationHelper: userVerificationHelper,
             vaultItemMoreOptionsHelper: DefaultVaultItemMoreOptionsHelper(
                 coordinator: asAnyCoordinator(),
+                masterPasswordRepromptHelper: masterPasswordRepromptHelper,
                 services: services
             )
         )

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -28,6 +28,9 @@ final class VaultGroupProcessor: StateProcessor<
     /// The `Coordinator` for this processor.
     private var coordinator: any Coordinator<VaultRoute, AuthAction>
 
+    /// The helper to handle master password reprompts.
+    private let masterPasswordRepromptHelper: MasterPasswordRepromptHelper
+
     /// The services for this processor.
     private var services: Services
 
@@ -50,17 +53,20 @@ final class VaultGroupProcessor: StateProcessor<
     ///
     /// - Parameters:
     ///   - coordinator: The `Coordinator` for this processor.
+    ///   - masterPasswordRepromptHelper: The helper to handle master password reprompts.
     ///   - services: The services for this processor.
     ///   - state: The initial state of this processor.
     ///   - vaultItemMoreOptionsHelper: The helper to handle the more options menu for a vault item.
     ///
     init(
         coordinator: any Coordinator<VaultRoute, AuthAction>,
+        masterPasswordRepromptHelper: MasterPasswordRepromptHelper,
         services: Services,
         state: VaultGroupState,
         vaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper
     ) {
         self.coordinator = coordinator
+        self.masterPasswordRepromptHelper = masterPasswordRepromptHelper
         self.services = services
         self.vaultItemMoreOptionsHelper = vaultItemMoreOptionsHelper
 
@@ -134,12 +140,12 @@ final class VaultGroupProcessor: StateProcessor<
             state.toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.verificationCode))
         case let .itemPressed(item):
             switch item.itemType {
-            case .cipher:
-                coordinator.navigate(to: .viewItem(id: item.id), context: self)
+            case let .cipher(cipherListView, _):
+                navigateToViewItem(cipherListView: cipherListView, id: item.id)
             case let .group(group, _):
                 coordinator.navigate(to: .group(group, filter: state.vaultFilterType))
             case let .totp(_, model):
-                coordinator.navigate(to: .viewItem(id: model.id))
+                navigateToViewItem(cipherListView: model.cipherListView, id: model.id)
             }
         case let .searchStateChanged(isSearching):
             if !isSearching {
@@ -165,6 +171,21 @@ final class VaultGroupProcessor: StateProcessor<
         let isPersonalOwnershipDisabled = await services.policyService.policyAppliesToUser(.personalOwnership)
         state.isPersonalOwnershipDisabled = isPersonalOwnershipDisabled
         state.canShowVaultFilter = await services.vaultRepository.canShowVaultFilter()
+    }
+
+    /// Navigates to the view item view for the specified cipher. If the cipher requires master
+    /// password reprompt, this will prompt the user before navigation.
+    ///
+    /// - Parameters:
+    ///     - cipherListView: The cipher list view item for the cipher that will be shown in the view item view.
+    ///     - id: The cipher's identifier.
+    ///
+    private func navigateToViewItem(cipherListView: CipherListView, id: String) {
+        Task {
+            await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+                self.coordinator.navigate(to: .viewItem(id: id))
+            }
+        }
     }
 
     /// Refreshes the vault group's TOTP Codes.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -183,7 +183,7 @@ final class VaultGroupProcessor: StateProcessor<
     private func navigateToViewItem(cipherListView: CipherListView, id: String) {
         Task {
             await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
-                self.coordinator.navigate(to: .viewItem(id: id))
+                self.coordinator.navigate(to: .viewItem(id: id, masterPasswordRepromptCheckCompleted: true))
             }
         }
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -697,7 +697,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         subject.receive(.itemPressed(.fixture(cipherListView: cipherListView)))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: "id"))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: "id", masterPasswordRepromptCheckCompleted: true))
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherListView, cipherListView)
     }
 
@@ -717,7 +717,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         subject.receive(.itemPressed(totpItem))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: totpItem.id))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: totpItem.id, masterPasswordRepromptCheckCompleted: true))
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherListView, cipherListView)
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -35,6 +35,9 @@ final class VaultListProcessor: StateProcessor<
     /// The `Coordinator` that handles navigation.
     private let coordinator: AnyCoordinator<VaultRoute, AuthAction>
 
+    /// The helper to handle master password reprompts.
+    private let masterPasswordRepromptHelper: MasterPasswordRepromptHelper
+
     /// The task that schedules the app review prompt.
     private(set) var reviewPromptTask: Task<Void, Never>?
 
@@ -50,17 +53,20 @@ final class VaultListProcessor: StateProcessor<
     ///
     /// - Parameters:
     ///   - coordinator: The `Coordinator` that handles navigation.
+    ///   - masterPasswordRepromptHelper: The helper to handle master password reprompts.
     ///   - services: The services used by this processor.
     ///   - state: The initial state of the processor.
     ///   - vaultItemMoreOptionsHelper: The helper to handle the more options menu for a vault item.
     ///
     init(
         coordinator: AnyCoordinator<VaultRoute, AuthAction>,
+        masterPasswordRepromptHelper: MasterPasswordRepromptHelper,
         services: Services,
         state: VaultListState,
         vaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper
     ) {
         self.coordinator = coordinator
+        self.masterPasswordRepromptHelper = masterPasswordRepromptHelper
         self.services = services
         self.vaultItemMoreOptionsHelper = vaultItemMoreOptionsHelper
         super.init(state: state)
@@ -136,12 +142,12 @@ final class VaultListProcessor: StateProcessor<
             reviewPromptTask?.cancel()
         case let .itemPressed(item):
             switch item.itemType {
-            case .cipher:
-                coordinator.navigate(to: .viewItem(id: item.id), context: self)
+            case let .cipher(cipherListView, _):
+                navigateToViewItem(cipherListView: cipherListView, id: item.id)
             case let .group(group, _):
                 coordinator.navigate(to: .group(group, filter: state.vaultFilterType))
             case let .totp(_, model):
-                coordinator.navigate(to: .viewItem(id: model.id))
+                navigateToViewItem(cipherListView: model.cipherListView, id: model.id)
             }
         case .navigateToFlightRecorderSettings:
             coordinator.navigate(to: .flightRecorderSettings)
@@ -251,6 +257,21 @@ extension VaultListProcessor {
             await requestNotificationPermissions()
         default:
             break
+        }
+    }
+
+    /// Navigates to the view item view for the specified cipher. If the cipher requires master
+    /// password reprompt, this will prompt the user before navigation.
+    ///
+    /// - Parameters:
+    ///     - cipherListView: The cipher list view item for the cipher that will be shown in the view item view.
+    ///     - id: The cipher's identifier.
+    ///
+    private func navigateToViewItem(cipherListView: CipherListView, id: String) {
+        Task {
+            await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
+                self.coordinator.navigate(to: .viewItem(id: id))
+            }
         }
     }
 
@@ -490,10 +511,10 @@ enum MoreOptionsAction: Equatable {
     )
 
     /// Generate and copy the TOTP code for the given `totpKey`.
-    case copyTotp(totpKey: TOTPKeyModel, requiresMasterPasswordReprompt: Bool)
+    case copyTotp(totpKey: TOTPKeyModel)
 
     /// Navigate to the view to edit the `cipherView`.
-    case edit(cipherView: CipherView, requiresMasterPasswordReprompt: Bool)
+    case edit(cipherView: CipherView)
 
     /// Launch the `url` in the device's browser.
     case launch(url: URL)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -270,7 +270,7 @@ extension VaultListProcessor {
     private func navigateToViewItem(cipherListView: CipherListView, id: String) {
         Task {
             await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherListView: cipherListView) {
-                self.coordinator.navigate(to: .viewItem(id: id))
+                self.coordinator.navigate(to: .viewItem(id: id, masterPasswordRepromptCheckCompleted: true))
             }
         }
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -1330,7 +1330,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         subject.receive(.itemPressed(item: item))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherListView, cipherListView)
     }
 
@@ -1351,7 +1351,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         subject.receive(.itemPressed(item: totpItem))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
-        XCTAssertEqual(coordinator.routes.last, .viewItem(id: "123"))
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: "123", masterPasswordRepromptCheckCompleted: true))
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherListView, cipherListView)
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
@@ -79,7 +79,10 @@ public enum VaultRoute: Equatable, Hashable {
 
     /// A route to the view item screen.
     ///
-    /// - Parameter id: The id of the item to display.
+    /// - Parameters:
+    ///   - id: The id of the item to display.
+    ///   - masterPasswordRepromptCheckCompleted: Whether the master password reprompt check has
+    ///     already been completed.
     ///
-    case viewItem(id: String)
+    case viewItem(id: String, masterPasswordRepromptCheckCompleted: Bool = false)
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -44,29 +44,6 @@ enum ViewItemAction: Equatable, Sendable {
 
     /// The toast was shown or hidden.
     case toastShown(Toast?)
-
-    /// A flag indicating if this action requires the user to reenter their master password to
-    /// complete. This value works hand-in-hand with the `isMasterPasswordRequired` value in
-    /// `ViewItemState`.
-    var requiresMasterPasswordReprompt: Bool {
-        switch self {
-        case .cardItemAction,
-             .customFieldVisibilityPressed,
-             .downloadAttachment,
-             .editPressed,
-             .morePressed,
-             .passwordVisibilityPressed,
-             .sshKeyItemAction:
-            true
-        case let .copyPressed(_, field):
-            field.requiresMasterPasswordReprompt
-        case .disappeared,
-             .dismissPressed,
-             .passwordHistoryPressed,
-             .toastShown:
-            false
-        }
-    }
 }
 
 // MARK: CopyableField
@@ -146,35 +123,6 @@ enum CopyableField {
         // TODO: PM-11977 add SSH private key copied event
         default:
             nil
-        }
-    }
-
-    /// Whether copying the field requires the user to be reprompted for their master password, if
-    /// master password reprompt is enabled.
-    var requiresMasterPasswordReprompt: Bool {
-        switch self {
-        case .cardNumber,
-             .customHiddenField,
-             .password,
-             .securityCode,
-             .sshPrivateKey,
-             .totp:
-            true
-        case .company,
-             .customTextField,
-             .email,
-             .fullAddress,
-             .identityName,
-             .licenseNumber,
-             .notes,
-             .passportNumber,
-             .phone,
-             .socialSecurityNumber,
-             .sshKeyFingerprint,
-             .sshPublicKey,
-             .uri,
-             .username:
-            false
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
@@ -49,46 +49,4 @@ class ViewItemActionTests: BitwardenTestCase {
         XCTAssertEqual(CopyableField.fullAddress.localizedName, Localizations.address)
         XCTAssertEqual(CopyableField.notes.localizedName, Localizations.notes)
     }
-
-    /// `requiresMasterPasswordReprompt` returns whether the user's master password needs to be
-    /// entered again before performing the action if master password reprompt is enabled.
-    func test_requiresMasterPasswordReprompt() {
-        XCTAssertTrue(ViewItemAction.cardItemAction(.toggleCodeVisibilityChanged(false)).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.sshKeyItemAction(.privateKeyVisibilityPressed).requiresMasterPasswordReprompt)
-
-        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .cardNumber).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .customHiddenField).requiresMasterPasswordReprompt)
-        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .customTextField).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .password).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .securityCode).requiresMasterPasswordReprompt)
-        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .sshKeyFingerprint).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .sshPrivateKey).requiresMasterPasswordReprompt)
-        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .sshPublicKey).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.copyPressed(value: "", field: .totp).requiresMasterPasswordReprompt)
-        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .uri).requiresMasterPasswordReprompt)
-        XCTAssertFalse(ViewItemAction.copyPressed(value: "", field: .username).requiresMasterPasswordReprompt)
-
-        XCTAssertTrue(
-            ViewItemAction.customFieldVisibilityPressed(CustomFieldState(id: "1", type: .hidden))
-                .requiresMasterPasswordReprompt
-        )
-
-        XCTAssertFalse(ViewItemAction.disappeared.requiresMasterPasswordReprompt)
-        XCTAssertFalse(ViewItemAction.dismissPressed.requiresMasterPasswordReprompt)
-
-        XCTAssertTrue(ViewItemAction.downloadAttachment(.fixture()).requiresMasterPasswordReprompt)
-
-        XCTAssertTrue(ViewItemAction.editPressed.requiresMasterPasswordReprompt)
-
-        XCTAssertTrue(ViewItemAction.morePressed(.attachments).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.morePressed(.clone).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.morePressed(.editCollections).requiresMasterPasswordReprompt)
-        XCTAssertTrue(ViewItemAction.morePressed(.moveToOrganization).requiresMasterPasswordReprompt)
-
-        XCTAssertFalse(ViewItemAction.passwordHistoryPressed.requiresMasterPasswordReprompt)
-
-        XCTAssertTrue(ViewItemAction.passwordVisibilityPressed.requiresMasterPasswordReprompt)
-
-        XCTAssertFalse(ViewItemAction.toastShown(nil).requiresMasterPasswordReprompt)
-    }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -112,20 +112,12 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
             }
         case .deletePressed:
             guard case let .data(cipherState) = state.loadingState else { return }
-            guard !state.isMasterPasswordRequired else {
-                presentMasterPasswordRepromptAlert { await self.perform(effect) }
-                return
-            }
             if cipherState.cipher.deletedDate == nil {
                 await showSoftDeleteConfirmation(cipherState.cipher)
             } else {
                 await showPermanentDeleteConfirmation(cipherState.cipher)
             }
         case .restorePressed:
-            guard !state.isMasterPasswordRequired else {
-                presentMasterPasswordRepromptAlert { await self.perform(effect) }
-                return
-            }
             await showRestoreItemConfirmation()
         case .toggleDisplayMultipleCollections:
             toggleDisplayMultipleCollections()
@@ -135,10 +127,6 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
     }
 
     override func receive(_ action: ViewItemAction) { // swiftlint:disable:this function_body_length
-        guard !state.isMasterPasswordRequired || !action.requiresMasterPasswordReprompt else {
-            presentMasterPasswordRepromptAlert { self.receive(action) }
-            return
-        }
         switch action {
         case let .cardItemAction(cardAction):
             handleCardAction(cardAction)
@@ -437,31 +425,6 @@ private extension ViewItemProcessor {
         }
     }
 
-    /// Presents the master password re-prompt alert for the specified action. This method will
-    /// process the action once the master password has been verified.
-    ///
-    /// - Parameter completion: A closure containing the action to perform once the password has
-    ///     been verified.
-    ///
-    private func presentMasterPasswordRepromptAlert(completion: @escaping () async -> Void) {
-        let alert = Alert.masterPasswordPrompt { [weak self] password in
-            guard let self else { return }
-
-            do {
-                let isValid = try await services.authRepository.validatePassword(password)
-                guard isValid else {
-                    coordinator.showAlert(.defaultAlert(title: Localizations.invalidMasterPassword))
-                    return
-                }
-                state.hasVerifiedMasterPassword = true
-                await completion()
-            } catch {
-                services.errorReporter.log(error: error)
-            }
-        }
-        coordinator.showAlert(alert)
-    }
-
     /// Restores the item currently stored in `state`.
     ///
     private func restoreItem(_ cipher: CipherView) async {
@@ -530,7 +493,6 @@ private extension ViewItemProcessor {
                 guard let cipher else { continue }
 
                 let hasPremium = await (try? services.vaultRepository.doesActiveAccountHavePremium()) ?? false
-                let hasMasterPassword = try await services.stateService.getUserHasMasterPassword()
                 let collections = try await services.vaultRepository.fetchCollections(includeReadOnly: true)
                 var folder: FolderView?
                 if let folderId = cipher.folderId {
@@ -553,7 +515,6 @@ private extension ViewItemProcessor {
 
                 guard var newState = ViewItemState(
                     cipherView: cipher,
-                    hasMasterPassword: hasMasterPassword,
                     hasPremium: hasPremium,
                     iconBaseURL: services.environmentService.iconsURL,
                     restrictCipherItemDeletionFlagEnabled: restrictCipherItemDeletionFlagEnabled
@@ -567,7 +528,6 @@ private extension ViewItemProcessor {
                     itemState.showWebIcons = showWebIcons
                     newState.loadingState = .data(itemState)
                 }
-                newState.hasVerifiedMasterPassword = state.hasVerifiedMasterPassword
                 state = newState
             }
         } catch {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -131,7 +131,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appeared() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
         stateService.showWebIcons = true
         vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
         let collections = [
@@ -175,7 +174,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         XCTAssertNotNil(subject.streamCipherDetailsTask)
         XCTAssertTrue(subject.state.hasPremiumFeatures)
-        XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertFalse(subject.state.restrictCipherItemDeletionFlagEnabled)
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
@@ -221,43 +219,11 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
 
-    /// `perform(_:)` with `.appeared` observes whether or not a user has a master password.
-    @MainActor
-    func test_perform_appeared_noMasterPassword() {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: false]
-
-        let cipherItem = CipherView.loginFixture(
-            id: "id"
-        )
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
-        vaultRepository.cipherDetailsSubject.send(cipherItem)
-
-        let task = Task {
-            await subject.perform(.appeared)
-        }
-
-        waitFor(subject.state.loadingState != .loading(nil))
-        task.cancel()
-
-        let expectedState = CipherItemState(
-            existing: cipherItem,
-            hasPremium: false,
-            iconBaseURL: URL(string: "https://example.com/icons")!
-        )!
-
-        XCTAssertFalse(subject.state.hasMasterPassword)
-        XCTAssertEqual(subject.state.loadingState, .data(expectedState))
-        XCTAssertFalse(vaultRepository.fetchSyncCalled)
-    }
-
     /// `perform(_:)` with `.appeared` observe the premium status of a user.
     @MainActor
     func test_perform_appeared_nonPremium() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         let cipherItem = CipherView.loginFixture(
             id: "id"
@@ -278,7 +244,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             iconBaseURL: URL(string: "https://example.com/icons")!
         )!
 
-        XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -288,7 +253,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appeared_unknownPremium() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
 
         let cipherItem = CipherView.loginFixture(
             id: "id"
@@ -309,7 +273,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             iconBaseURL: URL(string: "https://example.com/icons")!
         )!
 
-        XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -320,7 +283,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appearedWithFolder() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
         vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
         let collections = [
             CollectionView.fixture(id: "1"),
@@ -364,7 +326,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         expectedState.folderName = "FolderTest"
 
         XCTAssertTrue(subject.state.hasPremiumFeatures)
-        XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -375,7 +336,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appearedWithOrganization() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
         vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
         let collections = [
             CollectionView.fixture(id: "1"),
@@ -419,7 +379,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         expectedState.organizationName = "OrgTest"
 
         XCTAssertTrue(subject.state.hasPremiumFeatures)
-        XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -430,7 +389,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appearedWithOrganizationAndCollectionsDisplay() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.userHasMasterPassword = [account.profile.userId: true]
         vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
         let collections = [
             CollectionView.fixture(id: "1"),
@@ -477,7 +435,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         expectedState.organizationName = "OrgTest"
 
         XCTAssertTrue(subject.state.hasPremiumFeatures)
-        XCTAssertTrue(subject.state.hasMasterPassword)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
     }
@@ -858,33 +815,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(errorReporter.errors.first as? TestError, TestError())
     }
 
-    /// `perform(_:)` with `.deletePressed` reprompts the user for their master password if reprompt
-    /// is enabled prior to deleting the cipher.
-    @MainActor
-    func test_perform_deletePressed_masterPasswordReprompt() async throws {
-        subject.state = try XCTUnwrap(
-            ViewItemState(
-                cipherView: .fixture(reprompt: .password),
-                hasMasterPassword: true,
-                hasPremium: false,
-                iconBaseURL: nil,
-                restrictCipherItemDeletionFlagEnabled: true
-            )
-        )
-        await subject.perform(.deletePressed)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        repromptAlert.alertTextFields = [AlertTextField(id: "password", text: "password")]
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        let deleteConfirmationAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(deleteConfirmationAlert, .deleteCipherConfirmation(isSoftDelete: true) {})
-        try await deleteConfirmationAlert.tapAction(title: Localizations.yes)
-
-        XCTAssertEqual(vaultRepository.softDeletedCipher.last?.id, "1")
-    }
-
     /// `perform(_:)` with `.deletePressed` presents the confirmation alert before permanently
     /// deleting the item from the trash.
     @MainActor
@@ -1023,48 +953,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         let errorAlert = try XCTUnwrap(coordinator.errorAlertsShown.last)
         XCTAssertEqual(errorAlert as? TestError, TestError())
         XCTAssertEqual(errorReporter.errors.first as? TestError, TestError())
-    }
-
-    /// `perform(_:)` with `.restorePressed` reprompts the user for their master password if reprompt
-    /// is enabled prior to restore the item and displays toast if restoring succeeds.
-    @MainActor
-    func test_perform_restorePressed_masterPasswordReprompt() async throws {
-        let cipherState = CipherItemState(
-            existing: CipherView.loginFixture(deletedDate: .now, id: "123", reprompt: .password),
-            hasPremium: false
-        )!
-
-        let state = ViewItemState(
-            loadingState: .data(cipherState)
-        )
-        subject.state = state
-        vaultRepository.softDeleteCipherResult = .success(())
-        await subject.perform(.restorePressed)
-
-        let repromptAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(repromptAlert, .masterPasswordPrompt(completion: { _ in }))
-        repromptAlert.alertTextFields = [AlertTextField(id: "password", text: "password")]
-        try await repromptAlert.tapAction(title: Localizations.submit)
-
-        // Ensure the alert is shown.
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToRestoreCipher)
-        XCTAssertNil(alert?.message)
-
-        // Tap the "Yes" button on the alert.
-        let action = try XCTUnwrap(alert?.alertActions.first(where: { $0.title == Localizations.yes }))
-        await action.handler?(action, [])
-
-        XCTAssertNil(errorReporter.errors.first)
-        // Ensure the cipher is restored and the view is dismissed.
-        XCTAssertEqual(vaultRepository.restoredCipher.last?.id, "123")
-        var dismissAction: DismissAction?
-        if case let .dismiss(onDismiss) = coordinator.routes.last {
-            dismissAction = onDismiss
-        }
-        XCTAssertNotNil(dismissAction)
-        dismissAction?.action()
-        XCTAssertTrue(delegate.itemRestoredCalled)
     }
 
     /// `perform(_:)` with `.restorePressed` presents the confirmation alert before restore the item and displays
@@ -1362,27 +1250,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(coordinator.routes, [.editItem(cipherView, true)])
     }
 
-    /// Tests that the despite a cipher having a `.password` re-prompt property, a
-    /// re-prompt will not be shown for a user that has no password.
-    @MainActor
-    func test_receive_editPressed_noPassword() {
-        subject.state.hasMasterPassword = false
-
-        // Although the cipher calls for a password reprompt, it won't be shown
-        // because the user has no password.
-        let cipherView = CipherView.fixture(reprompt: .password)
-        let loginState = CipherItemState(
-            existing: cipherView,
-            hasPremium: true
-        )!
-        subject.state.loadingState = .data(loginState)
-
-        subject.receive(.editPressed)
-        waitFor(!coordinator.routes.isEmpty)
-        XCTAssertEqual(coordinator.routes, [.editItem(cipherView, true)])
-        XCTAssertFalse(subject.state.hasMasterPassword)
-    }
-
     /// `receive(_:)` with `.morePressed(.attachments)` navigates the user to attachments view.
     @MainActor
     func test_receive_morePressed_attachments() throws {
@@ -1582,35 +1449,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(subject.state.loadingState, .data(cipherState))
     }
 
-    /// `receive` with `.passwordVisibilityPressed` with a login state toggles the value
-    /// for `isPasswordVisible`.
-    @MainActor
-    func test_receive_passwordVisibilityPressed_withLoginState_withMasterPasswordReprompt() throws {
-        let cipherView = CipherView.fixture(
-            id: "123",
-            login: BitwardenSdk.LoginView(
-                username: nil,
-                password: nil,
-                passwordRevisionDate: nil,
-                uris: nil,
-                totp: nil,
-                autofillOnPageLoad: nil,
-                fido2Credentials: nil
-            ),
-            name: "name",
-            reprompt: .password,
-            revisionDate: Date()
-        )
-        let loginState = CipherItemState(
-            existing: cipherView,
-            hasPremium: true
-        )!
-        subject.state.loadingState = .data(loginState)
-        subject.receive(.passwordVisibilityPressed)
-
-        XCTAssertEqual(coordinator.alertShown.last, .masterPasswordPrompt(completion: { _ in }))
-    }
-
     /// `receive(_:)` with `.sshKeyItemAction` with `.privateKeyVisibilityPressed`  toggles
     /// the visibility of the `privateKey` field.
     @MainActor
@@ -1619,36 +1457,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         subject.receive(.sshKeyItemAction(.privateKeyVisibilityPressed))
 
         XCTAssertTrue(subject.state.loadingState.data?.sshKeyState.isPrivateKeyVisible == true)
-    }
-
-    /// `receive(_:)` with `.sshKeyItemAction` with `.privateKeyVisibilityPressed`  toggles
-    /// the visibility of the `privateKey` field when master password required.
-    @MainActor
-    func test_receive_sshKeyItemAction_privateKeyVisibilityPressedWithPaasswordReprompt() async throws {
-        initializeSshKeyState(reprompt: .password)
-        subject.receive(.sshKeyItemAction(.privateKeyVisibilityPressed))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.submitMasterPasswordReprompt(with: "password1234")
-
-        XCTAssertEqual(authRepository.validatePasswordPasswords, ["password1234"])
-
-        XCTAssertTrue(subject.state.loadingState.data?.sshKeyState.isPrivateKeyVisible == true)
-        XCTAssertTrue(subject.state.hasVerifiedMasterPassword)
-    }
-
-    /// `receive(_:)` with `.sshKeyItemAction` with `.privateKeyVisibilityPressed`  toggles
-    /// the visibility of the `privateKey` field when master password required.
-    @MainActor
-    func test_receive_sshKeyItemAction_privateKeyVisibilityPressedWithPaasswordRepromptCancelled() async throws {
-        initializeSshKeyState(reprompt: .password)
-        subject.receive(.sshKeyItemAction(.privateKeyVisibilityPressed))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.tapCancel()
-
-        XCTAssertTrue(subject.state.loadingState.data?.sshKeyState.isPrivateKeyVisible == false)
-        XCTAssertFalse(subject.state.hasVerifiedMasterPassword)
     }
 
     /// `receive(_:)` with `.sshKeyItemAction` with `.privateKeyVisibilityPressed`  but data is not loaded yet
@@ -1701,41 +1509,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.valueHasBeenCopied(Localizations.fingerprint)))
     }
 
-    /// `receive(_:)` with `.sshKeyItemAction` with `.copyPressed`  copies the corresponding field when
-    /// needing password reprompt and is correct.
-    @MainActor
-    func test_receive_sshKeyItemAction_copyPressedWithPasswordReprompt() async throws {
-        initializeSshKeyState(reprompt: .password)
-
-        subject.receive(.sshKeyItemAction(.copyPressed(value: "privateKey", field: .sshPrivateKey)))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.submitMasterPasswordReprompt(with: "password1234")
-
-        XCTAssertEqual(authRepository.validatePasswordPasswords, ["password1234"])
-        XCTAssertTrue(subject.state.hasVerifiedMasterPassword)
-
-        XCTAssertEqual(pasteboardService.copiedString, "privateKey")
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.valueHasBeenCopied(Localizations.privateKey)))
-    }
-
-    /// `receive(_:)` with `.sshKeyItemAction` with `.copyPressed`  copies the corresponding field when
-    /// needing password reprompt and is cancelled.
-    @MainActor
-    func test_receive_sshKeyItemAction_copyPressedWithPasswordRepromptCancelled() async throws {
-        initializeSshKeyState(reprompt: .password)
-
-        subject.receive(.sshKeyItemAction(.copyPressed(value: "privateKey", field: .sshPrivateKey)))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.tapCancel()
-
-        XCTAssertFalse(subject.state.hasVerifiedMasterPassword)
-
-        XCTAssertNil(pasteboardService.copiedString)
-        XCTAssertNil(subject.state.toast)
-    }
-
     /// `receive(_:)` with `.toastShown` with a value updates the state correctly.
     @MainActor
     func test_receive_toastShown_withValue() {
@@ -1743,91 +1516,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         subject.receive(.toastShown(toast))
 
         XCTAssertEqual(subject.state.toast, toast)
-    }
-
-    /// Tapping the "Submit" button in the master password reprompt alert validates the entered
-    /// password and completes the action.
-    @MainActor
-    func test_masterPasswordReprompt_submitButtonPressed() async throws {
-        let cipherView = CipherView.fixture(
-            id: "123",
-            login: BitwardenSdk.LoginView(
-                username: nil,
-                password: nil,
-                passwordRevisionDate: nil,
-                uris: nil,
-                totp: nil,
-                autofillOnPageLoad: nil,
-                fido2Credentials: nil
-            ),
-            name: "name",
-            reprompt: .password,
-            revisionDate: Date()
-        )
-        var cipherState = CipherItemState(
-            existing: cipherView,
-            hasPremium: true
-        )!
-        subject.state.loadingState = .data(cipherState)
-        subject.receive(.passwordVisibilityPressed)
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.submitMasterPasswordReprompt(with: "password1234")
-
-        XCTAssertEqual(authRepository.validatePasswordPasswords, ["password1234"])
-
-        cipherState.loginState.isPasswordVisible = true
-        XCTAssertEqual(subject.state.loadingState, .data(cipherState))
-        XCTAssertTrue(subject.state.hasVerifiedMasterPassword)
-    }
-
-    /// If validation the user's password fails, an error is logged.
-    @MainActor
-    func test_masterPasswordReprompt_submitButtonPressed_error() async throws {
-        struct ValidatePasswordError: Error {}
-        authRepository.validatePasswordResult = .failure(ValidatePasswordError())
-
-        let cipherView = CipherView.fixture(id: "1", reprompt: .password)
-        let cipherState = CipherItemState(
-            existing: cipherView,
-            hasPremium: true
-        )!
-        subject.state.loadingState = .data(cipherState)
-        subject.receive(.passwordVisibilityPressed)
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertNotNil(alert.alertTextFields.first)
-        let action = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
-        await action.handler?(action, [AlertTextField(id: "password", text: "password1234")])
-
-        XCTAssertEqual(authRepository.validatePasswordPasswords, ["password1234"])
-        XCTAssertFalse(subject.state.hasVerifiedMasterPassword)
-        XCTAssertTrue(errorReporter.errors.last is ValidatePasswordError)
-    }
-
-    /// If the user's password validation fails, an invalid password alert is presented.
-    @MainActor
-    func test_masterPasswordReprompt_submitButtonPressed_invalidPassword() async throws {
-        authRepository.validatePasswordResult = .success(false)
-
-        let cipherView = CipherView.fixture(id: "1", reprompt: .password)
-        let cipherState = CipherItemState(
-            existing: cipherView,
-            hasPremium: true
-        )!
-        subject.state.loadingState = .data(cipherState)
-        subject.receive(.passwordVisibilityPressed)
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertNotNil(alert.alertTextFields.first)
-        let action = try XCTUnwrap(alert.alertActions.first(where: { $0.title == Localizations.submit }))
-        await action.handler?(action, [AlertTextField(id: "password", text: "password1234")])
-
-        XCTAssertEqual(authRepository.validatePasswordPasswords, ["password1234"])
-        XCTAssertFalse(subject.state.hasVerifiedMasterPassword)
-
-        let invalidPasswordAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(invalidPasswordAlert, .defaultAlert(title: Localizations.invalidMasterPassword))
     }
 
     /// `getter:rehydrationState` returns the proper state with the cipher id.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -26,25 +26,8 @@ struct ViewItemState: Equatable, Sendable {
     /// appropriate internal state.
     var loadingState: LoadingState<CipherItemState> = .loading(nil)
 
-    /// Whether the user has a master password.
-    var hasMasterPassword = true
-
     /// A flag indicating if the user has premium features.
     var hasPremiumFeatures = false
-
-    /// A flag indicating if the master password has been verified yet.
-    var hasVerifiedMasterPassword = false
-
-    /// A flag indicating if the master password is required before interacting with this item.
-    var isMasterPasswordRequired: Bool {
-        guard !hasVerifiedMasterPassword else { return false }
-        return switch loadingState {
-        case let .data(state):
-            state.isMasterPasswordRePromptOn && hasMasterPassword
-        case .error, .loading:
-            false
-        }
-    }
 
     /// The view's navigation title.
     var navigationTitle: String {
@@ -75,26 +58,22 @@ extension ViewItemState {
     ///
     /// - Parameters:
     ///   - cipherView: The `CipherView` to create this state with.
-    ///   - hasMasterPassword: Whether the account has a master password.
     ///   - hasPremium: Does the account have premium features.
     ///   - iconBaseURL: The base url used to fetch icons.
     ///
     init?(
         cipherView: CipherView,
-        hasMasterPassword: Bool,
         hasPremium: Bool,
         iconBaseURL: URL?,
         restrictCipherItemDeletionFlagEnabled: Bool
     ) {
         guard var cipherItemState = CipherItemState(
             existing: cipherView,
-            hasMasterPassword: hasMasterPassword,
             hasPremium: hasPremium,
             iconBaseURL: iconBaseURL
         ) else { return nil }
         cipherItemState.restrictCipherItemDeletionFlagEnabled = restrictCipherItemDeletionFlagEnabled
         self.init(loadingState: .data(cipherItemState))
-        self.hasMasterPassword = hasMasterPassword
         hasPremiumFeatures = cipherItemState.accountHasPremium
         passwordHistory = cipherView.passwordHistory
         self.restrictCipherItemDeletionFlagEnabled = restrictCipherItemDeletionFlagEnabled

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
@@ -18,8 +18,7 @@ class ViewItemStateTests: BitwardenTestCase {
                     ),
                     hasPremium: true
                 )!
-            ),
-            hasVerifiedMasterPassword: false
+            )
         )
         XCTAssertTrue(subject.canClone)
     }
@@ -36,8 +35,7 @@ class ViewItemStateTests: BitwardenTestCase {
                     ),
                     hasPremium: true
                 )!
-            ),
-            hasVerifiedMasterPassword: false
+            )
         )
         XCTAssertFalse(subject.canClone)
     }
@@ -56,96 +54,6 @@ class ViewItemStateTests: BitwardenTestCase {
             XCTUnwrap(CipherItemState(existing: .fixture(deletedDate: .now), hasPremium: false))
         ))
         XCTAssertFalse(subject.canEdit)
-    }
-
-    /// `isMasterPasswordRequired` is false when the user has no password.
-    func test_isMasterPasswordRequired_repromptOff_noPassword() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .password
-                    ),
-                    hasPremium: true
-                )!
-            ),
-            hasMasterPassword: false,
-            hasVerifiedMasterPassword: false
-        )
-        XCTAssertFalse(subject.isMasterPasswordRequired)
-    }
-
-    /// `isMasterPasswordRequired` is true when the reprompt is on and the master password has not
-    /// been verified yet.
-    func test_isMasterPasswordRequired_repromptOn_unverifiedPassword() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .password
-                    ),
-                    hasPremium: true
-                )!
-            ),
-            hasVerifiedMasterPassword: false
-        )
-        XCTAssertTrue(subject.isMasterPasswordRequired)
-    }
-
-    /// `isMasterPasswordRequired` is false when the reprompt is on and the master password has been
-    /// verified.
-    func test_isMasterPasswordRequired_repromptOn_verifiedPassword() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .password
-                    ),
-                    hasPremium: true
-                )!
-            ),
-            hasVerifiedMasterPassword: true
-        )
-        XCTAssertFalse(subject.isMasterPasswordRequired)
-    }
-
-    /// `isMasterPasswordRequired` is false when the reprompt is off and the master password has not
-    /// been verified yet.
-    func test_isMasterPasswordRequired_repromptOff_unverifiedPassword() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .none
-                    ),
-                    hasPremium: true
-                )!
-            ),
-            hasVerifiedMasterPassword: false
-        )
-        XCTAssertFalse(subject.isMasterPasswordRequired)
-    }
-
-    /// `isMasterPasswordRequired` is false when the reprompt is off and the master password has
-    /// been verified.
-    func test_isMasterPasswordRequired_repromptOff_verifiedPassword() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .none
-                    ),
-                    hasPremium: true
-                )!
-            ),
-            hasVerifiedMasterPassword: true
-        )
-        XCTAssertFalse(subject.isMasterPasswordRequired)
     }
 
     /// `navigationTitle` returns the navigation title for the view based on the cipher type.
@@ -193,8 +101,7 @@ class ViewItemStateTests: BitwardenTestCase {
                     ),
                     hasPremium: true
                 )!
-            ),
-            hasVerifiedMasterPassword: false
+            )
         )
         XCTAssertFalse(subject.restrictCipherItemDeletionFlagEnabled)
     }
@@ -211,7 +118,6 @@ class ViewItemStateTests: BitwardenTestCase {
                     hasPremium: true
                 )!
             ),
-            hasVerifiedMasterPassword: false,
             restrictCipherItemDeletionFlagEnabled: true
         )
         XCTAssertTrue(subject.restrictCipherItemDeletionFlagEnabled)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -138,7 +138,6 @@ struct ViewItemView_Previews: PreviewProvider {
             hasPremium: true
         )!
         state.type = CipherType.card
-        state.isMasterPasswordRePromptOn = true
         state.name = "Points ALL Day"
         state.cardItemState = CardItemState(
             brand: .custom(.americanExpress),
@@ -165,7 +164,6 @@ struct ViewItemView_Previews: PreviewProvider {
                 value: "Value"
             ),
         ]
-        state.isMasterPasswordRePromptOn = false
         state.name = "Example"
         state.notes = "secure note"
         state.loginState.fido2Credentials = [

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewVaultItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewVaultItemState.swift
@@ -43,9 +43,6 @@ protocol ViewVaultItemState: Sendable, VaultItemWithDecorativeIcon {
     /// A flag indicating if item was soft deleted.
     var isSoftDeleted: Bool { get }
 
-    /// A flag indicating if master password re-prompt is required.
-    var isMasterPasswordRePromptOn: Bool { get set }
-
     /// The login item state.
     var loginState: LoginItemState { get set }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-10285](https://bitwarden.atlassian.net/browse/PM-10285)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Previously, the master password reprompt was triggered within the View Item view when performing certain actions. This protects the full View Item view by moving the prompt to display before navigating to the View Item view.

This handles the master password reprompt for the following flows:

- Vault list: view item
- Vault group list: view item
- Rehydrating the view item view after a timeout
- Autofill

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/0d455ec5-28a1-4c70-8cef-514e6fc3536e



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
