### PR TITLE
[PM-23543] Revert: Added Swift active compilation condition flag DISABLE_ASSERTION_FAILURE_ON_ERROR

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/OSLogErrorReporter.swift
+++ b/BitwardenKit/Core/Platform/Utilities/OSLogErrorReporter.swift
@@ -37,10 +37,8 @@ public final class OSLogErrorReporter: ErrorReporter {
 
         guard !error.isNonLoggableError else { return }
 
-        #if !DISABLE_ASSERTION_FAILURE_ON_ERROR
         // Crash in debug builds to make the error more visible during development.
         assertionFailure("Unexpected error: \(error)")
-        #endif
     }
 
     public func setRegion(_ region: String, isPreAuth: Bool) {

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -61,7 +61,7 @@ case "$MODE" in
     xcrun xcodebuild \
       -workspace Bitwarden.xcworkspace \
       -scheme "${BUILD_SCHEME}" \
-      -configuration Debug SWIFT_ACTIVE_COMPILATION_CONDITIONS="$(inherited) DISABLE_ASSERTION_FAILURE_ON_ERROR"\
+      -configuration Debug \
       -destination "generic/platform=iOS Simulator" \
       -derivedDataPath "${DERIVED_DATA_PATH}" \
       | xcbeautify --renderer github-actions


### PR DESCRIPTION
## 🎟️ Tracking

PM-23543

## 📔 Objective

Reverting #1843 as it's causing problems with the Simulator CI build

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
