### PR TITLE
[PM-20111] Filter out read-only collections when adding a new vault item

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -280,9 +280,9 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             // We need read-only collections so that we can include them in the state
             // to correctly calculate if the item can be deleted
             state.allUserCollections = try await services.vaultRepository.fetchCollections(includeReadOnly: true)
-            // Filter out any collection IDs that aren't included in the fetched collections.
+            // Filter out any collection IDs that aren't included in the fetched collections and aren't read-only.
             state.collectionIds = state.collectionIds.filter { collectionId in
-                state.allUserCollections.contains(where: { $0.id == collectionId })
+                state.allUserCollections.contains(where: { $0.id == collectionId && !$0.readOnly })
             }
 
             state.isPersonalOwnershipDisabled = isPersonalOwnershipDisabled


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-20111](https://bitwarden.atlassian.net/browse/PM-20111)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes an issue where the app doesn't show a helpful alert if you attempt to add a new item to a collection in which you have read-only access to.

Previously, the app would allow this and the API would return a "Resource not found." error.

This changes that to filter out any existing `collectionIds` which belong to read-only collections. Then when saving, this will trigger an error that at least one collection is required.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/5ae31e9d-f089-44cb-8c60-d39fec4e8661" /> | <video src="https://github.com/user-attachments/assets/9164c266-2b89-45a1-92aa-6ef371150d35" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-20111]: https://bitwarden.atlassian.net/browse/PM-20111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ