### PR TITLE
[PM-25567] Update profile switcher toolbar button to full circle

### DIFF
--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
@@ -28,9 +28,7 @@ struct ProfileSwitcherToolbarView: View {
             await store.perform(.requestedProfileSwitcher(visible: !store.state.isVisible))
         } label: {
             profileSwitcherIcon(
-                color: store.state.showPlaceholderToolbarIcon
-                    ? nil
-                    : store.state.activeAccountProfile?.color,
+                color: nil,
                 initials: store.state.showPlaceholderToolbarIcon
                     ? nil
                     : store.state.activeAccountProfile?.userInitials,
@@ -40,12 +38,12 @@ struct ProfileSwitcherToolbarView: View {
                 size: iconSize
             )
         }
+        .backport.buttonStyleGlassProminent()
+        .tint(color ?? SharedAsset.Colors.backgroundTertiary.swiftUIColor)
         .padding(.horizontal, horizontalPadding)
         .accessibilityIdentifier("CurrentActiveAccount")
         .accessibilityLabel(Localizations.account)
         .hidden(!store.state.showPlaceholderToolbarIcon && store.state.accounts.isEmpty)
-        .backport.buttonStyleGlassProminent()
-        .tint(color ?? SharedAsset.Colors.backgroundTertiary.swiftUIColor)
     }
 }
 
@@ -60,7 +58,7 @@ extension View {
     ///
     @ViewBuilder
     func profileSwitcherIcon(
-        color: Color?,
+        color: Color? = SharedAsset.Colors.backgroundTertiary.swiftUIColor,
         initials: String?,
         textColor: Color?,
         size: ProfileSwitcherIconSize = .standard
@@ -79,7 +77,7 @@ extension View {
                 }
             }
             .foregroundColor(textColor ?? SharedAsset.Colors.textInteraction.swiftUIColor)
-            .background(color ?? SharedAsset.Colors.backgroundTertiary.swiftUIColor)
+            .background(color)
             .if(size.shouldClipToCircle) { view in
                 view.clipShape(Circle())
             }
@@ -101,7 +99,7 @@ struct ProfileSwitcherIconSize {
 
     /// The text style for the user's initials.
     let textStyle: StyleGuideFont
-    
+
     /// Whether the user's initials and background should be clipped to a circle.
     let shouldClipToCircle: Bool
 }

--- a/BitwardenShared/UI/Platform/Application/Extensions/View+Backport.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View+Backport.swift
@@ -19,6 +19,17 @@ extension View {
 /// Adapted from https://davedelong.com/blog/2021/10/09/simplifying-backwards-compatibility-in-swift/
 ///
 extension Backport where Content: View {
+    /// On iOS 26+, configures the button style to use `glassProminent`.
+    ///
+    @available(iOS, deprecated: 26.0, message: "Use `buttonStyle(.glassProminent)` instead.")
+    func buttonStyleGlassProminent() -> some View {
+        if #available(iOS 26, *) {
+            return content.buttonStyle(.glassProminent)
+        } else {
+            return content
+        }
+    }
+
     /// On iOS 16+, configures the scroll view to dismiss the keyboard immediately.
     ///
     func dismissKeyboardImmediately() -> some View {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25567](https://bitwarden.atlassian.net/browse/PM-25567)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the profile switcher toolbar button to be the full circle on iOS 26+.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="568" height="1084" alt="Screenshot 2025-09-19 at 3 43 03 PM" src="https://github.com/user-attachments/assets/4e3b78fd-e093-4f11-9767-eab8f81166cc" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-25567]: https://bitwarden.atlassian.net/browse/PM-25567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ