### PR TITLE
[PM-22347] Fix open generator App Intent on cancel

### DIFF
--- a/Bitwarden/Application/AppIntents/OpenGeneratorIntent.swift
+++ b/Bitwarden/Application/AppIntents/OpenGeneratorIntent.swift
@@ -21,9 +21,9 @@ struct OpenGeneratorIntent: ForegroundContinuableIntent {
             throw BitwardenShared.AppIntentError.notAllowed
         }
 
-        await appIntentMediator.openGenerator()
-
-        try await requestToContinueInForeground()
+        try await requestToContinueInForeground {
+            await appIntentMediator.openGenerator()
+        }
 
         return .result()
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22347](https://bitwarden.atlassian.net/browse/PM-22347)

## 📔 Objective

Fix open generator App Intent so canceling on the alert doesn't set the pending intent. The issue was that cancelling was nonetheless redirecting to generator tab when the user went back to the app.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22347]: https://bitwarden.atlassian.net/browse/PM-22347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ