### PR TITLE
[PM-24711] Maintain vault timeout action when enabling a pin/biometrics without a master password

### DIFF
--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -211,6 +211,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
             } else {
                 // If the user doesn't have a master password and hasn't enabled a pin or
                 // biometrics, their timeout action needs to be logout.
+                try await stateService.setTimeoutAction(action: .logout, userId: userId)
                 return .logout
             }
         }

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -299,6 +299,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
 
         let timeoutAction = try await subject.sessionTimeoutAction(userId: "1")
         XCTAssertEqual(timeoutAction, .logout)
+        XCTAssertEqual(stateService.timeoutAction["1"], .logout)
     }
 
     /// `sessionTimeoutAction()` allows lock or logout if the user doesn't have a master password


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24711](https://bitwarden.atlassian.net/browse/PM-24711)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

For users without a master password, the default vault timeout action is "Log out" instead of "Lock". After enabling a PIN or biometrics, the app would incorrectly change the vault timeout action to "Lock".

This changes that so after enabling a PIN or biometrics, the vault timeout action will remain as "Log out" without changing it automatically.

The way this worked previously was that we had logic to provide a default value in the case that there wasn't a previously stored value. This default value was "Lock" unless you didn't have a master password with no PIN or biometrics enabled. So once a PIN or biometrics were enabled, the default value would switch from "Log out" to "Lock" automatically. This persists the "Log out" timeout value in the case of no master password/PIN/biometrics so that it doesn't revert back to the default ("Lock") once a PIN or biometrics is enabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/bc6e23fc-f1bf-49ca-ab17-f8aea8545abc" /> | <video src="https://github.com/user-attachments/assets/8fad162b-5962-491e-9db5-9fe0ef76b440" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24711]: https://bitwarden.atlassian.net/browse/PM-24711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ