### PR TITLE
[PM-26160] Fix xcode 26 TestFlight upload failures

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,6 +34,12 @@ ARTIFACT_EXTENSION = {
     "device" => "ipa",
 }
 
+APPLE_ID_MAP = {
+    "com.8bit.bitwarden" => "1137397744",
+    "com.8bit.bitwarden.beta" => "6477551146",
+    "com.bitwarden.authenticator" => "6497335175",
+}
+
 platform :ios do |options|
     before_all do
         # Support running independent lanes without --env argument
@@ -146,9 +152,16 @@ platform :ios do |options|
         UI.success("🧱 Successfully updated app CI Build info")
     end
 
-    desc "Push a new build to TestFlight"
+    desc "Upload a new build to TestFlight"
     lane :upload_build do |options|
         bundle_id = ENV["_BUNDLE_ID"] || options[:bundle_id] || "com.8bit.bitwarden" # provides backwards compatibility with old build workflows
+
+        # NOTE workaround for xcode26 altool bug, see:
+        # https://github.com/fastlane/fastlane/issues/29698
+        # https://github.com/fastlane/fastlane/discussions/29680
+        apple_id = APPLE_ID_MAP[bundle_id]
+        ENV["DELIVER_ALTOOL_ADDITIONAL_UPLOAD_PARAMETERS"] = "--apple-id #{apple_id}"
+
         upload_to_testflight(
             skip_submission: false,
             changelog: options[:changelog],


### PR DESCRIPTION
## 🎟️ Tracking

PM-26160

## 📔 Objective

Workaround for Xcode 26 altool's bug where the app ID isn't correctly set. Ongoing discussions:

* https://github.com/fastlane/fastlane/issues/29698
* https://github.com/fastlane/fastlane/discussions/29680

Test runs:
* https://github.com/bitwarden/ios/actions/runs/17984184711
* https://github.com/bitwarden/ios/actions/runs/17984607941

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
