### PR TITLE
[PM-23406] Fix authenticator sync initial key creation

### DIFF
--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockCryptoClient.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockCryptoClient.swift
@@ -20,6 +20,7 @@ class MockCryptoClient: CryptoClientProtocol {
     var enrollAdminPasswordPublicKey: String?
     var enrollAdminPasswordResetResult: Result<String, Error> = .success("RESET_PASSWORD_KEY")
 
+    var getUserEncryptionKeyCalled = false
     var getUserEncryptionKeyResult: Result<String, Error> = .success("USER_ENCRYPTION_KEY")
 
     var initializeOrgCryptoRequest: InitOrgCryptoRequest?
@@ -56,7 +57,8 @@ class MockCryptoClient: CryptoClientProtocol {
     }
 
     func getUserEncryptionKey() async throws -> String {
-        try getUserEncryptionKeyResult.get()
+        getUserEncryptionKeyCalled = true
+        return try getUserEncryptionKeyResult.get()
     }
 
     func initializeOrgCrypto(req: InitOrgCryptoRequest) async throws {

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -863,6 +863,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             authBridgeItemService: authBridgeItemService,
             authenticatorClientService: authenticatorClientService,
             cipherDataStore: dataStore,
+            clientService: clientService,
             configService: configService,
             errorReporter: errorReporter,
             keychainRepository: keychainRepository,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23406](https://bitwarden.atlassian.net/browse/PM-23406)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Update to #1750. When authenticator sync is initially enabled, we need to use an unlocked SDK client to create the key if it doesn't already exist. So this brings back the shared `clientService` for this purpose. Once the key is created, ongoing syncing can occur with the separate `authenticatorClientService`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23406]: https://bitwarden.atlassian.net/browse/PM-23406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ