### PR TITLE
[PM-22873] Remove isRemotelyConfigured for feature flags

### DIFF
--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuProcessorTests.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuProcessorTests.swift
@@ -50,7 +50,7 @@ class DebugMenuProcessorTests: BitwardenTestCase {
         XCTAssertTrue(subject.state.featureFlags.isEmpty)
 
         let flag = DebugMenuFeatureFlag(
-            feature: .testLocalFeatureFlag,
+            feature: .testFeatureFlag,
             isEnabled: false
         )
 
@@ -72,7 +72,7 @@ class DebugMenuProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_toggleFeatureFlag() async {
         let flag = DebugMenuFeatureFlag(
-            feature: .testLocalFeatureFlag,
+            feature: .testFeatureFlag,
             isEnabled: true
         )
 

--- a/AuthenticatorShared/UI/DebugMenu/DebugMenuViewTests.swift
+++ b/AuthenticatorShared/UI/DebugMenu/DebugMenuViewTests.swift
@@ -21,7 +21,7 @@ class DebugMenuViewTests: BitwardenTestCase {
             state: DebugMenuState(
                 featureFlags: [
                     .init(
-                        feature: .testLocalFeatureFlag,
+                        feature: .testFeatureFlag,
                         isEnabled: false
                     ),
                 ]
@@ -55,7 +55,7 @@ class DebugMenuViewTests: BitwardenTestCase {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             throw XCTSkip("Unable to run test in iOS 16, keep an eye on ViewInspector to see if it gets updated.")
         }
-        let featureFlagName = FeatureFlag.testLocalFeatureFlag.rawValue
+        let featureFlagName = FeatureFlag.testFeatureFlag.rawValue
         let toggle = try subject.inspect().find(viewWithAccessibilityIdentifier: featureFlagName).toggle()
         try toggle.tap()
         XCTAssertEqual(processor.effects.last, .toggleFeatureFlag(featureFlagName, true))
@@ -74,7 +74,7 @@ class DebugMenuViewTests: BitwardenTestCase {
     func test_snapshot_debugMenuWithFeatureFlags() {
         processor.state.featureFlags = [
             .init(
-                feature: .testRemoteFeatureFlag,
+                feature: .testFeatureFlag,
                 isEnabled: true
             ),
         ]

--- a/BitwardenKit/Core/Platform/Models/Domain/FeatureFlag.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/FeatureFlag.swift
@@ -5,14 +5,9 @@ import Foundation
 /// A struct that encapsulates information about a feature flag. Importing applications
 /// should extend this struct to add static members representing each flag.
 public struct FeatureFlag: Codable, Equatable, Sendable {
-    /// The initial value of the feature flag.
-    /// If `isRemotelyConfigured` is true for the flag, then this will get overridden by the server;
-    /// but if `isRemotelyConfigured` is false for the flag, then the value here will be used.
-    /// This is a helpful way to manage local feature flags.
+    /// The initial value of the feature flag. This will get overridden by the server, but this
+    /// serves as a fallback and is a helpful way to manage local feature flags.
     public let initialValue: AnyCodable?
-
-    /// Whether this feature can be enabled remotely.
-    public let isRemotelyConfigured: Bool
 
     /// The string name of the flag as sent by the server.
     public let rawValue: String
@@ -27,14 +22,11 @@ public struct FeatureFlag: Codable, Equatable, Sendable {
     /// - Parameters:
     ///   - rawValue: The string name of the flag as sent by the server.
     ///   - initialValue: The initial value of the feature flag (if any).
-    ///   - isRemotelyConfigured: Whether this feature can be enabled remotely.
     public init(
         rawValue: String,
-        initialValue: AnyCodable? = nil,
-        isRemotelyConfigured: Bool = true
+        initialValue: AnyCodable? = nil
     ) {
         self.initialValue = initialValue
-        self.isRemotelyConfigured = isRemotelyConfigured
         self.rawValue = rawValue
     }
 }

--- a/BitwardenKit/Core/Platform/Models/Domain/FeatureFlagTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/FeatureFlagTests.swift
@@ -8,9 +8,9 @@ final class FeatureFlagTests: BitwardenTestCase {
 
     /// `name` formats the raw value of a feature flag
     func test_name() {
-        XCTAssertEqual(FeatureFlag.testLocalFeatureFlag.name, "Test Local Feature Flag")
-        XCTAssertEqual(FeatureFlag.testLocalInitialBoolFlag.name, "Test Local Initial Bool Flag")
-        XCTAssertEqual(FeatureFlag.testLocalInitialIntFlag.name, "Test Local Initial Int Flag")
-        XCTAssertEqual(FeatureFlag.testLocalInitialStringFlag.name, "Test Local Initial String Flag")
+        XCTAssertEqual(FeatureFlag.testFeatureFlag.name, "Test Feature Flag")
+        XCTAssertEqual(FeatureFlag.testInitialBoolFlag.name, "Test Initial Bool Flag")
+        XCTAssertEqual(FeatureFlag.testInitialIntFlag.name, "Test Initial Int Flag")
+        XCTAssertEqual(FeatureFlag.testInitialStringFlag.name, "Test Initial String Flag")
     }
 }

--- a/BitwardenKit/Core/Platform/Models/Domain/Mocks/TestFeatureFlags.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/Mocks/TestFeatureFlags.swift
@@ -3,70 +3,35 @@
 import BitwardenKit
 
 extension FeatureFlag: @retroactive CaseIterable {
-    /// A test feature flag that isn't remotely configured and has no initial value.
-    public static let testLocalFeatureFlag = FeatureFlag(
-        rawValue: "test-local-feature-flag",
-        isRemotelyConfigured: false
+    /// A test feature flag that has no initial value.
+    public static let testFeatureFlag = FeatureFlag(
+        rawValue: "test-feature-flag"
     )
 
-    /// A test feature flag that has an initial boolean value and is not remotely configured.
-    public static let testLocalInitialBoolFlag = FeatureFlag(
-        rawValue: "test-local-initial-bool-flag",
-        initialValue: .bool(true),
-        isRemotelyConfigured: false
+    /// A test feature flag that has an initial boolean value.
+    public static let testInitialBoolFlag = FeatureFlag(
+        rawValue: "test-initial-bool-flag",
+        initialValue: .bool(true)
     )
 
-    /// A test feature flag that has an initial integer value and is not remotely configured.
-    public static let testLocalInitialIntFlag = FeatureFlag(
-        rawValue: "test-local-initial-int-flag",
-        initialValue: .int(42),
-        isRemotelyConfigured: false
+    /// A test feature flag that has an initial integer value.
+    public static let testInitialIntFlag = FeatureFlag(
+        rawValue: "test-initial-int-flag",
+        initialValue: .int(42)
     )
 
-    /// A test feature flag that has an initial string value and is not remotely configured.
-    public static let testLocalInitialStringFlag = FeatureFlag(
-        rawValue: "test-local-initial-string-flag",
-        initialValue: .string("Test String"),
-        isRemotelyConfigured: false
-    )
-
-    /// A test feature flag that can be remotely configured.
-    public static let testRemoteFeatureFlag = FeatureFlag(
-        rawValue: "test-remote-feature-flag",
-        isRemotelyConfigured: true
-    )
-
-    /// A test feature flag that has an initial boolean value and is not remotely configured.
-    public static let testRemoteInitialBoolFlag = FeatureFlag(
-        rawValue: "test-remote-initial-bool-flag",
-        initialValue: .bool(true),
-        isRemotelyConfigured: true
-    )
-
-    /// A test feature flag that has an initial integer value and is not remotely configured.
-    public static let testRemoteInitialIntFlag = FeatureFlag(
-        rawValue: "test-remote-initial-int-flag",
-        initialValue: .int(42),
-        isRemotelyConfigured: true
-    )
-
-    /// A test feature flag that has an initial string value and is not remotely configured.
-    public static let testRemoteInitialStringFlag = FeatureFlag(
-        rawValue: "test-remote-initial-string-flag",
-        initialValue: .string("Test String"),
-        isRemotelyConfigured: true
+    /// A test feature flag that has an initial string value.
+    public static let testInitialStringFlag = FeatureFlag(
+        rawValue: "test-initial-string-flag",
+        initialValue: .string("Test String")
     )
 
     public static var allCases: [FeatureFlag] {
         [
-            .testLocalFeatureFlag,
-            .testLocalInitialBoolFlag,
-            .testLocalInitialIntFlag,
-            .testLocalInitialStringFlag,
-            .testRemoteFeatureFlag,
-            .testRemoteInitialBoolFlag,
-            .testRemoteInitialIntFlag,
-            .testRemoteInitialStringFlag,
+            .testFeatureFlag,
+            .testInitialBoolFlag,
+            .testInitialIntFlag,
+            .testInitialStringFlag,
         ]
     }
 }

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/ValidServerConfig.json
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/ValidServerConfig.json
@@ -31,8 +31,7 @@
         "AC-1795_updated-subscription-status-section": true,
         "unassigned-items-banner": true,
         "AC-1218-delete-provider": false,
-        "test-local-feature-flag": true,
-        "test-remote-feature-flag": true
+        "test-feature-flag": true
     },
     "object": "config"
 }

--- a/BitwardenKit/Core/Platform/Services/ConfigService.swift
+++ b/BitwardenKit/Core/Platform/Services/ConfigService.swift
@@ -241,9 +241,6 @@ public class DefaultConfigService: ConfigService {
         }
         #endif
 
-        guard flag.isRemotelyConfigured else {
-            return flag.initialValue?.boolValue ?? defaultValue
-        }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag.rawValue]?.boolValue
             ?? flag.initialValue?.boolValue
@@ -256,9 +253,6 @@ public class DefaultConfigService: ConfigService {
         forceRefresh: Bool = false,
         isPreAuth: Bool = false
     ) async -> Int {
-        guard flag.isRemotelyConfigured else {
-            return flag.initialValue?.intValue ?? defaultValue
-        }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag.rawValue]?.intValue
             ?? flag.initialValue?.intValue
@@ -271,9 +265,6 @@ public class DefaultConfigService: ConfigService {
         forceRefresh: Bool = false,
         isPreAuth: Bool = false
     ) async -> String? {
-        guard flag.isRemotelyConfigured else {
-            return flag.initialValue?.stringValue ?? defaultValue
-        }
         let configuration = await getConfig(forceRefresh: forceRefresh, isPreAuth: isPreAuth)
         return configuration?.featureStates[flag.rawValue]?.stringValue
             ?? flag.initialValue?.stringValue

--- a/BitwardenKit/Core/Platform/Services/ConfigServiceTests.swift
+++ b/BitwardenKit/Core/Platform/Services/ConfigServiceTests.swift
@@ -169,7 +169,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         XCTAssertEqual(stateService.serverConfig["1"]?.gitHash, "75238191")
         XCTAssertEqual(
-            stateService.serverConfig["1"]?.featureStates[FeatureFlag.testRemoteFeatureFlag.rawValue],
+            stateService.serverConfig["1"]?.featureStates[FeatureFlag.testFeatureFlag.rawValue],
             .bool(true)
         )
     }
@@ -317,67 +317,37 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
 
         XCTAssertEqual(stateService.preAuthServerConfig?.gitHash, "75238191")
         XCTAssertEqual(
-            stateService.preAuthServerConfig?.featureStates[FeatureFlag.testRemoteFeatureFlag.rawValue],
+            stateService.preAuthServerConfig?.featureStates[FeatureFlag.testFeatureFlag.rawValue],
             .bool(true)
         )
     }
 
-    // MARK: Tests - getConfig initial values
+    // MARK: Tests - getFeatureFlag initial values
 
-    /// `getFeatureFlag(:)` returns the initial value for local-only booleans if it is configured.
+    /// `getFeatureFlag(:)` returns the initial value for booleans if it is configured.
     func test_getFeatureFlag_initialValue_localBool() async {
         let value = await subject.getFeatureFlag(
-            .testLocalInitialBoolFlag,
+            .testInitialBoolFlag,
             defaultValue: false,
             forceRefresh: false
         )
         XCTAssertTrue(value)
     }
 
-    /// `getFeatureFlag(:)` returns the initial value for local-only integers if it is configured.
+    /// `getFeatureFlag(:)` returns the initial value for integers if it is configured.
     func test_getFeatureFlag_initialValue_localInt() async {
         let value = await subject.getFeatureFlag(
-            .testLocalInitialIntFlag,
+            .testInitialIntFlag,
             defaultValue: 10,
             forceRefresh: false
         )
         XCTAssertEqual(value, 42)
     }
 
-    /// `getFeatureFlag(:)` returns the initial value for local-only strings if it is configured.
+    /// `getFeatureFlag(:)` returns the initial value for strings if it is configured.
     func test_getFeatureFlag_initialValue_localString() async {
         let value = await subject.getFeatureFlag(
-            .testLocalInitialStringFlag,
-            defaultValue: "Default",
-            forceRefresh: false
-        )
-        XCTAssertEqual(value, "Test String")
-    }
-
-    /// `getFeatureFlag(:)` returns the initial value for remote-configured booleans if it is configured.
-    func test_getFeatureFlag_initialValue_remoteBool() async {
-        let value = await subject.getFeatureFlag(
-            .testRemoteInitialBoolFlag,
-            defaultValue: false,
-            forceRefresh: false
-        )
-        XCTAssertTrue(value)
-    }
-
-    /// `getFeatureFlag(:)` returns the initial value for remote-configured integers if it is configured.
-    func test_getFeatureFlag_initialValue_remoteInt() async {
-        let value = await subject.getFeatureFlag(
-            .testRemoteInitialIntFlag,
-            defaultValue: 10,
-            forceRefresh: false
-        )
-        XCTAssertEqual(value, 42)
-    }
-
-    /// `getFeatureFlag(:)` returns the initial value for remote-configured integers if it is configured.
-    func test_getFeatureFlag_initialValue_remoteString() async {
-        let value = await subject.getFeatureFlag(
-            .testRemoteInitialStringFlag,
+            .testInitialStringFlag,
             defaultValue: "Default",
             forceRefresh: false
         )
@@ -392,13 +362,13 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["test-remote-feature-flag": .bool(true)],
+                featureStates: ["test-feature-flag": .bool(true)],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: false, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testFeatureFlag, defaultValue: false, forceRefresh: false)
         XCTAssertTrue(value)
     }
 
@@ -414,24 +384,8 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: true, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testFeatureFlag, defaultValue: true, forceRefresh: false)
         XCTAssertTrue(value)
-    }
-
-    /// `getFeatureFlag(:)` returns the default value if the feature is not remotely configurable for booleans
-    func test_getFeatureFlag_bool_notRemotelyConfigured() async {
-        stateService.serverConfig["1"] = ServerConfig(
-            date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
-            responseModel: ConfigResponseModel(
-                environment: nil,
-                featureStates: ["test-remote-feature-flag": .bool(true)],
-                gitHash: "75238191",
-                server: nil,
-                version: "2024.4.0"
-            )
-        )
-        let value = await subject.getFeatureFlag(.testLocalFeatureFlag, defaultValue: false, forceRefresh: false)
-        XCTAssertFalse(value)
     }
 
     /// `getFeatureFlag(:)` can return an integer if it's in the configuration
@@ -440,13 +394,13 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["test-remote-feature-flag": .int(42)],
+                featureStates: ["test-feature-flag": .int(42)],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: 30, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testFeatureFlag, defaultValue: 30, forceRefresh: false)
         XCTAssertEqual(value, 42)
     }
 
@@ -462,23 +416,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: 30, forceRefresh: false)
-        XCTAssertEqual(value, 30)
-    }
-
-    /// `getFeatureFlag(:)` returns the default value if the feature is not remotely configurable for integers
-    func test_getFeatureFlag_int_notRemotelyConfigured() async {
-        stateService.serverConfig["1"] = ServerConfig(
-            date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
-            responseModel: ConfigResponseModel(
-                environment: nil,
-                featureStates: ["test-remote-feature-flag": .int(42)],
-                gitHash: "75238191",
-                server: nil,
-                version: "2024.4.0"
-            )
-        )
-        let value = await subject.getFeatureFlag(.testLocalFeatureFlag, defaultValue: 30, forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testFeatureFlag, defaultValue: 30, forceRefresh: false)
         XCTAssertEqual(value, 30)
     }
 
@@ -488,13 +426,13 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["test-remote-feature-flag": .string("exists")],
+                featureStates: ["test-feature-flag": .string("exists")],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: "fallback", forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testFeatureFlag, defaultValue: "fallback", forceRefresh: false)
         XCTAssertEqual(value, "exists")
     }
 
@@ -510,23 +448,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
                 version: "2024.4.0"
             )
         )
-        let value = await subject.getFeatureFlag(.testRemoteFeatureFlag, defaultValue: "fallback", forceRefresh: false)
-        XCTAssertEqual(value, "fallback")
-    }
-
-    /// `getFeatureFlag(:)` returns the default value if the feature is not remotely configurable for strings
-    func test_getFeatureFlag_string_notRemotelyConfigured() async {
-        stateService.serverConfig["1"] = ServerConfig(
-            date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
-            responseModel: ConfigResponseModel(
-                environment: nil,
-                featureStates: ["test-remote-feature-flag": .string("exists")],
-                gitHash: "75238191",
-                server: nil,
-                version: "2024.4.0"
-            )
-        )
-        let value = await subject.getFeatureFlag(.testLocalFeatureFlag, defaultValue: "fallback", forceRefresh: false)
+        let value = await subject.getFeatureFlag(.testFeatureFlag, defaultValue: "fallback", forceRefresh: false)
         XCTAssertEqual(value, "fallback")
     }
 
@@ -536,15 +458,15 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
             date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
             responseModel: ConfigResponseModel(
                 environment: nil,
-                featureStates: ["test-remote-feature-flag": .bool(true)],
+                featureStates: ["test-feature-flag": .bool(true)],
                 gitHash: "75238191",
                 server: nil,
                 version: "2024.4.0"
             )
         )
-        appSettingsStore.overrideDebugFeatureFlag(name: "test-remote-feature-flag", value: false)
+        appSettingsStore.overrideDebugFeatureFlag(name: "test-feature-flag", value: false)
         let flags = await subject.getDebugFeatureFlags(FeatureFlag.allCases)
-        let flag = try? XCTUnwrap(flags.first { $0.feature.rawValue == "test-remote-feature-flag" })
+        let flag = try? XCTUnwrap(flags.first { $0.feature.rawValue == "test-feature-flag" })
         XCTAssertFalse(flag?.isEnabled ?? true)
     }
 
@@ -553,12 +475,12 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// `toggleDebugFeatureFlag` will correctly change the value of the flag given.
     func test_toggleDebugFeatureFlag() async throws {
         await subject.toggleDebugFeatureFlag(
-            name: FeatureFlag.testRemoteFeatureFlag.rawValue,
+            name: FeatureFlag.testFeatureFlag.rawValue,
             newValue: true
         )
         let flags = await subject.getDebugFeatureFlags(FeatureFlag.allCases)
         XCTAssertTrue(appSettingsStore.overrideDebugFeatureFlagCalled)
-        let flag = try XCTUnwrap(flags.first { $0.feature == .testRemoteFeatureFlag })
+        let flag = try XCTUnwrap(flags.first { $0.feature == .testFeatureFlag })
         XCTAssertTrue(flag.isEnabled)
     }
 
@@ -566,7 +488,7 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_refreshDebugFeatureFlags() async throws {
         let flags = await subject.refreshDebugFeatureFlags(FeatureFlag.allCases)
         XCTAssertTrue(appSettingsStore.overrideDebugFeatureFlagCalled)
-        let flag = try XCTUnwrap(flags.first { $0.feature == .testRemoteFeatureFlag })
+        let flag = try XCTUnwrap(flags.first { $0.feature == .testFeatureFlag })
         XCTAssertFalse(flag.isEnabled)
     }
 

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -19,10 +19,7 @@ extension FeatureFlag: @retroactive CaseIterable {
     static let emailVerification = FeatureFlag(rawValue: "email-verification")
 
     /// An SDK flag that enables individual cipher encryption.
-    static let enableCipherKeyEncryption = FeatureFlag(
-        rawValue: "enableCipherKeyEncryption",
-        isRemotelyConfigured: false
-    )
+    static let enableCipherKeyEncryption = FeatureFlag(rawValue: "enableCipherKeyEncryption")
 
     /// A feature flag for the use of new cipher permission properties.
     static let restrictCipherItemDeletion = FeatureFlag(

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlagTests.swift
@@ -10,16 +10,4 @@ final class FeatureFlagTests: BitwardenTestCase {
     func test_initialValues() {
         XCTAssertNil(FeatureFlag.cipherKeyEncryption.initialValue?.boolValue)
     }
-
-    /// `getter:isRemotelyConfigured` returns the correct value for each flag.
-    func test_isRemotelyConfigured() {
-        XCTAssertTrue(FeatureFlag.cipherKeyEncryption.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.cxpExportMobile.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.cxpImportMobile.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.emailVerification.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.restrictCipherItemDeletion.isRemotelyConfigured)
-        XCTAssertTrue(FeatureFlag.removeCardPolicy.isRemotelyConfigured)
-
-        XCTAssertFalse(FeatureFlag.enableCipherKeyEncryption.isRemotelyConfigured)
-    }
 }

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuProcessorTests.swift
@@ -55,7 +55,7 @@ class DebugMenuProcessorTests: BitwardenTestCase {
         XCTAssertTrue(subject.state.featureFlags.isEmpty)
 
         let flag = DebugMenuFeatureFlag(
-            feature: .testLocalFeatureFlag,
+            feature: .testFeatureFlag,
             isEnabled: false
         )
 
@@ -77,7 +77,7 @@ class DebugMenuProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_toggleFeatureFlag() async {
         let flag = DebugMenuFeatureFlag(
-            feature: .testLocalFeatureFlag,
+            feature: .testFeatureFlag,
             isEnabled: true
         )
 

--- a/BitwardenShared/UI/Platform/DebugMenu/DebugMenuViewTests.swift
+++ b/BitwardenShared/UI/Platform/DebugMenu/DebugMenuViewTests.swift
@@ -22,7 +22,7 @@ class DebugMenuViewTests: BitwardenTestCase {
             state: DebugMenuState(
                 featureFlags: [
                     .init(
-                        feature: .testLocalFeatureFlag,
+                        feature: .testFeatureFlag,
                         isEnabled: false
                     ),
                 ]
@@ -56,7 +56,7 @@ class DebugMenuViewTests: BitwardenTestCase {
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             throw XCTSkip("Unable to run test in iOS 16, keep an eye on ViewInspector to see if it gets updated.")
         }
-        let featureFlagName = FeatureFlag.testLocalFeatureFlag.rawValue
+        let featureFlagName = FeatureFlag.testFeatureFlag.rawValue
         let toggle = try subject.inspect().find(viewWithAccessibilityIdentifier: featureFlagName).toggle()
         try toggle.tap()
         XCTAssertEqual(processor.effects.last, .toggleFeatureFlag(featureFlagName, true))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-22873](https://bitwarden.atlassian.net/browse/PM-22873)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the `isRemotelyConfigured` flag for feature flags in favor of version targeting.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-22873]: https://bitwarden.atlassian.net/browse/PM-22873?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ