### PR TITLE
[PM-22852] [RC] Fix master password unlock subsequent attempts

### DIFF
--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
@@ -84,7 +84,7 @@ extension CipherListViewType {
     init(cipher: Cipher) {
         switch cipher.type {
         case .card:
-            self = .card
+            self = .card(.init(brand: nil))
         case .identity:
             self = .identity
         case .login:

--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
@@ -73,9 +73,12 @@ extension CipherListView {
             permissions: cipher.permissions,
             viewPassword: cipher.viewPassword,
             attachments: UInt32(cipher.attachments?.count ?? 0),
+            hasOldAttachments: false,
             creationDate: cipher.creationDate,
             deletedDate: cipher.deletedDate,
-            revisionDate: cipher.revisionDate
+            revisionDate: cipher.revisionDate,
+            copyableFields: [],
+            localData: cipher.localData.map(LocalDataView.init)
         )
     }
 }

--- a/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,7 +114,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bitwarden/sdk-swift",
       "state" : {
-        "revision" : "6324c3ab661606ef0ce7dd90ade730615ee9e2c8"
+        "revision" : "a9a790f3c0e3631bc625fae3fc28a14d26d7727a"
       }
     },
     {

--- a/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -114,7 +114,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bitwarden/sdk-swift",
       "state" : {
-        "revision" : "a9a790f3c0e3631bc625fae3fc28a14d26d7727a"
+        "revision" : "80dd7b284e5cdd09e065675b04f991a8ff7338fe"
       }
     },
     {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -1102,6 +1102,7 @@ extension DefaultAuthRepository: AuthRepository {
                 kdfParams: account.kdf.sdkKdf,
                 email: account.profile.email,
                 privateKey: encryptionKeys.encryptedPrivateKey,
+                signingKey: nil,
                 method: method
             )
         )

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1212,6 +1212,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: account.kdf.sdkKdf,
                 email: account.profile.email,
                 privateKey: "private",
+                signingKey: nil,
                 method: .password(password: "NEW_PASSWORD", userKey: "encryptedUserKey")
             )
         )
@@ -1728,6 +1729,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
                 email: "user@bitwarden.com",
                 privateKey: "PRIVATE_KEY",
+                signingKey: nil,
                 method: .password(password: "password", userKey: "USER_KEY")
             )
         )
@@ -1904,6 +1906,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: KdfConfig().sdkKdf,
                 email: "user@bitwarden.com",
                 privateKey: "private",
+                signingKey: nil,
                 method: .keyConnector(masterKey: "key", userKey: "user")
             )
         )
@@ -1955,6 +1958,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: KdfConfig().sdkKdf,
                 email: "user@bitwarden.com",
                 privateKey: "private",
+                signingKey: nil,
                 method: .keyConnector(masterKey: "key", userKey: "user")
             )
         )
@@ -2147,6 +2151,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
                 email: "user@bitwarden.com",
                 privateKey: "PRIVATE_KEY",
+                signingKey: nil,
                 method: .authRequest(
                     requestPrivateKey: "AUTH_REQUEST_PRIVATE_KEY",
                     method: .masterKey(protectedMasterKey: "KEY", authRequestKey: "USER_KEY")
@@ -2177,6 +2182,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
                 email: "user@bitwarden.com",
                 privateKey: "PRIVATE_KEY",
+                signingKey: nil,
                 method: .authRequest(
                     requestPrivateKey: "AUTH_REQUEST_PRIVATE_KEY",
                     method: .userKey(protectedUserKey: "KEY")
@@ -2210,6 +2216,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
                 email: "user@bitwarden.com",
                 privateKey: "PRIVATE_KEY",
+                signingKey: nil,
                 method: .pin(pin: "123", pinProtectedUserKey: "123")
             )
         )

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -345,6 +345,16 @@ extension BitwardenSdk.Cipher {
 extension BitwardenSdk.CipherListView: @retroactive Identifiable, Fido2UserVerifiableCipherView {}
 
 extension BitwardenSdk.CipherListViewType {
+    /// Whether the type is card.
+    var isCard: Bool {
+        switch self {
+        case .card:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Whether the type is login.
     var isLogin: Bool {
         switch self {

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdkVaultTests.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdkVaultTests.swift
@@ -78,7 +78,7 @@ class BitwardenSdkCipherListViewTypeTests: BitwardenTestCase {
     /// `isLogin` returns whether the type is a login.
     func test_isLogin() {
         XCTAssertTrue(CipherListViewType.login(.fixture()).isLogin)
-        XCTAssertFalse(CipherListViewType.card.isLogin)
+        XCTAssertFalse(CipherListViewType.card(.init(brand: nil)).isLogin)
         XCTAssertFalse(CipherListViewType.identity.isLogin)
         XCTAssertFalse(CipherListViewType.secureNote.isLogin)
         XCTAssertFalse(CipherListViewType.sshKey.isLogin)
@@ -91,7 +91,7 @@ class BitwardenSdkCipherListViewTypeTests: BitwardenTestCase {
             CipherListViewType.login(expectedResult).loginListView,
             expectedResult
         )
-        XCTAssertNil(CipherListViewType.card.loginListView)
+        XCTAssertNil(CipherListViewType.card(.init(brand: nil)).loginListView)
         XCTAssertNil(CipherListViewType.identity.loginListView)
         XCTAssertNil(CipherListViewType.secureNote.loginListView)
         XCTAssertNil(CipherListViewType.sshKey.loginListView)

--- a/BitwardenShared/Core/Vault/Models/Domain/Fixtures/CipherListView+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Fixtures/CipherListView+Fixtures.swift
@@ -18,9 +18,12 @@ extension CipherListView {
         permissions: BitwardenSdk.CipherPermissions? = nil,
         viewPassword: Bool = true,
         attachments: UInt32 = 0,
+        hasOldAttachments: Bool = false,
         creationDate: Date = Date(),
         deletedDate: Date? = nil,
-        revisionDate: Date = Date()
+        revisionDate: Date = Date(),
+        copyableFields: [CopyableCipherFields] = [],
+        localData: LocalDataView? = nil
     ) -> CipherListView {
         .init(
             id: id,
@@ -38,9 +41,12 @@ extension CipherListView {
             permissions: permissions,
             viewPassword: viewPassword,
             attachments: attachments,
+            hasOldAttachments: hasOldAttachments,
             creationDate: creationDate,
             deletedDate: deletedDate,
-            revisionDate: revisionDate
+            revisionDate: revisionDate,
+            copyableFields: copyableFields,
+            localData: localData
         )
     }
 
@@ -60,9 +66,12 @@ extension CipherListView {
         permissions: BitwardenSdk.CipherPermissions? = nil,
         viewPassword: Bool = true,
         attachments: UInt32 = 0,
+        hasOldAttachments: Bool = false,
         creationDate: Date = Date(),
         deletedDate: Date? = nil,
-        revisionDate: Date = Date()
+        revisionDate: Date = Date(),
+        copyableFields: [CopyableCipherFields] = [],
+        localData: LocalDataView? = nil
     ) -> CipherListView {
         .init(
             id: id,
@@ -80,9 +89,12 @@ extension CipherListView {
             permissions: permissions,
             viewPassword: viewPassword,
             attachments: attachments,
+            hasOldAttachments: hasOldAttachments,
             creationDate: creationDate,
             deletedDate: deletedDate,
-            revisionDate: revisionDate
+            revisionDate: revisionDate,
+            copyableFields: copyableFields,
+            localData: localData
         )
     }
 }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -767,7 +767,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
         let items: [VaultListItem]
         switch group {
         case .card:
-            items = activeCiphers.filter { $0.type == .card }.compactMap(VaultListItem.init)
+            items = activeCiphers.filter { $0.type.isCard }.compactMap(VaultListItem.init)
         case let .collection(id, _, _):
             items = activeCiphers.filter { $0.collectionIds.contains(id) }.compactMap(VaultListItem.init)
         case let .folder(id, _):
@@ -920,7 +920,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
             )
         }
 
-        let typesCardCount = activeCiphers.lazy.filter { $0.type == .card }.count
+        let typesCardCount = activeCiphers.lazy.filter { $0.type.isCard }.count
         let typesIdentityCount = activeCiphers.lazy.filter { $0.type == .identity }.count
         let typesLoginCount = activeCiphers.lazy.filter(\.type.isLogin).count
         let typesSecureNoteCount = activeCiphers.lazy.filter { $0.type == .secureNote }.count
@@ -1715,7 +1715,7 @@ private extension CipherListView {
     func belongsToGroup(_ group: VaultListGroup) -> Bool {
         return switch group {
         case .card:
-            type == .card
+            type.isCard
         case let .collection(id, _, _):
             collectionIds.contains(id)
         case let .folder(id, _):

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
@@ -84,7 +84,7 @@ extension CipherListViewType {
     init(cipher: Cipher) {
         switch cipher.type {
         case .card:
-            self = .card
+            self = .card(.init(brand: nil))
         case .identity:
             self = .identity
         case .login:

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/BitwardenSdk+VaultMocking.swift
@@ -73,9 +73,12 @@ extension CipherListView {
             permissions: cipher.permissions,
             viewPassword: cipher.viewPassword,
             attachments: UInt32(cipher.attachments?.count ?? 0),
+            hasOldAttachments: false,
             creationDate: cipher.creationDate,
             deletedDate: cipher.deletedDate,
-            revisionDate: cipher.revisionDate
+            revisionDate: cipher.revisionDate,
+            copyableFields: [],
+            localData: cipher.localData.map(LocalDataView.init)
         )
     }
 }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -66,7 +66,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         let account = Account.fixture()
         stateService.activeAccount = account
 
-        var item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(type: .card)))
+        var item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(type: .card(.init(brand: nil)))))
 
         // If the card item has no number or code, only the view and add buttons should display.
         vaultRepository.fetchCipherResult = .success(.cardFixture())

--- a/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
+++ b/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
@@ -102,9 +102,12 @@ extension CipherListView {
         permissions: CipherPermissions? = nil,
         viewPassword: Bool = false,
         attachments: UInt32 = 0,
+        hasOldAttachments: Bool = false,
         creationDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41),
         deletedDate: DateTime? = nil,
-        revisionDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41)
+        revisionDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41),
+        copyableFields: [CopyableCipherFields] = [],
+        localData: LocalDataView? = nil
     ) -> CipherListView {
         .init(
             id: id,
@@ -122,9 +125,12 @@ extension CipherListView {
             permissions: permissions,
             viewPassword: viewPassword,
             attachments: attachments,
+            hasOldAttachments: hasOldAttachments,
             creationDate: creationDate,
             deletedDate: deletedDate,
-            revisionDate: revisionDate
+            revisionDate: revisionDate,
+            copyableFields: copyableFields,
+            localData: localData
         )
     }
 
@@ -144,9 +150,12 @@ extension CipherListView {
         permissions: CipherPermissions? = nil,
         viewPassword: Bool = false,
         attachments: UInt32 = 0,
+        hasOldAttachments: Bool = false,
         creationDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41),
         deletedDate: DateTime? = nil,
-        revisionDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41)
+        revisionDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41),
+        copyableFields: [CopyableCipherFields] = [],
+        localData: LocalDataView? = nil
     ) -> CipherListView {
         .init(
             id: id,
@@ -164,9 +173,12 @@ extension CipherListView {
             permissions: permissions,
             viewPassword: viewPassword,
             attachments: attachments,
+            hasOldAttachments: hasOldAttachments,
             creationDate: creationDate,
             deletedDate: deletedDate,
-            revisionDate: revisionDate
+            revisionDate: revisionDate,
+            copyableFields: copyableFields,
+            localData: localData
         )
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+AutofillModeAllTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+AutofillModeAllTests.swift
@@ -105,7 +105,7 @@ class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swi
                 itemType: .cipher(
                     .fixture(
                         id: "1",
-                        type: .card
+                        type: .card(.init(brand: nil))
                     )
                 )
             ),
@@ -147,7 +147,7 @@ class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swi
                 itemType: .cipher(
                     .fixture(
                         id: "1",
-                        type: .card
+                        type: .card(.init(brand: nil))
                     )
                 )
             ),
@@ -156,7 +156,7 @@ class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swi
                 itemType: .cipher(
                     .fixture(
                         id: "2",
-                        type: .card
+                        type: .card(.init(brand: nil))
                     )
                 )
             ),
@@ -190,7 +190,7 @@ class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swi
                 itemType: .cipher(
                     .fixture(
                         id: "1",
-                        type: .card
+                        type: .card(.init(brand: nil))
                     )
                 )
             ),
@@ -230,7 +230,7 @@ class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swi
                 itemType: .cipher(
                     .fixture(
                         id: "1",
-                        type: .card
+                        type: .card(.init(brand: nil))
                     )
                 )
             ),
@@ -239,7 +239,7 @@ class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swi
                 itemType: .cipher(
                     .fixture(
                         id: "2",
-                        type: .card
+                        type: .card(.init(brand: nil))
                     )
                 )
             ),

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -392,7 +392,7 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
     @MainActor
     func test_perform_vaultListItemTapped_notLogin() async throws {
         let vaultListItem = try XCTUnwrap(VaultListItem(cipherListView: .fixture(
-            type: .card
+            type: .card(.init(brand: nil))
         )))
 
         await subject.perform(.vaultListItemTapped(vaultListItem))

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItemTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItemTests.swift
@@ -39,7 +39,7 @@ class VaultListItemTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         )
         XCTAssertNil(
             VaultListItem(
-                cipherListView: .fixture(id: ":)", type: .card),
+                cipherListView: .fixture(id: ":)", type: .card(.init(brand: nil))),
                 fido2CredentialAutofillView: .fixture()
             )
         )
@@ -118,7 +118,7 @@ class VaultListItemTests: BitwardenTestCase { // swiftlint:disable:this type_bod
     /// `icon` returns the expected value.
     func test_icon() { // swiftlint:disable:this function_body_length
         XCTAssertEqual(
-            VaultListItem(cipherListView: .fixture(type: .card))?.icon.name,
+            VaultListItem(cipherListView: .fixture(type: .card(.init(brand: nil))))?.icon.name,
             Asset.Images.card24.name
         )
         XCTAssertEqual(
@@ -195,7 +195,7 @@ class VaultListItemTests: BitwardenTestCase { // swiftlint:disable:this type_bod
     /// `getter:iconAccessibilityId` gets the appropriate id for each icon.
     func test_iconAccessibilityId() {
         XCTAssertEqual(
-            VaultListItem(cipherListView: .fixture(type: .card))?.iconAccessibilityId,
+            VaultListItem(cipherListView: .fixture(type: .card(.init(brand: nil))))?.iconAccessibilityId,
             "CardCipherIcon"
         )
         XCTAssertEqual(
@@ -240,7 +240,7 @@ class VaultListItemTests: BitwardenTestCase { // swiftlint:disable:this type_bod
             "CipherCell"
         )
         XCTAssertEqual(
-            VaultListItem(cipherListView: .fixture(type: .card))?.vaultItemAccessibilityId,
+            VaultListItem(cipherListView: .fixture(type: .card(.init(brand: nil))))?.vaultItemAccessibilityId,
             "CipherCell"
         )
         XCTAssertEqual(
@@ -364,7 +364,7 @@ class VaultListItemTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertEqual(
             VaultListItem(cipherListView: .fixture(
                 subtitle: "Mom's Credit Card, *7890",
-                type: .card
+                type: .card(.init(brand: nil))
             ))?.subtitle,
             "Mom's Credit Card, *7890"
         )

--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -23,7 +23,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: a9a790f3c0e3631bc625fae3fc28a14d26d7727a
+    revision: 80dd7b284e5cdd09e065675b04f991a8ff7338fe
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk

--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -23,7 +23,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: 6324c3ab661606ef0ce7dd90ade730615ee9e2c8
+    revision: a9a790f3c0e3631bc625fae3fc28a14d26d7727a
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -23,7 +23,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: a9a790f3c0e3631bc625fae3fc28a14d26d7727a
+    revision: 80dd7b284e5cdd09e065675b04f991a8ff7338fe
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -23,7 +23,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: 6324c3ab661606ef0ce7dd90ade730615ee9e2c8
+    revision: a9a790f3c0e3631bc625fae3fc28a14d26d7727a
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -24,7 +24,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: 6324c3ab661606ef0ce7dd90ade730615ee9e2c8
+    revision: a9a790f3c0e3631bc625fae3fc28a14d26d7727a
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -24,7 +24,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: a9a790f3c0e3631bc625fae3fc28a14d26d7727a
+    revision: 80dd7b284e5cdd09e065675b04f991a8ff7338fe
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk


### PR DESCRIPTION
## 🎟️ Tracking

[PM-22852](https://bitwarden.atlassian.net/browse/PM-22852)

## 📔 Objective

🍒 Cherry pick from #1686. 
🍒 It also includes #1671 so to update the SDK properly.

Fix master password unlock when entering the first times incorrectly and then correctly to properly unlock the vault when that happens. There was an issue with how the SDK was handling subsequent attempts that when the user entered the first times the password incorrectly then all the next times it will be incorrect event when the user entered the password correctly.
This PR fixes that by updating the SDK with the fixed logic.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22852]: https://bitwarden.atlassian.net/browse/PM-22852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ