### PR TITLE
[PM-26158] Fix AuthenticatorBridgeKit dependency warning

### DIFF
--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -225,6 +225,7 @@ targets:
     dependencies:
       - target: Authenticator
       - target: AuthenticatorShared
+      - target: BitwardenKit/AuthenticatorBridgeKitMocks
       - target: BitwardenKit/BitwardenKitMocks
       - target: BitwardenKit/TestHelpers
       - package: SnapshotTesting

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -154,6 +154,7 @@ targets:
           - "**/*Tests.*"
           - "**/TestHelpers/*"
     dependencies:
+      - target: AuthenticatorBridgeKitMocks
       - target: BitwardenKit
       - target: BitwardenKitMocks
       - target: TestHelpers

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -399,6 +399,7 @@ targets:
     dependencies:
       - target: Bitwarden
       - target: BitwardenShared
+      - target: BitwardenKit/AuthenticatorBridgeKitMocks
       - target: BitwardenKit/BitwardenKitMocks
       - target: BitwardenKit/TestHelpers
       - package: SnapshotTesting


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26158

## 📔 Objective

This adjusts our explicit dependency graph in our project YML files to avoid a warning that was appearing in the test logs.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
