### PR TITLE
[PM-23875] Enable SwiftFormat lint rule to enforce ternary style

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -6,6 +6,7 @@
 --funcattributes prev-line
 --typeattributes prev-line
 --varattributes preserve
+--wrapternary before-operators
 
 # file options
 --exclude **/Generated,build,vendor/bundle

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -601,9 +601,9 @@ extension ItemListProcessor: AuthenticatorKeyCaptureDelegate {
     ///     `false` if they have chosen to store it locally.
     ///
     private func confirmDefaultSaveAlert(key: String, sendToBitwarden: Bool) {
-        let title = sendToBitwarden ?
-            Localizations.setSaveToBitwardenAsYourDefaultSaveOption :
-            Localizations.setSaveLocallyAsYourDefaultSaveOption
+        let title = sendToBitwarden
+            ? Localizations.setSaveToBitwardenAsYourDefaultSaveOption
+            : Localizations.setSaveLocallyAsYourDefaultSaveOption
         let option: DefaultSaveOption = sendToBitwarden ? .saveToBitwarden : .saveHere
 
         coordinator.showAlert(.confirmDefaultSaveOption(

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryView.swift
@@ -108,12 +108,12 @@ struct ManualEntryView: View {
     /// - Returns: the configured `Button`.
     ///
     private func addButton(sendToBitwarden: Bool) -> some View {
-        let accessibilityIdentifier = sendToBitwarden ?
-            "ManualEntryAddCodeToBitwardenButton" :
-            "ManualEntryAddCodeButton"
-        let title = sendToBitwarden ?
-            Localizations.saveToBitwarden :
-            Localizations.saveHere
+        let accessibilityIdentifier = sendToBitwarden
+            ? "ManualEntryAddCodeToBitwardenButton"
+            : "ManualEntryAddCodeButton"
+        let title = sendToBitwarden
+            ? Localizations.saveToBitwarden
+            : Localizations.saveHere
 
         return Button(title) {
             store.send(

--- a/BitwardenShared/Core/Platform/Models/Domain/Account.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/Account.swift
@@ -60,8 +60,9 @@ extension Account {
                 avatarColor: nil,
                 email: tokenPayload.email,
                 emailVerified: nil,
-                forcePasswordResetReason: identityTokenResponseModel.forcePasswordReset ?
-                    .adminForcePasswordReset : nil,
+                forcePasswordResetReason: identityTokenResponseModel.forcePasswordReset
+                    ? .adminForcePasswordReset
+                    : nil,
                 hasPremiumPersonally: tokenPayload.hasPremium,
                 kdfIterations: identityTokenResponseModel.kdfIterations,
                 kdfMemory: identityTokenResponseModel.kdfMemory,

--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
@@ -20,11 +20,14 @@ struct ProfileSwitcherToolbarView: View {
         } label: {
             profileSwitcherIcon(
                 color: store.state.showPlaceholderToolbarIcon
-                    ? nil : store.state.activeAccountProfile?.color,
+                    ? nil
+                    : store.state.activeAccountProfile?.color,
                 initials: store.state.showPlaceholderToolbarIcon
-                    ? nil : store.state.activeAccountProfile?.userInitials,
+                    ? nil
+                    : store.state.activeAccountProfile?.userInitials,
                 textColor: store.state.showPlaceholderToolbarIcon
-                    ? nil : store.state.activeAccountProfile?.profileIconTextColor
+                    ? nil
+                    : store.state.activeAccountProfile?.profileIconTextColor
             )
         }
         .accessibilityIdentifier("CurrentActiveAccount")

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordState.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordState.swift
@@ -55,8 +55,8 @@ struct UpdateMasterPasswordState: Equatable, Sendable {
 
     /// The message to display for why the user's password needs to be updated.
     var updateMasterPasswordWarning: String {
-        forcePasswordResetReason == .weakMasterPasswordOnLogin ?
-            Localizations.updateWeakMasterPasswordWarning :
-            Localizations.updateMasterPasswordWarning
+        forcePasswordResetReason == .weakMasterPasswordOnLogin
+            ? Localizations.updateWeakMasterPasswordWarning
+            : Localizations.updateMasterPasswordWarning
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Extensions/Alert+Extensions.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/Alert+Extensions.swift
@@ -201,7 +201,8 @@ extension Alert {
         completion: @MainActor @escaping () async -> Void
     ) -> Alert {
         Alert(
-            title: isSoftDelete ? Localizations.doYouReallyWantToSoftDeleteCipher
+            title: isSoftDelete
+                ? Localizations.doYouReallyWantToSoftDeleteCipher
                 : Localizations.doYouReallyWantToPermanentlyDeleteCipher,
             message: nil,
             alertActions: [

--- a/BitwardenShared/UI/Platform/Application/Views/GuidedTourView/GuidedTourView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/GuidedTourView/GuidedTourView.swift
@@ -92,8 +92,10 @@ struct GuidedTourView: View {
             .animation(.smooth(duration: animationDuration), value: shouldRotateArrow)
             .position(
                 x: calculateArrowAbsoluteXPosition(),
-                y: isArrowVisible ? calculateArrowAbsoluteYPosition() :
-                    (shouldRotateArrow ? calculateArrowAbsoluteYPosition() - arrowSize.height
+                y: isArrowVisible
+                    ? calculateArrowAbsoluteYPosition()
+                    : (shouldRotateArrow
+                        ? calculateArrowAbsoluteYPosition() - arrowSize.height
                         : calculateArrowAbsoluteYPosition() + arrowSize.height)
             )
             .smoothTransition(animation: .smooth(duration: animationDuration), value: store.state.currentIndex)

--- a/BitwardenShared/UI/Platform/Application/Views/IllustratedMessageViewTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/IllustratedMessageViewTests.swift
@@ -13,7 +13,7 @@ class IllustratedMessageViewTests: BitwardenTestCase {
     @MainActor
     func test_button_tap() throws {
         var tapped = false
-        let subject: IllustratedMessageView = IllustratedMessageView(
+        let subject = IllustratedMessageView(
             image: Asset.Images.Illustrations.biometricsPhone,
             style: .mediumImage,
             title: Localizations.setUpUnlock,

--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -49,9 +49,9 @@ extension Alert {
     ///
     static func confirmDeleteLog(isBulkDeletion: Bool, action: @MainActor @escaping () async -> Void) -> Alert {
         Alert(
-            title: isBulkDeletion ?
-                Localizations.doYouReallyWantToDeleteAllRecordedLogs :
-                Localizations.doYouReallyWantToDeleteThisLog,
+            title: isBulkDeletion
+                ? Localizations.doYouReallyWantToDeleteAllRecordedLogs
+                : Localizations.doYouReallyWantToDeleteThisLog,
             message: nil,
             alertActions: [
                 AlertAction(title: Localizations.yes, style: .default) { _ in await action() },

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AppExtension/AppExtensionView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AppExtension/AppExtensionView.swift
@@ -82,9 +82,9 @@ struct AppExtensionView: View {
     /// The activate button.
     private var activateButton: some View {
         Button(
-            store.state.extensionEnabled ?
-                Localizations.reactivateAppExtension :
-                Localizations.extensionEnable
+            store.state.extensionEnabled
+                ? Localizations.reactivateAppExtension
+                : Localizations.extensionEnable
         ) {
             store.send(.activateButtonTapped)
         }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessor.swift
@@ -98,8 +98,9 @@ final class GeneratorProcessor: StateProcessor<GeneratorState, GeneratorAction, 
     }
 
     override func receive(_ action: GeneratorAction) { // swiftlint:disable:this function_body_length
-        var generateValueBehavior: GenerateValueBehavior? = action.shouldGenerateNewValue ?
-            .generateNewValue(shouldSave: true) : nil
+        var generateValueBehavior: GenerateValueBehavior? = action.shouldGenerateNewValue
+            ? .generateNewValue(shouldSave: true)
+            : nil
 
         switch action {
         case .copyGeneratedValue:

--- a/BitwardenWatchApp/Helpers/IconImageHelper.swift
+++ b/BitwardenWatchApp/Helpers/IconImageHelper.swift
@@ -33,7 +33,8 @@ class IconImageHelper {
         }
 
         let hostname = URL.createFullUri(from: uriString)?.host
-        return hostname == nil ? "\(EnvironmentService.shared.iconsUrl)/icon.png" :
-            "\(EnvironmentService.shared.iconsUrl)/\(hostname!)/icon.png"
+        return hostname == nil
+            ? "\(EnvironmentService.shared.iconsUrl)/icon.png"
+            : "\(EnvironmentService.shared.iconsUrl)/\(hostname!)/icon.png"
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23875](https://bitwarden.atlassian.net/browse/PM-23875)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables the SwiftFormat `--wrapternary before-operators` rule to wrap multi-line ternary statements before the operator:

```
let title = sendToBitwarden
    ? Localizations.setSaveToBitwardenAsYourDefaultSaveOption
    : Localizations.setSaveLocallyAsYourDefaultSaveOption
```

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23875]: https://bitwarden.atlassian.net/browse/PM-23875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ