### PR TITLE
[PM-22792] Add master password reprompt for copying SSH public key and fingerprint

### DIFF
--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -291,7 +291,7 @@ extension Alert {
                     await action(.copy(
                         toast: Localizations.publicKey,
                         value: sshKey.publicKey,
-                        requiresMasterPasswordReprompt: false,
+                        requiresMasterPasswordReprompt: true,
                         logEvent: nil,
                         cipherId: cipherView.id
                     ))
@@ -311,7 +311,7 @@ extension Alert {
                     await action(.copy(
                         toast: Localizations.fingerprint,
                         value: sshKey.fingerprint,
-                        requiresMasterPasswordReprompt: false,
+                        requiresMasterPasswordReprompt: true,
                         logEvent: nil,
                         cipherId: cipherView.id
                     ))

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -166,7 +166,7 @@ class AlertVaultTests: BitwardenTestCase {
             .copy(
                 toast: Localizations.publicKey,
                 value: "publicKey",
-                requiresMasterPasswordReprompt: false,
+                requiresMasterPasswordReprompt: true,
                 logEvent: nil,
                 cipherId: "123"
             )
@@ -192,7 +192,7 @@ class AlertVaultTests: BitwardenTestCase {
             .copy(
                 toast: Localizations.fingerprint,
                 value: "fingerprint",
-                requiresMasterPasswordReprompt: false,
+                requiresMasterPasswordReprompt: true,
                 logEvent: nil,
                 cipherId: "123"
             )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-22792](https://bitwarden.atlassian.net/browse/PM-22792)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds master password reprompt, if enabled, for copying the public key or fingerprint of an SSH key.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/f5c7d961-6639-4e58-acdc-09cb1fb0e43c



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22792]: https://bitwarden.atlassian.net/browse/PM-22792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ