### PR TITLE
[PM-25567] Fix profile switcher icon color on pre-iOS 26

### DIFF
--- a/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
+++ b/BitwardenShared/UI/Auth/ProfileSwitcher/ProfileSwitcherToolbarView.swift
@@ -16,9 +16,13 @@ struct ProfileSwitcherToolbarView: View {
 
     /// The Toolbar item for the profile switcher view
     @ViewBuilder var profileSwitcherToolbarItem: some View {
-        let color = store.state.showPlaceholderToolbarIcon
+        let tintColor = store.state.showPlaceholderToolbarIcon
             ? nil
             : store.state.activeAccountProfile?.color
+        // iOS 26+ uses the tint color on liquid glass to give the button its color. Prior to iOS 26,
+        // the button's background is colored in `profileSwitcherIcon`.
+        let iconColor: Color? = if #available(iOS 26, *) { nil } else { tintColor }
+
         let iconSize: ProfileSwitcherIconSize = if #available(iOS 26, *) { .toolbar } else { .standard }
         // On iOS 26+, remove extra padding applied around the button, which allows the initials
         // font size to scale larger without increasing the overall width of the button.
@@ -28,7 +32,7 @@ struct ProfileSwitcherToolbarView: View {
             await store.perform(.requestedProfileSwitcher(visible: !store.state.isVisible))
         } label: {
             profileSwitcherIcon(
-                color: nil,
+                color: iconColor,
                 initials: store.state.showPlaceholderToolbarIcon
                     ? nil
                     : store.state.activeAccountProfile?.userInitials,
@@ -39,7 +43,7 @@ struct ProfileSwitcherToolbarView: View {
             )
         }
         .backport.buttonStyleGlassProminent()
-        .tint(color ?? SharedAsset.Colors.backgroundTertiary.swiftUIColor)
+        .tint(tintColor ?? SharedAsset.Colors.backgroundTertiary.swiftUIColor)
         .padding(.horizontal, horizontalPadding)
         .accessibilityIdentifier("CurrentActiveAccount")
         .accessibilityLabel(Localizations.account)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25567](https://bitwarden.atlassian.net/browse/PM-25567)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

My last [change](https://github.com/bitwarden/ios/pull/1961/commits/e11eebdda868fbef285e53cf3a011fb528f07ce6) in https://github.com/bitwarden/ios/pull/1961 removed the profile switcher icon's background color since it was redundant with tinting and caused an issue with the transition. This should have only been applied to iOS 26 though, since previous versions still need the background color. Otherwise, the icon has no background on versions prior to iOS 26.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="568" height="1084" alt="Screenshot 2025-09-24 at 4 33 51 PM" src="https://github.com/user-attachments/assets/37252e7b-cf90-40b9-b0da-6099373ded7b" />


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
