### PR TITLE
[PM-23289] Migrate PIN unlock keys to PinProtectedUserKeyEnvelope

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1658,42 +1658,12 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_setPins() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        clientService.mockCrypto.derivePinKeyResult = .success(
-            DerivePinKeyResponse(pinProtectedUserKey: "12", encryptedPin: "34")
-        )
-
-        let userId = account.profile.userId
-        try await subject.setPins("123", requirePasswordAfterRestart: true)
-        XCTAssertEqual(stateService.pinProtectedUserKeyValue[userId], "12")
-        XCTAssertEqual(stateService.encryptedPinByUserId[userId], "34")
-        XCTAssertEqual(stateService.accountVolatileData[
-            userId,
-            default: AccountVolatileData()
-        ].pinProtectedUserKey, "12")
-    }
-
-    /// `setPins(_:requirePasswordAfterRestart:)` throws an error if one occurs.
-    func test_setPins_error() async throws {
-        clientService.mockCrypto.enrollPinResult = .failure(BitwardenTestError.example)
-        configService.featureFlagsBool[.pinProtectedKeyEnvelope] = true
-
-        await assertAsyncThrows(error: BitwardenTestError.example) {
-            try await subject.setPins("123", requirePasswordAfterRestart: true)
-        }
-    }
-
-    /// `setPins(_:requirePasswordAfterRestart:)` sets the user's pins when the pin protected key
-    /// envelope feature flag is on.
-    func test_setPins_pinProtectedKeyEnvelope() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
         clientService.mockCrypto.enrollPinResult = .success(
             EnrollPinResponse(
                 pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope",
                 userKeyEncryptedPin: "userKeyEncryptedPin"
             )
         )
-        configService.featureFlagsBool[.pinProtectedKeyEnvelope] = true
 
         try await subject.setPins("123", requirePasswordAfterRestart: true)
 
@@ -1705,6 +1675,15 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(stateService.encryptedPinByUserId[userId], "userKeyEncryptedPin")
         XCTAssertEqual(stateService.pinProtectedUserKeyEnvelopeValue[userId], "pinProtectedUserKeyEnvelope")
         XCTAssertNil(stateService.pinProtectedUserKeyValue[userId])
+    }
+
+    /// `setPins(_:requirePasswordAfterRestart:)` throws an error if one occurs.
+    func test_setPins_error() async throws {
+        clientService.mockCrypto.enrollPinResult = .failure(BitwardenTestError.example)
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            try await subject.setPins("123", requirePasswordAfterRestart: true)
+        }
     }
 
     /// `.shouldPerformMasterPasswordReprompt(reprompt:)`  when reprompt password
@@ -1763,7 +1742,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
         XCTAssertTrue(organizationService.initializeOrganizationCryptoCalled)
         XCTAssertEqual(authService.hashPasswordPassword, "password")
-        XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "ENCRYPTED_USER_KEY")
+        XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "pinProtectedUserKeyEnvelope")
         XCTAssertEqual(stateService.masterPasswordHashes["1"], "hashed")
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
         XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
@@ -1864,7 +1843,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             try await subject.unlockVaultWithBiometrics()
         }
 
-        XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "ENCRYPTED_USER_KEY")
+        XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "pinProtectedUserKeyEnvelope")
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
         XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
@@ -2188,7 +2167,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     // `unlockVaultWithPassword(_:)` unlocks the vault with the user's password and migrates the
     // legacy pin keys.
-    func test_unlockVaultWithPassword_pinProtectedKeyEnvelope_migratesPinProtectedKey() async throws {
+    func test_unlockVaultWithPassword_migratesPinProtectedUserKey() async throws {
         let account = Account.fixture()
         clientService.mockCrypto.enrollPinWithEncryptedPinResult = .success(
             EnrollPinResponse(
@@ -2196,7 +2175,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 userKeyEncryptedPin: "userKeyEncryptedPin"
             )
         )
-        configService.featureFlagsBool[.pinProtectedKeyEnvelope] = true
         stateService.activeAccount = account
         stateService.accountEncryptionKeys = [
             "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
@@ -2227,71 +2205,8 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(stateService.accountVolatileData["1"]?.pinProtectedUserKey, "pinProtectedUserKeyEnvelope")
     }
 
-    /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN.
-    func test_unlockVaultWithPIN() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-
-        stateService.accountEncryptionKeys = [
-            "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
-        ]
-
-        stateService.encryptedPinByUserId[account.profile.userId] = "123"
-        stateService.pinProtectedUserKeyValue[account.profile.userId] = "123"
-
-        await assertAsyncDoesNotThrow {
-            try await subject.unlockVaultWithPIN(pin: "123")
-        }
-
-        XCTAssertEqual(
-            clientService.mockCrypto.initializeUserCryptoRequest,
-            InitUserCryptoRequest(
-                userId: "1",
-                kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
-                email: "user@bitwarden.com",
-                privateKey: "PRIVATE_KEY",
-                signingKey: nil,
-                securityState: nil,
-                method: .pin(pin: "123", pinProtectedUserKey: "123")
-            )
-        )
-        XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
-        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
-        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
-    }
-
-    /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN when pin protected key envelope is on.
-    func test_unlockVaultWithPIN_pinProtectedKeyEnvelope() async throws {
-        let account = Account.fixture()
-        configService.featureFlagsBool[.pinProtectedKeyEnvelope] = true
-        stateService.activeAccount = account
-        stateService.accountEncryptionKeys = [
-            "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
-        ]
-        stateService.pinProtectedUserKeyEnvelopeValue[account.profile.userId] = "pinProtectedUserKeyEnvelope"
-
-        try await subject.unlockVaultWithPIN(pin: "123")
-
-        XCTAssertEqual(
-            clientService.mockCrypto.initializeUserCryptoRequest,
-            InitUserCryptoRequest(
-                userId: "1",
-                kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
-                email: "user@bitwarden.com",
-                privateKey: "PRIVATE_KEY",
-                signingKey: nil,
-                securityState: nil,
-                method: .pinEnvelope(pin: "123", pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope")
-            )
-        )
-        XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
-        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
-        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
-    }
-
-    /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN when pin protected key
-    /// envelope is on and migrates the legacy pin keys.
-    func test_unlockVaultWithPIN_pinProtectedKeyEnvelope_migratesPinProtectedKey() async throws {
+    /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN and migrates the legacy pin keys.
+    func test_unlockVaultWithPIN_pinProtectedUserKey_migratesPinProtectedUserKey() async throws {
         let account = Account.fixture()
         clientService.mockCrypto.enrollPinWithEncryptedPinResult = .success(
             EnrollPinResponse(
@@ -2299,7 +2214,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 userKeyEncryptedPin: "userKeyEncryptedPin"
             )
         )
-        configService.featureFlagsBool[.pinProtectedKeyEnvelope] = true
         stateService.activeAccount = account
         stateService.accountEncryptionKeys = [
             "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
@@ -2329,6 +2243,34 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(clientService.mockCrypto.enrollPinWithEncryptedPinEncryptedPin, "encryptedPin")
         XCTAssertEqual(stateService.pinProtectedUserKeyEnvelopeValue["1"], "pinProtectedUserKeyEnvelope")
         XCTAssertEqual(stateService.encryptedPinByUserId["1"], "userKeyEncryptedPin")
+    }
+
+    /// `unlockVaultWithPIN(_:)` unlocks the vault with the user's PIN using the pin protected user key envelope.
+    func test_unlockVaultWithPIN_pinProtectedUserKeyEnvelope() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.accountEncryptionKeys = [
+            "1": AccountEncryptionKeys(encryptedPrivateKey: "PRIVATE_KEY", encryptedUserKey: "USER_KEY"),
+        ]
+        stateService.pinProtectedUserKeyEnvelopeValue[account.profile.userId] = "pinProtectedUserKeyEnvelope"
+
+        try await subject.unlockVaultWithPIN(pin: "123")
+
+        XCTAssertEqual(
+            clientService.mockCrypto.initializeUserCryptoRequest,
+            InitUserCryptoRequest(
+                userId: "1",
+                kdfParams: .pbkdf2(iterations: UInt32(Constants.pbkdf2Iterations)),
+                email: "user@bitwarden.com",
+                privateKey: "PRIVATE_KEY",
+                signingKey: nil,
+                securityState: nil,
+                method: .pinEnvelope(pin: "123", pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope")
+            )
+        )
+        XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
     /// `unlockVaultWithPIN(_:)` throws an error if there's no pin.

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -17,9 +17,6 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// An SDK flag that enables individual cipher encryption.
     static let enableCipherKeyEncryption = FeatureFlag(rawValue: "enableCipherKeyEncryption")
 
-    /// Flag to enable/disable the new pin protected key envelope in the SDK.
-    static let pinProtectedKeyEnvelope = FeatureFlag(rawValue: "pin-protected-key-envelope")
-
     /// A feature flag to enable the removal of card item types.
     static let removeCardPolicy = FeatureFlag(
         rawValue: "pm-16442-remove-card-item-type-policy"
@@ -31,7 +28,6 @@ extension FeatureFlag: @retroactive CaseIterable {
             .cxpImportMobile,
             .cipherKeyEncryption,
             .enableCipherKeyEncryption,
-            .pinProtectedKeyEnvelope,
             .removeCardPolicy,
         ]
     }

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -17,6 +17,9 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// An SDK flag that enables individual cipher encryption.
     static let enableCipherKeyEncryption = FeatureFlag(rawValue: "enableCipherKeyEncryption")
 
+    /// Flag to enable/disable the new pin protected key envelope in the SDK.
+    static let pinProtectedKeyEnvelope = FeatureFlag(rawValue: "pin-protected-key-envelope")
+
     /// A feature flag to enable the removal of card item types.
     static let removeCardPolicy = FeatureFlag(
         rawValue: "pm-16442-remove-card-item-type-policy"
@@ -28,6 +31,7 @@ extension FeatureFlag: @retroactive CaseIterable {
             .cxpImportMobile,
             .cipherKeyEncryption,
             .enableCipherKeyEncryption,
+            .pinProtectedKeyEnvelope,
             .removeCardPolicy,
         ]
     }

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -563,6 +563,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         let vaultTimeoutService = DefaultVaultTimeoutService(
             biometricsRepository: biometricsRepository,
             clientService: clientService,
+            configService: configService,
             errorReporter: errorReporter,
             sharedTimeoutService: sharedTimeoutService,
             stateService: stateService,

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -646,21 +646,6 @@ protocol StateService: AnyObject {
 
     /// Set's the pin keys.
     ///
-    /// - Note: This is being replaced by ``setPinKeys(enrollPinResponse:requirePasswordAfterRestart:)``.
-    ///
-    /// - Parameters:
-    ///   - encryptedPin: The user's encrypted pin.
-    ///   - pinProtectedUserKey: The user's pin protected user key.
-    ///   - requirePasswordAfterRestart: Whether to require password after app restart.
-    ///
-    func setPinKeys(
-        encryptedPin: String,
-        pinProtectedUserKey: String,
-        requirePasswordAfterRestart: Bool
-    ) async throws
-
-    /// Set's the pin keys.
-    ///
     /// - Parameters:
     ///   - enrollPinResponse: The user's pin keys from enrolling a pin.
     ///   - requirePasswordAfterRestart: Whether to require password after app restart.
@@ -2015,19 +2000,6 @@ actor DefaultStateService: StateService, ConfigStateService { // swiftlint:disab
 
         appSettingsStore.pendingAppIntentActions = actions
         pendingAppIntentActionsSubject.send(actions)
-    }
-
-    func setPinKeys(
-        encryptedPin: String,
-        pinProtectedUserKey: String,
-        requirePasswordAfterRestart: Bool
-    ) async throws {
-        if requirePasswordAfterRestart {
-            try await setPinProtectedUserKeyToMemory(pinProtectedUserKey)
-        } else {
-            try appSettingsStore.setPinProtectedUserKey(key: pinProtectedUserKey, userId: getActiveAccountUserId())
-        }
-        try appSettingsStore.setEncryptedPin(encryptedPin, userId: getActiveAccountUserId())
     }
 
     func setPinKeys(

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -658,16 +658,18 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         await subject.addAccount(account)
 
         try await subject.setPinKeys(
-            encryptedPin: "123",
-            pinProtectedUserKey: "321",
+            enrollPinResponse: EnrollPinResponse(
+                pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope",
+                userKeyEncryptedPin: "userKeyEncryptedPin"
+            ),
             requirePasswordAfterRestart: true
         )
 
         let encryptedPin = try await subject.getEncryptedPin()
         let pinProtectedUserKey = await subject.accountVolatileData["1"]?.pinProtectedUserKey
 
-        XCTAssertEqual(encryptedPin, "123")
-        XCTAssertEqual(pinProtectedUserKey, "321")
+        XCTAssertEqual(encryptedPin, "userKeyEncryptedPin")
+        XCTAssertEqual(pinProtectedUserKey, "pinProtectedUserKeyEnvelope")
     }
 
     /// `getEnvironmentURLs()` returns the environment URLs for the active account.
@@ -2061,22 +2063,9 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertNil(appSettingsStore.pendingAppIntentActions)
     }
 
-    /// `setPinKeys(encryptedPin:pinProtectedUserKey:requirePasswordAfterRestart:)` sets pin keys for an account.
-    func test_setPinKeys() async throws {
-        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
-
-        try await subject.setPinKeys(
-            encryptedPin: "encryptedPin",
-            pinProtectedUserKey: "pinProtectedUserKey",
-            requirePasswordAfterRestart: false
-        )
-        XCTAssertEqual(appSettingsStore.pinProtectedUserKey["1"], "pinProtectedUserKey")
-        XCTAssertEqual(appSettingsStore.encryptedPinByUserId["1"], "encryptedPin")
-    }
-
     /// `setPinKeys(enrollPinResponse:requirePasswordAfterRestart)` sets the pin keys from the
     /// enroll pin response.
-    func test_setPinKeys_pinProtectedUserKeyEnvelope() async throws {
+    func test_setPinKeys() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
         appSettingsStore.pinProtectedUserKey["1"] = "old-pinProtectedUserKey"
 
@@ -2095,7 +2084,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
     /// `setPinKeys(enrollPinResponse:requirePasswordAfterRestart)` sets the pin keys from the
     /// enroll pin response when a master password is required after app restart.
-    func test_setPinKeys_pinProtectedUserKeyEnvelope_requiresPasswordAfterRestart() async throws {
+    func test_setPinKeys_requiresPasswordAfterRestart() async throws {
         await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
         appSettingsStore.pinProtectedUserKey["1"] = "old-pinProtectedUserKey"
 

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -134,12 +134,22 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         let account = Account.fixture()
         await subject.addAccount(account)
 
-        try await subject.clearPins()
-        let pinProtectedUserKey = try await subject.pinProtectedUserKey()
-        let encryptedPin = try await subject.getEncryptedPin()
+        appSettingsStore.encryptedPinByUserId["1"] = "encryptedPin"
+        appSettingsStore.pinProtectedUserKey["1"] = "pinProtectedUserKey"
+        appSettingsStore.pinProtectedUserKeyEnvelope["1"] = "pinProtectedUserKeyEnvelope"
 
-        XCTAssertNil(pinProtectedUserKey)
+        try await subject.clearPins()
+
+        let encryptedPin = try await subject.getEncryptedPin()
+        let pinProtectedUserKey = try await subject.pinProtectedUserKey()
+        let pinProtectedUserKeyEnvelope = try await subject.pinProtectedUserKeyEnvelope()
         XCTAssertNil(encryptedPin)
+        XCTAssertNil(pinProtectedUserKey)
+        XCTAssertNil(pinProtectedUserKeyEnvelope)
+
+        XCTAssertNil(appSettingsStore.encryptedPinByUserId["1"])
+        XCTAssertNil(appSettingsStore.pinProtectedUserKey["1"])
+        XCTAssertNil(appSettingsStore.pinProtectedUserKeyEnvelope["1"])
     }
 
     /// `deleteAccount()` deletes the active user's account, removing it from the state.
@@ -1551,6 +1561,48 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(pin, "123")
     }
 
+    /// `pinProtectedUserKeyEnvelope(userId:)` returns the pin protected user key envelope from `AppSettingsStore`.
+    func test_pinProtectedUserKeyEnvelope_appSettingsStore() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+        appSettingsStore.pinProtectedUserKeyEnvelope["1"] = "123"
+        let pin = try await subject.pinProtectedUserKeyEnvelope(userId: "1")
+        XCTAssertEqual(pin, "123")
+    }
+
+    /// `pinProtectedUserKeyEnvelope(userId:)` returns the pin protected user key envelope stored in memory.
+    func test_pinProtectedUserKeyEnvelope_inMemory() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+        try await subject.setPinProtectedUserKeyToMemory("123")
+        let pin = try await subject.pinProtectedUserKeyEnvelope(userId: "1")
+        XCTAssertEqual(pin, "123")
+    }
+
+    /// `pinUnlockRequiresPasswordAfterRestart(userId:)` returns `true` if there's no pin protected
+    /// user key stored.
+    func test_pinUnlockRequiresPasswordAfterRestart_noKey() async throws {
+        await subject.addAccount(.fixture())
+        let pinUnlockRequiresPasswordAfterRestart = try await subject.pinUnlockRequiresPasswordAfterRestart()
+        XCTAssertTrue(pinUnlockRequiresPasswordAfterRestart)
+    }
+
+    /// `pinUnlockRequiresPasswordAfterRestart(userId:)` returns `false` if there's a pin protected
+    /// user key stored.
+    func test_pinUnlockRequiresPasswordAfterRestart_pinProtectedUserKey() async throws {
+        await subject.addAccount(.fixture())
+        appSettingsStore.pinProtectedUserKey["1"] = "123"
+        let pinUnlockRequiresPasswordAfterRestart = try await subject.pinUnlockRequiresPasswordAfterRestart()
+        XCTAssertFalse(pinUnlockRequiresPasswordAfterRestart)
+    }
+
+    /// `pinUnlockRequiresPasswordAfterRestart(userId:)` returns `false` if there's a pin protected
+    /// user key envelope stored.
+    func test_pinUnlockRequiresPasswordAfterRestart_pinProtectedUserKeyEnvelope() async throws {
+        await subject.addAccount(.fixture())
+        appSettingsStore.pinProtectedUserKeyEnvelope["1"] = "123"
+        let pinUnlockRequiresPasswordAfterRestart = try await subject.pinUnlockRequiresPasswordAfterRestart()
+        XCTAssertFalse(pinUnlockRequiresPasswordAfterRestart)
+    }
+
     /// `rememberedOrgIdentifier` gets and sets the value as expected.
     func test_rememberedOrgIdentifier() {
         // Getting the value should get the value from the app settings store.
@@ -2020,6 +2072,46 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         )
         XCTAssertEqual(appSettingsStore.pinProtectedUserKey["1"], "pinProtectedUserKey")
         XCTAssertEqual(appSettingsStore.encryptedPinByUserId["1"], "encryptedPin")
+    }
+
+    /// `setPinKeys(enrollPinResponse:requirePasswordAfterRestart)` sets the pin keys from the
+    /// enroll pin response.
+    func test_setPinKeys_pinProtectedUserKeyEnvelope() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+        appSettingsStore.pinProtectedUserKey["1"] = "old-pinProtectedUserKey"
+
+        try await subject.setPinKeys(
+            enrollPinResponse: EnrollPinResponse(
+                pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope",
+                userKeyEncryptedPin: "userKeyEncryptedPin"
+            ),
+            requirePasswordAfterRestart: false
+        )
+
+        XCTAssertEqual(appSettingsStore.encryptedPinByUserId["1"], "userKeyEncryptedPin")
+        XCTAssertEqual(appSettingsStore.pinProtectedUserKeyEnvelope["1"], "pinProtectedUserKeyEnvelope")
+        XCTAssertNil(appSettingsStore.pinProtectedUserKey["1"]) // Ensure legacy key is removed.
+    }
+
+    /// `setPinKeys(enrollPinResponse:requirePasswordAfterRestart)` sets the pin keys from the
+    /// enroll pin response when a master password is required after app restart.
+    func test_setPinKeys_pinProtectedUserKeyEnvelope_requiresPasswordAfterRestart() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+        appSettingsStore.pinProtectedUserKey["1"] = "old-pinProtectedUserKey"
+
+        try await subject.setPinKeys(
+            enrollPinResponse: EnrollPinResponse(
+                pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope",
+                userKeyEncryptedPin: "userKeyEncryptedPin"
+            ),
+            requirePasswordAfterRestart: true
+        )
+
+        let accountVolatileData = await subject.accountVolatileData["1"]
+        XCTAssertEqual(accountVolatileData?.pinProtectedUserKey, "pinProtectedUserKeyEnvelope")
+        XCTAssertEqual(appSettingsStore.encryptedPinByUserId["1"], "userKeyEncryptedPin")
+        XCTAssertNil(appSettingsStore.pinProtectedUserKeyEnvelope["1"])
+        XCTAssertNil(appSettingsStore.pinProtectedUserKey["1"]) // Ensure legacy key is removed.
     }
 
     /// `setPreAuthEnvironmentURLs` saves the pre-auth URLs.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -230,10 +230,19 @@ protocol AppSettingsStore: AnyObject {
 
     /// The pin protected user key.
     ///
+    /// - Note: This is being replaced by ``pinProtectedUserKeyEnvelope(userId:)``.
+    ///
     /// - Parameter userId: The user ID associated with the pin protected user key.
     /// - Returns: The pin protected user key.
     ///
     func pinProtectedUserKey(userId: String) -> String?
+
+    /// The pin protected user key envelope.
+    ///
+    /// - Parameter userId: The user ID associated with the pin protected user key.
+    /// - Returns: The pin protected user key envelope.
+    ///
+    func pinProtectedUserKeyEnvelope(userId: String) -> String?
 
     /// Gets the environment URLs used to start the account creation flow.
     ///
@@ -427,11 +436,21 @@ protocol AppSettingsStore: AnyObject {
 
     /// Sets the pin protected user key.
     ///
+    /// - Note: This is being replaced by ``setPinProtectedUserKeyEnvelope(userId:)``.
+    ///
     /// - Parameters:
     ///  - key: A pin protected user key derived from the user's pin.
     ///   - userId: The user ID.
     ///
     func setPinProtectedUserKey(key: String?, userId: String)
+
+    /// Sets the pin protected user key envelope.
+    ///
+    /// - Parameters:
+    ///  - key: A pin protected user key envelope derived from the user's pin.
+    ///   - userId: The user ID.
+    ///
+    func setPinProtectedUserKeyEnvelope(key: String?, userId: String)
 
     /// Sets the environment URLs used to start the account creation flow.
     ///
@@ -742,7 +761,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case notificationsLastRegistrationDate(userId: String)
         case passwordGenerationOptions(userId: String)
         case pendingAppIntentActions
-        case pinProtectedUserKey(userId: String)
+        case pinProtectedUserKey(userId: String) // Replaced by `pinProtectedUserKeyEnvelope`.
+        case pinProtectedUserKeyEnvelope(userId: String)
         case preAuthEnvironmentURLs
         case accountCreationEnvironmentURLs(email: String)
         case preAuthServerConfig
@@ -839,6 +859,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 key = "pendingAppIntentActions"
             case let .pinProtectedUserKey(userId):
                 key = "pinKeyEncryptedUserKey_\(userId)"
+            case let .pinProtectedUserKeyEnvelope(userId):
+                key = "pinProtectedUserKeyEnvelope_\(userId)"
             case .preAuthEnvironmentURLs:
                 key = "preAuthEnvironmentUrls"
             case let .accountCreationEnvironmentURLs(email):
@@ -1084,6 +1106,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         fetch(for: .pinProtectedUserKey(userId: userId))
     }
 
+    func pinProtectedUserKeyEnvelope(userId: String) -> String? {
+        fetch(for: .pinProtectedUserKeyEnvelope(userId: userId))
+    }
+
     func accountCreationEnvironmentURLs(email: String) -> EnvironmentURLData? {
         fetch(
             for: .accountCreationEnvironmentURLs(email: email)
@@ -1184,6 +1210,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
 
     func setPinProtectedUserKey(key: String?, userId: String) {
         store(key, for: .pinProtectedUserKey(userId: userId))
+    }
+
+    func setPinProtectedUserKeyEnvelope(key: String?, userId: String) {
+        store(key, for: .pinProtectedUserKeyEnvelope(userId: userId))
     }
 
     func setAccountCreationEnvironmentURLs(environmentURLData: EnvironmentURLData, email: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -805,6 +805,15 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:pinKeyEncryptedUserKey_1"), pin)
     }
 
+    /// `pinProtectedUserKeyEnvelope(userId:)` can be used to get the pin protected user key envelope for a user.
+    func test_pinProtectedUserKeyEnvelope() {
+        let userId = Account.fixture().profile.userId
+        subject.setPinProtectedUserKeyEnvelope(key: "123", userId: userId)
+        let pin = subject.pinProtectedUserKeyEnvelope(userId: userId)
+        XCTAssertEqual(pin, "123")
+        XCTAssertEqual(userDefaults.string(forKey: "bwPreferencesStorage:pinProtectedUserKeyEnvelope_1"), "123")
+    }
+
     /// `preAuthEnvironmentURLs` returns `nil` if there isn't a previously stored value.
     func test_preAuthEnvironmentURLs_isInitiallyNil() {
         XCTAssertNil(subject.preAuthEnvironmentURLs)

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -50,6 +50,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var notificationsLastRegistrationDates = [String: Date]()
     var passwordGenerationOptions = [String: PasswordGenerationOptions]()
     var pinProtectedUserKey = [String: String]()
+    var pinProtectedUserKeyEnvelope = [String: String]()
     var accountCreationEnvironmentURLs = [String: EnvironmentURLData]()
     var serverConfig = [String: ServerConfig]()
     var shouldTrustDevice = [String: Bool?]()
@@ -165,6 +166,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func pinProtectedUserKey(userId: String) -> String? {
         pinProtectedUserKey[userId]
+    }
+
+    func pinProtectedUserKeyEnvelope(userId: String) -> String? {
+        pinProtectedUserKeyEnvelope[userId]
     }
 
     func accountCreationEnvironmentURLs(email: String) -> EnvironmentURLData? {
@@ -285,6 +290,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setPinProtectedUserKey(key: String?, userId: String) {
         pinProtectedUserKey[userId] = key
+    }
+
+    func setPinProtectedUserKeyEnvelope(key: String?, userId: String) {
+        pinProtectedUserKeyEnvelope[userId] = key
     }
 
     func setAccountCreationEnvironmentURLs(environmentURLData: EnvironmentURLData, email: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -635,23 +635,6 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         pendingAppIntentActions = actions
     }
 
-    func setPinKeys(
-        encryptedPin: String,
-        pinProtectedUserKey: String,
-        requirePasswordAfterRestart: Bool
-    ) async throws {
-        let userId = try unwrapUserId(nil)
-        pinProtectedUserKeyValue[userId] = pinProtectedUserKey
-        encryptedPinByUserId[userId] = encryptedPin
-
-        if requirePasswordAfterRestart {
-            accountVolatileData[
-                userId,
-                default: AccountVolatileData()
-            ].pinProtectedUserKey = pinProtectedUserKey
-        }
-    }
-
     func setPinKeys(enrollPinResponse: EnrollPinResponse, requirePasswordAfterRestart: Bool) async throws {
         let userId = try unwrapUserId(nil)
         pinProtectedUserKeyEnvelopeValue[userId] = enrollPinResponse.pinProtectedUserKeyEnvelope

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -1,5 +1,6 @@
 import BitwardenKit
 import BitwardenKitMocks
+import struct BitwardenSdk.EnrollPinResponse
 import Combine
 import Foundation
 
@@ -69,6 +70,9 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
     var pendingAppIntentActionsSubject = CurrentValueSubject<[PendingAppIntentAction]?, Never>(nil)
     var pinProtectedUserKeyError: Error?
     var pinProtectedUserKeyValue = [String: String]()
+    var pinProtectedUserKeyEnvelopeError: Error?
+    var pinProtectedUserKeyEnvelopeValue = [String: String]()
+    var pinUnlockRequiresPasswordAfterRestartValue = false // swiftlint:disable:this identifier_name
     var preAuthEnvironmentURLs: EnvironmentURLData?
     var accountCreationEnvironmentURLs = [String: EnvironmentURLData]()
     var preAuthServerConfig: ServerConfig?
@@ -429,6 +433,16 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
         return pinProtectedUserKeyValue[userId] ?? nil
     }
 
+    func pinProtectedUserKeyEnvelope(userId: String?) async throws -> String? {
+        if let pinProtectedUserKeyEnvelopeError { throw pinProtectedUserKeyEnvelopeError }
+        let userId = try unwrapUserId(userId)
+        return pinProtectedUserKeyEnvelopeValue[userId] ?? nil
+    }
+
+    func pinUnlockRequiresPasswordAfterRestart() async throws -> Bool {
+        pinUnlockRequiresPasswordAfterRestartValue
+    }
+
     func setAccountEncryptionKeys(_ encryptionKeys: AccountEncryptionKeys, userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         accountEncryptionKeys[userId] = encryptionKeys
@@ -635,6 +649,19 @@ class MockStateService: StateService { // swiftlint:disable:this type_body_lengt
                 userId,
                 default: AccountVolatileData()
             ].pinProtectedUserKey = pinProtectedUserKey
+        }
+    }
+
+    func setPinKeys(enrollPinResponse: EnrollPinResponse, requirePasswordAfterRestart: Bool) async throws {
+        let userId = try unwrapUserId(nil)
+        pinProtectedUserKeyEnvelopeValue[userId] = enrollPinResponse.pinProtectedUserKeyEnvelope
+        encryptedPinByUserId[userId] = enrollPinResponse.userKeyEncryptedPin
+
+        if requirePasswordAfterRestart {
+            accountVolatileData[
+                userId,
+                default: AccountVolatileData()
+            ].pinProtectedUserKey = enrollPinResponse.pinProtectedUserKeyEnvelope
         }
     }
 

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -181,12 +181,9 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     }
 
     func isPinUnlockAvailable(userId: String?) async throws -> Bool {
-        if await configService.getFeatureFlag(.pinProtectedKeyEnvelope),
-           try await stateService.pinProtectedUserKeyEnvelope(userId: userId) != nil {
-            true
-        } else {
-            try await stateService.pinProtectedUserKey(userId: userId) != nil
-        }
+        let hasPinProtectedUserKeyEnvelope = try await stateService.pinProtectedUserKeyEnvelope(userId: userId) != nil
+        let hasPinProtectedUserKey = try await stateService.pinProtectedUserKey(userId: userId) != nil
+        return hasPinProtectedUserKeyEnvelope || hasPinProtectedUserKey
     }
 
     func lockVault(userId: String?) async {

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -106,6 +106,9 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     /// The service that handles common client functionality such as encryption and decryption.
     private let clientService: ClientService
 
+    /// The service to get server-specified configuration.
+    private let configService: ConfigService
+
     /// The service used by the application to report non-fatal errors.
     private let errorReporter: ErrorReporter
 
@@ -128,6 +131,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     /// - Parameters:
     ///   - biometricsRepository: The service to use system biometrics for vault unlock.
     ///   - clientService: The service that handles common client functionality such as encryption and decryption.
+    ///   - configService: The service to get server-specified configuration.
     ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - sharedTimeoutService: The service that manages account timeout between apps.
     ///   - stateService: The StateService used by DefaultVaultTimeoutService.
@@ -136,6 +140,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     init(
         biometricsRepository: BiometricsRepository,
         clientService: ClientService,
+        configService: ConfigService,
         errorReporter: ErrorReporter,
         sharedTimeoutService: SharedTimeoutService,
         stateService: StateService,
@@ -143,6 +148,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     ) {
         self.biometricsRepository = biometricsRepository
         self.clientService = clientService
+        self.configService = configService
         self.errorReporter = errorReporter
         self.sharedTimeoutService = sharedTimeoutService
         self.stateService = stateService
@@ -175,7 +181,12 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     }
 
     func isPinUnlockAvailable(userId: String?) async throws -> Bool {
-        try await stateService.pinProtectedUserKey(userId: userId) != nil
+        if await configService.getFeatureFlag(.pinProtectedKeyEnvelope),
+           try await stateService.pinProtectedUserKeyEnvelope(userId: userId) != nil {
+            true
+        } else {
+            try await stateService.pinProtectedUserKey(userId: userId) != nil
+        }
     }
 
     func lockVault(userId: String?) async {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23289](https://bitwarden.atlassian.net/browse/PM-23289)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

> [!NOTE]
> This depends on https://github.com/bitwarden/sdk-internal/pull/372
 
Migrates any existing pin keys to a pin protected user key envelope. Existing pins will be migrated when the vault is unlocked. And any new pins will use a pin protected user key envelope on creation.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23289]: https://bitwarden.atlassian.net/browse/PM-23289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ