### PR TITLE
[PM-24564] Replace parenthesis in build artifact name

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,7 +86,7 @@ platform :ios do |options|
         build_scheme = ENV["_BUILD_SCHEME"]
         ext = ARTIFACT_EXTENSION[build_mode]
         app_config = lane_context[:APP_CONFIG]
-        UI.message "artifact_filename: #{bundle_id}-#{version_name}(#{version_number})-#{xcode_version}.#{ext}"
+        UI.message "artifact_filename: #{bundle_id}-#{version_name}-#{version_number}-#{xcode_version}.#{ext}"
         UI.message "export_filepath: #{export_path}/#{build_scheme}.#{ext}"
     end
 


### PR DESCRIPTION
## 🎟️ Tracking

PM-24564

## 📔 Objective

The GitHub Release artifacts uploading process replaced parenthesis with dots, making them look like different assets, this change replaces them with dashes so names match. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
