### PR TITLE
[PM-23728] Fix flaky test on CipherMatchingHelper

### DIFF
--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper+SingularMatchTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper+SingularMatchTests.swift
@@ -399,13 +399,10 @@ class CipherMatchingHelperSingularMatchTests: BitwardenTestCase { // swiftlint:d
         ])
 
         await subject.prepare(uri: "https://google.com")
-        // Given it's using a Set internally, the elements are unordered
-        // so we can't compare arrays as the order may change depending on the run.
-        // Instead we just check number of items and that the array contains
-        // the elements we expect.
-        XCTAssertEqual(subject.matchingDomains.count, 2)
-        XCTAssertTrue(subject.matchingDomains.contains("google.com"))
-        XCTAssertTrue(subject.matchingDomains.contains("youtube.com"))
+        XCTAssertEqual(subject.matchingDomains.sorted(), [
+            "google.com",
+            "youtube.com",
+        ])
     }
 
     /// `prepare(uri:)` sets the domains matching the equivalent domains
@@ -419,10 +416,10 @@ class CipherMatchingHelperSingularMatchTests: BitwardenTestCase { // swiftlint:d
         ])
 
         await subject.prepare(uri: "iosapp://example.com")
-        XCTAssertEqual(subject.matchingDomains.map(\.self), [
+        XCTAssertEqual(Array(subject.matchingDomains), [
             "iosapp://example.com",
         ])
-        XCTAssertEqual(subject.matchingFuzzyDomains.map(\.self), [
+        XCTAssertEqual(Array(subject.matchingFuzzyDomains), [
             "example.com",
         ])
     }

--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper+SingularMatchTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper+SingularMatchTests.swift
@@ -399,10 +399,13 @@ class CipherMatchingHelperSingularMatchTests: BitwardenTestCase { // swiftlint:d
         ])
 
         await subject.prepare(uri: "https://google.com")
-        XCTAssertEqual(subject.matchingDomains.map(\.self), [
-            "youtube.com",
-            "google.com",
-        ])
+        // Given it's using a Set internally, the elements are unordered
+        // so we can't compare arrays as the order may change depending on the run.
+        // Instead we just check number of items and that the array contains
+        // the elements we expect.
+        XCTAssertEqual(subject.matchingDomains.count, 2)
+        XCTAssertTrue(subject.matchingDomains.contains("google.com"))
+        XCTAssertTrue(subject.matchingDomains.contains("youtube.com"))
     }
 
     /// `prepare(uri:)` sets the domains matching the equivalent domains


### PR DESCRIPTION
## 🎟️ Tracking

[PM-23728](https://bitwarden.atlassian.net/browse/PM-23728)

## 📔 Objective

Fix flaky test on CipherMatchingHelper because of comparing  an array with results of an internal usage of Set that doesn't order items.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23728]: https://bitwarden.atlassian.net/browse/PM-23728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ