### PR TITLE
[PM-23632] Fix style of menu buttons on iOS 15 and 16

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Appearance/Styles/CircleMenuStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Styles/CircleMenuStyle.swift
@@ -1,0 +1,56 @@
+import BitwardenResources
+import SwiftUI
+
+// MARK: - CircleMenuStyle
+
+/// A custom `MenuStyle` for styling `Menu` components as a circular button. On iOS 17+, a `Menu`
+/// can be styled with a `ButtonStyle` instead of a `MenuStyle` (prior to iOS 17, a `ButtonStyle`
+/// has no effect on a `Menu`). `ButtonStyle` also allows using `configuration.isPressed` to style
+/// the pressed state.
+///
+@available(iOS, deprecated: 17, message: "Prefer using CircleButtonStyle to style Menu buttons on iOS 17+")
+struct CircleMenuStyle: MenuStyle {
+    // MARK: Properties
+
+    /// A Boolean value indicating whether the button is currently enabled or disabled.
+    @Environment(\.isEnabled) var isEnabled: Bool
+
+    /// The background color of this button.
+    var backgroundColor: Color {
+        isEnabled
+            ? SharedAsset.Colors.buttonFilledBackground.swiftUIColor
+            : SharedAsset.Colors.buttonFilledDisabledBackground.swiftUIColor
+    }
+
+    /// The diameter of the circle in the button.
+    let diameter: CGFloat
+
+    /// The color of the foreground elements, including text and template images.
+    var foregroundColor: Color {
+        isEnabled
+            ? SharedAsset.Colors.buttonFilledForeground.swiftUIColor
+            : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        Menu(configuration)
+            .foregroundColor(foregroundColor)
+            .frame(width: diameter, height: diameter)
+            .background(backgroundColor)
+            .clipShape(Circle())
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview {
+    Menu {
+        Button("First") {}
+        Button("Second") {}
+    } label: {
+        Asset.Images.plus32.swiftUIImage
+    }
+    .menuStyle(CircleMenuStyle(diameter: 50))
+}
+#endif

--- a/BitwardenShared/UI/Platform/Application/Appearance/Styles/PrimaryMenuStyle.swift
+++ b/BitwardenShared/UI/Platform/Application/Appearance/Styles/PrimaryMenuStyle.swift
@@ -1,0 +1,83 @@
+import BitwardenResources
+import SwiftUI
+
+// MARK: - PrimaryMenuStyle
+
+/// A custom `MenuStyle` for styling `Menu` components similar to `PrimaryButtonStyle`. On iOS 17+, a `Menu`
+/// can be styled with a `ButtonStyle` instead of a `MenuStyle` (prior to iOS 17, a `ButtonStyle`
+/// has no effect on a `Menu`). `ButtonStyle` also allows using `configuration.isPressed` to style
+/// the pressed state.
+///
+@available(iOS, deprecated: 17, message: "Prefer using PrimaryButtonStyle to style Menu buttons on iOS 17+")
+struct PrimaryMenuStyle: MenuStyle {
+    // MARK: Properties
+
+    @Environment(\.isEnabled) var isEnabled: Bool
+
+    /// The size of the button.
+    var size: ButtonStyleSize
+
+    /// If the menu's button should fill to take up as much width as possible.
+    var shouldFillWidth = true
+
+    /// The background color of this button.
+    var backgroundColor: Color {
+        isEnabled
+            ? SharedAsset.Colors.buttonFilledBackground.swiftUIColor
+            : SharedAsset.Colors.buttonFilledDisabledBackground.swiftUIColor
+    }
+
+    /// The color of the foreground elements in this button, including text and template
+    /// images.
+    var foregroundColor: Color {
+        isEnabled
+            ? SharedAsset.Colors.buttonFilledForeground.swiftUIColor
+            : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor
+    }
+
+    func makeBody(configuration: Configuration) -> some View {
+        Menu(configuration)
+            .foregroundColor(foregroundColor)
+            .multilineTextAlignment(.center)
+            .styleGuide(size.fontStyle, includeLinePadding: false, includeLineSpacing: false)
+            .padding(.vertical, size.verticalPadding)
+            .padding(.horizontal, size.horizontalPadding)
+            .frame(maxWidth: shouldFillWidth ? .infinity : nil, minHeight: size.minimumHeight)
+            .background(backgroundColor)
+            .clipShape(Capsule())
+    }
+}
+
+// MARK: - MenuStyle
+
+extension MenuStyle where Self == PrimaryMenuStyle {
+    /// The style for all primary menus in this application.
+    ///
+    /// - Parameters:
+    ///   - shouldFillWidth: A flag indicating if this menu's button should fill all available space.
+    ///   - size: The size of the menu's button. Defaults to `large`.
+    ///
+    static func primary(
+        shouldFillWidth: Bool = true,
+        size: ButtonStyleSize = .large
+    ) -> PrimaryMenuStyle {
+        PrimaryMenuStyle(
+            size: size,
+            shouldFillWidth: shouldFillWidth
+        )
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview {
+    Menu {
+        Button("First") {}
+        Button("Second") {}
+    } label: {
+        Asset.Images.plus32.swiftUIImage
+    }
+    .menuStyle(.primary())
+}
+#endif

--- a/BitwardenShared/UI/Platform/Application/Views/FloatingActionMenu.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/FloatingActionMenu.swift
@@ -23,7 +23,15 @@ struct FloatingActionMenu<Content: View>: View {
             image.imageStyle(.floatingActionButton)
         }
         .accessibilitySortPriority(1)
-        .buttonStyle(CircleButtonStyle(diameter: 50))
+        .apply { view in
+            if #available(iOS 17, *) {
+                view.buttonStyle(CircleButtonStyle(diameter: 50))
+            } else {
+                // Prior to iOS 17, applying a custom button style to a Menu component has no effect,
+                // so a custom menu style is needed instead.
+                view.menuStyle(CircleMenuStyle(diameter: 50))
+            }
+        }
     }
 
     // MARK: Initialization

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -104,6 +104,16 @@ private struct MainSendListView: View {
                         } label: {
                             newSendLabel
                         }
+                        .apply { view in
+                            if #available(iOS 17, *) {
+                                // Handled by the `buttonStyle(_:)` applied to the `Group`.
+                                view
+                            } else {
+                                // Prior to iOS 17, applying a custom button style to a Menu
+                                // component has no effect, so a custom menu style is needed instead.
+                                view.menuStyle(.primary(shouldFillWidth: false))
+                            }
+                        }
                     }
                 }
                 .buttonStyle(.primary(shouldFillWidth: false))

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -64,7 +64,7 @@ extension ViewItemState {
         hasPremium: Bool,
         iconBaseURL: URL?
     ) {
-        guard var cipherItemState = CipherItemState(
+        guard let cipherItemState = CipherItemState(
             existing: cipherView,
             hasPremium: hasPremium,
             iconBaseURL: iconBaseURL


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23632](https://bitwarden.atlassian.net/browse/PM-23632)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When we updated some FABs to show a menu, it seemed that a `Menu` could be styled with a `ButtonStyle` instead of a `MenuStyle`. This is convenient for the menu buttons that we use on a few screens, but this doesn't appear to work correctly on iOS 15 or 16. So this introduces two `MenuStyle`s that appear similar to existing `ButtonStyle`s that can be used to style these menu button's correctly.

This affects the following menus:

- Vault list FAB menu
- Send list FAB menu
- Send list empty state menu button

Closes #1735 

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

Vault list:

| Before | After |
|--------|--------|
| <img width="565" height="1068" alt="Screenshot 2025-08-11 at 4 40 22 PM" src="https://github.com/user-attachments/assets/f62364e4-164a-46d0-8418-8644103f2bf5" /> | <img width="565" height="1068" alt="Screenshot 2025-08-11 at 4 38 43 PM" src="https://github.com/user-attachments/assets/d06b1041-9c86-419a-891f-4d6936d5f229" /> | 


Send list:

| Before | After |
|--------|--------|
| <img width="565" height="1068" alt="Screenshot 2025-08-11 at 4 40 26 PM" src="https://github.com/user-attachments/assets/d189f54f-7db0-4637-b802-b8d9535cb2a7" /> | <img width="565" height="1068" alt="Screenshot 2025-08-11 at 4 38 58 PM" src="https://github.com/user-attachments/assets/ce70a9c7-6185-4b33-8957-e16d9207a353" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23632]: https://bitwarden.atlassian.net/browse/PM-23632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ