### PR TITLE
[PM-24131] Adjust BWA navigation bar for iOS 26

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
+++ b/AuthenticatorShared/UI/Platform/Application/Appearance/UI.swift
@@ -58,7 +58,10 @@ public enum UI {
     ///
     public static func applyDefaultAppearances() {
         let navigationBarAppearance = UINavigationBarAppearance()
-        navigationBarAppearance.backgroundColor = Asset.Colors.primaryContrastBitwarden.color
+        if #unavailable(iOS 26) {
+            // With Liquid Glass, we no longer make the navigation bar distinct with its own color
+            navigationBarAppearance.backgroundColor = Asset.Colors.primaryContrastBitwarden.color
+        }
         UINavigationBar.appearance().scrollEdgeAppearance = navigationBarAppearance
         UINavigationBar.appearance().standardAppearance = navigationBarAppearance
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -20,7 +20,7 @@ struct SettingsView: View {
     var body: some View {
         settingsItems
             .scrollView()
-            .navigationBar(title: Localizations.settings, titleDisplayMode: .large)
+            .navigationBar(title: Localizations.settings, titleDisplayMode: .inline)
             .toast(store.binding(
                 get: \.toast,
                 send: SettingsAction.toastShown

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -15,12 +15,21 @@ struct SettingsView: View {
     /// The `Store` for this view.
     @ObservedObject var store: Store<SettingsState, SettingsAction, SettingsEffect>
 
+    /// How the screen title is displayed, which depends on iOS version.
+    private var titleDisplayMode: NavigationBarItem.TitleDisplayMode {
+        if #available(iOS 26, *) {
+            return .inline
+        } else {
+            return .large
+        }
+    }
+
     // MARK: View
 
     var body: some View {
         settingsItems
             .scrollView()
-            .navigationBar(title: Localizations.settings, titleDisplayMode: .inline)
+            .navigationBar(title: Localizations.settings, titleDisplayMode: titleDisplayMode)
             .toast(store.binding(
                 get: \.toast,
                 send: SettingsAction.toastShown

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -352,6 +352,15 @@ struct ItemListView: View {
     /// The `TimeProvider` used to calculate TOTP expiration.
     var timeProvider: any TimeProvider
 
+    /// How the screen title is displayed, which depends on iOS version.
+    private var titleDisplayMode: NavigationBarItem.TitleDisplayMode {
+        if #available(iOS 26, *) {
+            return .inline
+        } else {
+            return .large
+        }
+    }
+
     var body: some View {
         ZStack {
             SearchableItemListView(
@@ -371,7 +380,7 @@ struct ItemListView: View {
             }
         }
         .navigationTitle(Localizations.verificationCodes)
-        .navigationBarTitleDisplayMode(.inline)
+        .navigationBarTitleDisplayMode(titleDisplayMode)
         .toolbar {
             addToolbarItem(hidden: !store.state.showAddToolbarItem) {
                 Task {

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -371,7 +371,7 @@ struct ItemListView: View {
             }
         }
         .navigationTitle(Localizations.verificationCodes)
-        .navigationBarTitleDisplayMode(.large)
+        .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             addToolbarItem(hidden: !store.state.showAddToolbarItem) {
                 Task {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-24131

## 📔 Objective

This removes the background color from the toolbar in iOS 26, which avoids issues with text disappearing because iOS 26 toolbars no longer should have background colors.

## 📸 Screenshots

<img width="402" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 15 50 24" src="https://github.com/user-attachments/assets/4d369d42-260e-454b-a4cd-9e22c2c99e44" />

<img width="402" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-13 at 15 50 26" src="https://github.com/user-attachments/assets/74712a33-dd00-42b2-901b-65ce54a71a41" />

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
