### PR TITLE
[PM-23279] Use master password unlock data if available when unlocking with master password

### DIFF
--- a/BitwardenShared/Core/Platform/Services/CryptoClientProtocol+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Services/CryptoClientProtocol+Extensions.swift
@@ -14,10 +14,19 @@ extension CryptoClientProtocol {
         encryptionKeys: AccountEncryptionKeys,
         method: InitUserCryptoMethod,
     ) async throws {
+        let kdf: KdfConfig = switch method {
+        case .password:
+            // Master password unlock should use the master password unlock data's KDF settings if
+            // available to support separate KDF settings from the user's auth method.
+            account.profile.userDecryptionOptions?.masterPasswordUnlock?.kdf ?? account.kdf
+        default:
+            account.kdf
+        }
+
         try await initializeUserCrypto(
             req: InitUserCryptoRequest(
                 userId: account.profile.userId,
-                kdfParams: account.kdf.sdkKdf,
+                kdfParams: kdf.sdkKdf,
                 email: account.profile.email,
                 privateKey: encryptionKeys.encryptedPrivateKey,
                 signingKey: encryptionKeys.accountKeys?.signatureKeyPair?.wrappedSigningKey,

--- a/BitwardenShared/Core/Platform/Services/CryptoClientProtocolExtensionsTests.swift
+++ b/BitwardenShared/Core/Platform/Services/CryptoClientProtocolExtensionsTests.swift
@@ -1,0 +1,105 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class CryptoClientProtocolExtensionsTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: MockCryptoClient!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        subject = MockCryptoClient()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    // `initializeUserCrypto(account:encryptionKeys:method:)` initializes the user crypto using a
+    // user's master password.
+    func test_initializeUserCrypto_masterPassword() async throws {
+        try await subject.initializeUserCrypto(
+            account: .fixture(),
+            encryptionKeys: AccountEncryptionKeys(
+                accountKeys: .fixtureFilled(),
+                encryptedPrivateKey: "PRIVATE_KEY",
+                encryptedUserKey: "encryptedUserKey",
+            ),
+            method: .password(password: "password123", userKey: "userKey"),
+        )
+
+        let request = try XCTUnwrap(subject.initializeUserCryptoRequest)
+        XCTAssertEqual(request.userId, "1")
+        XCTAssertEqual(request.kdfParams, .pbkdf2(iterations: 600_000))
+        XCTAssertEqual(request.email, "user@bitwarden.com")
+        XCTAssertEqual(request.method, .password(password: "password123", userKey: "userKey"))
+        XCTAssertEqual(request.privateKey, "PRIVATE_KEY")
+        XCTAssertEqual(request.securityState, "SECURITY_STATE")
+        XCTAssertEqual(request.signingKey, "WRAPPED_SIGNING_KEY")
+    }
+
+    // `initializeUserCrypto(account:encryptionKeys:method:)` initializes the user crypto using a
+    // user's master password and their master password unlock data.
+    func test_initializeUserCrypto_masterPassword_masterPasswordUnlockData() async throws {
+        try await subject.initializeUserCrypto(
+            account: .fixture(profile: .fixture(
+                userDecryptionOptions: UserDecryptionOptions(
+                    hasMasterPassword: true,
+                    masterPasswordUnlock: MasterPasswordUnlockResponseModel(
+                        kdf: KdfConfig(kdfType: .pbkdf2sha256, iterations: 850_000),
+                        masterKeyEncryptedUserKey: nil,
+                        salt: nil,
+                    ),
+                    keyConnectorOption: nil,
+                    trustedDeviceOption: nil,
+                ),
+            )),
+            encryptionKeys: AccountEncryptionKeys(
+                accountKeys: .fixtureFilled(),
+                encryptedPrivateKey: "PRIVATE_KEY",
+                encryptedUserKey: "encryptedUserKey",
+            ),
+            method: .password(password: "password123", userKey: "userKey"),
+        )
+
+        let request = try XCTUnwrap(subject.initializeUserCryptoRequest)
+        XCTAssertEqual(request.userId, "1")
+        XCTAssertEqual(request.kdfParams, .pbkdf2(iterations: 850_000))
+        XCTAssertEqual(request.email, "user@bitwarden.com")
+        XCTAssertEqual(request.method, .password(password: "password123", userKey: "userKey"))
+        XCTAssertEqual(request.privateKey, "PRIVATE_KEY")
+        XCTAssertEqual(request.securityState, "SECURITY_STATE")
+        XCTAssertEqual(request.signingKey, "WRAPPED_SIGNING_KEY")
+    }
+
+    // `initializeUserCrypto(account:encryptionKeys:method:)` initializes the user crypto using a
+    // user's PIN.
+    func test_initializeUserCrypto_pin() async throws {
+        try await subject.initializeUserCrypto(
+            account: .fixture(),
+            encryptionKeys: AccountEncryptionKeys(
+                accountKeys: .fixtureFilled(),
+                encryptedPrivateKey: "PRIVATE_KEY",
+                encryptedUserKey: "encryptedUserKey",
+            ),
+            method: .pin(pin: "1234", pinProtectedUserKey: "pinProtectedUserKey"),
+        )
+
+        let request = try XCTUnwrap(subject.initializeUserCryptoRequest)
+        XCTAssertEqual(request.userId, "1")
+        XCTAssertEqual(request.kdfParams, .pbkdf2(iterations: 600_000))
+        XCTAssertEqual(request.email, "user@bitwarden.com")
+        XCTAssertEqual(request.method, .pin(pin: "1234", pinProtectedUserKey: "pinProtectedUserKey"))
+        XCTAssertEqual(request.privateKey, "PRIVATE_KEY")
+        XCTAssertEqual(request.securityState, "SECURITY_STATE")
+        XCTAssertEqual(request.signingKey, "WRAPPED_SIGNING_KEY")
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-23279](https://bitwarden.atlassian.net/browse/PM-23279)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

After a KDF update, it's possible for a user to have separate KDF settings for auth and master password unlock. If a user has master password unlock data, those KDF settings should be used when unlocking the vault with a master password.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-23279]: https://bitwarden.atlassian.net/browse/PM-23279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ