### PR TITLE
[PM-25140] LandingView: hide account switcher toolbar button if no accounts

### DIFF
--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -20,8 +20,10 @@ struct LandingView: View {
         }
         .navigationBarTitle(Localizations.bitwarden, displayMode: .inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                profileSwitcherToolbarItem
+            ToolbarItem(placement: .topBarLeading) {
+                if !store.state.profileSwitcherState.accounts.isEmpty {
+                    profileSwitcherToolbarItem
+                }
             }
         }
         .task {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25140](https://bitwarden.atlassian.net/browse/PM-25140)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Prior to iOS 26, we relied on the fact that an empty view was enough to hide a toolbar button in the toolbar. However, iOS 26 shows the shadow for a button even if there's nothing in the button. This hides the profile switcher button completely if there's no accounts to show.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="568" height="1084" alt="Screenshot 2025-09-05 at 4 09 07 PM" src="https://github.com/user-attachments/assets/b873b040-6487-47de-a41f-232467cfa140" /> | <img width="568" height="1084" alt="Screenshot 2025-09-05 at 4 00 00 PM" src="https://github.com/user-attachments/assets/7f49d8a5-c6b8-4844-9f81-9e1582b611e6" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25140]: https://bitwarden.atlassian.net/browse/PM-25140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ