### PR TITLE
[PM-23210] Improve CI build time

### DIFF
--- a/.github/workflows/_build-any.yml
+++ b/.github/workflows/_build-any.yml
@@ -235,7 +235,7 @@ jobs:
           EOF
 
       - name: Validate app with App Store Connect
-        if: env._BUILD_MODE == 'Device'
+        if: env._BUILD_MODE == 'Device' && false # Set to true to debug failing submissions
         env:
           _EXPORT_FILEPATH: ${{ steps.get_file_paths.outputs.export_filepath }}
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -156,6 +156,7 @@ platform :ios do |options|
             skip_submission: false,
             changelog: options[:changelog],
             skip_waiting_for_build_processing: true,
+            notify_external_testers: false,
             api_key_path: options[:api_key_path],
             ipa: options[:ipa_path],
             app_identifier: ENV["_BUNDLE_ID"],

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -155,7 +155,7 @@ platform :ios do |options|
         upload_to_testflight(
             skip_submission: false,
             changelog: options[:changelog],
-            skip_waiting_for_build_processing: false,
+            skip_waiting_for_build_processing: true,
             api_key_path: options[:api_key_path],
             ipa: options[:ipa_path],
             app_identifier: ENV["_BUNDLE_ID"],


### PR DESCRIPTION
## 🎟️ Tracking

PM-23210

## 📔 Objective

While troubleshooting #1708 I found the following areas where we could improve our CI build times and reliability, cutting 5-10min of execution time per build:

1. Skip waiting for TestFlight to finish processing a build, saves ~5min in general - Per fastlane [source code](https://github.com/fastlane/fastlane/blob/e5dfe9e69f795f06c1420639faafc13fa4761a09/pilot/lib/pilot/build_manager.rb#L67) builds don't need to be fully processed for changelogs to be set, they just need to be visible and fastlane covers that. If we need to know when a build finishes processing we can look into the new TestFlight / AppStoreConnect Webhooks.
2. Skips AppStoreConnect validation, leaving the step in place for troubleshooting if required - build artifacts are stable at this point and this endpoint can be unreliable, best case this step takes ~50s but I've seen it hang multiple times, example: [hanging for 10mins](https://github.com/bitwarden/ios/actions/runs/16003114816/job/45143017278)
3. While at it, set notifying external testers to false (defaults to true) - we only distribute internally. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
