### PR TITLE
[PM-25284] Fix invalid URL on CXP flow when URL is IP address with port

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/String+Extensions.swift
+++ b/BitwardenKit/Core/Platform/Extensions/String+Extensions.swift
@@ -15,7 +15,7 @@ public extension String {
             return url.absoluteString
         }
 
-        if !self.hasPrefix("http") {
+        if !hasPrefix("http") {
             return "https://\(self)"
         }
 

--- a/BitwardenKit/Core/Platform/Extensions/String+Extensions.swift
+++ b/BitwardenKit/Core/Platform/Extensions/String+Extensions.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Extension helpers for `String`.
+public extension String {
+    /// Tries to convert the string to an `URL`, if it can't then it tries to fix it by adding
+    /// a http scheme prefix if it's an IP address or https scheme prefix in any other case.
+    /// - Returns: The same `String` if it can be converted to an `URL` or the fixed
+    /// `String` otherwise.
+    func fixURLIfNeeded() -> String {
+        if URL(string: self) != nil {
+            return self
+        }
+
+        if let url = URL(string: "http://\(self)"), url.isIPAddress {
+            return url.absoluteString
+        }
+
+        if !self.hasPrefix("http") {
+            return "https://\(self)"
+        }
+
+        return self
+    }
+}

--- a/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
@@ -1,0 +1,27 @@
+import BitwardenKit
+import Combine
+import XCTest
+
+class StringExtensionsTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `fixURLIfNeeded()` returns the same string when it can be directly converted to `URL`.
+    func test_fixURLIfNeeded_sameStringWhenCanConvertToURL() {
+        let string = "https://bitwarden.com"
+        XCTAssertEqual(string.fixURLIfNeeded(), "https://bitwarden.com")
+    }
+
+    /// `fixURLIfNeeded()` returns the same string prefixed with "http://" when it can't be
+    /// directly converted to `URL` and it's an IP address.
+    func test_fixURLIfNeeded_httpWhenIPAddress() {
+        let string = "192.168.0.1:8080"
+        XCTAssertEqual(string.fixURLIfNeeded(), "http://192.168.0.1:8080")
+    }
+
+    /// `fixURLIfNeeded()` returns the same string prefixed with "https://" when it can't be
+    /// directly converted to `URL` and it's not an IP address.
+    func test_fixURLIfNeeded_httpsWhenNotIPAddress() {
+        let string = "ht tp://broken.com"
+        XCTAssertEqual(string.fixURLIfNeeded(), "https://ht tp://broken.com")
+    }
+}

--- a/BitwardenKit/Core/Platform/Extensions/URL.swift
+++ b/BitwardenKit/Core/Platform/Extensions/URL.swift
@@ -1,6 +1,23 @@
 import Foundation
 
 public extension URL {
+    // MARK: Private Properties
+
+    /// A regular expression that matches IP addresses.
+    private var ipRegex: String {
+        "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+            "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+            "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
+            "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+    }
+
+    // MARK: Properties
+
+    /// Determines if the URI is an IP address.
+    var isIPAddress: Bool {
+        host?.range(of: ipRegex, options: .regularExpression) != nil
+    }
+
     /// Returns a sanitized version of the URL. This will add a https scheme to the URL if the
     /// scheme is missing and remove a trailing slash.
     var sanitized: URL {

--- a/BitwardenKit/Core/Platform/Extensions/URLTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/URLTests.swift
@@ -5,6 +5,18 @@ import XCTest
 class URLTests: BitwardenTestCase {
     // MARK: Tests
 
+    /// `isIPAddress` returns `true` when the URL is an IP Address, `false` otherwise.
+    func test_isIPAddress() {
+        XCTAssertFalse(URL(string: "https://localhost")?.isIPAddress == true)
+        XCTAssertFalse(URL(string: "https://localhost/test")?.isIPAddress == true)
+        XCTAssertTrue(URL(string: "https://1.1.1.1")?.isIPAddress == true)
+        XCTAssertTrue(URL(string: "http://192.168.0.1")?.isIPAddress == true)
+        XCTAssertTrue(URL(string: "http://192.168.0.1:8080")?.isIPAddress == true)
+
+        XCTAssertFalse(URL(string: "https://example.com")?.isIPAddress == true)
+        XCTAssertFalse(URL(string: "https://example.co.uk")?.isIPAddress == true)
+    }
+
     /// `sanitized` prepends a https scheme if the URL is missing a scheme.
     func test_sanitized_missingScheme() {
         XCTAssertEqual(

--- a/BitwardenKit/Core/Platform/Services/API/Extensions/JSONDecoder+Bitwarden.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Extensions/JSONDecoder+Bitwarden.swift
@@ -56,7 +56,7 @@ public extension JSONDecoder {
 
     /// A `JSONDecoder` instance that handles decoding JSON from Credential Exchange format to Apple's expected format.
     static let cxfDecoder: JSONDecoder = {
-        let decoder = JSONDecoder()
+        let decoder = URLFixingJSONDecoder(urlArrayPropertyNames: ["urls"])
         decoder.keyDecodingStrategy = .custom { keys in
             let key = keys.last!.stringValue
             return AnyKey(stringValue: keyToCamelCase(key: key))

--- a/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoder.swift
+++ b/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoder.swift
@@ -61,6 +61,6 @@ public class URLFixingJSONDecoder: JSONDecoder, @unchecked Sendable {
     /// - Returns: `true` if the `key` is one of the property names, `false` otherwise.
     private func isURLArrayProperty(_ key: String) -> Bool {
         let lowercasedKey = key.lowercased()
-        return urlArrayPropertyNames.contains { lowercasedKey.contains($0) }
+        return urlArrayPropertyNames.contains { lowercasedKey == $0 }
     }
 }

--- a/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoder.swift
+++ b/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoder.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+// MARK: - URLFixingJSONDecoder
+
+/// Custom Decoder that fixes data to decode so if there's something that should be converted to URL
+/// but can't because of lacking scheme, it will prefix it with "http" when it's an IP address and with
+/// "https" in any other case.
+public class URLFixingJSONDecoder: JSONDecoder, @unchecked Sendable {
+    /// The property names of the JSON to decode that are an array of URL objects.
+    private let urlArrayPropertyNames: [String]
+
+    /// initializes a `URLFixingJSONDecoder`.
+    /// - Parameter urlArrayPropertyNames: The property names of the JSON to decode that are an array of URL objects.
+    /// These properties will go through this custom URL fixing logic.
+    public init(urlArrayPropertyNames: [String]) {
+        self.urlArrayPropertyNames = urlArrayPropertyNames
+    }
+
+    override public func decode<T>(_ type: T.Type, from data: Data) throws -> T where T: Decodable {
+        let fixedData = try preprocessURLs(in: data)
+        return try super.decode(type, from: fixedData)
+    }
+
+    /// Performs the preprocessing of the data and fixes the URL properties if needed.
+    /// - Parameter data: The Data to process and fix if needed.
+    /// - Returns: The fixed data.
+    private func preprocessURLs(in data: Data) throws -> Data {
+        guard let jsonObject = try? JSONSerialization.jsonObject(with: data) else {
+            return data
+        }
+
+        let fixedObject = fixURLsInObject(jsonObject)
+        return try JSONSerialization.data(withJSONObject: fixedObject)
+    }
+
+    /// Traverses the JSON object and fixes the URL array properties if needed.
+    /// - Parameter object: The JSON object to check.
+    /// - Returns: The fixed JSON object.
+    private func fixURLsInObject(_ object: Any) -> Any {
+        if let dictionary = object as? [String: Any] {
+            var fixedDict = [String: Any]()
+            for (key, value) in dictionary {
+                if isURLArrayProperty(key), let urlArray = value as? [String] {
+                    // Auto-detect URL array properties
+                    fixedDict[key] = urlArray.map { $0.fixURLIfNeeded() }
+                } else {
+                    // Recursively process nested objects
+                    fixedDict[key] = fixURLsInObject(value)
+                }
+            }
+            return fixedDict
+        } else if let array = object as? [Any] {
+            return array.map { fixURLsInObject($0) }
+        } else {
+            return object
+        }
+    }
+
+    /// Checks whether the `key` passed is one of the property names configured for URL arrays.
+    /// - Parameter key: JSON key to check.
+    /// - Returns: `true` if the `key` is one of the property names, `false` otherwise.
+    private func isURLArrayProperty(_ key: String) -> Bool {
+        let lowercasedKey = key.lowercased()
+        return urlArrayPropertyNames.contains { lowercasedKey.contains($0) }
+    }
+}

--- a/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoderTests.swift
+++ b/BitwardenKit/Core/Platform/Utilities/URLFixingJSONDecoderTests.swift
@@ -1,0 +1,95 @@
+import XCTest
+
+@testable import BitwardenKit
+
+// MARK: - URLFixingJSONDecoderTests
+
+class URLFixingJSONDecoderTests: BitwardenTestCase {
+    // MARK: Types
+
+    private struct JSONContainerBody: Codable, Equatable {
+        let urls: [URL]
+        let someUrls: [URL]
+    }
+
+    private struct JSONBody: Codable, Equatable {
+        let id: String
+        let container: JSONContainerBody
+    }
+
+    // MARK: Properties
+
+    var subject: URLFixingJSONDecoder!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = URLFixingJSONDecoder(urlArrayPropertyNames: ["urls"])
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `decode` using this JSON decoder fixes IP address URLs with port and decodes
+    /// them correctly
+    func test_decode_withValidJSON_decodesSuccessfully() throws {
+        let toDecode =
+            """
+            {
+                "id": "1",
+                "container": {
+                    "urls": [
+                        "192.168.1.100:8080",
+                        "192.168.1.100",
+                        "10.0.0.2:4000/example",
+                        "api.example.com/v1/endpoint",
+                        "https://secure.example.com/api/v2"
+                    ],
+                    "someUrls": []
+                }
+            }   
+            """
+
+        let result = try subject.decode(JSONBody.self, from: Data(toDecode.utf8))
+        XCTAssertEqual(
+            result.container.urls.map(\.absoluteString),
+            [
+                "http://192.168.1.100:8080",
+                "192.168.1.100",
+                "http://10.0.0.2:4000/example",
+                "api.example.com/v1/endpoint",
+                "https://secure.example.com/api/v2",
+            ]
+        )
+    }
+
+    /// `decode` using this JSON decoder doesn't fix IP address URLs with port and throws when decoding
+    /// a URL array property not configured in the decoder initializer.
+    func test_decode_throwsWhenJSONHasURLsInPropertyNotIncludedInTheDecoderConfig() throws {
+        let toDecode =
+            """
+            {
+                "id": "1",
+                "container": {
+                    "urls": [],
+                    "someUrls": [
+                        "192.168.1.100:8080",
+                        "192.168.1.100",
+                        "10.0.0.2:4000/example",
+                        "api.example.com/v1/endpoint",
+                        "https://secure.example.com/api/v2"
+                    ]
+                }
+            }   
+            """
+
+        XCTAssertThrowsError(try subject.decode(JSONBody.self, from: Data(toDecode.utf8)))
+    }
+}

--- a/BitwardenShared/Core/Platform/Extensions/URL.swift
+++ b/BitwardenShared/Core/Platform/Extensions/URL.swift
@@ -2,16 +2,6 @@ import BitwardenKit
 import Foundation
 
 extension URL {
-    // MARK: Private Properties
-
-    /// A regular expression that matches IP addresses.
-    private var ipRegex: String {
-        "^(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
-            "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
-            "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\." +
-            "(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
-    }
-
     // MARK: Properties
 
     /// If the URL is for an app using the Bitwarden `iosapp://` URL scheme, this returns the web
@@ -24,8 +14,7 @@ extension URL {
 
     /// Returns the URL's domain constructed from the top-level and second-level domain.
     var domain: String? {
-        let isIpAddress = host?.range(of: ipRegex, options: .regularExpression) != nil
-        if host == "localhost" || isIpAddress {
+        if host == "localhost" || isIPAddress {
             return host
         }
         return DomainName.parseBaseDomain(url: self) ?? host


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25284](https://bitwarden.atlassian.net/browse/PM-25284)

## 📔 Objective

Fix CXP JSON decoder so it takes into consideration URIs where it has no scheme, are IP addresses and have a port. This was causing the URL(string:) initializer to return `nil` and breaking the decoding process. This fixes it by prefixing `http://` or `https://` accordingly depending on if it's an IP address or a different type of URI that can't be converted to `URL` directly.

Example of URL that was causing problems: `192.168.0.1:8080`.

> [!NOTE]
> A new decoder was added that can configure property names that are array of URLs to be taken into account for the fix. This will check whether the URL is an IP address and add the `http://` prefix to it so it's able to be automatically decoded to `URL` without problems.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25284]: https://bitwarden.atlassian.net/browse/PM-25284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ