### PR TITLE
[PM-25246] Update protobuf version to 1.31.0

### DIFF
--- a/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "d72aed98f8253ec1aa9ea1141e28150f408cf17f",
-        "version" : "1.29.0"
+        "revision" : "e3f69fd321d0c9fcdc16fb576a0cdd956675face",
+        "version" : "1.31.0"
       }
     },
     {

--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -36,7 +36,7 @@ packages:
     exactVersion: 1.18.4
   SwiftProtobuf:
     url: https://github.com/apple/swift-protobuf
-    exactVersion: 1.29.0
+    exactVersion: 1.31.0
   ViewInspector:
     url: https://github.com/nalexn/ViewInspector
     exactVersion: 0.10.1


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25246

## 📔 Objective

This fixes build failures with BWA that were caused because homebrew always grabs the latest version of protobuf (which right now is 1.31) but we were still using 1.29, and the two versions are incompatible, per [this issue on the swift-protobuf repo](https://github.com/apple/swift-protobuf/issues/1830). This therefore updates our version to 1.31.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
