### PR TITLE
Fix CI new manual builds to pass the Xcode version

### DIFF
--- a/.github/workflows/ci-bwa.yml
+++ b/.github/workflows/ci-bwa.yml
@@ -70,6 +70,7 @@ jobs:
       build-mode: ${{ inputs.build-mode }}
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }} #TODO: refactor all inputs to be consistent with - or _
+      xcode-version: ${{ inputs.xcode-version }}
       compiler-flags: ${{ inputs.compiler-flags }}
       distribute: ${{ github.event_name == 'workflow_dispatch' && inputs.distribute }} # event_name check is a workaround for github failing the workflow run when triggered by push
     secrets: inherit

--- a/.github/workflows/ci-bwpm.yml
+++ b/.github/workflows/ci-bwpm.yml
@@ -73,6 +73,7 @@ jobs:
       build-mode: ${{ inputs.build-mode }}
       version-name: ${{ needs.version.outputs.version_name }}
       version-number: ${{ needs.version.outputs.version_number }} #TODO: refactor all inputs to be consistent with - or _
+      xcode-version: ${{ inputs.xcode-version }}
       compiler-flags: ${{ inputs.compiler-flags }}
       distribute: ${{ github.event_name == 'workflow_dispatch' && inputs.distribute }} # event_name check is a workaround for github failing the workflow run when triggered by push
     secrets: inherit


### PR DESCRIPTION
## 📔 Objective

Fix CI new manual builds to pass the Xcode version to _build-any.yml so we can use Xcode beta version to build the apps.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
