### PR TITLE
[PM-23820] Migrate BWA to use strings from BitwardenResources

### DIFF
--- a/AuthenticatorShared/Core/Auth/Services/Biometrics/BiometricsService.swift
+++ b/AuthenticatorShared/Core/Auth/Services/Biometrics/BiometricsService.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import LocalAuthentication
 import OSLog
 

--- a/AuthenticatorShared/Core/Platform/Models/Enum/AppTheme.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/AppTheme.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import UIKit
 
 // MARK: - AppTheme

--- a/AuthenticatorShared/Core/Platform/Models/Enum/AppThemeTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/AppThemeTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import UIKit
 import XCTest
 

--- a/AuthenticatorShared/Core/Platform/Models/Enum/ClearClipboardValue.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/ClearClipboardValue.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 
 // MARK: - ClearClipboardValue

--- a/AuthenticatorShared/Core/Platform/Models/Enum/ClearClipboardValueTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/ClearClipboardValueTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/Core/Platform/Models/Enum/DefaultSaveOption.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/DefaultSaveOption.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 
 // MARK: - DefaultSaveOption

--- a/AuthenticatorShared/Core/Platform/Models/Enum/DefaultSaveOptionTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/DefaultSaveOptionTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/Core/Platform/Models/Enum/LanguageOption.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/LanguageOption.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 
 // MARK: - LanguageOption

--- a/AuthenticatorShared/Core/Platform/Models/Enum/LanguageOptionTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/LanguageOptionTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValue.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValue.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 
 // MARK: - SessionTimeoutValue
 

--- a/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
+++ b/AuthenticatorShared/Core/Platform/Models/Enum/SessionTimeoutValueTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
@@ -1,5 +1,6 @@
 import AuthenticatorBridgeKit
 import BitwardenKit
+import BitwardenResources
 import Combine
 import Foundation
 

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -1,6 +1,7 @@
 import AuthenticatorBridgeKit
 import AuthenticatorBridgeKitMocks
 import BitwardenKitMocks
+import BitwardenResources
 import InlineSnapshotTesting
 import TestHelpers
 import XCTest

--- a/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
+++ b/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - VaultUnlockView

--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuView.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuView.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import SwiftUI
 
 // MARK: - DebugMenuView

--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuViewTests.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuViewTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import SnapshotTesting
 import XCTest
 

--- a/AuthenticatorShared/UI/Platform/Application/Appearance/StyleGuideFont.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/StyleGuideFont.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 /// A `StyleGuideFont` contains the font to use for a specific style.
@@ -6,7 +7,7 @@ struct StyleGuideFont {
     // MARK: Properties
 
     /// The font to use for the style.
-    let font: Font
+    let font: SwiftUI.Font
 
     /// The line height for this style, in px.
     let lineHeight: CGFloat
@@ -64,12 +65,12 @@ extension StyleGuideFont {
 
 // MARK: Font + Style Guide
 
-private extension Font {
+private extension SwiftUI.Font {
     /// Returns a style guide font for the specified style.
     ///
     /// - Parameter style: The style for which to return a font for.
     /// - Returns: A font for the specified style.
-    static func styleGuide(_ style: StyleGuideFont) -> Font {
+    static func styleGuide(_ style: StyleGuideFont) -> SwiftUI.Font {
         style.font
     }
 }
@@ -121,7 +122,7 @@ extension Text {
     ///
     func styleGuide(
         _ style: StyleGuideFont,
-        weight: Font.Weight = .regular,
+        weight: SwiftUI.Font.Weight = .regular,
         isItalic: Bool = false,
         includeLineSpacing: Bool = true,
         monoSpacedDigit: Bool = false

--- a/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 import SwiftUI
 import UIKit
@@ -13,7 +14,14 @@ public enum UI {
     public static var animated = true
 
     /// The language code at initialization.
-    public static var initialLanguageCode: String?
+    public static var initialLanguageCode: String? {
+        get {
+            Resources.initialLanguageCode
+        }
+        set {
+            Resources.initialLanguageCode = newValue
+        }
+    }
 
     #if DEBUG
     /// App-wide flag that allows overriding the OS level sizeCategory for testing.

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/Alert+Networking.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/Alert+Networking.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import BitwardenSdk
 import Foundation
 

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/Alert+NetworkingTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/Alert+NetworkingTests.swift
@@ -2,6 +2,7 @@
 
 import BitwardenKit
 import BitwardenKitMocks
+import BitwardenResources
 import Foundation
 import Networking
 import TestHelpers

--- a/AuthenticatorShared/UI/Platform/Application/Extensions/View+Toolbar.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Extensions/View+Toolbar.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 /// Helper functions extended off the `View` protocol for supporting buttons and menus in toolbars.

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/Alert+Error.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/Alert+Error.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 
 // MARK: - Alert+Error

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertErrorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/Alert/AlertErrorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/UI/Platform/Application/Utilities/InputValidator/Validators/EmptyInputValidator.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Utilities/InputValidator/Validators/EmptyInputValidator.swift
@@ -1,3 +1,5 @@
+import BitwardenResources
+
 /// Validates that the input for a field is not empty.
 ///
 struct EmptyInputValidator: InputValidator {

--- a/AuthenticatorShared/UI/Platform/Application/Views/AccessoryButton.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/AccessoryButton.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 /// A view that displays a button for use as an accessory to a field.

--- a/AuthenticatorShared/UI/Platform/Application/Views/BitwardenMenuField.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/BitwardenMenuField.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - Menuable

--- a/AuthenticatorShared/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - BitwardenTextField

--- a/AuthenticatorShared/UI/Platform/Application/Views/ExpandableHeaderView.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/ExpandableHeaderView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ExpandableHeaderView

--- a/AuthenticatorShared/UI/Platform/Application/Views/SearchNoResultsView.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/SearchNoResultsView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - SearchNoResultsView

--- a/AuthenticatorShared/UI/Platform/Application/Views/SectionView.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Views/SectionView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - SectionView

--- a/AuthenticatorShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -1,3 +1,5 @@
+import BitwardenResources
+
 // MARK: - Alert + Settings
 
 extension Alert {

--- a/AuthenticatorShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ExportItemsView

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsViewTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SnapshotTesting
 import XCTest
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 
 // MARK: - ImportItemsProcessor

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsProcessorTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKitMocks
+import BitwardenResources
 import Foundation
 import TestHelpers
 import XCTest

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ImportItemsView

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsViewTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SnapshotTesting
 import XCTest
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - SelectLanguageView

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SelectLanguage/SelectLanguageViewTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SnapshotTesting
 import XCTest
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import OSLog
 
 // MARK: - SettingsProcessor

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKitMocks
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import Foundation
 
 /// An object that defines the current state of a `SettingsView`.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import SwiftUI
 
 // MARK: - SettingsView

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsViewTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import SnapshotTesting
 import XCTest
 

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - SettingsCoordinator

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 import XCTest
 

--- a/AuthenticatorShared/UI/Platform/Tabs/TabRoute.swift
+++ b/AuthenticatorShared/UI/Platform/Tabs/TabRoute.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import UIKit
 
 // MARK: - TabRoute

--- a/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialState.swift
+++ b/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialState.swift
@@ -1,3 +1,5 @@
+import BitwardenResources
+
 // MARK: - TutorialState
 
 /// An object that defines the current state of a `TutorialView`.

--- a/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialView.swift
+++ b/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - TutorialView

--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/AuthenticatorItemState.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/AuthenticatorItemState.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import BitwardenSdk
 import Foundation
 

--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 import OSLog
 

--- a/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
+++ b/AuthenticatorShared/UI/Vault/AuthenticatorItem/EditAuthenticatorItem/EditAuthenticatorItemView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import BitwardenSdk
 import SwiftUI
 

--- a/AuthenticatorShared/UI/Vault/Extensions/Alert+Scan.swift
+++ b/AuthenticatorShared/UI/Vault/Extensions/Alert+Scan.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import UIKit
 
 // MARK: Alert+Scan

--- a/AuthenticatorShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/AuthenticatorShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import UIKit
 
 // MARK: Alert+Vault

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ItemListCardView

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListCardViewTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SnapshotTesting
 import ViewInspector
 import XCTest

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
@@ -1,5 +1,6 @@
 import AuthenticatorBridgeKit
 import BitwardenKit
+import BitwardenResources
 import BitwardenSdk
 import Foundation
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 import Combine
 import Foundation
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKitMocks
+import BitwardenResources
 import TestHelpers
 import XCTest
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -1,6 +1,7 @@
 // swiftlint:disable file_length
 
 import BitwardenKit
+import BitwardenResources
 import SwiftUI
 
 // MARK: - SearchableItemListView

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListViewTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKitMocks
+import BitwardenResources
 import SnapshotTesting
 import SwiftUI
 import ViewInspector

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/Extensions/Alert+ScanError.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/Extensions/Alert+ScanError.swift
@@ -1,3 +1,5 @@
+import BitwardenResources
+
 extension Alert {
     /// An alert notifying the user that the TOTP key scan was unsuccessful.
     ///

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ManualEntryProcessor

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ManualEntryView

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryViewTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import SnapshotTesting
 import ViewInspector
 import XCTest

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeView.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeView.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import BitwardenResources
 import SwiftUI
 
 // MARK: - ScanCodeView

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeViewTests.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import BitwardenResources
 import SnapshotTesting
 import ViewInspector
 import XCTest

--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -189,8 +189,6 @@ targets:
         buildPhase: none
       - path: AuthenticatorShared/UI/Platform/Application/Support/Generated/Assets.swift
         optional: true
-      - path: AuthenticatorShared/UI/Platform/Application/Support/Generated/Localizations.swift
-        optional: true
       - path: AuthenticatorShared/Core/Vault/Services/Importers/Support/Generated/GoogleAuth.pb.swift
         optional: true
       - path: AuthenticatorShared/Sourcery/sourcery.yml
@@ -212,7 +210,6 @@ targets:
         basedOnDependencyAnalysis: false
         outputFiles:
           - $(SRCROOT)/AuthenticatorShared/UI/Platform/Application/Support/Generated/Assets.swift
-          - $(SRCROOT)/AuthenticatorShared/UI/Platform/Application/Support/Generated/Localizations.swift
       - name: Protobuf
         script: |
           if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then

--- a/swiftgen-bwa.yml
+++ b/swiftgen-bwa.yml
@@ -1,13 +1,4 @@
 output_dir: AuthenticatorShared/UI/Platform/Application/Support/Generated/
-strings:
-  inputs: AuthenticatorShared/UI/Platform/Application/Support/Localizations/en.lproj
-  outputs:
-    - templateName: structured-swift5
-      output: Localizations.swift
-      params:
-        enumName: Localizations
-        publicAccess: true
-        lookupFunction: UI.localizationFunction(key:table:fallbackValue:)
 xcassets:
   inputs:
     - AuthenticatorShared/UI/Platform/Application/Support/Colors.xcassets


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-23817

## 📔 Objective

Similar to [this PR for PM](https://github.com/bitwarden/ios/pull/1795), this removes the SwiftGen configuration to generate the `Localizations.swift` file in `AuthenticatorShared`, thus moving BWA to using the strings and translations in `BitwardenResources`. However, in order to tread carefully and make sure we don't accidentally lose translations, the `Localizable.strings` files still exist, and will be removed (along with Crowdin configuration for interacting with them) in a future PR.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
