### PR TITLE
[PM-24715] Fix iOS autofill extension app initialization URLs

### DIFF
--- a/BitwardenAutoFillExtension/CredentialProviderViewController.swift
+++ b/BitwardenAutoFillExtension/CredentialProviderViewController.swift
@@ -68,10 +68,12 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             return
         }
 
-        initializeApp(
-            with: DefaultCredentialProviderContext(.autofillCredential(credentialIdentity, userInteraction: false))
-        )
-        provideCredential(for: recordIdentifier)
+        Task {
+            await initializeAppWithoutUserInteraction(
+                with: DefaultCredentialProviderContext(.autofillCredential(credentialIdentity, userInteraction: false))
+            )
+            provideCredential(for: recordIdentifier)
+        }
     }
 
     @available(iOSApplicationExtension 17.0, *)
@@ -82,12 +84,14 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                 provideCredentialWithoutUserInteraction(for: passwordIdentity)
             }
         case let passkeyRequest as ASPasskeyCredentialRequest:
-            initializeApp(
-                with: DefaultCredentialProviderContext(
-                    .autofillFido2Credential(passkeyRequest, userInteraction: false)
+            Task {
+                await initializeAppWithoutUserInteraction(
+                    with: DefaultCredentialProviderContext(
+                        .autofillFido2Credential(passkeyRequest, userInteraction: false)
+                    )
                 )
-            )
-            provideFido2Credential(for: passkeyRequest)
+                provideFido2Credential(for: passkeyRequest)
+            }
         default:
             if #available(iOSApplicationExtension 18.0, *),
                let otpRequest = credentialRequest as? ASOneTimeCodeCredentialRequest,
@@ -161,6 +165,15 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
                 await appProcessor.start(appContext: .appExtension, navigator: self, window: nil)
             }
         }
+    }
+    
+    /// Sets up and initializes the app without user interaction.
+    /// - Parameter context: The context that describes how the extension is being used.
+    private func initializeAppWithoutUserInteraction(
+        with context: CredentialProviderContext
+    ) async {
+        initializeApp(with: context)
+        await appProcessor?.prepareEnvironmentConfig()
     }
 
     /// Attempts to provide the credential with the specified ID to the extension context to handle
@@ -264,10 +277,12 @@ class CredentialProviderViewController: ASCredentialProviderViewController {
             return
         }
 
-        initializeApp(
-            with: DefaultCredentialProviderContext(.autofillOTPCredential(otpIdentity, userInteraction: false))
-        )
-        provideOTPCredential(for: recordIdentifier)
+        Task {
+            await initializeAppWithoutUserInteraction(
+                with: DefaultCredentialProviderContext(.autofillOTPCredential(otpIdentity, userInteraction: false))
+            )
+            provideOTPCredential(for: recordIdentifier)
+        }
     }
 }
 

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -183,8 +183,7 @@ public class AppProcessor {
         )
 
         await services.migrationService.performMigrations()
-        await services.environmentService.loadURLsForActiveAccount()
-        _ = await services.configService.getConfig()
+        await prepareEnvironmentConfig()
         await completeAutofillAccountSetupIfEnabled()
 
         if let initialRoute {
@@ -241,6 +240,13 @@ public class AppProcessor {
             .importCredentials(credentialImportToken: credentialImportToken)
         )))
         await checkIfLockedAndPerformNavigation(route: route)
+    }
+
+    /// Perpares the current environment configuration by loading the URLs for the active account
+    /// and getting the current server config.
+    public func prepareEnvironmentConfig() async {
+        await services.environmentService.loadURLsForActiveAccount()
+        _ = await services.configService.getConfig()
     }
 
     // MARK: Autofill Methods

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -21,6 +21,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
     var clientService: MockClientService!
     var configService: MockConfigService!
     var coordinator: MockCoordinator<AppRoute, AppEvent>!
+    var environmentService: MockEnvironmentService!
     var errorReporter: MockErrorReporter!
     var fido2UserInterfaceHelper: MockFido2UserInterfaceHelper!
     var eventService: MockEventService!
@@ -56,6 +57,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         coordinator = MockCoordinator()
         appModule.authRouter = router
         appModule.appCoordinator = coordinator
+        environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         fido2UserInterfaceHelper = MockFido2UserInterfaceHelper()
         eventService = MockEventService()
@@ -81,6 +83,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
                 autofillCredentialService: autofillCredentialService,
                 clientService: clientService,
                 configService: configService,
+                environmentService: environmentService,
                 errorReporter: errorReporter,
                 eventService: eventService,
                 fido2UserInterfaceHelper: fido2UserInterfaceHelper,
@@ -107,6 +110,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         clientService = nil
         configService = nil
         coordinator = nil
+        environmentService = nil
         errorReporter = nil
         fido2UserInterfaceHelper = nil
         eventService = nil
@@ -1439,5 +1443,13 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertFalse(authRepository.logoutCalled)
         XCTAssertTrue(coordinator.isLoadingOverlayShowing)
         XCTAssertTrue(coordinator.events.isEmpty)
+    }
+
+    /// `prepareEnvironmentConfig()` loads the URLs for the active account and the configuration.
+    @MainActor
+    func test_prepareEnvironmentConfig() async throws {
+        await subject.prepareEnvironmentConfig()
+        XCTAssertTrue(environmentService.didLoadURLsForActiveAccount)
+        XCTAssertTrue(configService.configMocker.called)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-24715](https://bitwarden.atlassian.net/browse/PM-24715)

## 📔 Objective

🍒 Same change as in RC fix #1858 

Fix iOS autofill extension app initialization to load environment URLs and config when going through the flows without user interaction. This was causing the app to logout when session timeout was set to Never, Region not set to US and doing any API calls in the flows; like in certain Fido2 autofill scenarios. So instead of performing the API call to the correct server it was defaulting to US, returning a 401 and then when refreshing a 400 with `invalid_grant` logging out the user.

Additionally, needed to change the flows without user interaction be async so we can load the URLs and config correctly.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24715]: https://bitwarden.atlassian.net/browse/PM-24715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ