### PR TITLE
[PM-23304] Fix biometric unlock errors on background launch

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -81,6 +81,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var unlockWithPINResult: Result<Void, Error> = .success(())
 
     var unlockVaultResult: Result<Void, Error> = .success(())
+    var unlockVaultWithBiometricsCalled = false
     var unlockVaultWithBiometricsResult: Result<Void, Error> = .success(())
     var unlockVaultWithAuthVaultKeyCalled = false
     var unlockVaultWithAuthVaultKeyResult: Result<Void, Error> = .success(())
@@ -389,7 +390,8 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     }
 
     func unlockVaultWithBiometrics() async throws {
-        try unlockVaultWithBiometricsResult.get()
+        unlockVaultWithBiometricsCalled = true
+        return try unlockVaultWithBiometricsResult.get()
     }
 
     func unlockVaultWithNeverlockKey() async throws {

--- a/BitwardenShared/Core/Platform/Services/Application.swift
+++ b/BitwardenShared/Core/Platform/Services/Application.swift
@@ -3,6 +3,9 @@ import UIKit
 /// A protocol for the application instance (i.e. `UIApplication`).
 ///
 public protocol Application {
+    /// The app’s current state, or that of its most active scene.
+    @MainActor var applicationState: UIApplication.State { get }
+
     /// Marks the start of a task with a custom name that should continue if the app enters the background.
     /// See note in `UIApplication+Application.swift`
     /// TODO: PM-11189

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockApplication.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockApplication.swift
@@ -3,6 +3,7 @@ import UIKit
 @testable import BitwardenShared
 
 class MockApplication: Application {
+    var applicationState: UIApplication.State = .active
     var beginBackgroundTaskName: String?
     var beginBackgroundTaskHandler: (() -> Void)?
     var beginBackgroundTaskIdentifier: UIBackgroundTaskIdentifier = .invalid

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -44,6 +44,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     typealias Services = HasAccountAPIService
         & HasAppIdService
         & HasAppSettingsStore
+        & HasApplication
         & HasAuthAPIService
         & HasAuthRepository
         & HasAuthService


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23304](https://bitwarden.atlassian.net/browse/PM-23304)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This fixes a non-fatal error that's logged to Crashlytics if biometric unlock is attempted when `VaultUnlockView` is loaded while the app is running in the background. This can occur if the app is launched when a push notification is received. The system will throw a `errSecInteractionNotAllowed` error in this case. Now the app checks if it's running in the backdown and if so doesn't trigger biometric unlock automatically.

> General Error: VaultUnlock: Biometrics Unlock Error Code=4000
> NSUnderlyingError: BitwardenShared.KeychainServiceError.osStatusError(-25308)

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
