### PR TITLE
[PM-26064] Move BitwardenTextField to BitwardenKit

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Views/AccessoryButton.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/AccessoryButton.swift
@@ -1,10 +1,9 @@
-import BitwardenKit
 import BitwardenResources
 import SwiftUI
 
 /// A view that displays a button for use as an accessory to a field.
 ///
-struct AccessoryButton: View {
+public struct AccessoryButton: View {
     // MARK: Types
 
     /// A type that wraps a synchrounous or asynchrounous block that is executed by this button.
@@ -31,7 +30,7 @@ struct AccessoryButton: View {
     /// The image to display in the button.
     var asset: SharedImageAsset
 
-    var body: some View {
+    public var body: some View {
         switch action {
         case let .async(action):
             AsyncButton(action: action) {
@@ -64,7 +63,7 @@ struct AccessoryButton: View {
     ///   - accessibilityLabel: The accessibility label of the button.
     ///   - action: The action to perform when the user triggers the button.
     ///
-    init(asset: SharedImageAsset,
+    public init(asset: SharedImageAsset,
          accessibilityLabel: String,
          accessibilityIdentifier: String = "",
          action: @escaping () -> Void) {
@@ -83,7 +82,7 @@ struct AccessoryButton: View {
     ///   - accessibilityIdentifier: The accessibility identifier of the button.
     ///   - action: The action to perform when the user triggers the button.
     ///
-    init(asset: SharedImageAsset,
+    public init(asset: SharedImageAsset,
          accessibilityLabel: String,
          accessibilityIdentifier: String = "",
          action: @escaping () async -> Void) {

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenFloatingTextLabel.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenFloatingTextLabel.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// contains a value. At that point, the text label will float up above the input field. This is
 /// primarily meant to wrap a text field or view.
 ///
-struct BitwardenFloatingTextLabel<Content: View, TrailingContent: View>: View {
+public struct BitwardenFloatingTextLabel<Content: View, TrailingContent: View>: View {
     // MARK: Properties
 
     /// The primary content containing the text input field for the label.
@@ -31,7 +31,7 @@ struct BitwardenFloatingTextLabel<Content: View, TrailingContent: View>: View {
 
     // MARK: View
 
-    var body: some View {
+    public var body: some View {
         HStack(spacing: 8) {
             ZStack(alignment: showPlaceholder ? .leading : .topLeading) {
                 // The placeholder and title text which is vertically centered in the view when the
@@ -77,7 +77,7 @@ struct BitwardenFloatingTextLabel<Content: View, TrailingContent: View>: View {
     ///   - trailingContent: Optional trailing content to display on the trailing edge of the label
     ///     and text input field.
     ///
-    init(
+    public init(
         title: String?,
         isTextFieldDisabled: Bool = false,
         showPlaceholder: Bool,
@@ -100,7 +100,7 @@ struct BitwardenFloatingTextLabel<Content: View, TrailingContent: View>: View {
     ///     the field.
     ///   - content: The primary content containing the text input field for the label.
     ///
-    init(
+    public init(
         title: String?,
         isTextFieldDisabled: Bool = false,
         showPlaceholder: Bool,

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -11,7 +11,7 @@ import SwiftUIIntrospect
 /// displaying additional content on the trailing edge of the text field.
 ///
 @MainActor
-struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
+public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
     // MARK: Private Properties
 
     /// A value indicating whether the textfield is currently enabled or disabled.
@@ -68,7 +68,7 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
 
     // MARK: View
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0) {
             contentView
 
@@ -215,7 +215,7 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
     ///   - isTextFieldDisabled: Whether the text field is disabled.
     ///   - trailingContent: Optional content view that is displayed on the trailing edge of the field.
     ///
-    init(
+    public init(
         title: String? = nil,
         text: Binding<String>,
         footer: String? = nil,
@@ -254,7 +254,7 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
     ///   - trailingContent: Optional content view that is displayed on the trailing edge of the field.
     ///   - footerContent: The (optional) footer content to display underneath the field.
     ///
-    init(
+    public init(
         title: String? = nil,
         text: Binding<String>,
         accessibilityIdentifier: String? = nil,
@@ -280,7 +280,7 @@ struct BitwardenTextField<FooterContent: View, TrailingContent: View>: View {
     }
 }
 
-extension BitwardenTextField where TrailingContent == EmptyView {
+public extension BitwardenTextField where TrailingContent == EmptyView {
     /// Initializes a new `BitwardenTextField`.
     ///
     /// - Parameters:
@@ -321,7 +321,7 @@ extension BitwardenTextField where TrailingContent == EmptyView {
     }
 }
 
-extension BitwardenTextField where FooterContent == EmptyView, TrailingContent == EmptyView {
+public extension BitwardenTextField where FooterContent == EmptyView, TrailingContent == EmptyView {
     /// Initializes a new `BitwardenTextField`.
     ///
     /// - Parameters:

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnView.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Auth/PasswordHint/PasswordHintView.swift
+++ b/BitwardenShared/UI/Auth/PasswordHint/PasswordHintView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationView.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextValueField.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTextView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTextView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Platform/Application/Views/FormFields/FormTextFieldView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/FormFields/FormTextFieldView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import SwiftUI
 
 // MARK: - FormTextField

--- a/BitwardenShared/UI/Platform/Application/Views/SectionView.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/SectionView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCustomFields/AddEditCustomFieldsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCustomFields/AddEditCustomFieldsView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import BitwardenSdk
 import SwiftUI

--- a/GlobalTestHelpers/Extensions/InspectableView.swift
+++ b/GlobalTestHelpers/Extensions/InspectableView.swift
@@ -56,7 +56,7 @@ struct BitwardenTextFieldType: BaseViewType {
     static var typePrefix: String = "BitwardenTextField"
 
     static var namespacedPrefixes: [String] = [
-        "BitwardenShared.BitwardenTextField",
+        "BitwardenKit.BitwardenTextField",
     ]
 }
 

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -125,6 +125,7 @@ targets:
           - "**/GoogleService-Info.*.plist"
         buildPhase: none
     dependencies:
+      - package: SwiftUIIntrospect
       - target: BitwardenResources
       - target: Networking
   BitwardenKitMocks:

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -14,10 +14,6 @@ options:
 settings:
   MARKETING_VERSION: 2024.6.0    # Bump this for a new version update.
   CURRENT_PROJECT_VERSION: 1
-packages:
-  SwiftUIIntrospect:
-    url: https://github.com/siteline/SwiftUI-Introspect
-    exactVersion: 1.3.0
 projectReferences:
   BitwardenKit:
     path: BitwardenKit.xcodeproj
@@ -350,7 +346,6 @@ targets:
         buildPhase: none
     dependencies:
       - package: BitwardenSdk
-      - package: SwiftUIIntrospect
       - target: BitwardenKit/AuthenticatorBridgeKit
       - target: BitwardenKit/BitwardenKit
       - target: BitwardenKit/BitwardenResources


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-26064

## 📔 Objective

This moves `BitwardenTextField` to `BitwardenKit`, as part of a broader effort to move our various components into `BitwardenKit`. It does not, yet, migrate BWA into using it.

## 📸 Screenshots

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
