### PR TITLE
[PM-26071] [RC] Fix BWA AppProcessor tests race condition

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/AppProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppProcessor.swift
@@ -16,6 +16,11 @@ public class AppProcessor {
     /// The root coordinator of the app.
     var coordinator: AnyCoordinator<AppRoute, AppEvent>?
 
+    /// The number of notifications configured being listened to on publishers.
+    /// This is useful in tests to avoid race-conditions where the tasks to subscribe to the publishers
+    /// start late and the notification sent gets missed from there.
+    var notificationsListeningCount: Int = 0
+
     /// The services used by the app.
     let services: ServiceContainer
 
@@ -38,6 +43,7 @@ public class AppProcessor {
         UI.applyDefaultAppearances()
 
         Task {
+            notificationsListeningCount += 1
             for await _ in services.notificationCenterService.willEnterForegroundPublisher().values {
                 let userId = await services.stateService.getActiveAccountId()
 
@@ -48,6 +54,7 @@ public class AppProcessor {
         }
 
         Task {
+            notificationsListeningCount += 1
             for await _ in services.notificationCenterService.didEnterBackgroundPublisher().values {
                 let userId = await services.stateService.getActiveAccountId()
                 services.appSettingsStore.setLastActiveTime(.now, userId: userId)

--- a/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
@@ -26,7 +26,7 @@ class AppProcessorTests: BitwardenTestCase {
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
         notificationCenter = MockNotificationCenterService()
-        timeProvider = MockTimeProvider(.currentTime)
+        timeProvider = MockTimeProvider(.mockTime(Date(year: 2024, month: 6, day: 1, hour: 2, minute: 30, second: 10)))
 
         subject = AppProcessor(
             appModule: appModule,
@@ -54,10 +54,14 @@ class AppProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    @MainActor
     func test_background_storesLastActive() async throws {
         await subject.start(appContext: .mainApp,
                             navigator: MockRootNavigator(),
                             window: window)
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.didEnterBackgroundSubject.send()
         let userId = appSettingsStore.localUserId
 
@@ -79,7 +83,7 @@ class AppProcessorTests: BitwardenTestCase {
     @MainActor
     func test_vaultTimeout_never() async throws {
         let userId = await subject.services.stateService.getActiveAccountId()
-        appSettingsStore.setLastActiveTime(.now.advanced(by: -3601), userId: userId)
+        appSettingsStore.setLastActiveTime(timeProvider.presentTime.advanced(by: -3601), userId: userId)
         appSettingsStore.setVaultTimeout(minutes: SessionTimeoutValue.never.rawValue, userId: userId)
 
         var notificationReceived = false
@@ -88,6 +92,9 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
@@ -98,7 +105,7 @@ class AppProcessorTests: BitwardenTestCase {
     @MainActor
     func test_vaultTimeout_notSet() async throws {
         let userId = await subject.services.stateService.getActiveAccountId()
-        appSettingsStore.setLastActiveTime(.now.advanced(by: -3601), userId: userId)
+        appSettingsStore.setLastActiveTime(timeProvider.presentTime.advanced(by: -3601), userId: userId)
 
         var notificationReceived = false
         let publisher = notificationCenter.willEnterForegroundPublisher()
@@ -106,6 +113,9 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
@@ -117,7 +127,7 @@ class AppProcessorTests: BitwardenTestCase {
     @MainActor
     func test_vaultTimeout_onAppRestart() async throws {
         let userId = await subject.services.stateService.getActiveAccountId()
-        appSettingsStore.setLastActiveTime(.now.advanced(by: -3601), userId: userId)
+        appSettingsStore.setLastActiveTime(timeProvider.presentTime.advanced(by: -3601), userId: userId)
         appSettingsStore.setVaultTimeout(minutes: SessionTimeoutValue.onAppRestart.rawValue, userId: userId)
 
         var notificationReceived = false
@@ -126,6 +136,9 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
@@ -145,6 +158,9 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
@@ -156,7 +172,7 @@ class AppProcessorTests: BitwardenTestCase {
     @MainActor
     func test_vaultTimeout_oneMinute_notYetTimedOut() async throws {
         let userId = await subject.services.stateService.getActiveAccountId()
-        appSettingsStore.setLastActiveTime(.now, userId: userId)
+        appSettingsStore.setLastActiveTime(timeProvider.presentTime, userId: userId)
         appSettingsStore.setVaultTimeout(minutes: 1, userId: userId)
 
         var notificationReceived = false
@@ -165,6 +181,9 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
@@ -175,7 +194,7 @@ class AppProcessorTests: BitwardenTestCase {
     @MainActor
     func test_vaultTimeout_oneMinute_timeout() async throws {
         let userId = await subject.services.stateService.getActiveAccountId()
-        appSettingsStore.setLastActiveTime(.now.advanced(by: -120), userId: userId)
+        appSettingsStore.setLastActiveTime(timeProvider.presentTime.advanced(by: -120), userId: userId)
         appSettingsStore.setVaultTimeout(minutes: 1, userId: userId)
 
         var notificationReceived = false
@@ -184,6 +203,9 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
@@ -195,7 +217,7 @@ class AppProcessorTests: BitwardenTestCase {
     @MainActor
     func test_vaultTimeout_oneHour_timeout() async throws {
         let userId = await subject.services.stateService.getActiveAccountId()
-        appSettingsStore.setLastActiveTime(.now.advanced(by: -3700), userId: userId)
+        appSettingsStore.setLastActiveTime(timeProvider.presentTime.advanced(by: -3700), userId: userId)
         appSettingsStore.setVaultTimeout(minutes: 60, userId: userId)
 
         notificationCenter.willEnterForegroundSubject.send()
@@ -206,10 +228,22 @@ class AppProcessorTests: BitwardenTestCase {
                 notificationReceived = true
             }
         defer { publisher.cancel() }
+
+        try await ensureNotificationsSubscriptionsListening()
+
         notificationCenter.willEnterForegroundSubject.send()
 
         try await waitForAsync { notificationReceived }
         try await waitForAsync { !self.coordinator.events.isEmpty }
         XCTAssertEqual(coordinator.events.last, .vaultTimeout)
+    }
+
+    // MARK: Private
+
+    /// Ensures that the subscriptions to notifications are listening to avoid race-conditions. This is done
+    /// by checking the Tasks that starts the subscription have started.
+    @MainActor
+    private func ensureNotificationsSubscriptionsListening() async throws {
+        try await waitForAsync { self.subject.notificationsListeningCount == 2 }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26071](https://bitwarden.atlassian.net/browse/PM-26071)

## 📔 Objective

🍒 Cherry picked from #1968 

Fix BWA AppProcessor tests race conditions because of notification center subscriptions by adding a check to see that the task for the notifications subscription has run and also fixed to use the time provider mock present time instead of `.now`.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26071]: https://bitwarden.atlassian.net/browse/PM-26071?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ