### PR TITLE
[PM-18414] Workflow inputs redux

### DIFF
--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -62,7 +62,7 @@ jobs:
   build-manual:
     name: Build Manual - ${{ inputs.build-mode }}
     needs: version
-    if: ${{ github.event_name == 'workflow_dispatch' || inputs.build-mode != 'CI' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.build-mode != 'CI' }}
     uses: bitwarden/ios/.github/workflows/_build-any.yml@main
     with:
       bw-env: bwa_prod

--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -1,5 +1,5 @@
 name: CI / Authenticator
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Manual - Authenticator ({0})', inputs.build-mode) || 'CI - Authenticator' }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && inputs.build-mode != 'CI' && format('Manual - Authenticator ({0})', inputs.build-mode) || 'CI - Authenticator' }}
 
 on:
   push:

--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -24,6 +24,7 @@ on:
         options:
           - Device
           - Simulator
+          - CI
       version-name:
         description: "Version Name Override - e.g. '2024.8.1'"
         type: string
@@ -61,7 +62,7 @@ jobs:
   build-manual:
     name: Build Manual - ${{ inputs.build-mode }}
     needs: version
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || inputs.build-mode != 'CI' }}
     uses: bitwarden/ios/.github/workflows/_build-any.yml@main
     with:
       bw-env: bwa_prod
@@ -75,7 +76,7 @@ jobs:
   build-public:
     name: Build CI
     needs: version
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || inputs.build-mode == 'CI' }}
     uses: bitwarden/ios/.github/workflows/_build-any.yml@main
     strategy:
       matrix:

--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -70,7 +70,7 @@ jobs:
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }} #TODO: refactor all inputs to be consistent with - or _
       compiler-flags: ${{ inputs.compiler-flags }}
-      distribute: ${{ inputs.distribute || true }} # placeholder default for the analyser failing the workflow run when this job is skipped
+      distribute: ${{ github.event_name == 'workflow_dispatch' && inputs.distribute }} # event_name check is a workaround for github failing the workflow run when triggered by push
     secrets: inherit
 
   build-public:

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -11,14 +11,6 @@ on:
       - AuthenticatorShared/**
   workflow_dispatch:
     inputs:
-      build-variant:
-        description: "Build Variant"
-        required: true
-        default: "Beta"
-        type: choice
-        options:
-          - Beta
-          - Production
       build-mode:
         description: "Build Mode"
         required: true
@@ -28,6 +20,14 @@ on:
           - Device
           - Simulator
           - CI
+      build-variant:
+        description: "Build Variant"
+        required: true
+        default: "Beta"
+        type: choice
+        options:
+          - Beta
+          - Production
       version-name:
         description: "Version Name Override - e.g. '2024.8.1'"
         type: string

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -27,6 +27,7 @@ on:
         options:
           - Device
           - Simulator
+          - CI
       version-name:
         description: "Version Name Override - e.g. '2024.8.1'"
         type: string
@@ -64,7 +65,7 @@ jobs:
   build-manual:
     name: Build Manual - ${{ inputs.build-variant }} (${{ inputs.build-mode }})
     needs: version
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || inputs.build-mode != 'CI' }}
     uses: bitwarden/ios/.github/workflows/_build-any.yml@main
     with:
       bw-env: ${{ (inputs.build-variant == 'Production') && 'bwpm_prod' || 'bwpm_beta' }}
@@ -78,7 +79,7 @@ jobs:
   build-public:
     name: Build CI
     needs: version
-    if: ${{ github.event_name == 'push' }}
+    if: ${{ github.event_name == 'push' || inputs.build-mode == 'CI' }}
     uses: bitwarden/ios/.github/workflows/_build-any.yml@main
     strategy:
       matrix:

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -1,5 +1,5 @@
 name: CI / Password Manager
-run-name: ${{ github.event_name == 'workflow_dispatch' && format('Manual - Password Manager {0} ({1})', inputs.build-variant, inputs.build-mode) || 'CI - Password Manager' }}
+run-name: ${{ github.event_name == 'workflow_dispatch' && inputs.build-mode != 'CI' && format('Manual - Password Manager {0} ({1})', inputs.build-variant, inputs.build-mode) || 'CI - Password Manager' }}
 
 on:
   push:

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -65,7 +65,7 @@ jobs:
   build-manual:
     name: Build Manual - ${{ inputs.build-variant }} (${{ inputs.build-mode }})
     needs: version
-    if: ${{ github.event_name == 'workflow_dispatch' || inputs.build-mode != 'CI' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.build-mode != 'CI' }}
     uses: bitwarden/ios/.github/workflows/_build-any.yml@main
     with:
       bw-env: ${{ (inputs.build-variant == 'Production') && 'bwpm_prod' || 'bwpm_beta' }}

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -73,7 +73,7 @@ jobs:
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }} #TODO: refactor all inputs to be consistent with - or _
       compiler-flags: ${{ inputs.compiler-flags }}
-      distribute: ${{ inputs.distribute || true }} # placeholder default for the analyser failing the workflow run when this job is skipped
+      distribute: ${{ github.event_name == 'workflow_dispatch' && inputs.distribute }} # event_name check is a workaround for github failing the workflow run when triggered by push
     secrets: inherit
 
   build-public:


### PR DESCRIPTION
## 🎟️ Tracking

[PM-18414](https://bitwarden.atlassian.net/browse/PM-18414)

## 📔 Objective

1. `distribute` input should now work correctly for single builds we don't want to distribute, the workaround added in https://github.com/bitwarden/ios/pull/1729 didn't cover this case
2. Add input to force running the CI job. This will be used in a future PR to automate triggering release builds when release branches are created.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
