### PR TITLE
[PM-25449] Update view/edit cipher menu options for users not in an organization

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
@@ -16,6 +16,9 @@ protocol AddEditItemState: Sendable {
     /// Whether the user is able to delete the item.
     var canBeDeleted: Bool { get }
 
+    /// Whether or not this item can be moved to an organization.
+    var canMoveToOrganization: Bool { get }
+
     /// The Cipher underpinning the state
     var cipher: CipherView { get }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -120,7 +120,7 @@ struct AddEditItemView: View {
                             isCloneEnabled: false,
                             isCollectionsEnabled: store.state.canAssignToCollection,
                             isDeleteEnabled: store.state.canBeDeleted,
-                            isMoveToOrganizationEnabled: store.state.cipher.organizationId == nil,
+                            isMoveToOrganizationEnabled: store.state.canMoveToOrganization,
                             store: store.child(
                                 state: { _ in },
                                 mapAction: { .morePressed($0) },

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -144,6 +144,7 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
 
     /// Whether or not this item can be assigned to collections.
     var canAssignToCollection: Bool {
+        guard hasOrganizations, cipher.organizationId != nil else { return false }
         guard !collectionIds.isEmpty else { return true }
 
         return allUserCollections.contains { collection in
@@ -178,6 +179,11 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
 
         // New permission model from PM-18091
         return cipherPermissions.restore && isSoftDeleted
+    }
+
+    /// Whether or not this item can be moved to an organization.
+    var canMoveToOrganization: Bool {
+        hasOrganizations && cipher.organizationId == nil
     }
 
     /// The collections that the cipher belongs to.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -503,6 +503,8 @@ private extension ViewItemProcessor {
                 if let orgId = cipher.organizationId {
                     organization = try await services.vaultRepository.fetchOrganization(withId: orgId)
                 }
+                let ownershipOptions = try await services.vaultRepository
+                    .fetchCipherOwnershipOptions(includePersonal: false)
                 let showWebIcons = await services.stateService.getShowWebIcons()
 
                 var totpState = LoginTOTPState(cipher.login?.totp)
@@ -522,6 +524,7 @@ private extension ViewItemProcessor {
                     itemState.allUserCollections = collections
                     itemState.folderName = folder?.name
                     itemState.organizationName = organization?.name
+                    itemState.ownershipOptions = ownershipOptions
                     itemState.showWebIcons = showWebIcons
                     newState.loadingState = .data(itemState)
                 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -129,7 +129,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
     /// `perform(_:)` with `.appeared` starts listening for updates with the vault repository.
     @MainActor
-    func test_perform_appeared() {
+    func test_perform_appeared() { // swiftlint:disable:this function_body_length
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.showWebIcons = true
@@ -139,6 +139,11 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             CollectionView.fixture(id: "2"),
         ]
         vaultRepository.fetchCollectionsResult = .success(collections)
+        let cipherOwnershipOptions: [CipherOwner] = [
+            .personal(email: "user@bitwarden.com"),
+            .organization(id: "1", name: "Test Organization"),
+        ]
+        vaultRepository.fetchCipherOwnershipOptions = cipherOwnershipOptions
 
         let cipherItem = CipherView.fixture(
             id: "id",
@@ -172,6 +177,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         )!
 
         expectedState.allUserCollections = collections
+        expectedState.ownershipOptions = cipherOwnershipOptions
 
         XCTAssertNotNil(subject.streamCipherDetailsTask)
         XCTAssertTrue(subject.state.hasPremiumFeatures)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemView.swift
@@ -33,8 +33,7 @@ struct ViewItemView: View {
 
     /// Whether to show the move to organization option in the toolbar menu.
     var isMoveToOrganizationEnabled: Bool {
-        guard let cipher = store.state.loadingState.data?.cipher else { return false }
-        return cipher.organizationId == nil
+        store.state.loadingState.data?.canMoveToOrganization ?? false
     }
 
     /// The `Store` for this view.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25449](https://bitwarden.atlassian.net/browse/PM-25449)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the "Move to Organization" and "Collection" menu options when viewing or editing a cipher if the user doesn't belong to an organization. Also, the "Collection" menu option is hidden until the cipher has been moved into an organization.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

User not in organization:

| View | Edit |
|--------|--------|
| <img width="557" height="1063" alt="Screenshot 2025-09-08 at 1 47 14 PM" src="https://github.com/user-attachments/assets/e1b118e3-93c5-4d8f-ab8c-41d46613456f" /> | <img width="557" height="1063" alt="Screenshot 2025-09-08 at 1 48 04 PM" src="https://github.com/user-attachments/assets/f990a1ce-9c5e-47b4-a7e5-70a1836f8cf6" /> | 

User in organization, item in personal vault:

| View | Edit |
|--------|--------|
| <img width="557" height="1063" alt="Screenshot 2025-09-08 at 3 38 08 PM" src="https://github.com/user-attachments/assets/63cc0222-df5d-4d2b-b905-3dda5b773126" /> | <img width="557" height="1063" alt="Screenshot 2025-09-08 at 3 38 15 PM" src="https://github.com/user-attachments/assets/5233553d-a1e2-428a-ad6e-488bd3f78aab" /> |

User in organization, item in organization vault:

| View | Edit |
|--------|--------|
| <img width="557" height="1063" alt="Screenshot 2025-09-08 at 3 38 30 PM" src="https://github.com/user-attachments/assets/64066709-685a-4e28-b596-e114b589563a" /> | <img width="557" height="1063" alt="Screenshot 2025-09-08 at 3 38 35 PM" src="https://github.com/user-attachments/assets/d4824a96-b100-45d7-a97e-4ce64e7d2946" /> |

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25449]: https://bitwarden.atlassian.net/browse/PM-25449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ