### PR TITLE
[PM-23087] Fix crash presenting 'Share error details' share sheet on iPadOS

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Extensions/UIViewController.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/UIViewController.swift
@@ -1,6 +1,48 @@
 import UIKit
 
 extension UIViewController {
+    /// Presents a view controller modally. Supports presenting on top of presented modals if necessary.
+    ///
+    /// - Parameters:
+    ///   - viewController: The view controller to present.
+    ///   - animated: Whether the transition should be animated.
+    ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
+    ///   - onCompletion: A closure to call on completion.
+    ///
+    public func present(
+        _ viewController: UIViewController,
+        animated: Bool = UI.animated,
+        overFullscreen: Bool = false,
+        onCompletion: (() -> Void)? = nil
+    ) {
+        var presentedChild = presentedViewController
+        var availablePresenter: UIViewController? = self
+        while presentedChild != nil {
+            availablePresenter = presentedChild
+            presentedChild = presentedChild?.presentedViewController
+        }
+        if overFullscreen {
+            viewController.modalPresentationStyle = .overFullScreen
+        }
+        if let popoverPresentationController = viewController.popoverPresentationController,
+           popoverPresentationController.sourceView == nil,
+           popoverPresentationController.barButtonItem == nil,
+           let parentView = availablePresenter?.view {
+            // Provide a default source view and rect when presenting a popover if one isn't
+            // already specified. This prevents a crash when presenting popovers on iPadOS.
+            popoverPresentationController.sourceView = parentView
+            popoverPresentationController.sourceRect = CGRect(
+                x: parentView.bounds.midX, y: parentView.bounds.midY, width: 0, height: 0
+            )
+            popoverPresentationController.permittedArrowDirections = []
+        }
+        availablePresenter?.present(
+            viewController,
+            animated: animated,
+            completion: onCompletion
+        )
+    }
+
     /// Returns the topmost view controller starting from this view controller and navigating down the view hierarchy.
     ///
     /// - Returns: The topmost view controller from this view controller.

--- a/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Coordinator.swift
@@ -211,7 +211,7 @@ extension Coordinator where Self: HasErrorAlertServices, Self: HasNavigator {
                         activityItems: [errorReport],
                         applicationActivities: nil
                     )
-                    self.navigator?.rootViewController?.present(viewController, animated: UI.animated)
+                    self.navigator?.present(viewController)
                 },
                 tryAgain: tryAgain
             )

--- a/BitwardenShared/UI/Platform/Application/Utilities/CoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/CoordinatorTests.swift
@@ -95,9 +95,9 @@ class CoordinatorTests: BitwardenTestCase {
         let alert = try XCTUnwrap(stackNavigator.alerts.first)
         try await alert.tapAction(title: Localizations.shareErrorDetails)
 
-        try await waitForAsync { rootViewController.presentedViewController != nil }
-        let viewController = rootViewController.presentedViewController
-        XCTAssertTrue(viewController is UIActivityViewController)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view as? UIViewController is UIActivityViewController)
 
         XCTAssertEqual(errorReportBuilder.buildShareErrorLogError as? BitwardenTestError, .example)
         XCTAssertEqual(errorReportBuilder.buildShareErrorLogCallStack?.isEmpty, false)

--- a/BitwardenShared/UI/Platform/Application/Utilities/Navigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/Navigator.swift
@@ -13,12 +13,46 @@ public protocol Navigator: AlertPresentable, AnyObject {
 
     /// The root view controller of this `Navigator`.
     var rootViewController: UIViewController? { get }
+
+    // MARK: Methods
+
+    /// Presents a view controller modally. Supports presenting on top of presented modals if necessary.
+    ///
+    /// - Parameters:
+    ///   - viewController: The view controller to present.
+    ///   - animated: Whether the transition should be animated.
+    ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
+    ///   - onCompletion: A closure to call on completion.
+    ///
+    func present(
+        _ viewController: UIViewController,
+        animated: Bool,
+        overFullscreen: Bool,
+        onCompletion: (() -> Void)?
+    )
 }
 
 extension Navigator {
     /// A flag indicating if this navigator is currently presenting a view modally.
     public var isPresenting: Bool {
         rootViewController?.presentedViewController != nil
+    }
+
+    /// Presents a view controller modally. Supports presenting on top of presented modals if necessary.
+    ///
+    /// - Parameters:
+    ///   - viewController: The view controller to present.
+    ///   - animated: Whether the transition should be animated.
+    ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
+    ///   - onCompletion: A closure to call on completion.
+    ///
+    func present(
+        _ viewController: UIViewController,
+        animated: Bool = UI.animated,
+        overFullscreen: Bool = false,
+        onCompletion: (() -> Void)? = nil
+    ) {
+        present(viewController, animated: animated, overFullscreen: overFullscreen, onCompletion: onCompletion)
     }
 
     /// Shows the loading overlay view.

--- a/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/StackNavigator.swift
@@ -78,21 +78,6 @@ public protocol StackNavigator: Navigator {
         onCompletion: (() -> Void)?
     )
 
-    /// Presents a view controller modally. Supports presenting on top of presented modals if necessary.
-    ///
-    /// - Parameters:
-    ///   - viewController: The view controller to present.
-    ///   - animated: Whether the transition should be animated.
-    ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
-    ///   - onCompletion: A closure to call on completion.
-    ///
-    func present(
-        _ viewController: UIViewController,
-        animated: Bool,
-        overFullscreen: Bool,
-        onCompletion: (() -> Void)?
-    )
-
     /// Replaces the stack with the specified view.
     ///
     /// - Parameters:
@@ -225,27 +210,6 @@ extension StackNavigator {
         )
     }
 
-    /// Presents a view controller modally. Supports presenting on top of presented modals if necessary. Animation is
-    /// controlled by `UI.animated`.
-    ///
-    /// - Parameters:
-    ///   - viewController: The view controller to present.
-    ///   - overFullscreen: Whether or not the presented modal should cover the full screen.
-    ///   - onCompletion: The closure to call after presenting.
-    ///
-    func present(
-        _ viewController: UIViewController,
-        overFullscreen: Bool = false,
-        onCompletion: (() -> Void)? = nil
-    ) {
-        present(
-            viewController,
-            animated: UI.animated,
-            overFullscreen: overFullscreen,
-            onCompletion: onCompletion
-        )
-    }
-
     /// Replaces the stack with the specified view. Animation is controlled by `UI.animated`.
     ///
     /// - Parameter view: The view that will replace the stack.
@@ -317,40 +281,6 @@ extension UINavigationController: StackNavigator {
         }
         let animated = self.view.window != nil ? animated : false
         present(controller, animated: animated, onCompletion: onCompletion)
-    }
-
-    public func present(
-        _ viewController: UIViewController,
-        animated: Bool,
-        overFullscreen: Bool = false,
-        onCompletion: (() -> Void)? = nil
-    ) {
-        var presentedChild = presentedViewController
-        var availablePresenter: UIViewController? = self
-        while presentedChild != nil {
-            availablePresenter = presentedChild
-            presentedChild = presentedChild?.presentedViewController
-        }
-        if overFullscreen {
-            viewController.modalPresentationStyle = .overFullScreen
-        }
-        if let popoverPresentationController = viewController.popoverPresentationController,
-           popoverPresentationController.sourceView == nil,
-           popoverPresentationController.barButtonItem == nil,
-           let parentView = availablePresenter?.view {
-            // Provide a default source view and rect when presenting a popover if one isn't
-            // already specified. This prevents a crash when presenting popovers on iPadOS.
-            popoverPresentationController.sourceView = parentView
-            popoverPresentationController.sourceRect = CGRect(
-                x: parentView.bounds.midX, y: parentView.bounds.midY, width: 0, height: 0
-            )
-            popoverPresentationController.permittedArrowDirections = []
-        }
-        availablePresenter?.present(
-            viewController,
-            animated: animated,
-            completion: onCompletion
-        )
     }
 
     public func replace<Content: View>(_ view: Content, animated: Bool) {

--- a/GlobalTestHelpers/MockRootNavigator.swift
+++ b/GlobalTestHelpers/MockRootNavigator.swift
@@ -15,6 +15,13 @@ final class MockRootNavigator: RootNavigator {
         alerts.append(alert)
     }
 
+    func present(
+        _ viewController: UIViewController,
+        animated: Bool,
+        overFullscreen: Bool,
+        onCompletion: (() -> Void)?
+    ) {}
+
     func show(child: Navigator) {
         navigatorShown = child
     }

--- a/GlobalTestHelpers/MockTabNavigator.swift
+++ b/GlobalTestHelpers/MockTabNavigator.swift
@@ -17,6 +17,13 @@ final class MockTabNavigator: TabNavigator {
         return navigatorForTabReturns
     }
 
+    func present(
+        _ viewController: UIViewController,
+        animated: Bool,
+        overFullscreen: Bool,
+        onCompletion: (() -> Void)?
+    ) {}
+
     func setNavigators<Tab: Hashable & TabRepresentable>(_ tabs: [Tab: Navigator]) {
         navigators = tabs
             .sorted { $0.key.index < $1.key.index }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23087](https://bitwarden.atlassian.net/browse/PM-23087)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The 'Share error details' button on alerts when a generic error occurs presents a share sheet for sharing the details of the error. On iPadOS, presenting the `UIActivityViewController` requires setting the popover presentation controller's source view or it will crash. We have logic to handle this in the StackNavigator's `present(_:)` method, but since this was being presented from the navigator's `rootViewController`, that didn't apply. I ended up moving the present view controller method out of `StackNavigator` and into `Navigator`, which then can be used by all navigators and fixes the crash.

> *** Terminating app due to uncaught exception 'NSGenericException', reason: 'UIPopoverPresentationController (<UIPopoverPresentationController: 0x101d10430>) should have a non-nil sourceView or barButtonItem set before the presentation occurs.'


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/8f29437c-195f-49eb-a089-5b4565441de2

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23087]: https://bitwarden.atlassian.net/browse/PM-23087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ