### PR TITLE
[PM-23820] Copy one PM string to BitwardenResources and update Crowdin configuration

### DIFF
--- a/BitwardenResources/Localizations/Base.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/Base.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+// Empty file needed to get Xcodegen to correctly detect the Localizable.string files.

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+"SearchGroup" = "Search %1$@";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1,1 +1,1 @@
-"SearchGroup" = "Search %1$@";
+"Created" = "Created: %1$@";

--- a/BitwardenResources/Resources.swift
+++ b/BitwardenResources/Resources.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Utility and factory methods for handling shared resources
+///
+public class Resources {
+    /// The language code at initialization.
+    public static var initialLanguageCode: String?
+
+    /// Override SwiftGen's lookup function in order to determine the language manually.
+    public static func localizationFunction(key: String, table: String, fallbackValue: String) -> String {
+        if let languageCode = initialLanguageCode,
+           let path = Bundle(for: Resources.self).path(forResource: languageCode, ofType: "lproj"),
+           let bundle = Bundle(path: path) {
+            return bundle.localizedString(forKey: key, value: fallbackValue, table: table)
+        }
+        return Bundle.main.localizedString(forKey: key, value: fallbackValue, table: table)
+    }
+}

--- a/BitwardenShared/UI/Platform/Application/Appearance/UI.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/UI.swift
@@ -14,7 +14,14 @@ public enum UI {
     public static var animated = true
 
     /// The language code at initialization.
-    public static var initialLanguageCode: String?
+    public static var initialLanguageCode: String? {
+        get {
+            Resources.initialLanguageCode
+        }
+        set {
+            Resources.initialLanguageCode = newValue
+        }
+    }
 
     #if DEBUG
     /// App-wide flag that allows overriding the OS level sizeCategory for testing.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -361,7 +361,7 @@ struct ViewItemDetailsView: View { // swiftlint:disable:this type_body_length
     /// The updated date footer.
     private var updatedDate: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(Localizations.created(store.state.cipher.creationDate.dateTimeDisplay))
+            Text(BitwardenResources.Localizations.created(store.state.cipher.creationDate.dateTimeDisplay))
                 .styleGuide(.callout)
 
             Text(Localizations.lastEdited(store.state.updatedDate.dateTimeDisplay))

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -361,7 +361,7 @@ struct ViewItemDetailsView: View { // swiftlint:disable:this type_body_length
     /// The updated date footer.
     private var updatedDate: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(BitwardenResources.Localizations.created(store.state.cipher.creationDate.dateTimeDisplay))
+            Text(Localizations.created(store.state.cipher.creationDate.dateTimeDisplay))
                 .styleGuide(.callout)
 
             Text(Localizations.lastEdited(store.state.updatedDate.dateTimeDisplay))

--- a/crowdin-pm.yml
+++ b/crowdin-pm.yml
@@ -14,7 +14,7 @@ files:
     dest: "/ios-watch/%original_file_name%"
     translation: "/BitwardenWatchApp/Localization/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved
-  - source: "/BitwardenResources/Localization/en.lproj/Localizable.strings"
+  - source: "/BitwardenResources/Localizations/en.lproj/Localizable.strings"
     dest: "/ios-resources/%original_file_name%"
-    translation: "/BitwardeResources/Localization/%osx_code%/%original_file_name%"
+    translation: "/BitwardenResources/Localizations/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved

--- a/crowdin-pm.yml
+++ b/crowdin-pm.yml
@@ -14,3 +14,7 @@ files:
     dest: "/ios-watch/%original_file_name%"
     translation: "/BitwardenWatchApp/Localization/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved
+  - source: "/BitwardenResources/Localization/en.lproj/Localizable.strings"
+    dest: "/ios-resources/%original_file_name%"
+    translation: "/BitwardeResources/Localization/%osx_code%/%original_file_name%"
+    update_option: update_as_unapproved

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -196,6 +196,8 @@ targets:
       - path: BitwardenResources
       - path: BitwardenResources/Generated/Fonts.swift
         optional: true
+      - path: BitwardenResources/Generated/Localizations.swift
+        optional: true
       - path: BitwardenResources/Generated/SharedAssets.swift
         optional: true
     preBuildScripts:
@@ -208,6 +210,7 @@ targets:
         basedOnDependencyAnalysis: false
         outputFiles:
           - $(SRCROOT)/BitwardenResources/Generated/Fonts.swift
+          - $(SRCROOT)/BitwardenResources/Generated/Localizations.swift
           - $(SRCROOT)/BitwardenResources/Generated/SharedAssets.swift
   Networking:
     type: framework

--- a/swiftgen-bwr.yml
+++ b/swiftgen-bwr.yml
@@ -6,6 +6,16 @@ fonts:
     output: Fonts.swift
     params:
       publicAccess: true
+strings:
+  inputs:
+    - BitwardenResources/Localizations/en.lproj
+  outputs:
+    - templateName: structured-swift5
+      output: Localizations.swift
+      params:
+        enumName: Localizations
+        publicAccess: true
+        lookupFunction: Resources.localizationFunction(key:table:fallbackValue:)
 xcassets:
   inputs:
     - BitwardenResources/Colors.xcassets


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23820

## 📔 Objective

Similar to [this PR](https://github.com/bitwarden/android/pull/5550) on the Android side, this copies one string into `BitwardenResources` and updates the appropriate configuration files for SwiftGen, Crowdin, and so on; this will allow us to make sure everything works in Crowdin before moving all of the localizations.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
