### PR TITLE
[PM-18414] Revert "Transition new build workflow back to shared versioning for QA testing"

### DIFF
--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -49,63 +49,17 @@ on:
 
 permissions:
   contents: read
-  actions: write #required for dispatch-and-download.yml
 
 jobs:
   version:
     name: Calculate Version Name and Number
-    runs-on: ubuntu-22.04
-    outputs:
-      version_name: ${{ steps.version_info.outputs.version_name }}
-      version_number: ${{ steps.version_info.outputs.version_number }}
-    steps:
-      - name: Log inputs to job summary
-        run: |
-          echo "<details><summary>CI-main Workflow Inputs</summary>" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo '```json' >> $GITHUB_STEP_SUMMARY
-          echo '${{ toJson(inputs) }}' >> $GITHUB_STEP_SUMMARY
-          echo '```' >> $GITHUB_STEP_SUMMARY
-          echo "</details>" >> $GITHUB_STEP_SUMMARY
-
-      - name: Calculate version
-        if: ${{ inputs.version-number == '' || inputs.version-name == '' }}
-        uses: bitwarden/ios/.github/actions/dispatch-and-download@main
-        id: dispatch-version
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repo: ios
-          owner: bitwarden
-          workflow: _version.yml
-          workflow_inputs: '{"base_version_number": "1500", "version_name": "${{ inputs.version-name }}", "version_number": "${{ inputs.version-number }}"}'
-
-      - name: Read version info
-        id: version_info
-        run: |
-          # test if dispatch-version was skipped. In that case, creates the same .json file expected by the Upload artifact step
-          if [ ! -f version-info/version_info.json ]; then
-            echo "::warning::version-version.json not found, was the previous step skipped? Creating a new file"
-            json='{
-              "version_number": "${{ inputs.version-number }}",
-              "version_name": "${{ inputs.version-name }}"
-            }'
-
-            # file will be used by the upload step
-            mkdir version-info
-            echo "$json" > version-info/version_info.json
-          else
-              echo "::notice::version-version.json found!"
-          fi
-
-          content=$(cat version-info/version_info.json)
-          echo "version_name=$(echo $content | jq -r .version_name)" >> $GITHUB_OUTPUT
-          echo "version_number=$(echo $content | jq -r .version_number)" >> $GITHUB_OUTPUT
-
-      - name: Upload version info artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: version-info
-          path: version-info/version_info.json
+    uses: bitwarden/ios/.github/workflows/_version.yml@main
+    with:
+      base_version_number: 2100
+      version_name: ${{ inputs.version-name }}
+      version_number: ${{ inputs.version-number }}
+      patch_version: ${{ inputs.patch_version && '999' || '' }}
+    secrets: inherit
 
   build-manual:
     name: Build Manual - ${{ inputs.build-variant }} (${{ inputs.build-mode }})


### PR DESCRIPTION
## 🎟️ Tracking

PM-18414

## 📔 Objective

Now that we've deprecated the old build workflows we can revert the versioning job to the new (faster) approach https://github.com/bitwarden/ios/pull/1713

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
