### PR TITLE
[PM-18414] Fix compiler flags not being set in new build workflows

### DIFF
--- a/.github/workflows/_build-any.yml
+++ b/.github/workflows/_build-any.yml
@@ -154,6 +154,7 @@ jobs:
             build_mode:$_BUILD_MODE \
             version_name:$_VERSION_NAME \
             version_number:$_VERSION_NUMBER \
+            compiler_flags:"$_COMPILER_FLAGS"
 
           bundle exec fastlane update_ci_build_info \
             --env $_BW_ENV \


### PR DESCRIPTION
## 🎟️ Tracking

PM-18414

## 📔 Objective

Compiler flags are now set. Test run in a different branch, confirmed by QA: https://github.com/bitwarden/ios/actions/runs/16011074192/job/45168843064

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
