### PR TITLE
updated copy to bitwarden texts

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -129,7 +129,7 @@
 "SyncWithBitwardenApp" = "Sync with Bitwarden app";
 "LocalCodes" = "Local codes";
 "AccountsSyncedFromBitwardenApp" = "Accounts synced from Bitwarden app";
-"CopyToBitwarden" = "Copy to Bitwarden";
+"CopyToBitwardenVault" = "Copy to Bitwarden vault";
 "ScanComplete" = "Scan complete";
 "SaveThisAuthenticatorKeyHereOrAddItToALoginInYourBitwardenApp" = "Save this authenticator key here, or add it to a login in your Bitwarden app.";
 "SaveHere" = "Save here";

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -237,7 +237,7 @@ private struct SearchableItemListView: View { // swiftlint:disable:this type_bod
                         await store.perform(.moveToBitwardenPressed(item))
                     } label: {
                         HStack(spacing: 4) {
-                            Text(Localizations.copyToBitwarden)
+                            Text(Localizations.copyToBitwardenVault)
                             Spacer()
                             Image(decorative: Asset.Images.rightArrow)
                                 .imageStyle(.accessoryIcon(scaleWithFont: true))


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/BWA-167

## 📔 Objective

Updated "Copy to bitwarden" to also include "vault" at the end

## 📸 Screenshots
<img width="314" alt="Authenticator screen displaying the long press options" src="https://github.com/user-attachments/assets/9128638a-68c6-4323-b4fa-57662cfdd220">

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
