### PR TITLE
[PM-23682] Remove app intents flag

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -8,9 +8,6 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// A feature flag to enable/disable the ability to add a custom domain for anonAddy users.
     static let anonAddySelfHostAlias = FeatureFlag(rawValue: "anon-addy-self-host-alias")
 
-    /// A feature flag to enable/disable `AppIntent` execution.
-    static let appIntents = FeatureFlag(rawValue: "app-intents")
-
     /// Flag to enable/disable Credential Exchange export flow.
     static let cxpExportMobile = FeatureFlag(rawValue: "cxp-export-mobile")
 
@@ -69,7 +66,6 @@ extension FeatureFlag: @retroactive CaseIterable {
     public static var allCases: [FeatureFlag] {
         [
             .anonAddySelfHostAlias,
-            .appIntents,
             .cxpExportMobile,
             .cxpImportMobile,
             .cipherKeyEncryption,

--- a/BitwardenShared/UI/Platform/Application/AppIntentMediator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppIntentMediator.swift
@@ -56,10 +56,6 @@ struct DefaultAppIntentMediator: AppIntentMediator {
 
     @available(iOSApplicationExtension 16, *)
     func canRunAppIntents() async throws -> Bool {
-        guard await configService.getFeatureFlag(.appIntents) else {
-            return false
-        }
-
         do {
             return try await stateService.getSiriAndShortcutsAccess()
         } catch StateServiceError.noAccounts, StateServiceError.noActiveAccount {

--- a/BitwardenShared/UI/Platform/Application/AppIntentMediatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppIntentMediatorTests.swift
@@ -53,25 +53,15 @@ class AppIntentMediatorTests: BitwardenTestCase {
     /// `canRunAppIntents()` returns `true` when it can run app intents.
     @MainActor
     func test_canRunAppIntents_true() async throws {
-        configService.featureFlagsBool[.appIntents] = true
         stateService.activeAccount = .fixture()
         stateService.siriAndShortcutsAccess["1"] = true
         let canRunAppIntents = try await subject.canRunAppIntents()
         XCTAssertTrue(canRunAppIntents)
     }
 
-    /// `canRunAppIntents()` returns `false` when it can't run app intents when the flag is not enabled.
-    @MainActor
-    func test_canRunAppIntents_falseBecauseOfFeatureFlag() async throws {
-        configService.featureFlagsBool[.appIntents] = false
-        let canRunAppIntents = try await subject.canRunAppIntents()
-        XCTAssertFalse(canRunAppIntents)
-    }
-
     /// `canRunAppIntents()` returns `false` when it can't run app intents when the setting is not enabled.
     @MainActor
     func test_canRunAppIntents_falseBecauseOfSiriAndShortcutsSettingDisabled() async throws {
-        configService.featureFlagsBool[.appIntents] = true
         stateService.activeAccount = .fixture()
         stateService.siriAndShortcutsAccess["1"] = false
         let canRunAppIntents = try await subject.canRunAppIntents()
@@ -82,14 +72,13 @@ class AppIntentMediatorTests: BitwardenTestCase {
     @available(iOS 16, *)
     @MainActor
     func test_canRunAppIntents_throwsBecauseGettingSiriAndShortcutsSettingThrows() async throws {
-        configService.featureFlagsBool[.appIntents] = true
         stateService.activeAccount = nil
         await assertAsyncThrows(error: BitwardenShared.AppIntentError.noActiveAccount) {
             _ = try await subject.canRunAppIntents()
         }
     }
 
-    /// `generatePassphrase(settings:)` calls the repository to generate a passhprase with the request.
+    /// `generatePassphrase(settings:)` calls the repository to generate a passphrase with the request.
     func test_generatePassphrase() async throws {
         let request = PassphraseGeneratorRequest(
             numWords: 6,

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessor.swift
@@ -84,7 +84,6 @@ final class OtherSettingsProcessor: StateProcessor<OtherSettingsState, OtherSett
             state.isConnectToWatchToggleOn = try await services.settingsRepository.getConnectToWatch()
             state.isSiriAndShortcutsAccessToggleOn = try await services.settingsRepository.getSiriAndShortcutsAccess()
             state.shouldShowConnectToWatchToggle = services.watchService.isSupported()
-            state.shouldShowSiriAndShortcutsAccess = await services.configService.getFeatureFlag(.appIntents)
         } catch {
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsProcessorTests.swift
@@ -62,7 +62,6 @@ class OtherSettingsProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.loadInitialValues` fetches the allow sync on refresh value.
     @MainActor
     func test_perform_loadInitialValues_success() async {
-        configService.featureFlagsBool[.appIntents] = true
         settingsRepository.allowSyncOnRefresh = true
         settingsRepository.clearClipboardValue = .thirtySeconds
         settingsRepository.connectToWatch = true
@@ -76,7 +75,6 @@ class OtherSettingsProcessorTests: BitwardenTestCase {
         XCTAssertTrue(subject.state.isConnectToWatchToggleOn)
         XCTAssertTrue(subject.state.isSiriAndShortcutsAccessToggleOn)
         XCTAssertTrue(subject.state.shouldShowConnectToWatchToggle)
-        XCTAssertTrue(subject.state.shouldShowSiriAndShortcutsAccess)
     }
 
     /// `perform(_:)` with `.streamLastSyncTime` updates the state's last sync time whenever it changes.

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsState.swift
@@ -30,7 +30,4 @@ struct OtherSettingsState {
 
     /// Whether the connect to watch toggle should be shown.
     var shouldShowConnectToWatchToggle: Bool = false
-
-    /// Whether the Siri & Shortcuts access toggle should be shown.
-    var shouldShowSiriAndShortcutsAccess: Bool = false
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsView.swift
@@ -30,9 +30,7 @@ struct OtherSettingsView: View {
                     connectToWatch
                 }
 
-                if store.state.shouldShowSiriAndShortcutsAccess {
-                    siriAndShortcutsAccess
-                }
+                siriAndShortcutsAccess
             }
         }
         .scrollView()

--- a/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Other/OtherSettingsViewTests.swift
@@ -48,34 +48,11 @@ class OtherSettingsViewTests: BitwardenTestCase {
         XCTAssertNoThrow(try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.connectToWatch))
     }
 
-    /// The Siri & Shortcuts access toggle is hidden if the feature is not enabled.
-    @MainActor
-    func test_siriAndShortcutsAccess_hidden() async throws {
-        processor.state.shouldShowSiriAndShortcutsAccess = false
-        XCTAssertThrowsError(
-            try subject.inspect().find(
-                toggleWithAccessibilityLabel: Localizations.siriAndShortcutsAccess
-            )
-        )
-    }
-
-    /// The Siri & Shortcuts access toggle is visible if the feature is enabled.
-    @MainActor
-    func test_siriAndShortcutsAccess_visible() async throws {
-        processor.state.shouldShowSiriAndShortcutsAccess = true
-        XCTAssertNoThrow(
-            try subject.inspect().find(
-                toggleWithAccessibilityLabel: Localizations.siriAndShortcutsAccess
-            )
-        )
-    }
-
     /// The view renders correctly.
     @MainActor
     func test_view_render() {
         processor.state.lastSyncDate = Date(year: 2023, month: 5, day: 14, hour: 16, minute: 52)
         processor.state.shouldShowConnectToWatchToggle = true
-        processor.state.shouldShowSiriAndShortcutsAccess = true
         assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23682

## 📔 Objective

This removes the `app-intents` flag now that 2025.06.0 has been released. This also removes some second-order code that assumed the feature could be turned off.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
