### PR TITLE
[PM-24348] Update type_name lint rule max length from 40 to 50

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -79,6 +79,9 @@ type_contents_order:
     - other_method
     - subscript
 
+type_name:
+  max_length: 50
+
 identifier_name:
   excluded:
     - id

--- a/BitwardenShared/Core/Auth/Extensions/MasterPasswordPolicyOptionsExtensionsTests.swift
+++ b/BitwardenShared/Core/Auth/Extensions/MasterPasswordPolicyOptionsExtensionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-class MasterPasswordPolicyOptionsExtensionsTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class MasterPasswordPolicyOptionsExtensionsTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `isInEffect` returns `false` if none of the policy options apply.

--- a/BitwardenShared/Core/Auth/Models/Response/OrganizationAutoEnrollStatusResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/OrganizationAutoEnrollStatusResponseModel.swift
@@ -4,7 +4,7 @@ import Networking
 
 /// The response returned from the API when requesting the auto-enroll status for an organization.
 ///
-struct OrganizationAutoEnrollStatusResponseModel: JSONResponse, Equatable { // swiftlint:disable:this type_name
+struct OrganizationAutoEnrollStatusResponseModel: JSONResponse, Equatable {
     // MARK: Properties
 
     /// The organization's ID.

--- a/BitwardenShared/Core/Auth/Services/API/OrganizationUser/Requests/OrganizationUserResetPasswordEnrollmentRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/OrganizationUser/Requests/OrganizationUserResetPasswordEnrollmentRequest.swift
@@ -4,7 +4,7 @@ import Networking
 
 /// A networking request to enroll the user in password reset for an organization.
 ///
-struct OrganizationUserResetPasswordEnrollmentRequest: Request { // swiftlint:disable:this type_name
+struct OrganizationUserResetPasswordEnrollmentRequest: Request {
     typealias Response = EmptyResponse
 
     // MARK: Properties

--- a/BitwardenShared/Core/Autofill/Models/ASPasskeyCredentialRequestExtensionsTests.swift
+++ b/BitwardenShared/Core/Autofill/Models/ASPasskeyCredentialRequestExtensionsTests.swift
@@ -5,7 +5,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-class ASPasskeyCredentialRequestExtensionsTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class ASPasskeyCredentialRequestExtensionsTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `excludedCredentialsList()` gets the excluded credential list using the

--- a/BitwardenShared/Core/Autofill/Models/Fido2CredentialAutofillViewExtensionsTests.swift
+++ b/BitwardenShared/Core/Autofill/Models/Fido2CredentialAutofillViewExtensionsTests.swift
@@ -4,7 +4,7 @@ import XCTest
 import BitwardenResources
 @testable import BitwardenShared
 
-class Fido2CredentialAutofillViewExtensionsTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class Fido2CredentialAutofillViewExtensionsTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `toFido2CredentialIdentity()` returns the converted `ASPasskeyCredentialIdentity`.

--- a/BitwardenShared/Core/Autofill/Models/PublicKeyCredentialDescriptorExtensionsTests.swift
+++ b/BitwardenShared/Core/Autofill/Models/PublicKeyCredentialDescriptorExtensionsTests.swift
@@ -6,7 +6,6 @@ import XCTest
 
 // MARK: - ASAuthorizationPublicKeyCredentialDescriptorExtensionTests
 
-// swiftlint:disable:next type_name
 class PublicKeyCredentialDescriptorExtensionsTests: BitwardenTestCase {
     // MARK: Tests
 
@@ -26,8 +25,6 @@ class PublicKeyCredentialDescriptorExtensionsTests: BitwardenTestCase {
 
 /// A mock of `ASAuthorizationPublicKeyCredentialDescriptor`.
 class MockASAuthorizationPublicKeyCredentialDescriptor: NSObject, ASAuthorizationPublicKeyCredentialDescriptor {
-    // swiftlint:disable:previous type_name
-
     // MARK: Properties
 
     static var supportsSecureCoding = false

--- a/BitwardenShared/Core/Autofill/Models/PublicKeyCredentialParametersExtensionsTests.swift
+++ b/BitwardenShared/Core/Autofill/Models/PublicKeyCredentialParametersExtensionsTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-class PublicKeyCredentialParametersExtensionsTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class PublicKeyCredentialParametersExtensionsTests: BitwardenTestCase {
     let publicKeyType = "public-key"
 
     // MARK: Tests

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdkVaultTests.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdkVaultTests.swift
@@ -8,7 +8,7 @@ import XCTest
 
 // MARK: - BitwardenSdk.CipherType
 
-class BitwardenSdkVaultBitwardenCipherTypeTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class BitwardenSdkVaultBitwardenCipherTypeTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `init(type:)` initializes the SDK cipher type based on the cipher type.
@@ -44,7 +44,7 @@ class BitwardenSdkVaultCipherTests: BitwardenTestCase {
 
 // MARK: - CipherDetailsResponseModel
 
-class BitwardenSdkVaultCipherDetailsResponseModelTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class BitwardenSdkVaultCipherDetailsResponseModelTests: BitwardenTestCase {
     // MARK: Tests
 
     /// `init(cipher:)` Inits a cipher details response model from an SDK cipher without id throws.
@@ -266,7 +266,7 @@ class CipherViewTests: BitwardenTestCase {
 
 // MARK: - Collection
 
-class BitwardenSdkVaultBitwardenCollectionTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class BitwardenSdkVaultBitwardenCollectionTests: BitwardenTestCase {
     /// `init(collectionDetailsResponseModel:)` sets `manage` with the value in the model
     /// if the server sent a value
     func test_init_manageNotNull() {

--- a/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
@@ -13,8 +13,6 @@ protocol VaultListPreparedDataBuilderFactory { // sourcery: AutoMockable
 
 /// The default implementation of `VaultListPreparedDataBuilderFactory`.
 struct DefaultVaultListPreparedDataBuilderFactory: VaultListPreparedDataBuilderFactory {
-    // swiftlint:disable:previous type_name
-
     /// The service used by the application to handle encryption and decryption tasks.
     let clientService: ClientService
     /// The service used by the application to report non-fatal errors.

--- a/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreServiceTests.swift
@@ -333,7 +333,7 @@ class Fido2CredentialStoreServiceTests: BitwardenTestCase { // swiftlint:disable
     }
 }
 
-class DebuggingFido2CredentialStoreServiceTests: BitwardenTestCase { // swiftlint:disable:this type_name
+class DebuggingFido2CredentialStoreServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var fido2CredentialStore: MockFido2CredentialStore!

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
@@ -421,7 +421,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase { // swiftlint:disab
     }
 }
 
-class MockFido2UserVerificationMediatorDelegate: // swiftlint:disable:this type_name
+class MockFido2UserVerificationMediatorDelegate:
     MockUserVerificationHelperDelegate,
     Fido2UserVerificationMediatorDelegate {
     var onNeedsUserInteractionCalled = false

--- a/BitwardenShared/UI/Platform/Application/Utilities/PendingAppIntentActionMediatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/PendingAppIntentActionMediatorTests.swift
@@ -153,7 +153,6 @@ class PendingAppIntentActionMediatorTests: BitwardenTestCase {
 }
 
 class MockPendingAppIntentActionMediatorDelegate: PendingAppIntentActionMediatorDelegate {
-    // swiftlint:disable:previous type_name
     var onPendingAppIntentActionSuccessAction: PendingAppIntentAction?
     var onPendingAppIntentActionSuccessData: Any?
 

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+AutofillModeAllTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+AutofillModeAllTests.swift
@@ -9,7 +9,7 @@ import XCTest
 @testable import BitwardenShared
 
 @available(iOS 18.0, *)
-class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase { // swiftlint:disable:this type_name line_length
+class VaultAutofillListProcessorAutofillModeAllTests: BitwardenTestCase {
     // MARK: Properties
 
     var appExtensionDelegate: MockAutofillAppExtensionDelegate!


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24348](https://bitwarden.atlassian.net/browse/PM-24348)

## 📔 Objective

Update `type_name` lint rule max length from 40 to 50 and remove disable statements not needed anymore.

Discussion: https://github.com/bitwarden/ios/pull/1821#discussion_r2243122746

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24348]: https://bitwarden.atlassian.net/browse/PM-24348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ