### PR TITLE
[PM-23682] Remove flight recorder flag

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -33,9 +33,6 @@ extension FeatureFlag: @retroactive CaseIterable {
         isRemotelyConfigured: false
     )
 
-    /// A feature flag for the flight recorder, which can be enabled to collect app logs.
-    static let flightRecorder = FeatureFlag(rawValue: "enable-pm-flight-recorder")
-
     /// A flag to ignore the environment check for the two-factor authentication
     /// notice. If this is on, then it will display even on self-hosted servers,
     /// which means it's easier to dev/QA the feature.
@@ -76,7 +73,6 @@ extension FeatureFlag: @retroactive CaseIterable {
             .emailVerification,
             .enableAuthenticatorSync,
             .enableCipherKeyEncryption,
-            .flightRecorder,
             .ignore2FANoticeEnvironmentCheck,
             .importLoginsFlow,
             .mobileErrorReporting,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -19,7 +19,6 @@ final class FeatureFlagTests: BitwardenTestCase {
         XCTAssertTrue(FeatureFlag.cxpImportMobile.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.emailVerification.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.enableAuthenticatorSync.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.flightRecorder.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.importLoginsFlow.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.preLoginSettings.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.restrictCipherItemDeletion.isRemotelyConfigured)

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutEffect.swift
@@ -3,9 +3,6 @@
 /// Effects that can be processed by the `AboutProcessor`.
 ///
 enum AboutEffect: Equatable {
-    /// The view appeared so the initial data should be loaded.
-    case loadData
-
     /// Stream the active flight recorder log.
     case streamFlightRecorderLog
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
@@ -51,8 +51,6 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
 
     override func perform(_ effect: AboutEffect) async {
         switch effect {
-        case .loadData:
-            await loadData()
         case .streamFlightRecorderLog:
             await streamFlightRecorderLog()
         case let .toggleFlightRecorder(isOn):
@@ -106,11 +104,6 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
     private func handleVersionTapped() {
         services.pasteboardService.copy(services.appInfoService.appInfoString)
         state.toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo))
-    }
-
-    /// Load any initial data for the view.
-    private func loadData() async {
-        state.isFlightRecorderFeatureFlagEnabled = await services.configService.getFeatureFlag(.flightRecorder)
     }
 
     /// Streams the flight recorder's active log metadata.

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
@@ -79,18 +79,6 @@ class AboutProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.version, "1.0 (1)")
     }
 
-    /// `perform(_:)` with `.loadData` loads the flight recorder feature flag.
-    @MainActor
-    func test_perform_loadData_flightRecorderFeatureFlag() async {
-        configService.featureFlagsBool[.flightRecorder] = true
-        await subject.perform(.loadData)
-        XCTAssertTrue(subject.state.isFlightRecorderFeatureFlagEnabled)
-
-        configService.featureFlagsBool[.flightRecorder] = false
-        await subject.perform(.loadData)
-        XCTAssertFalse(subject.state.isFlightRecorderFeatureFlagEnabled)
-    }
-
     /// `perform(_:)` with `.streamFlightRecorderLog` subscribes to the active flight recorder log.
     @MainActor
     func test_perform_streamFlightRecorderLog() async throws {

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutState.swift
@@ -16,9 +16,6 @@ struct AboutState {
     /// The flight recorder's active log metadata, if logging is enabled.
     var flightRecorderActiveLog: FlightRecorderData.LogMetadata?
 
-    /// Whether the flight recorder feature is enabled.
-    var isFlightRecorderFeatureFlagEnabled = false
-
     /// Whether the submit crash logs toggle is on.
     var isSubmitCrashLogsToggleOn: Bool = false
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutView.swift
@@ -29,9 +29,6 @@ struct AboutView: View {
         .scrollView()
         .navigationBar(title: Localizations.about, titleDisplayMode: .inline)
         .task {
-            await store.perform(.loadData)
-        }
-        .task {
             await store.perform(.streamFlightRecorderLog)
         }
         .toast(store.binding(
@@ -63,41 +60,39 @@ struct AboutView: View {
 
     /// The section for the flight recorder.
     @ViewBuilder private var flightRecorderSection: some View {
-        if store.state.isFlightRecorderFeatureFlagEnabled {
-            ContentBlock(dividerLeadingPadding: 16) {
-                BitwardenToggle(
-                    isOn: store.bindingAsync(
-                        get: { $0.flightRecorderActiveLog != nil },
-                        perform: AboutEffect.toggleFlightRecorder
-                    ),
-                    accessibilityIdentifier: "FlightRecorderSwitch",
-                    accessibilityLabel: store.state.flightRecorderToggleAccessibilityLabel
-                ) {
-                    VStack(alignment: .leading, spacing: 2) {
-                        HStack(spacing: 8) {
-                            Text(Localizations.flightRecorder)
+        ContentBlock(dividerLeadingPadding: 16) {
+            BitwardenToggle(
+                isOn: store.bindingAsync(
+                    get: { $0.flightRecorderActiveLog != nil },
+                    perform: AboutEffect.toggleFlightRecorder
+                ),
+                accessibilityIdentifier: "FlightRecorderSwitch",
+                accessibilityLabel: store.state.flightRecorderToggleAccessibilityLabel
+            ) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 8) {
+                        Text(Localizations.flightRecorder)
 
-                            Button {
-                                openURL(ExternalLinksConstants.flightRecorderHelp)
-                            } label: {
-                                Asset.Images.questionCircle16.swiftUIImage
-                                    .scaledFrame(width: 16, height: 16)
-                                    .accessibilityLabel(Localizations.learnMore)
-                            }
-                            .buttonStyle(.fieldLabelIcon)
+                        Button {
+                            openURL(ExternalLinksConstants.flightRecorderHelp)
+                        } label: {
+                            Asset.Images.questionCircle16.swiftUIImage
+                                .scaledFrame(width: 16, height: 16)
+                                .accessibilityLabel(Localizations.learnMore)
                         }
+                        .buttonStyle(.fieldLabelIcon)
+                    }
 
-                        if let log = store.state.flightRecorderActiveLog {
-                            Text(Localizations.loggingEndsOnDateAtTime(log.formattedEndDate, log.formattedEndTime))
-                                .foregroundStyle(Asset.Colors.textSecondary.swiftUIColor)
-                                .styleGuide(.subheadline)
-                        }
+                    if let log = store.state.flightRecorderActiveLog {
+                        Text(Localizations.loggingEndsOnDateAtTime(log.formattedEndDate, log.formattedEndTime))
+                            .foregroundStyle(Asset.Colors.textSecondary.swiftUIColor)
+                            .styleGuide(.subheadline)
                     }
                 }
+            }
 
-                SettingsListItem(Localizations.viewRecordedLogs) {
-                    store.send(.viewFlightRecorderLogsTapped)
-                }
+            SettingsListItem(Localizations.viewRecordedLogs) {
+                store.send(.viewFlightRecorderLogsTapped)
             }
         }
     }
@@ -160,7 +155,6 @@ struct AboutView: View {
         flightRecorderActiveLog: FlightRecorderData.LogMetadata(
             duration: .eightHours,
             startDate: Date(timeIntervalSinceNow: 60 * 60 * -4)
-        ),
-        isFlightRecorderFeatureFlagEnabled: true
+        )
     ))))
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutViewTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutViewTests.swift
@@ -40,19 +40,9 @@ class AboutViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .helpCenterTapped)
     }
 
-    /// The flight recorder toggle doesn't exist in the view when the feature flag is disabled.
+    /// The flight recorder toggle turns logging on and off.
     @MainActor
-    func test_flightRecorderToggle_hiddenWithFeatureFlagDisabled() {
-        processor.state.isFlightRecorderFeatureFlagEnabled = false
-        XCTAssertThrowsError(
-            try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.flightRecorder)
-        )
-    }
-
-    /// The flight recorder toggle exists in the view when the feature flag is enabled.
-    @MainActor
-    func test_flightRecorderToggle_visibleWithFeatureFlagEnabled() async throws {
-        processor.state.isFlightRecorderFeatureFlagEnabled = true
+    func test_flightRecorderToggle_tap() async throws {
         let toggle = try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.flightRecorder)
 
         try toggle.tap()
@@ -93,8 +83,6 @@ class AboutViewTests: BitwardenTestCase {
     /// Tapping the view recorded logs button dispatches the `.viewFlightRecorderLogsTapped` action.
     @MainActor
     func test_viewRecordedLogsButton_tap() throws {
-        processor.state.isFlightRecorderFeatureFlagEnabled = true
-
         let button = try subject.inspect().find(button: Localizations.viewRecordedLogs)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .viewFlightRecorderLogsTapped)
@@ -113,7 +101,6 @@ class AboutViewTests: BitwardenTestCase {
     /// The default view renders correctly.
     @MainActor
     func test_snapshot_default() {
-        processor.state.isFlightRecorderFeatureFlagEnabled = true
         assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23682

## 📔 Objective

This removes the `enable-pm-flight-recorder` flag now that 2025.6.0 has been released. This also removes some second-order code that assumed the feature could be turned off.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
