### PR TITLE
[PM-22888] Fix StateService no account errors when all users are logged out

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1748,11 +1748,14 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
     }
 
     func isAuthenticated(userId: String?) async throws -> Bool {
-        let userId = try getAccount(userId: userId).profile.userId
-
         do {
+            let userId = try getAccount(userId: userId).profile.userId
             _ = try await keychainRepository.getAccessToken(userId: userId)
             return true
+        } catch StateServiceError.noActiveAccount {
+            return false
+        } catch StateServiceError.noAccounts {
+            return false
         } catch KeychainServiceError.osStatusError(errSecItemNotFound) {
             return false
         }

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -1323,11 +1323,18 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         }
     }
 
-    /// `isAuthenticated()` throws an error if there's no accounts.
-    func test_isAuthenticated_noAccount() async throws {
-        await assertAsyncThrows(error: StateServiceError.noAccounts) {
-            _ = try await subject.isAuthenticated()
-        }
+    /// `isAuthenticated()` returns false if there's no accounts.
+    func test_isAuthenticated_noAccounts() async throws {
+        let isAuthenticated = try await subject.isAuthenticated()
+        XCTAssertFalse(isAuthenticated)
+    }
+
+    /// `isAuthenticated()` returns false if there's no active account.
+    func test_isAuthenticated_noActiveAccount() async throws {
+        appSettingsStore.state = State()
+
+        let isAuthenticated = try await subject.isAuthenticated()
+        XCTAssertFalse(isAuthenticated)
     }
 
     /// `logoutAccount()` clears any account data.

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -451,6 +451,8 @@ extension AppProcessor {
                 else { continue }
                 try await services.stateService.setAccountSetupAutofill(.complete, userId: userId)
             }
+        } catch StateServiceError.noAccounts {
+            // No-op: nothing to do if there's no accounts.
         } catch {
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -1128,6 +1128,18 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(stateService.accountSetupAutofill, ["1": .setUpLater])
     }
 
+    /// `start(navigator:)` doesn't log an error if there's no accounts.
+    @MainActor
+    func test_start_completeAutofillAccountSetupIfEnabled_noAccounts() async throws {
+        autofillCredentialService.isAutofillCredentialsEnabled = true
+
+        let rootNavigator = MockRootNavigator()
+        await subject.start(appContext: .mainApp, navigator: rootNavigator, window: nil)
+
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+        XCTAssertTrue(stateService.accountSetupAutofill.isEmpty)
+    }
+
     /// `start(navigator:)` doesn't update the user's autofill setup progress if they have no
     /// current progress recorded.
     @MainActor


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-22888](https://bitwarden.atlassian.net/browse/PM-22888)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes several `StateService` errors that are logged to Crashlytics if there's no accounts on the device:

- `AppProcessor.completeAutofillAccountSetupIfEnabled()`: this is called when the app is started/foreground to check if the autofill setup has been completed. If autofill is enabled while there's no logged in accounts, we were logging an error, but this can be ignored.
- `AppDelegate.application(_:didReceiveRemoteNotification:)` / `DefaultNotificationService.messageReceived(_:notificationDismissed:notificationTapped:)`: if the app receives a push notification after the user has logged out, we can ignore it.
- `DefaultNotificationService.didRegister(withToken:)`: if register for remote notifications occurs after the user has logged out.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
