### PR TITLE
[PM-24322] Add event log when exporting individual vaults

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessor.swift
@@ -12,6 +12,7 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
     typealias Services = HasAuthRepository
         & HasConfigService
         & HasErrorReporter
+        & HasEventService
         & HasExportVaultService
         & HasPolicyService
         & HasStateService
@@ -132,6 +133,8 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
 
         let fileURL = try await services.exportVaultService.exportVault(format: exportFormat)
         coordinator.navigate(to: .shareURL(fileURL))
+
+        await services.eventService.collect(eventType: .userClientExportedVault)
     }
 
     /// Load any initial data for the view.

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
@@ -12,6 +12,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
     var authRepository: MockAuthRepository!
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
     var errorReporter: MockErrorReporter!
+    var eventService: MockEventService!
     var exportService: MockExportVaultService!
     var policyService: MockPolicyService!
     var subject: ExportVaultProcessor!
@@ -24,11 +25,13 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         authRepository = MockAuthRepository()
         coordinator = MockCoordinator<SettingsRoute, SettingsEvent>()
         errorReporter = MockErrorReporter()
+        eventService = MockEventService()
         exportService = MockExportVaultService()
         policyService = MockPolicyService()
         let services = ServiceContainer.withMocks(
             authRepository: authRepository,
             errorReporter: errorReporter,
+            eventService: eventService,
             exportVaultService: exportService,
             policyService: policyService
         )
@@ -45,6 +48,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         authRepository = nil
         coordinator = nil
         errorReporter = nil
+        eventService = nil
         exportService = nil
         policyService = nil
         subject = nil
@@ -146,6 +150,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
         XCTAssertEqual(exportService.exportVaultContentsFormat, .encryptedJson(password: "file password"))
         XCTAssertEqual(coordinator.routes.last, .shareURL(testURL))
+        XCTAssertEqual(eventService.collectEventType, .userClientExportedVault)
     }
 
     /// `.receive()` with  `.exportVaultTapped` logs an error on export failure.
@@ -273,6 +278,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         try await confirmationAlert.tapAction(title: Localizations.exportVault)
 
         XCTAssertEqual(coordinator.routes.last, .shareURL(testURL))
+        XCTAssertEqual(eventService.collectEventType, .userClientExportedVault)
     }
 
     /// `.receive()` with  `.exportVaultTapped` clears the user's master password after exporting
@@ -297,6 +303,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertTrue(subject.state.filePasswordConfirmationText.isEmpty)
         XCTAssertNil(subject.state.filePasswordStrengthScore)
         XCTAssertTrue(subject.state.masterPasswordOrOtpText.isEmpty)
+        XCTAssertEqual(eventService.collectEventType, .userClientExportedVault)
     }
 
     /// `receive()` with `.exportVaultTapped` verifies the user's OTP code and exports the vault if

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -70,6 +70,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasEnvironmentService
         & HasErrorAlertServices.ErrorAlertServices
         & HasErrorReporter
+        & HasEventService
         & HasExportCXFCiphersRepository
         & HasExportVaultService
         & HasFlightRecorder

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessor.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessor.swift
@@ -11,6 +11,7 @@ class ExportCXFProcessor: StateProcessor<ExportCXFState, ExportCXFAction, Export
 
     typealias Services = HasConfigService
         & HasErrorReporter
+        & HasEventService
         & HasExportCXFCiphersRepository
         & HasPolicyService
         & HasStateService
@@ -126,6 +127,7 @@ class ExportCXFProcessor: StateProcessor<ExportCXFState, ExportCXFAction, Export
                 presentationAnchor: { await delegate.presentationAnchorForASCredentialExportManager() }
             )
             coordinator.navigate(to: .dismiss)
+            await services.eventService.collect(eventType: .userClientExportedVault)
         } catch ASAuthorizationError.failed {
             coordinator
                 .showAlert(

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXF/ExportCXFProcessorTests.swift
@@ -15,6 +15,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     var coordinator: MockCoordinator<ExportCXFRoute, Void>!
     var delegate: MockExportCXFProcessorDelegate!
     var errorReporter: MockErrorReporter!
+    var eventService: MockEventService!
     var exportCXFCiphersRepository: MockExportCXFCiphersRepository!
     var policyService: MockPolicyService!
     var stackNavigator: MockStackNavigator!
@@ -31,6 +32,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         coordinator = MockCoordinator<ExportCXFRoute, Void>()
         delegate = MockExportCXFProcessorDelegate()
         errorReporter = MockErrorReporter()
+        eventService = MockEventService()
         exportCXFCiphersRepository = MockExportCXFCiphersRepository()
         policyService = MockPolicyService()
         stackNavigator = MockStackNavigator()
@@ -42,6 +44,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
             services: ServiceContainer.withMocks(
                 configService: configService,
                 errorReporter: errorReporter,
+                eventService: eventService,
                 exportCXFCiphersRepository: exportCXFCiphersRepository,
                 policyService: policyService,
                 stateService: stateService,
@@ -58,6 +61,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         coordinator = nil
         delegate = nil
         errorReporter = nil
+        eventService = nil
         exportCXFCiphersRepository = nil
         policyService = nil
         stackNavigator = nil
@@ -226,6 +230,7 @@ class ExportCXFProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(coordinator.loadingOverlaysShown[0].title, Localizations.loading)
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(eventService.collectEventType, .userClientExportedVault)
     }
 
     /// `perform(_:)` with `.mainButtonTapped` in `.prepared` status does nothing when there's no delegate.

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXFCoordinator.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXFCoordinator.swift
@@ -10,6 +10,7 @@ class ExportCXFCoordinator: Coordinator, HasStackNavigator {
     typealias Services = HasConfigService
         & HasErrorAlertServices.ErrorAlertServices
         & HasErrorReporter
+        & HasEventService
         & HasExportCXFCiphersRepository
         & HasPolicyService
         & HasStateService


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24322](https://bitwarden.atlassian.net/browse/PM-24322)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Logs a `EventType.userClientExportedVault (1007)` event when the user exports a vault.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24322]: https://bitwarden.atlassian.net/browse/PM-24322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ