### PR TITLE
[PM-24246] Remove restrict-item-deletion-to-can-manage-permission feature flag

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -21,11 +21,6 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// An SDK flag that enables individual cipher encryption.
     static let enableCipherKeyEncryption = FeatureFlag(rawValue: "enableCipherKeyEncryption")
 
-    /// A feature flag for the use of new cipher permission properties.
-    static let restrictCipherItemDeletion = FeatureFlag(
-        rawValue: "pm-15493-restrict-item-deletion-to-can-manage-permission"
-    )
-
     /// A feature flag to enable the removal of card item types.
     static let removeCardPolicy = FeatureFlag(
         rawValue: "pm-16442-remove-card-item-type-policy"
@@ -39,7 +34,6 @@ extension FeatureFlag: @retroactive CaseIterable {
             .emailVerification,
             .enableCipherKeyEncryption,
             .removeCardPolicy,
-            .restrictCipherItemDeletion,
         ]
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -128,7 +128,6 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     override func perform(_ effect: AddEditItemEffect) async {
         switch effect {
         case .appeared:
-            await loadRestrictItemDeletionFlag()
             await showPasswordAutofillAlertIfNeeded()
             await checkIfUserHasMasterPassword()
             await checkLearnNewLoginActionCardEligibility()
@@ -679,14 +678,6 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
-    }
-
-    /// Load the restrict item deletion flag from the config service to state.
-    ///
-    func loadRestrictItemDeletionFlag() async {
-        state.restrictCipherItemDeletionFlagEnabled = await services.configService.getFeatureFlag(
-            .restrictCipherItemDeletion
-        )
     }
 
     /// Shows the password autofill information alert if it hasn't been shown before and the user

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -800,14 +800,6 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.showMasterPasswordReprompt)
     }
 
-    /// `perform(_:)` with `.appeared` checks restrictCipherItemDeletionFlag and sets value to state.
-    @MainActor
-    func test_perform_appeared_loadRestrictItemDeletionFlag() async {
-        configService.featureFlagsBool[.restrictCipherItemDeletion] = true
-        await subject.perform(.appeared)
-        XCTAssertTrue(subject.state.restrictCipherItemDeletionFlagEnabled)
-    }
-
     /// `perform` with `.checkPasswordPressed` checks the password with the HIBP service.
     @MainActor
     func test_perform_checkPasswordPressed_exposedPassword() async throws {

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
@@ -97,9 +97,6 @@ protocol AddEditItemState: Sendable {
     /// A computed property that indicates if we should show the learn new login action card.
     var shouldShowLearnNewLoginActionCard: Bool { get }
 
-    /// A flag indicating if cipher permissions should be used.
-    var restrictCipherItemDeletionFlagEnabled: Bool { get set }
-
     /// The SSH key item state.
     var sshKeyState: SSHKeyItemState { get set }
 

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -110,9 +110,6 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
     /// The list of ownership options that can be selected for the cipher.
     var ownershipOptions: [CipherOwner]
 
-    /// A flag indicating if cipher permissions should be used.
-    var restrictCipherItemDeletionFlag: Bool = false
-
     /// If master password reprompt toggle should be shown
     var showMasterPasswordReprompt: Bool
 
@@ -157,7 +154,7 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
     /// Whether or not this item can be deleted by the user.
     var canBeDeleted: Bool {
         // backwards compatibility for old server versions
-        guard restrictCipherItemDeletionFlagEnabled, let cipherPermissions = cipher.permissions else {
+        guard let cipherPermissions = cipher.permissions else {
             guard !collectionIds.isEmpty else { return true }
             return allUserCollections.contains { collection in
                 guard let id = collection.id else { return false }
@@ -172,7 +169,7 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
     /// Whether or not this item can be restored by the user.
     var canBeRestored: Bool {
         // backwards compatibility for old server versions
-        guard restrictCipherItemDeletionFlagEnabled, let cipherPermissions = cipher.permissions else {
+        guard let cipherPermissions = cipher.permissions else {
             return isSoftDeleted
         }
 
@@ -243,11 +240,6 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
             organizationId = newValue?.organizationId
             collectionIds = []
         }
-    }
-
-    var restrictCipherItemDeletionFlagEnabled: Bool {
-        get { restrictCipherItemDeletionFlag }
-        set { restrictCipherItemDeletionFlag = newValue }
     }
 
     /// The flag indicating if we should show the learn new login action card.

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -153,8 +153,7 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
                 restore: true
             )
         )
-        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        state.restrictCipherItemDeletionFlagEnabled = true
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
         XCTAssertFalse(state.canBeDeleted)
     }
 
@@ -167,7 +166,6 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
             permissions: nil
         )
         var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        state.restrictCipherItemDeletionFlagEnabled = true
         XCTAssertFalse(state.canBeRestored)
 
         cipher = CipherView.loginFixture(
@@ -191,8 +189,7 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
                 restore: true
             )
         )
-        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        state.restrictCipherItemDeletionFlagEnabled = true
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
         XCTAssertTrue(state.canBeRestored)
     }
 
@@ -207,8 +204,7 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
                 restore: false
             )
         )
-        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        state.restrictCipherItemDeletionFlagEnabled = true
+        let state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
         XCTAssertFalse(state.canBeRestored)
     }
 
@@ -245,22 +241,6 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
         state.ownershipOptions = []
 
         XCTAssertFalse(state.hasOrganizations)
-    }
-
-    /// `restrictCipherItemDeletionFlagEnable` default value is false
-    func test_restrictCipherItemDeletionFlagValue() throws {
-        let cipher = CipherView.loginFixture(
-            login: .fixture(),
-            permissions: CipherPermissions(
-                delete: false,
-                restore: true
-            )
-        )
-
-        var state = try XCTUnwrap(CipherItemState(existing: cipher, hasPremium: true))
-        XCTAssertFalse(state.restrictCipherItemDeletionFlagEnabled)
-        state.restrictCipherItemDeletionFlagEnabled = true
-        XCTAssertTrue(state.restrictCipherItemDeletionFlagEnabled)
     }
 
     /// `getter:icon` returns the icon for a card cipher with a known brand.
@@ -401,4 +381,4 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
         state.isLearnNewLoginActionCardEligible = false
         XCTAssertFalse(state.shouldShowLearnNewLoginActionCard)
     }
-} // swiftlint:disable:this file_length
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -505,9 +505,6 @@ private extension ViewItemProcessor {
                 }
                 let showWebIcons = await services.stateService.getShowWebIcons()
 
-                let restrictCipherItemDeletionFlagEnabled: Bool = await services.configService.getFeatureFlag(
-                    .restrictCipherItemDeletion
-                )
                 var totpState = LoginTOTPState(cipher.login?.totp)
                 if let key = totpState.authKeyModel,
                    let updatedState = try? await services.vaultRepository.refreshTOTPCode(for: key) {
@@ -517,8 +514,7 @@ private extension ViewItemProcessor {
                 guard var newState = ViewItemState(
                     cipherView: cipher,
                     hasPremium: hasPremium,
-                    iconBaseURL: services.environmentService.iconsURL,
-                    restrictCipherItemDeletionFlagEnabled: restrictCipherItemDeletionFlagEnabled
+                    iconBaseURL: services.environmentService.iconsURL
                 ) else { continue }
 
                 if case var .data(itemState) = newState.loadingState {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -175,7 +175,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         XCTAssertNotNil(subject.streamCipherDetailsTask)
         XCTAssertTrue(subject.state.hasPremiumFeatures)
-        XCTAssertFalse(subject.state.restrictCipherItemDeletionFlagEnabled)
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
 
@@ -409,25 +408,6 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(subject.state.hasPremiumFeatures)
         XCTAssertEqual(subject.state.loadingState, .data(expectedState))
         XCTAssertFalse(vaultRepository.fetchSyncCalled)
-    }
-
-    /// `perform(_:)` with `.appeared` loads feature flag value for .restrictCipherItemDeletion.
-    @MainActor
-    func test_perform_appeared_restrictItemDeletion() {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-        configService.featureFlagsBool = [
-            .restrictCipherItemDeletion: true,
-        ]
-
-        let task = Task {
-            await subject.perform(.appeared)
-        }
-
-        waitFor(subject.state.loadingState != .loading(nil))
-        task.cancel()
-
-        XCTAssertTrue(subject.state.restrictCipherItemDeletionFlagEnabled)
     }
 
     /// `perform` with `.checkPasswordPressed` records any errors.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -45,9 +45,6 @@ struct ViewItemState: Equatable, Sendable {
     /// The password history of the item.
     var passwordHistory: [PasswordHistoryView]?
 
-    /// A flag indicating if cipher permissions should be used.
-    var restrictCipherItemDeletionFlagEnabled = false
-
     /// A toast message to show in the view.
     var toast: Toast?
 }
@@ -65,18 +62,15 @@ extension ViewItemState {
     init?(
         cipherView: CipherView,
         hasPremium: Bool,
-        iconBaseURL: URL?,
-        restrictCipherItemDeletionFlagEnabled: Bool
+        iconBaseURL: URL?
     ) {
         guard var cipherItemState = CipherItemState(
             existing: cipherView,
             hasPremium: hasPremium,
             iconBaseURL: iconBaseURL
         ) else { return nil }
-        cipherItemState.restrictCipherItemDeletionFlagEnabled = restrictCipherItemDeletionFlagEnabled
         self.init(loadingState: .data(cipherItemState))
         hasPremiumFeatures = cipherItemState.accountHasPremium
         passwordHistory = cipherView.passwordHistory
-        self.restrictCipherItemDeletionFlagEnabled = restrictCipherItemDeletionFlagEnabled
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemStateTests.swift
@@ -90,37 +90,4 @@ class ViewItemStateTests: BitwardenTestCase {
         let subject = ViewItemState()
         XCTAssertEqual(subject.navigationTitle, "")
     }
-
-    /// `restrictCipherItemDeletionFlagEnabled` default value is false.
-    func test_restrictCipherItemDeletionFlagEnabled() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .password
-                    ),
-                    hasPremium: true
-                )!
-            )
-        )
-        XCTAssertFalse(subject.restrictCipherItemDeletionFlagEnabled)
-    }
-
-    /// `restrictCipherItemDeletionFlagEnabled` is correctly initialized.
-    func test_restrictCipherItemDeletionFlagEnabled_value() {
-        let subject = ViewItemState(
-            loadingState: .data(
-                CipherItemState(
-                    existing: .fixture(
-                        id: "id",
-                        reprompt: .password
-                    ),
-                    hasPremium: true
-                )!
-            ),
-            restrictCipherItemDeletionFlagEnabled: true
-        )
-        XCTAssertTrue(subject.restrictCipherItemDeletionFlagEnabled)
-    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24246](https://bitwarden.atlassian.net/browse/PM-24246)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the `pm-15493-restrict-item-deletion-to-can-manage-permission` feature flag

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24246]: https://bitwarden.atlassian.net/browse/PM-24246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ