### PR TITLE
[PM-24003] Fix sync to only have the 30min interval check on app opened/resumed

### DIFF
--- a/BitwardenShared/Core/Platform/Services/KeyConnectorService.swift
+++ b/BitwardenShared/Core/Platform/Services/KeyConnectorService.swift
@@ -177,9 +177,12 @@ extension DefaultKeyConnectorService: KeyConnectorService {
     }
 
     func userNeedsMigration() async throws -> Bool {
-        let isExternal = try await tokenService.getIsExternal()
-        let usesKeyConnector = try await stateService.getUsesKeyConnector()
-        let organization = try await getManagingOrganization()
-        return isExternal && !usesKeyConnector && organization != nil
+        guard try await tokenService.getIsExternal() else {
+            return false
+        }
+        guard try await stateService.getUsesKeyConnector() == false else {
+            return false
+        }
+        return try await getManagingOrganization() != nil
     }
 }

--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -45,9 +45,10 @@ public protocol SendRepository: AnyObject {
     /// Performs an API request to sync the user's send data. The publishers in the repository can
     /// be used to subscribe to the send data, which are updated as a result of the request.
     ///
-    /// - Parameter forceSync: Whether the sync should be forced.
-    ///
-    func fetchSync(forceSync: Bool) async throws
+    /// - Parameters:
+    ///   - forceSync: Whether the sync should be forced.
+    ///   - isPeriodic: Whether the sync is periodic to take into account the minimum interval.
+    func fetchSync(forceSync: Bool, isPeriodic: Bool) async throws
 
     /// Performs an API request to remove the password on the provided send.
     ///
@@ -224,10 +225,10 @@ class DefaultSendRepository: SendRepository {
 
     // MARK: API Methods
 
-    func fetchSync(forceSync: Bool) async throws {
+    func fetchSync(forceSync: Bool, isPeriodic: Bool) async throws {
         let allowSyncOnRefresh = try await stateService.getAllowSyncOnRefresh()
         if !forceSync || allowSyncOnRefresh {
-            try await syncService.fetchSync(forceSync: forceSync)
+            try await syncService.fetchSync(forceSync: forceSync, isPeriodic: isPeriodic)
         }
     }
 

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -15,6 +15,7 @@ class MockSendRepository: SendRepository {
 
     var fetchSyncCalled = false
     var fetchSyncForceSync: Bool?
+    var fetchSyncIsPeriodic: Bool?
     var fetchSyncHandler: (() -> Void)?
     var fetchSyncResult: Result<Void, Error> = .success(())
 
@@ -84,9 +85,10 @@ class MockSendRepository: SendRepository {
         try doesActiveAccountHaveVerifiedEmailResult.get()
     }
 
-    func fetchSync(forceSync: Bool) async throws {
+    func fetchSync(forceSync: Bool, isPeriodic: Bool) async throws {
         fetchSyncCalled = true
         fetchSyncForceSync = forceSync
+        fetchSyncIsPeriodic = isPeriodic
         fetchSyncHandler?()
         try fetchSyncResult.get()
     }

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -58,6 +58,7 @@ class MockVaultRepository: VaultRepository {
 
     var fetchSyncCalled = false
     var fetchSyncForceSync: Bool?
+    var fetchSyncIsPeriodic: Bool?
     var fetchSyncResult: Result<Void, Error> = .success(())
 
     var getActiveAccountIdResult: Result<String, StateServiceError> = .failure(.noActiveAccount)
@@ -215,10 +216,12 @@ class MockVaultRepository: VaultRepository {
 
     func fetchSync(
         forceSync: Bool,
-        filter _: VaultFilterType
+        filter _: VaultFilterType,
+        isPeriodic: Bool
     ) async throws {
         fetchSyncCalled = true
         fetchSyncForceSync = forceSync
+        fetchSyncIsPeriodic = isPeriodic
         try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -13,10 +13,11 @@ public protocol VaultRepository: AnyObject {
     /// be used to subscribe to the vault data, which are updated as a result of the request.
     ///
     /// - Parameters:
-    ///   - isRefresh: Whether the sync is being performed as a manual refresh.
+    ///   - forceSync: Whether the sync is forced.
     ///   - filter: The filter to apply to the vault.
+    ///   - isPeriodic: Whether the sync is periodic to take into account the minimum interval.
     ///
-    func fetchSync(forceSync: Bool, filter: VaultFilterType) async throws
+    func fetchSync(forceSync: Bool, filter: VaultFilterType, isPeriodic: Bool) async throws
 
     // MARK: Data Methods
 
@@ -992,10 +993,10 @@ class DefaultVaultRepository { // swiftlint:disable:this type_body_length
 extension DefaultVaultRepository: VaultRepository {
     // MARK: API Methods
 
-    func fetchSync(forceSync: Bool, filter: VaultFilterType) async throws {
+    func fetchSync(forceSync: Bool, filter: VaultFilterType, isPeriodic: Bool) async throws {
         let allowSyncOnRefresh = try await stateService.getAllowSyncOnRefresh()
         guard !forceSync || allowSyncOnRefresh else { return }
-        try await syncService.fetchSync(forceSync: forceSync)
+        try await syncService.fetchSync(forceSync: forceSync, isPeriodic: isPeriodic)
     }
 
     // MARK: Data Methods

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -15,12 +15,6 @@ protocol SyncService: AnyObject {
 
     // MARK: Methods
 
-    /// Performs an API request to sync the user's vault data.
-    ///
-    /// - Parameter forceSync: Whether syncing should be forced, bypassing the account revision and
-    ///     minimum sync interval checks.
-    func fetchSync(forceSync: Bool) async throws
-
     /// Deletes the cipher specified in the notification data in local storage.
     ///
     /// - Parameter data: The notification data for the cipher delete action.
@@ -38,6 +32,14 @@ protocol SyncService: AnyObject {
     /// - Parameter data: The notification data for the send delete action.
     ///
     func deleteSend(data: SyncSendNotification) async throws
+
+    /// Performs an API request to sync the user's vault data.
+    ///
+    /// - Parameters:
+    ///   - forceSync: Whether syncing should be forced, bypassing the account revision and
+    ///     minimum sync interval checks.
+    ///   - isPeriodic: Whether this is a periodic sync to take into consideration the minimum sync interval.
+    func fetchSync(forceSync: Bool, isPeriodic: Bool) async throws
 
     /// Synchronizes the cipher specified in the notification data with the server.
     ///
@@ -65,6 +67,17 @@ protocol SyncService: AnyObject {
     ///
     /// - Returns: A bool indicating if the user needs a sync or not.
     func needsSync(for userId: String, onlyCheckLocalData: Bool) async throws -> Bool
+}
+
+extension SyncService {
+    /// Performs an API request to sync the user's vault data.
+    ///
+    /// - Parameters:
+    ///   - forceSync: Whether syncing should be forced, bypassing the account revision and
+    ///     minimum sync interval checks.
+    func fetchSync(forceSync: Bool) async throws {
+        try await fetchSync(forceSync: forceSync, isPeriodic: false)
+    }
 }
 
 // MARK: - SyncServiceDelegate
@@ -207,7 +220,12 @@ class DefaultSyncService: SyncService {
     }
 
     func needsSync(for userId: String, onlyCheckLocalData: Bool) async throws -> Bool {
-        try await needsSync(forceSync: false, onlyCheckLocalData: onlyCheckLocalData, userId: userId)
+        try await needsSync(
+            forceSync: false,
+            isPeriodic: onlyCheckLocalData,
+            onlyCheckLocalData: onlyCheckLocalData,
+            userId: userId
+        )
     }
 
     // MARK: Private
@@ -219,10 +237,16 @@ class DefaultSyncService: SyncService {
     ///     sync interval checks.
     ///   - onlyCheckLocalData: If `true` it will only check local data to establish whether sync is needed.
     ///     Otherwise, it can also perform requests to server to have additional data to check.
+    ///   - isPeriodic: If `true`then needs to check if the minimum sync interval has been reached to trigger a sync.
     ///   - userId: The user ID of the account to sync.
     /// - Returns: Whether a sync should be performed.
     ///
-    private func needsSync(forceSync: Bool, onlyCheckLocalData: Bool = false, userId: String) async throws -> Bool {
+    private func needsSync(
+        forceSync: Bool,
+        isPeriodic: Bool = false,
+        onlyCheckLocalData: Bool = false,
+        userId: String
+    ) async throws -> Bool {
         guard !forceSync, let lastSyncTime = try await stateService.getLastSyncTime(userId: userId) else {
             return true
         }
@@ -231,9 +255,10 @@ class DefaultSyncService: SyncService {
             return true
         }
 
-        guard lastSyncTime.addingTimeInterval(Constants.minimumSyncInterval) < timeProvider.presentTime else {
+        if isPeriodic && lastSyncTime.addingTimeInterval(Constants.minimumSyncInterval) >= timeProvider.presentTime {
             return false
         }
+
         guard !onlyCheckLocalData else {
             return true
         }
@@ -260,11 +285,13 @@ class DefaultSyncService: SyncService {
 }
 
 extension DefaultSyncService {
-    func fetchSync(forceSync: Bool) async throws {
+    func fetchSync(forceSync: Bool, isPeriodic: Bool) async throws {
         let account = try await stateService.getActiveAccount()
         let userId = account.profile.userId
 
-        guard try await needsSync(forceSync: forceSync, userId: userId) else { return }
+        guard try await needsSync(forceSync: forceSync, isPeriodic: isPeriodic, userId: userId) else {
+            return
+        }
 
         let response = try await syncAPIService.getSync()
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
@@ -6,6 +6,7 @@ class MockSyncService: SyncService {
     weak var delegate: SyncServiceDelegate?
     var didFetchSync = false
     var fetchSyncForceSync: Bool?
+    var fetchSyncIsPeriodic: Bool?
     var fetchSyncResult: Result<Void, Error> = .success(())
 
     var deleteCipherData: SyncCipherNotification?
@@ -29,9 +30,10 @@ class MockSyncService: SyncService {
     var needsSyncResult: Result<Bool, Error> = .success(false)
     var needsSyncOnlyCheckLocalData: Bool = false
 
-    func fetchSync(forceSync: Bool) async throws {
+    func fetchSync(forceSync: Bool, isPeriodic: Bool) async throws {
         didFetchSync = true
         fetchSyncForceSync = forceSync
+        fetchSyncIsPeriodic = isPeriodic
         try fetchSyncResult.get()
     }
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -139,7 +139,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     ///
     private func refresh() async {
         do {
-            try await services.sendRepository.fetchSync(forceSync: false)
+            try await services.sendRepository.fetchSync(forceSync: false, isPeriodic: false)
         } catch {
             await coordinator.showErrorAlert(error: error) {
                 await self.refresh()
@@ -215,7 +215,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
                         // If a sync is needed and there are no sends in the user's vault, it could
                         // mean the initial sync hasn't completed so sync first.
                         do {
-                            try await services.sendRepository.fetchSync(forceSync: false)
+                            try await services.sendRepository.fetchSync(forceSync: false, isPeriodic: true)
                             state.loadingState = .data(sections)
                         } catch {
                             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -105,6 +105,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await subject.perform(.refresh)
 
         XCTAssertTrue(sendRepository.fetchSyncCalled)
+        XCTAssertFalse(try XCTUnwrap(sendRepository.fetchSyncIsPeriodic))
         XCTAssertEqual(sendRepository.fetchSyncForceSync, false)
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -233,7 +233,11 @@ final class VaultGroupProcessor: StateProcessor<
     ///
     private func refreshVaultGroup() async {
         do {
-            try await services.vaultRepository.fetchSync(forceSync: true, filter: state.vaultFilterType)
+            try await services.vaultRepository.fetchSync(
+                forceSync: true,
+                filter: state.vaultFilterType,
+                isPeriodic: false
+            )
         } catch {
             await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -231,6 +231,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_perform_refreshed() async {
         await subject.perform(.refresh)
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
+        XCTAssertFalse(try XCTUnwrap(vaultRepository.fetchSyncIsPeriodic))
     }
 
     /// `perform(_:)` with `.refreshed` records an error if applicable.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -187,11 +187,13 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     }
 
     /// `perform(_:)` with `.appeared` starts listening for updates with the vault repository.
+    /// In this case sync is flagged as periodic.
     @MainActor
     func test_perform_appeared() async {
         await subject.perform(.appeared)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
+        XCTAssertTrue(try XCTUnwrap(vaultRepository.fetchSyncIsPeriodic))
     }
 
     /// `perform(_:)` with `.appeared` doesn't show an alert or log an error if the request was cancelled.
@@ -498,11 +500,12 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
+        XCTAssertFalse(try XCTUnwrap(vaultRepository.fetchSyncIsPeriodic))
         XCTAssertEqual(vaultRepository.fetchSyncForceSync, false)
     }
 
     /// `perform(_:)` with `.refreshVault` requests a vault sync and sets the loading state if the
-    /// vault is empty.
+    /// vault is empty; in this case sync is not flagged as periodic.
     @MainActor
     func test_perform_refreshVault_emptyVault() async {
         vaultRepository.isVaultEmptyResult = .success(true)
@@ -510,6 +513,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         await subject.perform(.refreshVault)
 
         XCTAssertTrue(vaultRepository.fetchSyncCalled)
+        XCTAssertFalse(try XCTUnwrap(vaultRepository.fetchSyncIsPeriodic))
         XCTAssertEqual(vaultRepository.fetchSyncForceSync, false)
         XCTAssertEqual(subject.state.loadingState, .data([]))
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24003](https://bitwarden.atlassian.net/browse/PM-24003)

## 📔 Objective

Fixes a bug where the sync was checking that at least 30min has passed on all non-forced syncs.
This has been changed to only do the periodic interval check when app is opened/resumed (vault/send tab appears).

Additionally, improved `KeyConnectorService` logic to short-circuit as soon as possible to not execute unneeded logic.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24003]: https://bitwarden.atlassian.net/browse/PM-24003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ