### PR TITLE
[PM-23119] Navigation bar updates

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View+Toolbar.swift
@@ -227,7 +227,7 @@ extension View {
     @ToolbarContentBuilder
     func largeNavigationTitleToolbarItem(_ title: String, hidden: Bool = false) -> some ToolbarContent {
         ToolbarItem(placement: .topBarLeading) {
-            if !hidden {
+            if !hidden, !shouldHideLargeNavigationToolbarItem {
                 Text(title)
                     .styleGuide(.largeTitle, weight: .semibold)
                     .accessibilityAddTraits(.isHeader)
@@ -235,11 +235,26 @@ extension View {
         }
 
         ToolbarItem(placement: .principal) {
-            if !hidden {
+            if !hidden, !shouldHideLargeNavigationToolbarItem {
                 // Hide the centered navigation title view with an empty view.
                 Text("")
                     .accessibilityHidden(true)
             }
         }
+    }
+}
+
+// MARK: Private
+
+extension View {
+    /// Whether the navigation bar's large title displayed on the leading edge should be hidden.
+    /// iPadOS 18+ moves the tab bar into the navigation bar. Since the selected tab matches the
+    /// navigation bar's title both don't need to be displayed. This fixes an issue where even
+    /// though the navigation bar was displayed inline, there was still extra padding in the
+    /// navigation bar where the centered title would be displayed below the tab bar.
+    ///
+    private var shouldHideLargeNavigationToolbarItem: Bool {
+        guard #available(iOS 18, *) else { return false }
+        return UIDevice.current.userInterfaceIdiom == .pad
     }
 }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
@@ -21,7 +21,7 @@ struct SendListState: Sendable {
     var loadingState: LoadingState<[SendListSection]> = .loading(nil)
 
     /// The navigation title for this screen.
-    var navigationTitle: String { type?.localizedName ?? Localizations.sends }
+    var navigationTitle: String { type?.localizedName ?? Localizations.send }
 
     /// The text that the user is currently searching for.
     var searchText: String = ""

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListStateTests.swift
@@ -34,7 +34,7 @@ class SendListStateTests: BitwardenTestCase {
     /// `navigationTitle` is `Sends` when `type` is `nil`.
     func test_navigationTitle_nilType() {
         let subject = SendListState(type: nil)
-        XCTAssertEqual(subject.navigationTitle, Localizations.sends)
+        XCTAssertEqual(subject.navigationTitle, Localizations.send)
     }
 
     /// `navigationTitle` is `text` when `type` is `.text`.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -238,7 +238,7 @@ struct SendListView: View {
                         Button {
                             store.send(.infoButtonPressed)
                         } label: {
-                            Image(asset: Asset.Images.informationCircle24, label: Text(Localizations.aboutSend))
+                            Image(asset: Asset.Images.questionCircle24, label: Text(Localizations.aboutSend))
                                 .foregroundColor(Asset.Colors.iconSecondary.swiftUIColor)
                         }
                         .frame(minHeight: 44)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23119](https://bitwarden.atlassian.net/browse/PM-23119)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a few additional things related to the navigation bar updates in #1674:

- The navigation title for the Send tab should be "Send", not "Sends".
- The about Send web icon in the Send navigation bar should be the question circle icon.
- On iPadOS 18+, there was still additional padding in the navigation bar because the tab bar also exists in the navigation bar so it was leaving extra space for the empty title below the tab bar. Since the selected item in the tab bar matches the navigation bar's title, we can omit the large title navigation bar on these devices.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="833" alt="Screenshot 2025-06-27 at 2 29 08 PM" src="https://github.com/user-attachments/assets/6179a267-6d94-4ca2-a145-4a518c2641e8" /> | <img width="833" alt="Screenshot 2025-06-27 at 4 19 51 PM" src="https://github.com/user-attachments/assets/a271d510-eb7d-4b53-a604-f58266cc7a1c" /> | 


https://github.com/user-attachments/assets/b67edc3b-e885-4c1a-a95f-cc82acab5fc4



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
