### PR TITLE
[PM-18414] Fix CI run failure due to missing workflow_dispatch input

### DIFF
--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -69,7 +69,7 @@ jobs:
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }} #TODO: refactor all inputs to be consistent with - or _
       compiler-flags: ${{ inputs.compiler-flags }}
-      distribute: ${{ inputs.distribute }}
+      distribute: ${{ inputs.distribute || true }} # placeholder default for the analyser failing the workflow run when this job is skipped
     secrets: inherit
 
   build-public:

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -118,7 +118,7 @@ jobs:
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }} #TODO: refactor all inputs to be consistent with - or _
       compiler-flags: ${{ inputs.compiler-flags }}
-      distribute: ${{ inputs.distribute }}
+      distribute: ${{ inputs.distribute || true }} # placeholder default for the analyser failing the workflow run when this job is skipped
     secrets: inherit
 
   build-public:


### PR DESCRIPTION
## 🎟️ Tracking

PM-18414


## 📔 Objective

Fix CI run failure due to empty input in skipped job. :hurtrealbad:  

![image](https://github.com/user-attachments/assets/9770c0f4-186b-4336-84ca-e7d08fdc05f0)

* https://github.com/bitwarden/ios/actions/runs/16155066484
* https://github.com/bitwarden/ios/actions/runs/16155066481

Context for reviewers: Our CI is runs with the `on: push:` trigger, when that happens the `workflow_dispatch` inputs are empty including boolean inputs with defaults set, reason why the error message is `Unexpected value ''`. For reusable workflows like our `build-any.yml` GitHub is validating inputs before the job skip condition. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
