### PR TITLE
[PM-18414] Distribute CI device builds

### DIFF
--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -82,11 +82,14 @@ jobs:
         include:
           - bw-env: bwa_prod
             build-mode: Device
+            distribute: true
           - bw-env: bwa_prod
             build-mode: Simulator
+            distribute: false
     with:
       bw-env: ${{ matrix.bw-env }}
       build-mode: ${{ matrix.build-mode }}
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }}
+      distribute: ${{ matrix.distribute }}
     secrets: inherit

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -85,15 +85,19 @@ jobs:
         include:
           - bw-env: bwpm_prod
             build-mode: Device
+            distribute: true
           - bw-env: bwpm_prod
             build-mode: Simulator
+            distribute: false
           - bw-env: bwpm_beta
             build-mode: Device
             compiler-flags: DEBUG_MENU
+            distribute: true
     with:
       bw-env: ${{ matrix.bw-env }}
       build-mode: ${{ matrix.build-mode }}
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }}
       compiler-flags: ${{ matrix.compiler-flags }}
+      distribute: ${{ matrix.distribute }}
     secrets: inherit


### PR DESCRIPTION
## 🎟️ Tracking

PM-18414

## 📔 Objective

Set the distribute input for CI builds. This was previously missed from https://github.com/bitwarden/ios/pull/1727 :hurtrealbad:

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
