### PR TITLE
[PM-23024] Remove throw from doesActiveAccountHavePremium

### DIFF
--- a/AuthenticatorBridgeKit/Mocks/MockAuthenticatorBridgeItemService.swift
+++ b/AuthenticatorBridgeKit/Mocks/MockAuthenticatorBridgeItemService.swift
@@ -11,9 +11,7 @@ public class MockAuthenticatorBridgeItemService: AuthenticatorBridgeItemService 
 
     public init() {}
 
-    public func checkForLogout() async throws {
-
-    }
+    public func checkForLogout() async throws {}
 
     public func deleteAllForUserId(_ userId: String) async throws {
         guard errorToThrow == nil else { throw errorToThrow! }

--- a/AuthenticatorBridgeKit/Tests/AuthenticatorBridgeItemServiceTests.swift
+++ b/AuthenticatorBridgeKit/Tests/AuthenticatorBridgeItemServiceTests.swift
@@ -6,7 +6,7 @@ import Foundation
 import TestHelpers
 import XCTest
 
-// swiftlint:disable file_length type_body_length function_body_length
+// swiftlint:disable file_length type_body_length
 
 final class AuthenticatorBridgeItemServiceTests: AuthenticatorBridgeKitTestCase {
     // MARK: Properties
@@ -406,4 +406,4 @@ final class AuthenticatorBridgeItemServiceTests: AuthenticatorBridgeKitTestCase 
     }
 }
 
-// swiftlint:enable file_length type_body_length function_body_length
+// swiftlint:enable file_length type_body_length

--- a/AuthenticatorBridgeKit/Tests/SharedCryptographyServiceTests.swift
+++ b/AuthenticatorBridgeKit/Tests/SharedCryptographyServiceTests.swift
@@ -1,4 +1,3 @@
-import AuthenticatorBridgeKit
 import AuthenticatorBridgeKitMocks
 import CryptoKit
 import Foundation

--- a/BitwardenKit/Core/Platform/Extensions/Date.swift
+++ b/BitwardenKit/Core/Platform/Extensions/Date.swift
@@ -1,6 +1,21 @@
 import Foundation
 
 public extension Date {
+    /// A string to display the current datetime in the desired format taking locale into consideration.
+    var dateTimeDisplay: String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.locale = Locale.current
+        dateFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+
+        let timeFormatter = DateFormatter()
+        timeFormatter.locale = Locale.current
+        timeFormatter.setLocalizedDateFormatFromTemplate("jj:mm")
+
+        let dateString = dateFormatter.string(from: self)
+        let timeString = timeFormatter.string(from: self)
+        return "\(dateString), \(timeString)"
+    }
+
     /// A convenience initializer for `Date` to specify a specific point in time.
     init(
         year: Int,
@@ -25,21 +40,6 @@ public extension Date {
             nanosecond: nanosecond
         )
         self = dateComponents.date!
-    }
-
-    /// A string to display the current datetime in the desired format taking locale into consideration.
-    var dateTimeDisplay: String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.locale = Locale.current
-        dateFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
-
-        let timeFormatter = DateFormatter()
-        timeFormatter.locale = Locale.current
-        timeFormatter.setLocalizedDateFormatFromTemplate("jj:mm")
-
-        let dateString = dateFormatter.string(from: self)
-        let timeString = timeFormatter.string(from: self)
-        return "\(dateString), \(timeString)"
     }
 
     // MARK: Methods

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -41,7 +41,7 @@ protocol StateService: AnyObject {
     ///
     /// - Returns: Whether the active account has access to premium features.
     ///
-    func doesActiveAccountHavePremium() async throws -> Bool
+    func doesActiveAccountHavePremium() async -> Bool
 
     /// Gets the account for an id.
     ///
@@ -1375,6 +1375,9 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
     /// The data store that handles performing data requests.
     private let dataStore: DataStore
 
+    /// The service used by the application to report non-fatal errors.
+    private let errorReporter: ErrorReporter
+
     /// A subject containing the last sync time mapped to user ID.
     private var lastSyncTimeByUserIdSubject = CurrentValueSubject<[String: Date], Never>([:])
 
@@ -1411,6 +1414,7 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
     ) {
         self.appSettingsStore = appSettingsStore
         self.dataStore = dataStore
+        self.errorReporter = errorReporter
         self.keychainRepository = keychainRepository
 
         appThemeSubject = CurrentValueSubject(AppTheme(appSettingsStore.appTheme))
@@ -1456,17 +1460,22 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
         }
     }
 
-    func doesActiveAccountHavePremium() async throws -> Bool {
-        let account = try await getActiveAccount()
-        let hasPremiumPersonally = account.profile.hasPremiumPersonally ?? false
-        guard !hasPremiumPersonally else {
-            return true
-        }
+    func doesActiveAccountHavePremium() async -> Bool {
+        do {
+            let account = try await getActiveAccount()
+            let hasPremiumPersonally = account.profile.hasPremiumPersonally ?? false
+            guard !hasPremiumPersonally else {
+                return true
+            }
 
-        let organizations = try await dataStore
-            .fetchAllOrganizations(userId: account.profile.userId)
-            .filter { $0.enabled && $0.usersGetPremium }
-        return !organizations.isEmpty
+            let organizations = try await dataStore
+                .fetchAllOrganizations(userId: account.profile.userId)
+                .filter { $0.enabled && $0.usersGetPremium }
+            return !organizations.isEmpty
+        } catch {
+            errorReporter.log(error: error)
+            return false
+        }
     }
 
     func getAccount(userId: String?) throws -> Account {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -198,7 +198,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     /// `doesActiveAccountHavePremium()` with premium personally and no organizations returns true.
     func test_doesActiveAccountHavePremium_personalTrue_noOrganization() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: true)))
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
     }
 
@@ -206,7 +206,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     /// false.
     func test_doesActiveAccountHavePremium_personalFalse_noOrganization() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: false)))
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertFalse(hasPremium)
     }
 
@@ -214,7 +214,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     /// false.
     func test_doesActiveAccountHavePremium_personalNil_noOrganization() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: nil)))
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertFalse(hasPremium)
     }
 
@@ -223,7 +223,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_doesActiveAccountHavePremium_personalTrue_organizationFalse() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: true)))
         try await dataStore.replaceOrganizations([.fixture(usersGetPremium: false)], userId: "1")
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
     }
 
@@ -232,7 +232,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_doesActiveAccountHavePremium_personalFalse_organizationTrue() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: false)))
         try await dataStore.replaceOrganizations([.fixture(usersGetPremium: true)], userId: "1")
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
     }
 
@@ -241,7 +241,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_doesActiveAccountHavePremium_personalTrue_organizationTrue() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: true)))
         try await dataStore.replaceOrganizations([.fixture(usersGetPremium: true)], userId: "1")
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
     }
 
@@ -250,7 +250,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_doesActiveAccountHavePremium_personalTrue_organizationTrueDisabled() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: true)))
         try await dataStore.replaceOrganizations([.fixture(enabled: false, usersGetPremium: true)], userId: "1")
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
     }
 
@@ -259,7 +259,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_doesActiveAccountHavePremium_personalFalse_organizationTrueDisabled() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: false)))
         try await dataStore.replaceOrganizations([.fixture(enabled: false, usersGetPremium: true)], userId: "1")
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertFalse(hasPremium)
     }
 
@@ -268,7 +268,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_doesActiveAccountHavePremium_personalFalse_organizationTrueForOtherUser() async throws {
         await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: false)))
         try await dataStore.replaceOrganizations([.fixture(enabled: true, usersGetPremium: true)], userId: "2")
-        let hasPremium = try await subject.doesActiveAccountHavePremium()
+        let hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertFalse(hasPremium)
     }
 

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -35,7 +35,7 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var didAccountSwitchInExtensionResult: Result<Bool, Error> = .success(false)
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
-    var doesActiveAccountHavePremiumResult: Result<Bool, Error> = .success(true)
+    var doesActiveAccountHavePremiumResult: Bool = true
     var encryptedPinByUserId = [String: String]()
     var environmentURLs = [String: EnvironmentURLData]()
     var environmentURLsError: Error?
@@ -136,9 +136,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         try didAccountSwitchInExtensionResult.get()
     }
 
-    func doesActiveAccountHavePremium() async throws -> Bool {
+    func doesActiveAccountHavePremium() async -> Bool {
         doesActiveAccountHavePremiumCalled = true
-        return try doesActiveAccountHavePremiumResult.get()
+        return doesActiveAccountHavePremiumResult
     }
 
     func getAccountEncryptionKeys(userId: String?) async throws -> AccountEncryptionKeys {

--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -34,7 +34,7 @@ public protocol SendRepository: AnyObject {
     ///
     /// - Returns: Whether the active account has premium.
     ///
-    func doesActiveAccountHavePremium() async throws -> Bool
+    func doesActiveAccountHavePremium() async -> Bool
 
     /// Validates the user's active account has a verified email.
     ///
@@ -170,8 +170,8 @@ class DefaultSendRepository: SendRepository {
 
     // MARK: Methods
 
-    func doesActiveAccountHavePremium() async throws -> Bool {
-        try await stateService.doesActiveAccountHavePremium()
+    func doesActiveAccountHavePremium() async -> Bool {
+        await stateService.doesActiveAccountHavePremium()
     }
 
     func doesActiveAccountHaveVerifiedEmail() async throws -> Bool {

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -134,13 +134,13 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `doesActiveAccountHavePremium()` returns whether the active account has access to premium features.
-    func test_doesActiveAccountHavePremium() async throws {
-        stateService.doesActiveAccountHavePremiumResult = .success(true)
-        var hasPremium = try await subject.doesActiveAccountHavePremium()
+    func test_doesActiveAccountHavePremium() async {
+        stateService.doesActiveAccountHavePremiumResult = true
+        var hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
 
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
-        hasPremium = try await subject.doesActiveAccountHavePremium()
+        stateService.doesActiveAccountHavePremiumResult = false
+        hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertFalse(hasPremium)
     }
 

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -9,7 +9,7 @@ import Foundation
 class MockSendRepository: SendRepository {
     // MARK: Properties
 
-    var doesActivateAccountHavePremiumResult: Result<Bool, Error> = .success(true)
+    var doesActivateAccountHavePremiumResult: Bool = true
 
     var doesActiveAccountHaveVerifiedEmailResult: Result<Bool, Error> = .success(true)
 
@@ -76,8 +76,8 @@ class MockSendRepository: SendRepository {
         return try updateSendResult.get()
     }
 
-    func doesActiveAccountHavePremium() async throws -> Bool {
-        try doesActivateAccountHavePremiumResult.get()
+    func doesActiveAccountHavePremium() async -> Bool {
+        doesActivateAccountHavePremiumResult
     }
 
     func doesActiveAccountHaveVerifiedEmail() async throws -> Bool {

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -35,7 +35,7 @@ class MockVaultRepository: VaultRepository {
     var deleteCipherResult: Result<Void, Error> = .success(())
 
     var doesActiveAccountHavePremiumCalled = false
-    var doesActiveAccountHavePremiumResult: Result<Bool, Error> = .success(true)
+    var doesActiveAccountHavePremiumResult: Bool = true
 
     var downloadAttachmentAttachment: AttachmentView?
     var downloadAttachmentResult: Result<URL?, Error> = .success(nil)
@@ -174,9 +174,9 @@ class MockVaultRepository: VaultRepository {
         try deleteCipherResult.get()
     }
 
-    func doesActiveAccountHavePremium() async throws -> Bool {
+    func doesActiveAccountHavePremium() async -> Bool {
         doesActiveAccountHavePremiumCalled = true
-        return try doesActiveAccountHavePremiumResult.get()
+        return doesActiveAccountHavePremiumResult
     }
 
     func downloadAttachment(_ attachment: AttachmentView, cipher _: CipherView) async throws -> URL? {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -64,7 +64,7 @@ public protocol VaultRepository: AnyObject {
     ///
     /// - Returns: Whether the active account has premium.
     ///
-    func doesActiveAccountHavePremium() async throws -> Bool
+    func doesActiveAccountHavePremium() async -> Bool
 
     /// Download and decrypt an attachment and save the file to local storage on the device.
     ///
@@ -597,7 +597,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
         from ciphers: [CipherListView],
         filter: VaultFilterType?
     ) async throws -> [VaultListItem] {
-        let hasPremiumFeaturesAccess = await (try? doesActiveAccountHavePremium()) ?? false
+        let hasPremiumFeaturesAccess = await doesActiveAccountHavePremium()
         let userHasMasterPassword = await (try? stateService.getUserHasMasterPassword()) ?? false
 
         // Filter and sort the list.
@@ -767,7 +767,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
         let items: [VaultListItem]
         switch group {
         case .card:
-            items = activeCiphers.filter { $0.type.isCard }.compactMap(VaultListItem.init)
+            items = activeCiphers.filter(\.type.isCard).compactMap(VaultListItem.init)
         case let .collection(id, _, _):
             items = activeCiphers.filter { $0.collectionIds.contains(id) }.compactMap(VaultListItem.init)
         case let .folder(id, _):
@@ -920,7 +920,7 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
             )
         }
 
-        let typesCardCount = activeCiphers.lazy.filter { $0.type.isCard }.count
+        let typesCardCount = activeCiphers.lazy.filter(\.type.isCard).count
         let typesIdentityCount = activeCiphers.lazy.filter { $0.type == .identity }.count
         let typesLoginCount = activeCiphers.lazy.filter(\.type.isLogin).count
         let typesSecureNoteCount = activeCiphers.lazy.filter { $0.type == .secureNote }.count
@@ -1075,8 +1075,8 @@ extension DefaultVaultRepository: VaultRepository {
         return nil
     }
 
-    func doesActiveAccountHavePremium() async throws -> Bool {
-        try await stateService.doesActiveAccountHavePremium()
+    func doesActiveAccountHavePremium() async -> Bool {
+        await stateService.doesActiveAccountHavePremium()
     }
 
     func downloadAttachment(_ attachmentView: AttachmentView, cipher: CipherView) async throws -> URL? {
@@ -1133,7 +1133,7 @@ extension DefaultVaultRepository: VaultRepository {
             return nil
         }
 
-        let accountHavePremium = try await doesActiveAccountHavePremium()
+        let accountHavePremium = await doesActiveAccountHavePremium()
         if !cipher.organizationUseTotp, !accountHavePremium {
             return nil
         }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -806,12 +806,12 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `doesActiveAccountHavePremium()` returns whether the active account has access to premium features.
     func test_doesActiveAccountHavePremium() async throws {
-        stateService.doesActiveAccountHavePremiumResult = .success(true)
-        var hasPremium = try await subject.doesActiveAccountHavePremium()
+        stateService.doesActiveAccountHavePremiumResult = true
+        var hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertTrue(hasPremium)
 
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
-        hasPremium = try await subject.doesActiveAccountHavePremium()
+        stateService.doesActiveAccountHavePremiumResult = false
+        hasPremium = await subject.doesActiveAccountHavePremium()
         XCTAssertFalse(hasPremium)
     }
 
@@ -1105,7 +1105,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_getTOTPKeyIfAllowedToCopy_accountHasPremium() async throws {
         stateService.activeAccount = .fixture()
         stateService.disableAutoTotpCopyByUserId["1"] = false
-        stateService.doesActiveAccountHavePremiumResult = .success(true)
+        stateService.doesActiveAccountHavePremiumResult = true
         let totpKey = try await subject.getTOTPKeyIfAllowedToCopy(cipher: .fixture(
             login: .fixture(totp: "123"),
             organizationUseTotp: false
@@ -1119,7 +1119,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_getTOTPKeyIfAllowedToCopy_orgUsesTOTPAndAccountHasPremium() async throws {
         stateService.activeAccount = .fixture()
         stateService.disableAutoTotpCopyByUserId["1"] = false
-        stateService.doesActiveAccountHavePremiumResult = .success(true)
+        stateService.doesActiveAccountHavePremiumResult = true
         let totpKey = try await subject.getTOTPKeyIfAllowedToCopy(cipher: .fixture(
             login: .fixture(totp: "123"),
             organizationUseTotp: true
@@ -1155,7 +1155,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     func test_getTOTPKeyIfAllowedToCopy_orgDoesntUseTOTPAndAccountDoesntHavePremium() async throws {
         stateService.activeAccount = .fixture()
         stateService.disableAutoTotpCopyByUserId["1"] = false
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
         let totpKey = try await subject.getTOTPKeyIfAllowedToCopy(cipher: .fixture(
             login: .fixture(totp: "123"),
             organizationUseTotp: false
@@ -3045,7 +3045,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     /// `vaultListPublisher(group:filter:)` does not return TOTP items for non-premium accounts.
     func test_vaultListPublisher_groups_totp_notPremium() async throws {
         stateService.activeAccount = nonPremiumAccount
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
         let cipher = Cipher.fixture(id: "1", login: .fixture(totp: "123"), type: .login)
         cipherService.ciphersSubject.send([cipher])
 
@@ -3062,7 +3062,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     /// accounts if the organization uses TOTP.
     func test_vaultListPublisher_groups_totp_organizationUseTotp() async throws {
         stateService.activeAccount = nonPremiumAccount
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
         cipherService.ciphersSubject.send([
             Cipher.fixture(
                 id: "1",
@@ -3099,7 +3099,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     /// master password.
     func test_vaultListPublisher_groups_totp_organizationUseTotp_userWithoutMP() async throws {
         stateService.activeAccount = nonPremiumAccount
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
         stateService.userHasMasterPassword[nonPremiumAccount.profile.userId] = false
 
         cipherService.ciphersSubject.send([
@@ -3320,7 +3320,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     ///   with no TOTP items for accounts without premium.
     func test_vaultListPublisher_section_nonPremium() async throws { // swiftlint:disable:this function_body_length
         stateService.activeAccount = nonPremiumAccount
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
         let ciphers: [Cipher] = [
             .fixture(folderId: "1", id: "1", type: .login),
             .fixture(id: "2", login: .fixture(totp: "123"), type: .login),
@@ -3388,7 +3388,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     ///  with a TOTP section if the user has ciphers where the organization uses TOTP.
     func test_vaultListPublisher_section_nonPremiumOrganizationUseTotp() async throws {
         stateService.activeAccount = nonPremiumAccount
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
         let ciphers: [Cipher] = [
             .fixture(id: "1", login: .fixture(totp: "123"), type: .login),
             .fixture(id: "2", login: .fixture(totp: "123"), organizationUseTotp: true, type: .login),

--- a/BitwardenShared/Core/Vault/Services/TOTP/TOTPService.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TOTPService.swift
@@ -55,7 +55,7 @@ struct DefaultTOTPService: TOTPService {
             return
         }
 
-        let accountHasPremium = try await stateService.doesActiveAccountHavePremium()
+        let accountHasPremium = await stateService.doesActiveAccountHavePremium()
         guard cipher.organizationUseTotp || accountHasPremium else {
             return
         }

--- a/BitwardenShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
@@ -66,7 +66,7 @@ final class TOTPServiceTests: BitwardenTestCase {
             organizationUseTotp: true
         )
         stateService.activeAccount = .fixture()
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
 
         try await subject.copyTotpIfPossible(cipher: cipher)
 
@@ -123,7 +123,7 @@ final class TOTPServiceTests: BitwardenTestCase {
             )
         )
         stateService.activeAccount = .fixture()
-        stateService.doesActiveAccountHavePremiumResult = .success(false)
+        stateService.doesActiveAccountHavePremiumResult = false
 
         try await subject.copyTotpIfPossible(cipher: cipher)
 
@@ -139,23 +139,6 @@ final class TOTPServiceTests: BitwardenTestCase {
         )
 
         await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
-            try await subject.copyTotpIfPossible(cipher: cipher)
-        }
-
-        XCTAssertNil(pasteboardService.copiedString)
-    }
-
-    /// `copyTotpIfPossible(cipher:)` throws when getting if current account has premium.
-    func test_copyTotpIfPossible_throwsAccountPremium() async throws {
-        let cipher = CipherView.fixture(
-            login: .fixture(
-                totp: "totp"
-            )
-        )
-        stateService.activeAccount = .fixture()
-        stateService.doesActiveAccountHavePremiumResult = .failure(BitwardenTestError.example)
-
-        await assertAsyncThrows(error: BitwardenTestError.example) {
             try await subject.copyTotpIfPossible(cipher: cipher)
         }
 

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -543,4 +543,4 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
             ]
         )
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -125,13 +125,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     ///
     private func addNewSend(sendType: SendType) async {
         if sendType.requiresPremium {
-            let hasPremium: Bool
-            do {
-                hasPremium = try await services.sendRepository.doesActiveAccountHavePremium()
-            } catch {
-                hasPremium = false
-                services.errorReporter.log(error: error)
-            }
+            let hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
 
             guard hasPremium else {
                 coordinator.showAlert(.defaultAlert(title: Localizations.sendFilePremiumRequired))

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -66,26 +66,10 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     }
 
     /// `perform(_:)` with `.addItemPressed` shows an alert if attempting to add a file send and
-    /// there's an error determining if the user has premium.
-    @MainActor
-    func test_perform_addItemPressed_fileType_error() async throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .failure(BitwardenTestError.example)
-        subject.state.type = .file
-        await subject.perform(.addItemPressed(.file))
-
-        XCTAssertEqual(
-            coordinator.alertShown,
-            [.defaultAlert(title: Localizations.sendFilePremiumRequired)]
-        )
-        XCTAssertTrue(coordinator.routes.isEmpty)
-        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-    }
-
-    /// `perform(_:)` with `.addItemPressed` shows an alert if attempting to add a file send and
     /// the user doesn't have premium.
     @MainActor
     func test_perform_addItemPressed_fileType_withoutPremium() async throws {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(false)
+        sendRepository.doesActivateAccountHavePremiumResult = false
         subject.state.type = .file
         await subject.perform(.addItemPressed(.file))
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -60,10 +60,9 @@ class AddEditSendItemProcessor:
             await copyLink(to: sendView)
         case .deletePressed:
             guard let sendView = state.originalSendView else { return }
-            let alert = Alert.confirmationDestructive(
-                title: Localizations.areYouSureDeleteSend) { [weak self] in
-                    await self?.deleteSend(sendView)
-                }
+            let alert = Alert.confirmationDestructive(title: Localizations.areYouSureDeleteSend) { [weak self] in
+                await self?.deleteSend(sendView)
+            }
             coordinator.showAlert(alert)
         case .loadData:
             await loadData()
@@ -297,8 +296,8 @@ class AddEditSendItemProcessor:
         // Only perform further checks for file sends.
         guard state.type == .file else { return true }
 
-        let hasPremium = try? await services.sendRepository.doesActiveAccountHavePremium()
-        guard hasPremium ?? false else {
+        let hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
+        guard hasPremium else {
             let alert = Alert.defaultAlert(
                 message: Localizations.sendFilePremiumRequired
             )
@@ -400,4 +399,4 @@ extension AddEditSendItemProcessor: ProfileSwitcherHandler {
     func showAlert(_ alert: Alert) {
         coordinator.showAlert(alert)
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -293,7 +293,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     /// `perform(_:)` with `.savePressed` and no premium shows a validation alert.
     @MainActor
     func test_perform_savePressed_add_file_noPremium() async {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(false)
+        sendRepository.doesActivateAccountHavePremiumResult = false
         subject.state.name = "Name"
         subject.state.fileData = Data("example".utf8)
         subject.state.fileName = "filename"
@@ -310,7 +310,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     /// `perform(_:)` with `.savePressed` and an unverified email shows a validation alert.
     @MainActor
     func test_perform_savePressed_add_file_noVerifiedEmail() async {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+        sendRepository.doesActivateAccountHavePremiumResult = true
         sendRepository.doesActiveAccountHaveVerifiedEmailResult = .success(false)
         subject.state.name = "Name"
         subject.state.fileData = Data("example".utf8)
@@ -328,7 +328,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     /// `perform(_:)` with `.savePressed` and no file data shows a validation alert.
     @MainActor
     func test_perform_savePressed_add_file_noFileData() async {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+        sendRepository.doesActivateAccountHavePremiumResult = true
         sendRepository.doesActiveAccountHaveVerifiedEmailResult = .success(true)
         subject.state.name = "Name"
         subject.state.fileData = nil
@@ -350,7 +350,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     /// `perform(_:)` with `.savePressed` and no file name shows a validation alert.
     @MainActor
     func test_perform_savePressed_add_file_noFileName() async {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+        sendRepository.doesActivateAccountHavePremiumResult = true
         sendRepository.doesActiveAccountHaveVerifiedEmailResult = .success(true)
         subject.state.name = "Name"
         subject.state.fileData = Data("example".utf8)
@@ -372,7 +372,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     /// `perform(_:)` with `.savePressed` and file data that is too large shows a validation alert.
     @MainActor
     func test_perform_savePressed_add_file_fileDataTooLarge() async {
-        sendRepository.doesActivateAccountHavePremiumResult = .success(true)
+        sendRepository.doesActivateAccountHavePremiumResult = true
         sendRepository.doesActiveAccountHaveVerifiedEmailResult = .success(true)
         subject.state.name = "Name"
         subject.state.fileData = Data(String(repeating: "a", count: Constants.maxFileSizeBytes + 1).utf8)

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -78,7 +78,7 @@ class AutofillHelper {
     private func copyTotpIfNeeded(cipherView: CipherView) async {
         do {
             let disableAutoTotpCopy = try await services.vaultRepository.getDisableAutoTotpCopy()
-            let accountHasPremium = try await services.vaultRepository.doesActiveAccountHavePremium()
+            let accountHasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
 
             if !disableAutoTotpCopy, let totp = cipherView.login?.totp,
                cipherView.organizationUseTotp || accountHasPremium {

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -380,7 +380,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `handleCipherForAutofill(cipherListView:)` copies the TOTP code for the login if the
     /// organization uses TOTP.
     func test_handleCipherForAutofill_totpCopyOrganizationUseTotp() async {
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
+        vaultRepository.doesActiveAccountHavePremiumResult = false
         vaultRepository.fetchCipherResult = .success(.fixture(
             login: .fixture(password: "PASSWORD", username: "user@bitwarden.com", totp: "totp"),
             organizationUseTotp: true
@@ -419,7 +419,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         vaultRepository.fetchCipherResult = .success(.fixture(
             login: .fixture(password: "PASSWORD", username: "user@bitwarden.com", totp: "totp")
         ))
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
+        vaultRepository.doesActiveAccountHavePremiumResult = false
 
         let cipher = CipherListView.fixture(id: "1")
         await subject.handleCipherForAutofill(cipherListView: cipher) { _ in }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -82,7 +82,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             }
 
             let canEdit = cipherView.deletedDate == nil
-            let hasPremium = try await services.vaultRepository.doesActiveAccountHavePremium()
+            let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
 
             coordinator.showAlert(.moreOptions(
                 canCopyTotp: hasPremium || cipherView.organizationUseTotp,

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -232,7 +232,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
     func test_showMoreOptionsAlert_copyTotp_organizationUseTotp() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
+        vaultRepository.doesActiveAccountHavePremiumResult = false
         vaultRepository.refreshTOTPCodeResult = .success(
             LoginTOTPState(
                 authKeyModel: TOTPKeyModel(authenticatorKey: .standardTotpKey),
@@ -310,24 +310,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         try await optionsAlert.tapAction(title: Localizations.copyTotp)
 
         XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.anErrorHasOccurred))
-        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-    }
-
-    /// `showMoreOptionsAlert()` logs an error if fetching whether the account has premium fails.
-    @MainActor
-    func test_showMoreOptionsAlert_doesActiveAccountHavePremiumError() async throws {
-        stateService.activeAccount = .fixture()
-        vaultRepository.doesActiveAccountHavePremiumResult = .failure(BitwardenTestError.example)
-
-        vaultRepository.fetchCipherResult = .success(.fixture())
-        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
-        await subject.showMoreOptionsAlert(
-            for: item,
-            handleDisplayToast: { _ in },
-            handleOpenURL: { _ in }
-        )
-
-        XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -197,11 +197,11 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
             showAddFolder()
         case let .addItem(group, newCipherOptions, organizationId, type):
             Task {
-                let hasPremium = try? await services.vaultRepository.doesActiveAccountHavePremium()
+                let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
                 showVaultItem(
                     route: .addItem(
                         group: group,
-                        hasPremium: hasPremium ?? false,
+                        hasPremium: hasPremium,
                         newCipherOptions: newCipherOptions,
                         organizationId: organizationId,
                         type: type
@@ -215,9 +215,9 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
             showAutofillListForGroup(group)
         case let .editItem(cipher):
             Task {
-                let hasPremium = try? await services.vaultRepository.doesActiveAccountHavePremium()
+                let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
                 showVaultItem(
-                    route: .editItem(cipher, hasPremium ?? false),
+                    route: .editItem(cipher, hasPremium),
                     delegate: context as? CipherItemOperationDelegate
                 )
             }

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -100,17 +100,12 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
 
     /// Load the user's premium status and display an alert if they do not have access to premium features.
     private func loadPremiumStatus() async {
-        do {
-            // Fetch the user's premium status.
-            state.hasPremium = try await services.vaultRepository.doesActiveAccountHavePremium()
+        // Fetch the user's premium status.
+        state.hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
 
-            // If the user does not have access to premium features, show an alert.
-            if !state.hasPremium {
-                coordinator.showAlert(.defaultAlert(title: Localizations.premiumRequired))
-            }
-        } catch {
-            await coordinator.showErrorAlert(error: error)
-            services.errorReporter.log(error: error)
+        // If the user does not have access to premium features, show an alert.
+        if !state.hasPremium {
+            coordinator.showAlert(.defaultAlert(title: Localizations.premiumRequired))
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -54,24 +54,12 @@ class AttachmentsProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.loadPremiumStatus` loads the premium status and displays an alert if necessary.
     @MainActor
     func test_perform_loadPremiumStatus() async throws {
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
+        vaultRepository.doesActiveAccountHavePremiumResult = false
 
         await subject.perform(.loadPremiumStatus)
 
         XCTAssertFalse(subject.state.hasPremium)
         XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.premiumRequired))
-    }
-
-    /// `perform(_:)` with `.loadPremiumStatus` records any errors.
-    @MainActor
-    func test_perform_loadPremiumStatus_error() async throws {
-        vaultRepository.doesActiveAccountHavePremiumResult = .failure(BitwardenTestError.example)
-
-        await subject.perform(.loadPremiumStatus)
-
-        XCTAssertFalse(subject.state.hasPremium)
-        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
-        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
     /// `perform(_:)` with `.save` saves the attachment and updates the view.

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -400,4 +400,4 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
         state.isLearnNewLoginActionCardEligible = false
         XCTAssertFalse(state.shouldShowLearnNewLoginActionCard)
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
@@ -64,25 +64,7 @@ class VaultItemCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this t
     /// `navigate(to:)` with `.addItem` without a group pushes the add item view onto the stack navigator.
     @MainActor
     func test_navigateTo_addItem_nonPremium() throws {
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
-        let task = Task {
-            subject.navigate(to: .addItem(type: .login))
-        }
-        waitFor(!stackNavigator.actions.isEmpty)
-        task.cancel()
-
-        let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .replaced)
-        let view = try XCTUnwrap(action.view as? AddEditItemView)
-        XCTAssertEqual(view.store.state.type, .login)
-        XCTAssertFalse(view.store.state.loginState.isTOTPAvailable)
-    }
-
-    /// `navigate(to:)` with `.addItem` without a group pushes the add item view onto the stack navigator.
-    @MainActor
-    func test_navigateTo_addItem_unknownPremium() throws {
-        struct TestError: Error {}
-        vaultRepository.doesActiveAccountHavePremiumResult = .failure(TestError())
+        vaultRepository.doesActiveAccountHavePremiumResult = false
         let task = Task {
             subject.navigate(to: .addItem(type: .login))
         }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -203,7 +203,7 @@ private extension ViewItemProcessor {
     /// - Parameter cipher: The cipher to clone.
     ///
     private func cloneItem(_ cipher: CipherView) async {
-        let hasPremium = await (try? services.vaultRepository.doesActiveAccountHavePremium()) ?? false
+        let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
         if cipher.login?.fido2Credentials?.isEmpty == false {
             coordinator.showAlert(.confirmCloneExcludesFido2Credential {
                 self.coordinator.navigate(to: .cloneItem(cipher: cipher, hasPremium: hasPremium), context: self)
@@ -291,8 +291,8 @@ private extension ViewItemProcessor {
             return
         }
         Task {
-            let hasPremium = try? await services.vaultRepository.doesActiveAccountHavePremium()
-            coordinator.navigate(to: .editItem(cipher, hasPremium ?? false), context: self)
+            let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
+            coordinator.navigate(to: .editItem(cipher, hasPremium), context: self)
         }
     }
 
@@ -492,7 +492,7 @@ private extension ViewItemProcessor {
             for try await cipher in try await services.vaultRepository.cipherDetailsPublisher(id: itemId) {
                 guard let cipher else { continue }
 
-                let hasPremium = await (try? services.vaultRepository.doesActiveAccountHavePremium()) ?? false
+                let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
                 let collections = try await services.vaultRepository.fetchCollections(includeReadOnly: true)
                 var folder: FolderView?
                 if let folderId = cipher.folderId {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -132,7 +132,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.showWebIcons = true
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
+        vaultRepository.doesActiveAccountHavePremiumResult = true
         let collections = [
             CollectionView.fixture(id: "1"),
             CollectionView.fixture(id: "2"),
@@ -228,36 +228,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         let cipherItem = CipherView.loginFixture(
             id: "id"
         )
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(false)
-        vaultRepository.cipherDetailsSubject.send(cipherItem)
-
-        let task = Task {
-            await subject.perform(.appeared)
-        }
-
-        waitFor(subject.state.loadingState != .loading(nil))
-        task.cancel()
-
-        let expectedState = CipherItemState(
-            existing: cipherItem,
-            hasPremium: false,
-            iconBaseURL: URL(string: "https://example.com/icons")!
-        )!
-
-        XCTAssertEqual(subject.state.loadingState, .data(expectedState))
-        XCTAssertFalse(vaultRepository.fetchSyncCalled)
-    }
-
-    /// `perform(_:)` with `.appeared` observe the premium status of a user.
-    @MainActor
-    func test_perform_appeared_unknownPremium() {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-
-        let cipherItem = CipherView.loginFixture(
-            id: "id"
-        )
-        vaultRepository.doesActiveAccountHavePremiumResult = .failure(BitwardenTestError.example)
+        vaultRepository.doesActiveAccountHavePremiumResult = false
         vaultRepository.cipherDetailsSubject.send(cipherItem)
 
         let task = Task {
@@ -283,7 +254,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appearedWithFolder() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
+        vaultRepository.doesActiveAccountHavePremiumResult = true
         let collections = [
             CollectionView.fixture(id: "1"),
             CollectionView.fixture(id: "2"),
@@ -336,7 +307,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appearedWithOrganization() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
+        vaultRepository.doesActiveAccountHavePremiumResult = true
         let collections = [
             CollectionView.fixture(id: "1"),
             CollectionView.fixture(id: "2"),
@@ -389,7 +360,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appearedWithOrganizationAndCollectionsDisplay() {
         let account = Account.fixture()
         stateService.activeAccount = account
-        vaultRepository.doesActiveAccountHavePremiumResult = .success(true)
+        vaultRepository.doesActiveAccountHavePremiumResult = true
         let collections = [
             CollectionView.fixture(id: "1"),
             CollectionView.fixture(id: "2"),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23024](https://bitwarden.atlassian.net/browse/PM-23024)

## 📔 Objective

Remove `throw` from `doesActiveAccountHavePremium` function and handle error inside logging it and returning default `false` to ease usage in callers and tests.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
