### PR TITLE
[PM-25539] Fix flaky tests in PasteboardServiceTests making waitFor async

### DIFF
--- a/BitwardenShared/Core/Platform/Services/PasteboardServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/PasteboardServiceTests.swift
@@ -28,11 +28,6 @@ class PasteboardServiceTests: BitwardenTestCase {
             pasteboard: pasteboard,
             stateService: stateService
         )
-
-        // Wait for the `DefaultPasteboardService.init` task to set the initial clear clipboard
-        // value for the active account, otherwise there's a potential race condition between that
-        // and the tests below.
-        waitFor { subject.clearClipboardValue == .oneMinute }
     }
 
     override func tearDown() {
@@ -49,13 +44,15 @@ class PasteboardServiceTests: BitwardenTestCase {
     /// Test that copying a string puts the value on the `UIPasteboard` as expected.
     @MainActor
     func test_copy() async throws {
+        try await waitForInitialization()
+
         try await stateService.setClearClipboardValue(.never)
         subject.copy("Test string")
         XCTAssertEqual(pasteboard.strings?.last, "Test string")
         XCTAssertTrue(pasteboard.isPersistent)
 
         subject.updateClearClipboardValue(.fiveMinutes)
-        waitFor { self.stateService.clearClipboardValues["1"] != .never }
+        try await waitForAsync { self.stateService.clearClipboardValues["1"] != .never }
         let value = try await stateService.getClearClipboardValue()
         XCTAssertEqual(value, .fiveMinutes)
 
@@ -67,11 +64,13 @@ class PasteboardServiceTests: BitwardenTestCase {
     /// Test that an error from no account should use the default value without recording an error.
     @MainActor
     func test_error_noAccount() async throws {
+        try await waitForInitialization()
+
         stateService.activeAccount = nil
 
         stateService.activeIdSubject.send(nil)
 
-        waitFor { subject.clearClipboardValue == .never }
+        try await waitForAsync { self.subject.clearClipboardValue == .never }
         XCTAssertEqual(subject.clearClipboardValue, .never)
         XCTAssertTrue(errorReporter.errors.isEmpty)
     }
@@ -79,22 +78,39 @@ class PasteboardServiceTests: BitwardenTestCase {
     /// Test that an error updating besides not being logged in should be recorded.
     @MainActor
     func test_error_other() async throws {
+        try await waitForInitialization()
+
         stateService.clearClipboardResult = .failure(BitwardenTestError.example)
 
         stateService.activeIdSubject.send(nil)
 
-        waitFor { self.errorReporter.errors.isEmpty == false }
+        try await waitForAsync { self.errorReporter.errors.isEmpty == false }
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
     /// Test that any errors from updating the value are recorded.
     @MainActor
     func test_error_updating() async throws {
+        try await waitForInitialization()
+
         stateService.clearClipboardResult = .failure(BitwardenTestError.example)
 
         subject.updateClearClipboardValue(.twentySeconds)
 
-        waitFor { self.errorReporter.errors.isEmpty == false }
+        try await waitForAsync { self.errorReporter.errors.isEmpty == false }
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    // MARK: Private
+    
+    /// Waits for the `DefaultPasteboardService.init` task to initialize the correct value to avoid race conditions.
+    func waitForInitialization() async throws {
+        // Wait for the `DefaultPasteboardService.init` task to set the initial clear clipboard
+        // value for the active account, otherwise there's a potential race condition between that
+        // and the tests.
+        try await waitForAsync { [weak self] in
+            guard let self else { return false }
+            return subject.clearClipboardValue == .oneMinute
+        }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-25539](https://bitwarden.atlassian.net/browse/PM-25539)

## 📔 Objective

Sometimes `PasteboardServiceTests` fail in CI randomly, so this tries to fix a race-condition that may be happening in there and making it more robust by using `waitForAsync` instead of `waitFor` which has less problems on async tests.

Locally I wasn't able to reproduce the error even running multiple times (100, 200 several times) but did this change which hopefully fixes it and it has worked on other places.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
