### PR TITLE
[PM-24564] fix: action not found in GitHub Release creation workflow

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -57,12 +57,12 @@ jobs:
 
           case "$workflow_name" in
             *"Password Manager"* | "Build" | "CI - main")
-              echo "app_name=Password Manager" >> $GITHUB_OUTPUT
-              echo "app_name_suffix=bwpm" >> $GITHUB_OUTPUT
+              app_name="Password Manager"
+              app_name_suffix="bwpm"
               ;;
             *"Authenticator"*)
-              echo "app_name=Authenticator" >> $GITHUB_OUTPUT
-              echo "app_name_suffix=bwa" >> $GITHUB_OUTPUT
+              app_name="Authenticator"
+              app_name_suffix="bwa"
               ;;
             *)
               echo "::error::Unknown workflow name: $workflow_name"
@@ -71,6 +71,8 @@ jobs:
           esac
           echo "🔖 App name: $app_name"
           echo "🔖 App name suffix: $app_name_suffix"
+          echo "app_name=$app_name" >> $GITHUB_OUTPUT
+          echo "app_name_suffix=$app_name_suffix" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
         env:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -24,15 +24,15 @@ jobs:
       id-token: write
 
     steps:
-      - name: Log inputs to job summary
-        uses: ./.github/actions/log-inputs
-        with:
-          inputs: ${{ toJson(inputs) }}
-
       - name: Check out repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+
+      - name: Log inputs to job summary
+        uses: ./.github/actions/log-inputs
+        with:
+          inputs: ${{ toJson(inputs) }}
 
       - name: Get branch from workflow run
         id: get_release_branch
@@ -184,7 +184,6 @@ jobs:
 
           echo "✅ Release created: $release_url"
           echo "🔖 Release ID from URL: $release_id_from_url"
-          echo "🔖 Release URL: $release_url"
 
       - name: Update Release Description
         id: update_release_description


### PR DESCRIPTION
## 🎟️ Tracking

PM-24564

## 📔 Objective

Fix action not being found by doing the repo checkout first. While at it, fixed run logs not showing values for some variables.  

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
