### PR TITLE
[PM-21862] Provide SDK with account keys

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/Fixtures/IdentityTokenResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/Fixtures/IdentityTokenResponseModel+Fixtures.swift
@@ -35,6 +35,7 @@ extension AuthMethodsData {
 
 extension IdentityTokenResponseModel {
     static func fixture(
+        accountKeys: PrivateKeysResponseModel? = nil,
         forcePasswordReset: Bool = false,
         kdf: KdfType = .pbkdf2sha256,
         kdfIterations: Int = 600_000,
@@ -58,6 +59,7 @@ extension IdentityTokenResponseModel {
         refreshToken: String = "REFRESH_TOKEN"
     ) -> IdentityTokenResponseModel {
         IdentityTokenResponseModel(
+            accountKeys: accountKeys,
             forcePasswordReset: forcePasswordReset,
             kdf: kdf,
             kdfIterations: kdfIterations,

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
@@ -8,6 +8,9 @@ struct IdentityTokenResponseModel: Equatable, JSONResponse, KdfConfigProtocol {
 
     // MARK: Account Properties
 
+    /// The user's account keys.
+    let accountKeys: PrivateKeysResponseModel? // TODO: PM-24659 Make it non-optional when server released for a while.
+
     /// Whether the app needs to force a password reset.
     @DefaultFalse var forcePasswordReset: Bool
 

--- a/BitwardenShared/Core/Platform/Models/Domain/AccountEncryptionKeys.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/AccountEncryptionKeys.swift
@@ -3,6 +3,9 @@
 struct AccountEncryptionKeys: Equatable {
     // MARK: Properties
 
+    /// The user's v2 account keys.
+    let accountKeys: PrivateKeysResponseModel?
+
     /// The encrypted private key for the account.
     let encryptedPrivateKey: String
 
@@ -16,8 +19,14 @@ extension AccountEncryptionKeys {
     /// - Parameter identityTokenResponseModel: The response model from the identity token request.
     ///
     init?(identityTokenResponseModel: IdentityTokenResponseModel) {
-        guard let privateKey = identityTokenResponseModel.privateKey else { return nil }
+        let privateKey = identityTokenResponseModel.accountKeys?.publicKeyEncryptionKeyPair.wrappedPrivateKey
+                            ?? identityTokenResponseModel.privateKey
+        guard let privateKey else {
+            return nil
+        }
+
         self.init(
+            accountKeys: identityTokenResponseModel.accountKeys,
             encryptedPrivateKey: privateKey,
             encryptedUserKey: identityTokenResponseModel.key
         )

--- a/BitwardenShared/Core/Platform/Models/Domain/AccountEncryptionKeysTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/AccountEncryptionKeysTests.swift
@@ -8,11 +8,13 @@ class AccountEncryptionKeysTests: BitwardenTestCase {
     /// `init(identityTokenResponseModel:)` initializes an `AccountEncryptionKeys` from an identity
     /// token response.
     func test_init_identityTokenResponseModel() {
-        let subject = AccountEncryptionKeys(identityTokenResponseModel: .fixture())
+        let accountKeys = PrivateKeysResponseModel.fixture()
+        let subject = AccountEncryptionKeys(identityTokenResponseModel: .fixture(accountKeys: accountKeys))
 
         XCTAssertEqual(
             subject,
             AccountEncryptionKeys(
+                accountKeys: accountKeys,
                 encryptedPrivateKey: "PRIVATE_KEY",
                 encryptedUserKey: "KEY"
             )

--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncService.swift
@@ -368,15 +368,9 @@ actor DefaultAuthenticatorSyncService: NSObject, AuthenticatorSyncService {
         let encryptionKeys = try await stateService.getAccountEncryptionKeys(userId: userId)
 
         try await authenticatorClientService.crypto().initializeUserCrypto(
-            req: InitUserCryptoRequest(
-                userId: account.profile.userId,
-                kdfParams: account.kdf.sdkKdf,
-                email: account.profile.email,
-                privateKey: encryptionKeys.encryptedPrivateKey,
-                signingKey: nil,
-                securityState: nil,
-                method: .decryptedKey(decryptedUserKey: authenticatorKey)
-            )
+            account: account,
+            encryptionKeys: encryptionKeys,
+            method: .decryptedKey(decryptedUserKey: authenticatorKey)
         )
         try await initializeOrganizationCrypto(userId: userId)
     }

--- a/BitwardenShared/Core/Platform/Services/CryptoClient.swift
+++ b/BitwardenShared/Core/Platform/Services/CryptoClient.swift
@@ -1,0 +1,29 @@
+import BitwardenSdk
+
+/// Extension for helper functions of `CryptoClientProtocol`.
+extension CryptoClientProtocol {
+    // MARK: Methods
+
+    /// Initialization method for the user crypto. Needs to be called before any other crypto operations.
+    /// - Parameters:
+    ///   - account: The account of the user to initialize crypto.
+    ///   - encryptionKeys: The encryption keys for the user.
+    ///   - method: The crypto initialization method.
+    func initializeUserCrypto(
+        account: Account,
+        encryptionKeys: AccountEncryptionKeys,
+        method: InitUserCryptoMethod
+    ) async throws {
+        try await initializeUserCrypto(
+            req: InitUserCryptoRequest(
+                userId: account.profile.userId,
+                kdfParams: account.kdf.sdkKdf,
+                email: account.profile.email,
+                privateKey: encryptionKeys.encryptedPrivateKey,
+                signingKey: encryptionKeys.accountKeys?.signatureKeyPair?.wrappedSigningKey,
+                securityState: encryptionKeys.accountKeys?.securityState?.securityState,
+                method: method
+            )
+        )
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/KeyConnectorService.swift
+++ b/BitwardenShared/Core/Platform/Services/KeyConnectorService.swift
@@ -131,6 +131,7 @@ extension DefaultKeyConnectorService: KeyConnectorService {
 
         try await stateService.setAccountEncryptionKeys(
             AccountEncryptionKeys(
+                accountKeys: nil,
                 encryptedPrivateKey: keyConnectorResponse.keys.private,
                 encryptedUserKey: keyConnectorResponse.encryptedUserKey
             )

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -579,6 +579,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             clientService: clientService,
             collectionService: collectionService,
             folderService: folderService,
+            keychainRepository: keychainRepository,
             keyConnectorService: keyConnectorService,
             organizationService: organizationService,
             policyService: policyService,

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1497,6 +1497,7 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
             throw StateServiceError.noEncryptedPrivateKey
         }
         return AccountEncryptionKeys(
+            accountKeys: appSettingsStore.accountKeys(userId: userId),
             encryptedPrivateKey: encryptedPrivateKey,
             encryptedUserKey: appSettingsStore.encryptedUserKey(userId: userId)
         )
@@ -1800,6 +1801,7 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
 
     func setAccountEncryptionKeys(_ encryptionKeys: AccountEncryptionKeys, userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setAccountKeys(encryptionKeys.accountKeys, userId: userId)
         appSettingsStore.setEncryptedPrivateKey(key: encryptionKeys.encryptedPrivateKey, userId: userId)
         appSettingsStore.setEncryptedUserKey(key: encryptionKeys.encryptedUserKey, userId: userId)
     }

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -282,6 +282,12 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
     /// `getAccountEncryptionKeys(_:)` returns the encryption keys for the user account.
     func test_getAccountEncryptionKeys() async throws {
+        appSettingsStore.accountKeys["1"] = .fixture(
+            publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+        )
+        appSettingsStore.accountKeys["2"] = .fixture(
+            publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")
+        )
         appSettingsStore.encryptedPrivateKeys["1"] = "1:PRIVATE_KEY"
         appSettingsStore.encryptedPrivateKeys["2"] = "2:PRIVATE_KEY"
         appSettingsStore.encryptedUserKeys["1"] = "1:USER_KEY"
@@ -297,6 +303,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(
             accountKeys,
             AccountEncryptionKeys(
+                accountKeys: .fixture(
+                    publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+                ),
                 encryptedPrivateKey: "1:PRIVATE_KEY",
                 encryptedUserKey: "1:USER_KEY"
             )
@@ -307,6 +316,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(
             otherAccountKeys,
             AccountEncryptionKeys(
+                accountKeys: .fixture(
+                    publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")
+                ),
                 encryptedPrivateKey: "2:PRIVATE_KEY",
                 encryptedUserKey: "2:USER_KEY"
             )
@@ -316,6 +328,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(
             accountKeysForUserId,
             AccountEncryptionKeys(
+                accountKeys: .fixture(
+                    publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+                ),
                 encryptedPrivateKey: "1:PRIVATE_KEY",
                 encryptedUserKey: "1:USER_KEY"
             )
@@ -1350,6 +1365,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let account = Account.fixture(profile: Account.AccountProfile.fixture(userId: "1"))
         await subject.addAccount(account)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(),
             encryptedPrivateKey: "PRIVATE_KEY",
             encryptedUserKey: "USER_KEY"
         ))
@@ -1392,6 +1408,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         try await subject.logoutAccount(userInitiated: true)
 
         XCTAssertEqual(appSettingsStore.biometricAuthenticationEnabled, [:])
+        XCTAssertEqual(appSettingsStore.accountKeys, [:])
         XCTAssertEqual(appSettingsStore.encryptedPrivateKeys, [:])
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, [:])
         XCTAssertEqual(appSettingsStore.defaultUriMatchTypeByUserId, [:])
@@ -1418,6 +1435,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let account = Account.fixture(profile: Account.AccountProfile.fixture(userId: "1"))
         await subject.addAccount(account)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(),
             encryptedPrivateKey: "PRIVATE_KEY",
             encryptedUserKey: "USER_KEY"
         ))
@@ -1430,6 +1448,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertNil(state.activeUserId)
 
         // Additional user keys are removed.
+        XCTAssertEqual(appSettingsStore.accountKeys, [:])
         XCTAssertEqual(appSettingsStore.encryptedPrivateKeys, [:])
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, [:])
     }
@@ -1440,6 +1459,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let firstAccount = Account.fixture(profile: Account.AccountProfile.fixture(userId: "1"))
         await subject.addAccount(firstAccount)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "1:PRIVATE_KEY",
             encryptedUserKey: "1:USER_KEY"
         ))
@@ -1447,6 +1469,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let secondAccount = Account.fixture(profile: Account.AccountProfile.fixture(userId: "2"))
         await subject.addAccount(secondAccount)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "2:PRIVATE_KEY",
             encryptedUserKey: "2:USER_KEY"
         ))
@@ -1459,6 +1484,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(state.activeUserId, "1")
 
         // Additional user keys are removed.
+        XCTAssertEqual(appSettingsStore.accountKeys, [
+            "1": .fixture(publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")),
+        ])
         XCTAssertEqual(appSettingsStore.encryptedPrivateKeys, ["1": "1:PRIVATE_KEY"])
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, ["1": "1:USER_KEY"])
     }
@@ -1469,6 +1497,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let firstAccount = Account.fixture(profile: Account.AccountProfile.fixture(userId: "1"))
         await subject.addAccount(firstAccount)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "1:PRIVATE_KEY",
             encryptedUserKey: "1:USER_KEY"
         ))
@@ -1476,6 +1507,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let secondAccount = Account.fixture(profile: Account.AccountProfile.fixture(userId: "2"))
         await subject.addAccount(secondAccount)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "2:PRIVATE_KEY",
             encryptedUserKey: "2:USER_KEY"
         ))
@@ -1488,6 +1522,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(state.activeUserId, "2")
 
         // Additional user keys are removed.
+        XCTAssertEqual(appSettingsStore.accountKeys, [
+            "1": .fixture(publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")),
+        ])
         XCTAssertEqual(appSettingsStore.encryptedPrivateKeys, ["2": "2:PRIVATE_KEY"])
         XCTAssertEqual(appSettingsStore.encryptedUserKeys, ["2": "2:USER_KEY"])
     }
@@ -1497,12 +1534,16 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let account = Account.fixture(profile: .fixture(userId: "1"))
         await subject.addAccount(account)
         try await subject.setAccountEncryptionKeys(AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "1:PRIVATE_KEY",
             encryptedUserKey: "1:USER_KEY"
         ))
 
         try await subject.logoutAccount(userInitiated: false)
 
+        XCTAssertNil(appSettingsStore.accountKeys["1"])
         XCTAssertNil(appSettingsStore.encryptedPrivateKeys["1"])
         XCTAssertNil(appSettingsStore.encryptedUserKeys["1"])
         XCTAssertEqual(appSettingsStore.state?.accounts, ["1": account])
@@ -1592,17 +1633,27 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         await subject.addAccount(.fixture(profile: .fixture(userId: "2")))
 
         let encryptionKeys = AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "1:PRIVATE_KEY",
             encryptedUserKey: "1:USER_KEY"
         )
         try await subject.setAccountEncryptionKeys(encryptionKeys, userId: "1")
 
         let otherEncryptionKeys = AccountEncryptionKeys(
+            accountKeys: .fixture(
+                publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")
+            ),
             encryptedPrivateKey: "2:PRIVATE_KEY",
             encryptedUserKey: "2:USER_KEY"
         )
         try await subject.setAccountEncryptionKeys(otherEncryptionKeys)
 
+        XCTAssertEqual(appSettingsStore.accountKeys, [
+            "1": .fixture(publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "1:WRAPPED_PRIVATE_KEY")),
+            "2": .fixture(publicKeyEncryptionKeyPair: .fixture(wrappedPrivateKey: "2:WRAPPED_PRIVATE_KEY")),
+        ])
         XCTAssertEqual(
             appSettingsStore.encryptedPrivateKeys,
             [

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -73,6 +73,13 @@ protocol AppSettingsStore: AnyObject {
     /// The app's account state.
     var state: State? { get set }
 
+    /// The user's v2 account keys.
+    ///
+    /// - Parameter userId: The user ID associated with the stored account keys.
+    /// - Returns: The user's account keys.
+    ///
+    func accountKeys(userId: String) -> PrivateKeysResponseModel?
+
     /// The user's progress for setting up autofill.
     ///
     /// - Parameter userId: The user ID associated with the stored autofill setup progress.
@@ -248,6 +255,14 @@ protocol AppSettingsStore: AnyObject {
     /// - Parameter userId: The user ID associated with the server config.
     /// - Returns: The server config for that user ID.
     func serverConfig(userId: String) -> ServerConfig?
+
+    /// Sets the account v2 keys for a user ID.
+    ///
+    /// - Parameters:
+    ///   - keys: The user's account keys.
+    ///   - userId: The user ID associated with the encrypted private key.
+    ///
+    func setAccountKeys(_ keys: PrivateKeysResponseModel?, userId: String)
 
     /// Sets the user's progress for autofill setup.
     ///
@@ -706,6 +721,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
     /// The keys used to store their associated values.
     ///
     enum Keys {
+        case accountKeys(userId: String)
         case accountSetupAutofill(userId: String)
         case accountSetupImportLogins(userId: String)
         case accountSetupVaultUnlock(userId: String)
@@ -765,6 +781,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         var storageKey: String {
             let key: String
             switch self {
+            case let .accountKeys(userId):
+                key = "accountKeys_\(userId)"
             case let .accountSetupAutofill(userId):
                 key = "accountSetupAutofill_\(userId)"
             case let .accountSetupImportLogins(userId):
@@ -980,6 +998,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         }
     }
 
+    func accountKeys(userId: String) -> PrivateKeysResponseModel? {
+        fetch(for: .accountKeys(userId: userId))
+    }
+
     func accountSetupAutofill(userId: String) -> AccountSetupProgress? {
         fetch(for: .accountSetupAutofill(userId: userId))
     }
@@ -1092,6 +1114,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
 
     func serverConfig(userId: String) -> ServerConfig? {
         fetch(for: .serverConfig(userId: userId))
+    }
+
+    func setAccountKeys(_ keys: PrivateKeysResponseModel?, userId: String) {
+        store(keys, for: .accountKeys(userId: userId))
     }
 
     func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -5,6 +5,7 @@ import Foundation
 @testable import BitwardenShared
 
 class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_body_length
+    var accountKeys = [String: PrivateKeysResponseModel]()
     var accountSetupAutofill = [String: AccountSetupProgress]()
     var accountSetupImportLogins = [String: AccountSetupProgress]()
     var accountSetupVaultUnlock = [String: AccountSetupProgress]()
@@ -69,6 +70,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var usernameGenerationOptions = [String: UsernameGenerationOptions]()
 
     var activeIdSubject = CurrentValueSubject<String?, Never>(nil)
+
+    func accountKeys(userId: String) -> PrivateKeysResponseModel? {
+        accountKeys[userId]
+    }
 
     func accountSetupAutofill(userId: String) -> AccountSetupProgress? {
         accountSetupAutofill[userId]
@@ -177,6 +182,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func serverConfig(userId: String) -> ServerConfig? {
         serverConfig[userId]
+    }
+
+    func setAccountKeys(_ keys: BitwardenShared.PrivateKeysResponseModel?, userId: String) {
+        accountKeys[userId] = keys
     }
 
     func setAccountSetupAutofill(_ autofillSetup: AccountSetupProgress?, userId: String) {

--- a/BitwardenShared/Core/Platform/Utilities/KeyManagementTypes.swift
+++ b/BitwardenShared/Core/Platform/Utilities/KeyManagementTypes.swift
@@ -1,0 +1,16 @@
+import BitwardenSdk
+
+/// A private key, encrypted with a symmetric key.
+typealias WrappedPrivateKey = EncString
+
+/// A public key, signed with the accounts signature key.
+typealias SignedPublicKey = String
+
+/// A public key in base64 encoded SPKI-DER.
+typealias UnsignedPublicKey = [UInt8]
+
+/// A signature key encrypted with a symmetric key.
+typealias WrappedSigningKey = EncString
+
+/// A signature public key (verifying key) in base64 encoded CoseKey format.
+typealias VerifyingKey = String

--- a/BitwardenShared/Core/Vault/Models/Response/KeyManagement/Fixtures/PrivateKeysResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/KeyManagement/Fixtures/PrivateKeysResponseModel+Fixtures.swift
@@ -1,0 +1,29 @@
+@testable import BitwardenShared
+
+extension PrivateKeysResponseModel {
+    static func fixture(
+        publicKeyEncryptionKeyPair: PublicKeyEncryptionKeyPairResponseModel = .fixture(),
+        signatureKeyPair: SignatureKeyPairResponseModel? = nil,
+        securityState: SecurityStateResponseModel? = nil
+    ) -> PrivateKeysResponseModel {
+        self.init(
+            publicKeyEncryptionKeyPair: publicKeyEncryptionKeyPair,
+            signatureKeyPair: signatureKeyPair,
+            securityState: securityState
+        )
+    }
+}
+
+extension PublicKeyEncryptionKeyPairResponseModel {
+    static func fixture(
+        wrappedPrivateKey: WrappedPrivateKey = "",
+        publicKey: UnsignedPublicKey = [],
+        signedPublicKey: SignedPublicKey? = nil
+    ) -> PublicKeyEncryptionKeyPairResponseModel {
+        self.init(
+            wrappedPrivateKey: wrappedPrivateKey,
+            publicKey: publicKey,
+            signedPublicKey: signedPublicKey
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Response/KeyManagement/PrivateKeysResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/KeyManagement/PrivateKeysResponseModel.swift
@@ -1,0 +1,13 @@
+/// API response model for the privately accessible view of an entity (account / org)'s keys.
+/// This includes the full key-pairs for public-key encryption and signing, as well as the security state if available.
+///
+struct PrivateKeysResponseModel: Codable, Equatable {
+    /// The public key encryption key pair.
+    let publicKeyEncryptionKeyPair: PublicKeyEncryptionKeyPairResponseModel
+
+    /// The signature key pair.
+    let signatureKeyPair: SignatureKeyPairResponseModel?
+
+    /// The security state.
+    let securityState: SecurityStateResponseModel?
+}

--- a/BitwardenShared/Core/Vault/Models/Response/KeyManagement/PublicKeyEncryptionKeyPairResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/KeyManagement/PublicKeyEncryptionKeyPairResponseModel.swift
@@ -1,0 +1,12 @@
+/// API response model for a public key encryption key pair.
+///
+struct PublicKeyEncryptionKeyPairResponseModel: Codable, Equatable {
+    /// The wrapped private key.
+    let wrappedPrivateKey: WrappedPrivateKey;
+
+    /// The public key.
+    let publicKey: UnsignedPublicKey;
+
+    /// The signed public key.
+    let signedPublicKey: SignedPublicKey?;
+}

--- a/BitwardenShared/Core/Vault/Models/Response/KeyManagement/SecurityStateResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/KeyManagement/SecurityStateResponseModel.swift
@@ -1,0 +1,8 @@
+import BitwardenSdk
+
+/// API response model for the security state.
+///
+struct SecurityStateResponseModel: Codable, Equatable {
+    /// The security state.
+    let securityState: SignedSecurityState?;
+}

--- a/BitwardenShared/Core/Vault/Models/Response/KeyManagement/SignatureKeyPairResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/KeyManagement/SignatureKeyPairResponseModel.swift
@@ -1,0 +1,9 @@
+/// API response model for a signature key pair.
+///
+struct SignatureKeyPairResponseModel: Codable, Equatable {
+    /// The wrapped signing key.
+    let wrappedSigningKey: WrappedSigningKey;
+
+    /// The verifying key.
+    let verifyingKey: VerifyingKey;
+}

--- a/BitwardenShared/Core/Vault/Models/Response/ProfileResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/ProfileResponseModel.swift
@@ -5,6 +5,9 @@ import Foundation
 struct ProfileResponseModel: Codable, Equatable {
     // MARK: Properties
 
+    /// The user's account keys.
+    let accountKeys: PrivateKeysResponseModel? // TODO: PM-24659 Make it non-optional when server released for a while.
+
     /// The user's avatar color.
     let avatarColor: String?
 
@@ -45,6 +48,7 @@ struct ProfileResponseModel: Codable, Equatable {
     @DefaultFalse var premiumFromOrganization: Bool
 
     /// The user's private key.
+    @available(*, deprecated, message: "Use accountKeys instead when possible") // TODO: PM-24659 remove
     let privateKey: String?
 
     /// The user's security stamp.

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -16,6 +16,7 @@ class SyncServiceTests: BitwardenTestCase {
     var clientService: MockClientService!
     var collectionService: MockCollectionService!
     var folderService: MockFolderService!
+    var keychainRepository: MockKeychainRepository!
     var keyConnectorService: MockKeyConnectorService!
     var organizationService: MockOrganizationService!
     var policyService: MockPolicyService!
@@ -37,6 +38,7 @@ class SyncServiceTests: BitwardenTestCase {
         clientService = MockClientService()
         collectionService = MockCollectionService()
         folderService = MockFolderService()
+        keychainRepository = MockKeychainRepository()
         keyConnectorService = MockKeyConnectorService()
         organizationService = MockOrganizationService()
         policyService = MockPolicyService()
@@ -61,6 +63,7 @@ class SyncServiceTests: BitwardenTestCase {
             clientService: clientService,
             collectionService: collectionService,
             folderService: folderService,
+            keychainRepository: keychainRepository,
             keyConnectorService: keyConnectorService,
             organizationService: organizationService,
             policyService: policyService,
@@ -82,6 +85,7 @@ class SyncServiceTests: BitwardenTestCase {
         clientService = nil
         collectionService = nil
         folderService = nil
+        keychainRepository = nil
         keyConnectorService = nil
         organizationService = nil
         policyService = nil


### PR DESCRIPTION
## 🎟️ Tracking

PM-21862

## 📔 Objective

Implement passing AEAD (Authenticated Encryption with Associated Data) keys to the SDK crypto initialization and storing them.

> [!WARNING]  
> Ongoing work, missing tests and also missing crypto re-initialization from syncing responses.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
