### PR TITLE
Increase Test workflow timeout and use xlarge runners to troubleshoot xcode 26 longer execution times

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -59,8 +59,8 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: macos-26
-    timeout-minutes: 60
+    runs-on: macos-26-xlarge
+    timeout-minutes: 50
     permissions:
       contents: read
 

--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -60,7 +60,7 @@ jobs:
   test:
     name: Test
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,7 +55,7 @@ jobs:
   test:
     name: Test
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: macos-26
-    timeout-minutes: 60
+    runs-on: macos-26-xlarge
+    timeout-minutes: 50
     permissions:
       contents: read
 


### PR DESCRIPTION
## 🎟️ Tracking

N/A 

## 📔 Objective

After the xcode 26 update our Test workflows have been hitting the 30min timeout limit. When runs are cancelled, we don't get a working `.xcresult` which blocks our ability to troubleshoot. Increasing the timeout limit and using xlarge runners with the hope that we'll get useful `.xcresult` files that may help us find a root cause. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
