### PR TITLE
[PM-24371] Fix cipher out-of-date error when deleting an attachment

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Response/DeleteAttachmentResponse.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/DeleteAttachmentResponse.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Networking
+
+/// API response for deleting an attachment.
+///
+struct DeleteAttachmentResponse: JSONResponse, Codable, Equatable {
+    // MARK: Types
+
+    /// Data model for the cipher properties returned from the delete attachment API response.
+    ///
+    struct DeleteAttachmentResponseCipher: Codable, Equatable {
+        /// The date the cipher was last updated.
+        let revisionDate: Date
+    }
+
+    // MARK: Properties
+
+    /// The updated cipher properties.
+    let cipher: DeleteAttachmentResponseCipher
+}

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIService.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIService.swift
@@ -43,7 +43,7 @@ protocol CipherAPIService {
     ///
     /// - Returns: The `EmptyResponse`.
     ///
-    func deleteAttachment(withID attachmentId: String, cipherId: String) async throws -> EmptyResponse
+    func deleteAttachment(withID attachmentId: String, cipherId: String) async throws -> DeleteAttachmentResponse
 
     /// Performs an API request to delete an existing cipher in the user's vault.
     ///
@@ -149,7 +149,7 @@ extension APIService: CipherAPIService {
         try await apiService.send(AddCipherWithCollectionsRequest(cipher: cipher, encryptedFor: encryptedFor))
     }
 
-    func deleteAttachment(withID attachmentId: String, cipherId: String) async throws -> EmptyResponse {
+    func deleteAttachment(withID attachmentId: String, cipherId: String) async throws -> DeleteAttachmentResponse {
         try await apiService.send(DeleteAttachmentRequest(attachmentId: attachmentId, cipherId: cipherId))
     }
 

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIServiceTests.swift
@@ -140,14 +140,23 @@ class CipherAPIServiceTests: XCTestCase { // swiftlint:disable:this type_body_le
 
     /// `deleteAttachment(withID:cipherId:)` performs the delete attachment request.
     func test_deleteAttachment() async throws {
-        client.result = .httpSuccess(testData: .emptyResponse)
+        client.result = .httpSuccess(testData: .deleteAttachment)
 
-        _ = try await subject.deleteAttachment(withID: "456", cipherId: "123")
+        let response = try await subject.deleteAttachment(withID: "456", cipherId: "123")
 
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertNil(client.requests[0].body)
         XCTAssertEqual(client.requests[0].method, .delete)
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/ciphers/123/attachment/456")
+
+        XCTAssertEqual(
+            response,
+            DeleteAttachmentResponse(
+                cipher: DeleteAttachmentResponse.DeleteAttachmentResponseCipher(
+                    revisionDate: Date(year: 2025, month: 9, day: 17)
+                )
+            )
+        )
     }
 
     /// `deleteCipher()` performs the delete cipher request.

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/DeleteAttachmentRequest.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/DeleteAttachmentRequest.swift
@@ -6,7 +6,7 @@ import Networking
 /// Data model for performing a delete attachment request.
 ///
 struct DeleteAttachmentRequest: Request {
-    typealias Response = EmptyResponse
+    typealias Response = DeleteAttachmentResponse
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Vault/Services/API/Fixtures/APITestData+Vault.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Fixtures/APITestData+Vault.swift
@@ -2,6 +2,7 @@ import TestHelpers
 
 extension APITestData {
     static let cipherResponse = loadFromJsonBundle(resource: "cipherResponse")
+    static let deleteAttachment = loadFromJsonBundle(resource: "deleteAttachment")
     static let downloadAttachment = loadFromJsonBundle(resource: "downloadAttachment")
     static let folderResponse = loadFromJsonBundle(resource: "folderResponse")
     static let saveAttachment = loadFromJsonBundle(resource: "saveAttachment")

--- a/BitwardenShared/Core/Vault/Services/API/Fixtures/deleteAttachment.json
+++ b/BitwardenShared/Core/Vault/Services/API/Fixtures/deleteAttachment.json
@@ -1,0 +1,17 @@
+{
+  "cipher": {
+    "id": "a2317b11-5db0-4a0d-b55f-68fcb8acac44",
+    "userId": "c7857827-d5ea-4d72-b1a1-b4ebb64da788",
+    "organizationId": null,
+    "type": 1,
+    "favorites": null,
+    "folders": null,
+    "attachments": "{\"c7t1t240hbds9onc1nvrmqex0pn63dzx\":{\"Size\":\"3724737\",\"FileName\":\"encrypted file name\",\"Key\":\"encrypted key\",\"ContainerName\":\"attachments-v2\",\"Validated\":true,\"TempMetadata\":null}}",
+    "creationDate": "2025-09-01T00:00:00.0000000Z",
+    "revisionDate": "2025-09-17T00:00:00.0000000Z",
+    "deletedDate": null,
+    "reprompt": 0,
+    "key": null,
+    "archivedDate": null
+  }
+}

--- a/BitwardenShared/Core/Vault/Services/CipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherService.swift
@@ -207,7 +207,7 @@ extension DefaultCipherService {
         let userId = try await stateService.getActiveAccountId()
 
         // Delete attachment from the backend.
-        _ = try await cipherAPIService.deleteAttachment(withID: attachmentId, cipherId: cipherId)
+        let response = try await cipherAPIService.deleteAttachment(withID: attachmentId, cipherId: cipherId)
 
         // Remove the attachment from the cipher.
         guard let cipher = try await cipherDataStore.fetchCipher(withId: cipherId, userId: userId) else { return nil }
@@ -215,7 +215,10 @@ extension DefaultCipherService {
         if let index = attachments.firstIndex(where: { $0.id == attachmentId }) {
             attachments.remove(at: index)
         }
-        let updatedCipher = cipher.update(attachments: attachments)
+        let updatedCipher = cipher.update(
+            attachments: attachments,
+            revisionDate: response.cipher.revisionDate
+        )
 
         // Update the cipher in local storage.
         try await cipherDataStore.upsertCipher(updatedCipher, userId: userId)

--- a/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
@@ -110,12 +110,13 @@ class CipherServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
     func test_deleteAttachmentWithServer() async throws {
         stateService.activeAccount = .fixture()
         cipherDataStore.fetchCipherResult = .fixture(attachments: [.fixture(id: "456")])
-        client.result = .httpSuccess(testData: .emptyResponse)
+        client.result = .httpSuccess(testData: .deleteAttachment)
 
         let updatedCipher = try await subject.deleteAttachmentWithServer(attachmentId: "456", cipherId: "123")
 
-        XCTAssertEqual(cipherDataStore.upsertCipherValue, .fixture(attachments: []))
-        XCTAssertEqual(updatedCipher, .fixture(attachments: []))
+        let expectedCipher = Cipher.fixture(attachments: [], revisionDate: Date(year: 2025, month: 9, day: 17))
+        XCTAssertEqual(cipherDataStore.upsertCipherValue, expectedCipher)
+        XCTAssertEqual(updatedCipher, expectedCipher)
     }
 
     /// `deleteCipherWithServer(id:)` deletes the cipher item from remote server and persisted cipher in the data store.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/Cipher+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/Cipher+Update.swift
@@ -1,12 +1,15 @@
 import BitwardenSdk
+import Foundation
 
 extension Cipher {
     /// Returns a copy of the existing cipher with an updated list of attachments
     ///
-    /// - Parameter attachments: The attachments owned by the cipher.
+    /// - Parameters:
+    ///   - attachments: The attachments owned by the cipher.
+    ///   - revisionDate: The date of the cipher's last update.
     /// - Returns: A copy of the existing cipher, with the specified properties updated.
     ///
-    func update(attachments: [Attachment]) -> Cipher {
+    func update(attachments: [Attachment], revisionDate: Date) -> Cipher {
         Cipher(
             id: id,
             organizationId: organizationId,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24371](https://bitwarden.atlassian.net/browse/PM-24371)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

A follow-up to https://github.com/bitwarden/ios/pull/1930.

Deleting an attachment updates the revision date on the cipher. This revision date is returned from the `DELETE /ciphers/<cipher-id>/attachment/<attachment-id>` response. We weren't previously parsing this response. This updates that to get the cipher's revision date and update the cipher in the local database.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24371]: https://bitwarden.atlassian.net/browse/PM-24371?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ