### PR TITLE
[PM-25540] Removed advanced text from learn more modals on URI Match detection

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -84,14 +84,14 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
         switch defaultUriMatchType {
         case .regularExpression:
             coordinator.showAlert(.confirmRegularExpressionMatchDetectionAlert {
-                await self.updateDefaultUriMatchType(defaultUriMatchType, showLearnMore: true)
+                await self.updateDefaultUriMatchType(defaultUriMatchType)
             })
         case .startsWith:
             coordinator.showAlert(.confirmStartsWithMatchDetectionAlert {
-                await self.updateDefaultUriMatchType(defaultUriMatchType, showLearnMore: true)
+                await self.updateDefaultUriMatchType(defaultUriMatchType)
             })
         default:
-            await updateDefaultUriMatchType(defaultUriMatchType, showLearnMore: false)
+            await updateDefaultUriMatchType(defaultUriMatchType)
         }
     }
 
@@ -131,16 +131,22 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     }
 
     /// Updates the default URI match type value for the user.
-    /// - Parameters:
-    /// - defaultUriMatchType: The default URI match type.
-    /// - showLearnMore: If should display the learn more dialog.
-    /// 
-    private func updateDefaultUriMatchType(_ defaultUriMatchType: UriMatchType, showLearnMore: Bool) async {
+    /// - Parameter defaultUriMatchType: The default URI match type.
+    ///
+    private func updateDefaultUriMatchType(_ defaultUriMatchType: UriMatchType) async {
         do {
             state.defaultUriMatchType = defaultUriMatchType
             try await services.settingsRepository.updateDefaultUriMatchType(defaultUriMatchType)
-            if showLearnMore {
-                showLearnMoreAlert(defaultUriMatchType.localizedName)
+
+            switch defaultUriMatchType {
+            case .regularExpression:
+                showLearnMoreAlert(Localizations.regEx)
+
+            case .startsWith:
+                showLearnMoreAlert(Localizations.startsWith)
+
+            default:
+                return
             }
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -83,15 +83,26 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     private func confirmAndUpdateDefaultUriMatchType(_ defaultUriMatchType: UriMatchType) async {
         switch defaultUriMatchType {
         case .regularExpression:
-            coordinator.showAlert(.confirmRegularExpressionMatchDetectionAlert {
-                await self.updateDefaultUriMatchType(defaultUriMatchType)
-            })
+            coordinator.showAlert(
+                .confirmRegularExpressionMatchDetectionAlert {
+                    await self.updateDefaultUriMatchType(
+                        defaultUriMatchType,
+                        learnMoreLocalizedMatchType: Localizations.regEx
+                    )
+                })
         case .startsWith:
-            coordinator.showAlert(.confirmStartsWithMatchDetectionAlert {
-                await self.updateDefaultUriMatchType(defaultUriMatchType)
-            })
+            coordinator.showAlert(
+                .confirmStartsWithMatchDetectionAlert {
+                    await self.updateDefaultUriMatchType(
+                        defaultUriMatchType,
+                        learnMoreLocalizedMatchType: Localizations.startsWith
+                    )
+                })
         default:
-            await updateDefaultUriMatchType(defaultUriMatchType)
+            await updateDefaultUriMatchType(
+                defaultUriMatchType,
+                learnMoreLocalizedMatchType: nil
+            )
         }
     }
 
@@ -131,22 +142,20 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     }
 
     /// Updates the default URI match type value for the user.
-    /// - Parameter defaultUriMatchType: The default URI match type.
+    /// - Parameters:
+    ///   - updateUriMatchType: The new selected URI match type.
+    ///   - learnMoreLocalizedMatchType: The localized text to display on the learn more dialog.
     ///
-    private func updateDefaultUriMatchType(_ defaultUriMatchType: UriMatchType) async {
+    private func updateDefaultUriMatchType(
+        _ defaultUriMatchType: UriMatchType,
+        learnMoreLocalizedMatchType: String?
+    ) async {
         do {
             state.defaultUriMatchType = defaultUriMatchType
             try await services.settingsRepository.updateDefaultUriMatchType(defaultUriMatchType)
 
-            switch defaultUriMatchType {
-            case .regularExpression:
-                showLearnMoreAlert(Localizations.regEx)
-
-            case .startsWith:
-                showLearnMoreAlert(Localizations.startsWith)
-
-            default:
-                return
+            if let learnMoreText = learnMoreLocalizedMatchType, !learnMoreText.isEmpty {
+                showLearnMoreAlert(learnMoreText)
             }
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
@@ -4,6 +4,7 @@ import XCTest
 
 @testable import BitwardenShared
 
+// swiftlint:disable:next type_body_length
 class AutoFillProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
@@ -250,6 +251,16 @@ class AutoFillProcessorTests: BitwardenTestCase {
 
         waitFor(settingsRepository.updateDefaultUriMatchTypeValue == .regularExpression)
         let alertLearnMore = try XCTUnwrap(coordinator.alertShown.last)
+
+        XCTAssertEqual(alertLearnMore, Alert(
+            title: Localizations.keepYourCredentialsSecure,
+            message: Localizations.learnMoreAboutHowToKeepCredentialsSecureWhenUsingX(Localizations.regEx),
+            alertActions: [
+                AlertAction(title: Localizations.close, style: .cancel),
+                AlertAction(title: Localizations.learnMore, style: .default) { _ in },
+            ]
+        ))
+
         try await alertLearnMore.tapAction(title: Localizations.learnMore)
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.uriMatchDetections)
     }
@@ -313,6 +324,16 @@ class AutoFillProcessorTests: BitwardenTestCase {
 
         waitFor(settingsRepository.updateDefaultUriMatchTypeValue == .startsWith)
         let alertLearnMore = try XCTUnwrap(coordinator.alertShown.last)
+        
+        XCTAssertEqual(alertLearnMore, Alert(
+            title: Localizations.keepYourCredentialsSecure,
+            message: Localizations.learnMoreAboutHowToKeepCredentialsSecureWhenUsingX(Localizations.startsWith),
+            alertActions: [
+                AlertAction(title: Localizations.close, style: .cancel),
+                AlertAction(title: Localizations.learnMore, style: .default) { _ in },
+            ]
+        ))
+        
         try await alertLearnMore.tapAction(title: Localizations.learnMore)
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.uriMatchDetections)
     }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -745,48 +745,56 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     ///
     /// - Parameter newUriMatchType: The default URI match type.
     ///
-    private func confirmAndUpdateDefaultUriMatchType(_ newUriMatchType: DefaultableType<UriMatchType>,
-                                                     _ index: Int) async {
+    private func confirmAndUpdateDefaultUriMatchType(
+        _ newUriMatchType: DefaultableType<UriMatchType>,
+        _ index: Int
+    ) async {
         switch newUriMatchType.customValue {
         case .regularExpression:
-            coordinator.showAlert(.confirmRegularExpressionMatchDetectionAlert {
-                await self.updateUriMatchType(newUriMatchType, index)
-            })
+            coordinator.showAlert(
+                .confirmRegularExpressionMatchDetectionAlert {
+                    await self.updateUriMatchType(
+                        newUriMatchType: newUriMatchType,
+                        index: index,
+                        learnMoreLocalizedMatchType: Localizations.regEx
+                    )
+                }
+            )
         case .startsWith:
-            coordinator.showAlert(.confirmStartsWithMatchDetectionAlert {
-                await self.updateUriMatchType(newUriMatchType, index)
-            })
+            coordinator.showAlert(
+                .confirmStartsWithMatchDetectionAlert {
+                    await self.updateUriMatchType(
+                        newUriMatchType: newUriMatchType,
+                        index: index,
+                        learnMoreLocalizedMatchType: Localizations.startsWith
+                    )
+                }
+            )
         default:
-            await updateUriMatchType(newUriMatchType, index)
+            await updateUriMatchType(
+                newUriMatchType: newUriMatchType,
+                index: index,
+                learnMoreLocalizedMatchType: nil
+            )
         }
     }
 
     /// Updates the URI match type value for the uri.
     ///
-    /// - Parameter updateUriMatchType: The new selected URI match type.
-    /// - Parameter index: The index of the uri to update the URI Match tupe
+    /// - Parameters:
+    ///   - updateUriMatchType: The new selected URI match type.
+    ///   - index: The index of the uri to update the URI Match type.
+    ///   - learnMoreLocalizedMatchType: The localized text to display on the learn more dialog.
     ///
     private func updateUriMatchType(
-        _ newUriMatchType: DefaultableType<UriMatchType>,
-        _ index: Int
+        newUriMatchType: DefaultableType<UriMatchType>,
+        index: Int,
+        learnMoreLocalizedMatchType: String?
     ) async {
         state.loginState.uris[index].matchType = newUriMatchType
 
-        switch newUriMatchType {
-        case .default:
-            return
-
-        case let .custom(matchType):
-            switch matchType {
-            case .regularExpression:
-                showLearnMoreAlert(Localizations.regEx)
-
-            case .startsWith:
-                showLearnMoreAlert(Localizations.startsWith)
-
-            default:
-                return
-            }
+        if let learnMoreText = learnMoreLocalizedMatchType, !learnMoreText.isEmpty {
+            showLearnMoreAlert(learnMoreText)
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -745,34 +745,48 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     ///
     /// - Parameter newUriMatchType: The default URI match type.
     ///
-    private func confirmAndUpdateDefaultUriMatchType(_ newUriMatchType: DefaultableType<UriMatchType>, _ index: Int) async {
+    private func confirmAndUpdateDefaultUriMatchType(_ newUriMatchType: DefaultableType<UriMatchType>,
+                                                     _ index: Int) async {
         switch newUriMatchType.customValue {
         case .regularExpression:
             coordinator.showAlert(.confirmRegularExpressionMatchDetectionAlert {
-                await self.updateUriMatchType(newUriMatchType, index, showLearnMore: true)
+                await self.updateUriMatchType(newUriMatchType, index)
             })
         case .startsWith:
             coordinator.showAlert(.confirmStartsWithMatchDetectionAlert {
-                await self.updateUriMatchType(newUriMatchType, index, showLearnMore: true)
+                await self.updateUriMatchType(newUriMatchType, index)
             })
         default:
-            await updateUriMatchType(newUriMatchType, index, showLearnMore: false)
+            await updateUriMatchType(newUriMatchType, index)
         }
     }
 
-    /// Updates the URI match type value for the cipher.
+    /// Updates the URI match type value for the uri.
     ///
     /// - Parameter updateUriMatchType: The new selected URI match type.
-    /// - Parameter showLearnMore: If should display the learn more dialog.
+    /// - Parameter index: The index of the uri to update the URI Match tupe
     ///
     private func updateUriMatchType(
         _ newUriMatchType: DefaultableType<UriMatchType>,
-        _ index: Int,
-        showLearnMore: Bool
+        _ index: Int
     ) async {
         state.loginState.uris[index].matchType = newUriMatchType
-        if showLearnMore {
-            showLearnMoreAlert(newUriMatchType.localizedName)
+
+        switch newUriMatchType {
+        case .default:
+            return
+
+        case let .custom(matchType):
+            switch matchType {
+            case .regularExpression:
+                showLearnMoreAlert(Localizations.regEx)
+
+            case .startsWith:
+                showLearnMoreAlert(Localizations.startsWith)
+
+            default:
+                return
+            }
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -2654,6 +2654,16 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.yes)
         let alertLearnMore = try XCTUnwrap(coordinator.alertShown.last)
+        
+        XCTAssertEqual(alertLearnMore, Alert(
+            title: Localizations.keepYourCredentialsSecure,
+            message: Localizations.learnMoreAboutHowToKeepCredentialsSecureWhenUsingX(Localizations.regEx),
+            alertActions: [
+                AlertAction(title: Localizations.close, style: .cancel),
+                AlertAction(title: Localizations.learnMore, style: .default) { _ in },
+            ]
+        ))
+        
         try await alertLearnMore.tapAction(title: Localizations.learnMore)
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.uriMatchDetections)
     }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -2654,7 +2654,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.yes)
         let alertLearnMore = try XCTUnwrap(coordinator.alertShown.last)
-        
+
         XCTAssertEqual(alertLearnMore, Alert(
             title: Localizations.keepYourCredentialsSecure,
             message: Localizations.learnMoreAboutHowToKeepCredentialsSecureWhenUsingX(Localizations.regEx),
@@ -2663,7 +2663,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
                 AlertAction(title: Localizations.learnMore, style: .default) { _ in },
             ]
         ))
-        
+
         try await alertLearnMore.tapAction(title: Localizations.learnMore)
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.uriMatchDetections)
     }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-25540

## 📔 Objective

The learn more dialog has (advanced) appended to the Math detection type name. This uses strings without the advanced part for that modal.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
