### PR TITLE
[PM-22884] Remove extra action sheet in logout flow from vault unlock

### DIFF
--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockAction.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockAction.swift
@@ -4,11 +4,11 @@ enum VaultUnlockAction: Equatable {
     /// The cancel button was pressed.
     case cancelPressed
 
+    /// The log out button was tapped.
+    case logOut
+
     /// The value for the master password was changed.
     case masterPasswordChanged(String)
-
-    /// The more button was pressed.
-    case morePressed
 
     /// A forwarded profile switcher action.
     case profileSwitcher(ProfileSwitcherAction)

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
@@ -77,21 +77,10 @@ class VaultUnlockProcessor: StateProcessor<
         switch action {
         case .cancelPressed:
             appExtensionDelegate?.didCancel()
+        case .logOut:
+            showLogoutConfirmation()
         case let .masterPasswordChanged(masterPassword):
             state.masterPassword = masterPassword
-        case .morePressed:
-            let alert = Alert(
-                title: Localizations.options,
-                message: nil,
-                preferredStyle: .actionSheet,
-                alertActions: [
-                    AlertAction(title: Localizations.logOut, style: .default) { _ in
-                        self.showLogoutConfirmation()
-                    },
-                    AlertAction(title: Localizations.cancel, style: .cancel),
-                ]
-            )
-            coordinator.showAlert(alert)
         case let .pinChanged(pin):
             state.pin = pin
         case let .profileSwitcher(profileAction):

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -43,7 +43,7 @@ struct VaultUnlockView: View {
                 } else {
                     optionsToolbarMenu {
                         Button(Localizations.logOut) {
-                            store.send(.morePressed)
+                            store.send(.logOut)
                         }
                     }
                 }

--- a/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlock/VaultUnlockViewTests.swift
@@ -72,7 +72,7 @@ class VaultUnlockViewTests: BitwardenTestCase {
     func test_optionsButton_logOut_tap() throws {
         let button = try subject.inspect().find(button: Localizations.logOut)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .morePressed)
+        XCTAssertEqual(processor.dispatchedActions.last, .logOut)
     }
 
     /// Updating the secure field dispatches the `.masterPasswordChanged()` action.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-22884](https://bitwarden.atlassian.net/browse/PM-22884)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In the logout flow from vault unlock, there's an extra action sheet which requires tapping 'Log out' twice which can be removed. The updated flow is:

- Tap the options button to show a context menu
- Tap 'Log out' from the context menu
- The log out confirmation alert is shown

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/6b3f2011-1769-4310-a9c3-57261f830a3e" /> | <video src="https://github.com/user-attachments/assets/d61a4919-1acd-4db4-8ad8-3ea38548837f" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22884]: https://bitwarden.atlassian.net/browse/PM-22884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ