### PR TITLE
[PM-24116] Show placeholder hyphen when generating catch-all username with an empty domain

### DIFF
--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState+UsernameState.swift
@@ -142,8 +142,9 @@ extension GeneratorState.UsernameState {
     /// generated.
     var canGenerateUsername: Bool {
         switch usernameGeneratorType {
-        case .catchAllEmail,
-             .plusAddressedEmail,
+        case .catchAllEmail:
+            !domain.isEmpty
+        case .plusAddressedEmail,
              .randomWord:
             true
         case .forwardedEmail:

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -537,6 +537,8 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         var subject = GeneratorState().usernameState
 
         subject.usernameGeneratorType = .catchAllEmail
+        XCTAssertFalse(subject.canGenerateUsername)
+        subject.domain = "example.com"
         XCTAssertTrue(subject.canGenerateUsername)
 
         subject.usernameGeneratorType = .plusAddressedEmail


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24116](https://bitwarden.atlassian.net/browse/PM-24116)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In the generator, when generating a catch-all username, display the placeholder (-) until a non-empty domain has been entered.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="557" height="1063" alt="Screenshot 2025-07-29 at 2 38 47 PM" src="https://github.com/user-attachments/assets/154dd03c-eb12-4cd8-9e75-b525944ce7f7" /> | <img width="557" height="1063" alt="Screenshot 2025-07-29 at 2 48 52 PM" src="https://github.com/user-attachments/assets/cf0b838a-4907-466c-a0e0-64df127f671b" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24116]: https://bitwarden.atlassian.net/browse/PM-24116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ