### PR TITLE
[PM-24140] Remove anon-addy-self-host-alias feature flag

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -5,9 +5,6 @@ import Foundation
 
 /// An enum to represent a feature flag sent by the server
 extension FeatureFlag: @retroactive CaseIterable {
-    /// A feature flag to enable/disable the ability to add a custom domain for anonAddy users.
-    static let anonAddySelfHostAlias = FeatureFlag(rawValue: "anon-addy-self-host-alias")
-
     /// Flag to enable/disable Credential Exchange export flow.
     static let cxpExportMobile = FeatureFlag(rawValue: "cxp-export-mobile")
 
@@ -42,7 +39,6 @@ extension FeatureFlag: @retroactive CaseIterable {
 
     public static var allCases: [FeatureFlag] {
         [
-            .anonAddySelfHostAlias,
             .cxpExportMobile,
             .cxpImportMobile,
             .cipherKeyEncryption,

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -13,7 +13,6 @@ final class FeatureFlagTests: BitwardenTestCase {
 
     /// `getter:isRemotelyConfigured` returns the correct value for each flag.
     func test_isRemotelyConfigured() {
-        XCTAssertTrue(FeatureFlag.anonAddySelfHostAlias.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.cipherKeyEncryption.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.cxpExportMobile.isRemotelyConfigured)
         XCTAssertTrue(FeatureFlag.cxpImportMobile.isRemotelyConfigured)

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -82,7 +82,6 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     override func perform(_ effect: GeneratorEffect) async {
         switch effect {
         case .appeared:
-            await loadFlags()
             await reloadGeneratorOptions()
             await generateValue(shouldSavePassword: true)
             await checkLearnGeneratorActionCardEligibility()
@@ -192,13 +191,6 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     }
 
     // MARK: Private
-
-    /// Loads feature flags and updates state accordingly.
-    ///
-    private func loadFlags() async {
-        state.usernameState.addyIOSelfHostServerUrlEnabled = await services.configService
-            .getFeatureFlag(.anonAddySelfHostAlias)
-    }
 
     /// Checks the eligibility of the generator Login action card.
     ///

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -473,15 +473,6 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertFalse(subject.state.isLearnGeneratorActionCardEligible)
     }
 
-    /// `perform(:)` with `.appeared` should set the `addyIOSelfHostServerUrlEnabled` to
-    /// feature flag `anonAddySelfHostAlias` value.
-    @MainActor
-    func test_perform_loadFlags() async {
-        configService.featureFlagsBool[.anonAddySelfHostAlias] = true
-        await subject.perform(.appeared)
-        XCTAssertTrue(subject.state.usernameState.addyIOSelfHostServerUrlEnabled)
-    }
-
     /// `receive(_:)` with `.copyGeneratedValØue` copies the generated password to the system
     /// pasteboard and shows a toast.
     @MainActor

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -15,9 +15,6 @@ extension GeneratorState {
 
         // MARK: Properties
 
-        /// A flag indicating if the addy IO selfhost is enabled.
-        var addyIOSelfHostServerUrlEnabled = false
-
         /// An optional website host used to generate usernames (either plus addressed or catch all).
         var emailWebsite: String?
 

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -413,15 +413,13 @@ extension GeneratorState {
                         title: Localizations.domainNameRequiredParenthesis
                     ),
                 ])
-                if usernameState.addyIOSelfHostServerUrlEnabled {
-                    fields.append(contentsOf: [
-                        textField(
-                            accessibilityId: "AnonAddySelfHosteUrlEntry",
-                            keyPath: \.usernameState.addyIOSelfHostServerUrl,
-                            title: Localizations.selfHostServerURL
-                        ),
-                    ])
-                }
+                fields.append(contentsOf: [
+                    textField(
+                        accessibilityId: "AnonAddySelfHosteUrlEntry",
+                        keyPath: \.usernameState.addyIOSelfHostServerUrl,
+                        title: Localizations.selfHostServerURL
+                    ),
+                ])
             case .duckDuckGo:
                 fields.append(
                     textField(

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -100,7 +100,6 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject.generatorType = .username
         subject.usernameState.usernameGeneratorType = .forwardedEmail
         subject.usernameState.forwardedEmailService = .addyIO
-        subject.usernameState.addyIOSelfHostServerUrlEnabled = true
 
         assertInlineSnapshot(of: dumpFormSections(subject.formSections), as: .lines) {
             """


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24140](https://bitwarden.atlassian.net/browse/PM-24140)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the `anon-addy-self-host-alias` feature flag.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24140]: https://bitwarden.atlassian.net/browse/PM-24140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ