### PR TITLE
[PM-18414] Increase build timeout

### DIFF
--- a/.github/workflows/_build-any.yml
+++ b/.github/workflows/_build-any.yml
@@ -39,7 +39,7 @@ jobs:
   build:
     name: Build ${{ inputs.bw-env }}
     runs-on: macos-15
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
     env:


### PR DESCRIPTION
## 🎟️ Tracking

PM-18414

## 📔 Objective

https://github.com/bitwarden/ios/actions/runs/16171916231/job/45647414163

Simulator build took longer than usual and hit the 30min limit, runner may have been exhausted :finnadie:. Increasing the timeout for the _time_ being while we monitor future runs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
