### PR TITLE
[PM-24171] [BEEEP] Improved AutoMockable stencil to use short method name

### DIFF
--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
@@ -603,7 +603,8 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
     /// The sync service should handle multiple vaults being sync'd at the same time.
     ///
     @MainActor
-    func test_determineSyncForUserId_unlockMultipleVaults() async throws { // swiftlint:disable:this function_body_length
+    func test_determineSyncForUserId_unlockMultipleVaults() async throws {
+        // swiftlint:disable:previous function_body_length
         setupInitialState()
         cipherDataStore.cipherSubjectByUserId["2"] = CurrentValueSubject<[Cipher], Error>([])
         await subject.start()
@@ -959,7 +960,9 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
         XCTAssertEqual(items.first?.id, "1234")
         XCTAssertNotNil(authenticatorClientService.mockCrypto.initializeUserCryptoRequest)
         XCTAssertNotNil(authenticatorClientService.mockCrypto.initializeOrgCryptoRequest)
-        XCTAssertEqual(authenticatorClientService.mockCrypto.initializeOrgCryptoRequest?.organizationKeys, ["org-1": "key-org-1"])
+        XCTAssertEqual(
+            authenticatorClientService.mockCrypto.initializeOrgCryptoRequest?.organizationKeys, ["org-1": "key-org-1"]
+        )
         XCTAssertTrue(authenticatorClientService.userClientArray.isEmpty)
     }
 

--- a/BitwardenShared/Core/Platform/Services/ClientService.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientService.swift
@@ -279,7 +279,7 @@ actor DefaultClientService: ClientService {
             return clientBuilder.buildClient()
         }
     }
-    
+
     /// Configures a new SDK client.
     /// - Parameters:
     ///   - client: The SDK client to configure.

--- a/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientServiceTests.swift
@@ -26,7 +26,7 @@ final class ClientServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         configService = MockConfigService()
         errorReporter = MockErrorReporter()
         sdkRepositoryFactory = MockSdkRepositoryFactory()
-        sdkRepositoryFactory.makeCipherRepositoryUserIdReturnValue = MockSdkCipherRepository()
+        sdkRepositoryFactory.makeCipherRepositoryReturnValue = MockSdkCipherRepository()
         stateService = MockStateService()
         subject = DefaultClientService(
             clientBuilder: clientBuilder,
@@ -227,7 +227,7 @@ final class ClientServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         let auth = try await subject.auth()
         let client = try XCTUnwrap(clientBuilder.clients.first)
         XCTAssertIdentical(auth, client.authClient)
-        XCTAssertTrue(sdkRepositoryFactory.makeCipherRepositoryUserIdCalled)
+        XCTAssertTrue(sdkRepositoryFactory.makeCipherRepositoryCalled)
         XCTAssertNotNil(client.platformClient.stateMock.registerCipherRepositoryReceivedStore)
     }
 

--- a/BitwardenShared/Core/Vault/Helpers/TestHelpers/MockVaultListPreparedDataBuilder+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Helpers/TestHelpers/MockVaultListPreparedDataBuilder+Extensions.swift
@@ -8,27 +8,27 @@ extension MockVaultListPreparedDataBuilder {
     func setUpCallOrderHelper() -> MockCallOrderHelper {
         let helper = MockCallOrderHelper()
 
-        addCipherDecryptionFailureCipherClosure = { _ -> VaultListPreparedDataBuilder in
+        addCipherDecryptionFailureClosure = { _ -> VaultListPreparedDataBuilder in
             helper.recordCall("addCipherDecryptionFailure")
             return self
         }
-        addFavoriteItemCipherClosure = { _ -> VaultListPreparedDataBuilder in
+        addFavoriteItemClosure = { _ -> VaultListPreparedDataBuilder in
             helper.recordCall("addFavoriteItem")
             return self
         }
-        addFolderItemCipherFilterFoldersClosure = { _, _, _ -> VaultListPreparedDataBuilder in
+        addFolderItemClosure = { _, _, _ -> VaultListPreparedDataBuilder in
             helper.recordCall("addFolderItem")
             return self
         }
-        addItemForGroupWithClosure = { _, _ -> VaultListPreparedDataBuilder in
+        addItemClosure = { _, _ -> VaultListPreparedDataBuilder in
             helper.recordCall("addItemForGroup")
             return self
         }
-        addNoFolderItemCipherClosure = { _ -> VaultListPreparedDataBuilder in
+        addNoFolderItemClosure = { _ -> VaultListPreparedDataBuilder in
             helper.recordCall("addNoFolderItem")
             return self
         }
-        incrementCipherTypeCountCipherClosure = { _ -> VaultListPreparedDataBuilder in
+        incrementCipherTypeCountClosure = { _ -> VaultListPreparedDataBuilder in
             helper.recordCall("incrementCipherTypeCount")
             return self
         }
@@ -36,23 +36,23 @@ extension MockVaultListPreparedDataBuilder {
             helper.recordCall("incrementCipherDeletedCount")
             return self
         }
-        incrementCollectionCountCipherClosure = { _ -> VaultListPreparedDataBuilder in
+        incrementCollectionCountClosure = { _ -> VaultListPreparedDataBuilder in
             helper.recordCall("incrementCollectionCount")
             return self
         }
-        incrementTOTPCountCipherClosure = { _ async -> VaultListPreparedDataBuilder in
+        incrementTOTPCountClosure = { _ async -> VaultListPreparedDataBuilder in
             helper.recordCall("incrementTOTPCount")
             return self
         }
-        prepareCollectionsCollectionsFilterTypeClosure = { _, _ -> VaultListPreparedDataBuilder in
+        prepareCollectionsClosure = { _, _ -> VaultListPreparedDataBuilder in
             helper.recordCall("prepareCollections")
             return self
         }
-        prepareFoldersFoldersFilterTypeClosure = { _, _ -> VaultListPreparedDataBuilder in
+        prepareFoldersClosure = { _, _ -> VaultListPreparedDataBuilder in
             helper.recordCall("prepareFolders")
             return self
         }
-        prepareRestrictItemsPolicyOrganizationsRestrictedOrganizationIdsClosure = { _ -> VaultListPreparedDataBuilder in
+        prepareRestrictItemsPolicyOrganizationsClosure = { _ -> VaultListPreparedDataBuilder in
             helper.recordCall("prepareRestrictItemsPolicyOrganizations")
             return self
         }
@@ -61,17 +61,17 @@ extension MockVaultListPreparedDataBuilder {
     }
 
     func setUpFluentReturn() {
-        addCipherDecryptionFailureCipherReturnValue = self
-        addFavoriteItemCipherReturnValue = self
-        addFolderItemCipherFilterFoldersReturnValue = self
-        addItemForGroupWithReturnValue = self
-        addNoFolderItemCipherReturnValue = self
-        incrementCipherTypeCountCipherReturnValue = self
+        addCipherDecryptionFailureReturnValue = self
+        addFavoriteItemReturnValue = self
+        addFolderItemReturnValue = self
+        addItemReturnValue = self
+        addNoFolderItemReturnValue = self
+        incrementCipherTypeCountReturnValue = self
         incrementCipherDeletedCountReturnValue = self
-        incrementCollectionCountCipherReturnValue = self
-        incrementTOTPCountCipherReturnValue = self
-        prepareCollectionsCollectionsFilterTypeReturnValue = self
-        prepareFoldersFoldersFilterTypeReturnValue = self
-        prepareRestrictItemsPolicyOrganizationsRestrictedOrganizationIdsReturnValue = self
+        incrementCollectionCountReturnValue = self
+        incrementTOTPCountReturnValue = self
+        prepareCollectionsReturnValue = self
+        prepareFoldersReturnValue = self
+        prepareRestrictItemsPolicyOrganizationsReturnValue = self
     }
 }

--- a/BitwardenShared/Core/Vault/Helpers/TestHelpers/MockVaultListSectionsBuilder+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Helpers/TestHelpers/MockVaultListSectionsBuilder+Extensions.swift
@@ -24,11 +24,11 @@ extension MockVaultListSectionsBuilder {
             helper.recordCall("addTypesSection")
             return self
         }
-        addFoldersSectionNestedFolderIdClosure = { (_: String?) throws -> VaultListSectionsBuilder in
+        addFoldersSectionClosure = { (_: String?) throws -> VaultListSectionsBuilder in
             helper.recordCall("addFoldersSection")
             return self
         }
-        addCollectionsSectionNestedCollectionIdClosure = { (_: String?) throws -> VaultListSectionsBuilder in
+        addCollectionsSectionClosure = { (_: String?) throws -> VaultListSectionsBuilder in
             helper.recordCall("addCollectionsSection")
             return self
         }

--- a/BitwardenShared/Core/Vault/Helpers/VaultListDirectors/MainVaultListDirectorStrategyTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListDirectors/MainVaultListDirectorStrategyTests.swift
@@ -30,7 +30,7 @@ class MainVaultListDirectorStrategyTests: BitwardenTestCase {
         vaultListSectionsBuilder = MockVaultListSectionsBuilder()
         mockCallOrderHelper = vaultListSectionsBuilder.setUpCallOrderHelper()
         vaultListSectionsBuilderFactory = MockVaultListSectionsBuilderFactory()
-        vaultListSectionsBuilderFactory.makeWithDataReturnValue = vaultListSectionsBuilder
+        vaultListSectionsBuilderFactory.makeReturnValue = vaultListSectionsBuilder
 
         subject = MainVaultListDirectorStrategy(
             builderFactory: vaultListSectionsBuilderFactory,
@@ -74,7 +74,7 @@ class MainVaultListDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareDataFromCollectionsFoldersFilterReturnValue = nil
+        vaultListDataPreparator.prepareDataReturnValue = nil
 
         var iteratorPublisher = try await subject.build(filter: VaultListFilter()).makeAsyncIterator()
         let vaultListData = try await iteratorPublisher.next()
@@ -88,7 +88,7 @@ class MainVaultListDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [
@@ -125,7 +125,7 @@ class MainVaultListDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [
@@ -162,7 +162,7 @@ class MainVaultListDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [
@@ -198,7 +198,7 @@ class MainVaultListDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [

--- a/BitwardenShared/Core/Vault/Helpers/VaultListDirectors/MainVaultListGroupDirectorStrategyTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListDirectors/MainVaultListGroupDirectorStrategyTests.swift
@@ -30,7 +30,7 @@ class MainVaultListGroupDirectorStrategyTests: BitwardenTestCase {
         vaultListSectionsBuilder = MockVaultListSectionsBuilder()
         mockCallOrderHelper = vaultListSectionsBuilder.setUpCallOrderHelper()
         vaultListSectionsBuilderFactory = MockVaultListSectionsBuilderFactory()
-        vaultListSectionsBuilderFactory.makeWithDataReturnValue = vaultListSectionsBuilder
+        vaultListSectionsBuilderFactory.makeReturnValue = vaultListSectionsBuilder
 
         subject = MainVaultListGroupDirectorStrategy(
             builderFactory: vaultListSectionsBuilderFactory,
@@ -74,7 +74,7 @@ class MainVaultListGroupDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareGroupDataFromCollectionsFoldersFilterReturnValue = nil
+        vaultListDataPreparator.prepareGroupDataReturnValue = nil
 
         var iteratorPublisher = try await subject.build(filter: VaultListFilter()).makeAsyncIterator()
         let vaultListData = try await iteratorPublisher.next()
@@ -88,7 +88,7 @@ class MainVaultListGroupDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareGroupDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareGroupDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [
@@ -118,7 +118,7 @@ class MainVaultListGroupDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareGroupDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareGroupDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [
@@ -149,7 +149,7 @@ class MainVaultListGroupDirectorStrategyTests: BitwardenTestCase {
         collectionService.collectionsSubject.value = []
         folderService.foldersSubject.value = []
 
-        vaultListDataPreparator.prepareGroupDataFromCollectionsFoldersFilterReturnValue = VaultListPreparedData()
+        vaultListDataPreparator.prepareGroupDataReturnValue = VaultListPreparedData()
 
         vaultListSectionsBuilder.buildReturnValue = VaultListData(
             sections: [

--- a/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
@@ -67,6 +67,7 @@ protocol VaultListPreparedDataBuilder { // sourcery: AutoMockable
     /// Prepares folders to the prepared data that then can be used for filtering.
     func prepareFolders(folders: [Folder], filterType: VaultFilterType) -> VaultListPreparedDataBuilder
     /// Prepares the sections with restricted organization IDs.
+    @discardableResult
     func prepareRestrictItemsPolicyOrganizations(restrictedOrganizationIds: [String]) -> VaultListPreparedDataBuilder
 }
 

--- a/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilder.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilder.swift
@@ -164,6 +164,7 @@ class DefaultVaultListSectionsBuilder: VaultListSectionsBuilder {
     }
 
     func addFoldersSection(nestedFolderId: String? = nil) async throws -> VaultListSectionsBuilder {
+        // swiftlint:disable:previous function_body_length
         guard !preparedData.folders.isEmpty else {
             return self
         }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -59,7 +59,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService = MockStateService()
 
         vaultListDirectorStrategy = MockVaultListDirectorStrategy()
-        vaultListDirectorStrategyFactory.makeFilterReturnValue = vaultListDirectorStrategy
+        vaultListDirectorStrategyFactory.makeReturnValue = vaultListDirectorStrategy
 
         subject = DefaultVaultRepository(
             cipherService: cipherService,
@@ -238,7 +238,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
 
-        vaultListDirectorStrategy.buildFilterReturnValue = AsyncThrowingPublisher(publisher)
+        vaultListDirectorStrategy.buildReturnValue = AsyncThrowingPublisher(publisher)
 
         var iterator = try await subject.ciphersAutofillPublisher(
             availableFido2CredentialsPublisher: MockFido2UserInterfaceHelper()
@@ -251,9 +251,9 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let vaultListData = try await iterator.next()
         let sections = try XCTUnwrap(vaultListData?.sections)
 
-        XCTAssertTrue(vaultListDirectorStrategyFactory.makeFilterCalled)
-        XCTAssertNotNil(vaultListDirectorStrategyFactory.makeFilterReceivedFilter)
-        XCTAssertTrue(vaultListDirectorStrategy.buildFilterCalled)
+        XCTAssertTrue(vaultListDirectorStrategyFactory.makeCalled)
+        XCTAssertNotNil(vaultListDirectorStrategyFactory.makeReceivedFilter)
+        XCTAssertTrue(vaultListDirectorStrategy.buildCalled)
         XCTAssertEqual(sections.count, 1)
         XCTAssertEqual(sections[safeIndex: 0]?.id, "1")
         XCTAssertEqual(sections[safeIndex: 0]?.name, "TestingSection")
@@ -2830,16 +2830,16 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
 
-        vaultListDirectorStrategy.buildFilterReturnValue = AsyncThrowingPublisher(publisher)
+        vaultListDirectorStrategy.buildReturnValue = AsyncThrowingPublisher(publisher)
 
         let filter = VaultListFilter(addTOTPGroup: true)
         var iterator = try await subject.vaultListPublisher(filter: filter).makeAsyncIterator()
         let vaultListData = try await iterator.next()
         let sections = try XCTUnwrap(vaultListData?.sections)
 
-        XCTAssertTrue(vaultListDirectorStrategyFactory.makeFilterCalled)
-        XCTAssertNotNil(vaultListDirectorStrategyFactory.makeFilterReceivedFilter)
-        XCTAssertTrue(vaultListDirectorStrategy.buildFilterCalled)
+        XCTAssertTrue(vaultListDirectorStrategyFactory.makeCalled)
+        XCTAssertNotNil(vaultListDirectorStrategyFactory.makeReceivedFilter)
+        XCTAssertTrue(vaultListDirectorStrategy.buildCalled)
         XCTAssertEqual(sections.count, 1)
         XCTAssertEqual(sections[safeIndex: 0]?.id, "1")
         XCTAssertEqual(sections[safeIndex: 0]?.name, "TestingSection")

--- a/BitwardenShared/Core/Vault/Services/ExportVaultServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultServiceTests.swift
@@ -310,7 +310,8 @@ final class ExportVaultServiceTests: BitwardenTestCase { // swiftlint:disable:th
         )
     }
 
-    /// `exportVaultFileContents(format:)` still applies login/secureNote filter when using CSV export with restrictedTypes
+    /// `exportVaultFileContents(format:)` still applies login/secureNote filter when using CSV export
+    /// with restrictedTypes.
     ///
     func test_fileContent_restrictedTypes_csvWithRestrictions() async throws {
         clientService.mockExporters.exportVaultResult = .success("success")

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -255,7 +255,7 @@ class DefaultSyncService: SyncService {
             return true
         }
 
-        if isPeriodic && lastSyncTime.addingTimeInterval(Constants.minimumSyncInterval) >= timeProvider.presentTime {
+        if isPeriodic, lastSyncTime.addingTimeInterval(Constants.minimumSyncInterval) >= timeProvider.presentTime {
             return false
         }
 

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenMenuField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenMenuField.swift
@@ -124,8 +124,8 @@ struct BitwardenMenuField<
                                 includeLineSpacing: false
                             )
                             .foregroundColor(isEnabled
-                                 ? SharedAsset.Colors.textSecondary.swiftUIColor
-                                 : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor
+                                ? SharedAsset.Colors.textSecondary.swiftUIColor
+                                : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor
                             )
                             .onSizeChanged { size in
                                 titleWidth = size.width

--- a/Sourcery/Templates/AutoMockable.stencil
+++ b/Sourcery/Templates/AutoMockable.stencil
@@ -18,9 +18,13 @@ import {{ import }}
 
 {% macro cleanString string %}{{ string | replace:"(","_" | replace:")","" | replace:":","_" | replace:"`","" | replace:" ","_" | replace:"?","_" | replace:"!","_" | replace:",","_" | replace:"->","_" | replace:"@","_" | replace:".","_" | replace:"[","" | replace:"]","" | replace:"<","" | replace:">","" | replace:"&","" | snakeToCamelCase }}{% endmacro %}
 {%- macro swiftifyMethodName method -%}
-    {%- set cleanMethodName %}{% call cleanString method.selectorName %}{% endset %}
-    {%- set cleanMethodReturnTypeName %}{% call cleanString method.actualReturnTypeName.name %}{% endset -%}
-    {{ cleanMethodName | lowerFirstLetter }}
+    {%- if method.annotations.useSelectorName %}
+        {%- set cleanMethodName %}{% call cleanString method.selectorName %}{% endset -%}
+        {{ cleanMethodName | lowerFirstLetter }}
+    {%- else %}
+        {%- set cleanMethodName %}{% call cleanString method.shortName %}{% endset -%}
+        {{ cleanMethodName | lowerFirstLetter }}
+    {%- endif %}
 {%- endmacro -%}
 
 {% macro accessLevel level %}{% if level != 'internal' %}{{ level }} {% endif %}{% endmacro %}
@@ -45,11 +49,15 @@ import {{ import }}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }} = {% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}{% endfor %}
-        {% call swiftifyMethodName method %}ReceivedInvocations.append({% for param in method.parameters %}{% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}){% endfor %}
+        {% if method.annotations.mockReceivedInvocations %}
+            {%- call swiftifyMethodName method %}ReceivedInvocations.append({% for param in method.parameters %}{% if not param.name == "" %}{{ param.name }}{% else %}arg{{ param.index }}{% endif %}){% endfor %}
+        {% endif %}
     {% else %}
     {% if not method.parameters.count == 0 and not hasNonEscapingClosures %}
         {% call swiftifyMethodName method %}ReceivedArguments = ({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %})
-        {% call swiftifyMethodName method %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+        {% if method.annotations.mockReceivedInvocations %}
+            {%- call swiftifyMethodName method %}ReceivedInvocations.append(({% for param in method.parameters %}{{ param.name }}: {{ param.name }}{% if not forloop.last%}, {% endif %}{% endfor %}))
+        {% endif %}
     {% endif %}
     {% endif %}
 {% endmacro %}
@@ -88,10 +96,14 @@ import {{ import }}
     {% endset %}
     {% if method.parameters.count == 1 and not hasNonEscapingClosures %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}: {{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{{ ')' if param.isClosure }})?{% endfor %}
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% if method.annotations.mockReceivedInvocations %}
+        {%- call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations{% for param in method.parameters %}: [{{ '(' if param.isClosure }}({% call existentialClosureVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}){{ ')' if param.isClosure }}{%if param.typeName.isOptional%}?{%endif%}]{% endfor %} = []
+    {% endif %}
     {% elif not method.parameters.count == 0 and not hasNonEscapingClosures %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedArguments: ({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureTupleVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureTupleVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})?
-    {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureTupleVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureTupleVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% if method.annotations.mockReceivedInvocations %}
+        {%-call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReceivedInvocations: [({% for param in method.parameters %}{{ param.name }}: {% if param.typeAttributes.escaping %}{% call existentialClosureTupleVariableTypeName param.typeName.unwrappedTypeName param.isVariadic false %}{% else %}{% call existentialClosureTupleVariableTypeName param.typeName param.isVariadic false %}{% endif %}{{ ', ' if not forloop.last }}{% endfor %})] = []
+    {% endif %}
     {% endif %}
     {% if not method.returnTypeName.isVoid and not method.isInitializer %}
     {% call accessLevel method.accessLevel %}{% call staticSpecifier method %}var {% call swiftifyMethodName method %}ReturnValue: {{ '(' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any "}}{% call existentialVariableTypeName method.returnTypeName false %}{{ ')' if method.returnTypeName.isClosure and not method.isOptionalReturnType or method.returnTypeName|contains:"any " }}{{ '!' if not method.isOptionalReturnType }}
@@ -153,11 +165,15 @@ import {{ import }}
         {% call swiftifyMethodName method %}CallsCount = 0
         {% endif %}
         {% if method.parameters.count == 1 %}
-        {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}{% endfor %} = nil
-        {% call swiftifyMethodName method %}ReceivedInvocations = []
+            {% call swiftifyMethodName method %}Received{% for param in method.parameters %}{{ param.name|upperFirstLetter }}{% endfor %} = nil
+            {% if method.annotations.mockReceivedInvocations %}
+                {%- call swiftifyMethodName method %}ReceivedInvocations = []
+            {% endif %}    
         {% elif not method.parameters.count == 0 %}
         {% call swiftifyMethodName method %}ReceivedArguments = nil
-        {% call swiftifyMethodName method %}ReceivedInvocations = []
+            {% if method.annotations.mockReceivedInvocations %}
+                {%- call swiftifyMethodName method %}ReceivedInvocations = []
+            {% endif %}    
         {% endif %}
         {% call methodClosureName method %} = nil
         {% if method.throws %}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24171](https://bitwarden.atlassian.net/browse/PM-24171)

## 📔 Objective

Improved `AutoMockable.stencil` so it uses short method name by default to generate the mocked properties and added some custom annotations logic to better handle specific cases.

### Custom annotations:

- **useSelectorName**: Add this annotation to a method where you want to use the selector name instead of the short name, e.g. on function overloading.
- **mockReceivedInvocations**: Add this annotation to a method where you want to mock the different received parameters invocations to a method.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24171]: https://bitwarden.atlassian.net/browse/PM-24171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ