### PR TITLE
Fix sdk version name

### DIFF
--- a/project-common.yml
+++ b/project-common.yml
@@ -14,7 +14,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: bb36b4848c5006b4c14f53c07476d12e6f8708ef # 1.0.0-283-7b5d9db
+    revision: bb36b4848c5006b4c14f53c07476d12e6f8708ef # 1.0.0-2207-03d02e6
     branch: unstable
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk


### PR DESCRIPTION
## 🎟️ Tracking

N/A

## 📔 Objective

Used the wrong sdk version name to run the workflow that created https://github.com/bitwarden/ios/pull/1909, manually updated the PR title and description, this PR fixes the code comment to match.

 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
