### PR TITLE
[PM-26394] Prevent changing from Shared collections to Default ones on cipher edition

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessor.swift
@@ -87,8 +87,15 @@ class EditCollectionsProcessor: StateProcessor<
     ///
     private func fetchCipherOptions() async {
         do {
-            state.collections = try await services.vaultRepository.fetchCollections(includeReadOnly: false)
+            let collections = try await services.vaultRepository.fetchCollections(includeReadOnly: false)
                 .filter { $0.organizationId == state.cipher.organizationId }
+
+            state.collections = collections.filter { collection in
+                guard let collectionId = collection.id else {
+                    return false
+                }
+                return collection.type != .defaultUserCollection || state.collectionIds.contains(collectionId)
+            }
         } catch {
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/EditCollections/EditCollectionsProcessorTests.swift
@@ -65,6 +65,54 @@ class EditCollectionsProcessorTests: BitwardenTestCase {
         try XCTAssertFalse(XCTUnwrap(vaultRepository.fetchCollectionsIncludeReadOnly))
     }
 
+    /// `perform(_:)` with `.fetchCipherOptions` fetches the ownership options for a cipher from the repository.
+    /// If there is a default user collection that is not selected on the cipher then it's filtered out.
+    @MainActor
+    func test_perform_fetchCipherOptionsDefaultCollectionFilteredOut() async {
+        let collections: [CollectionView] = [
+            .fixture(id: "1", name: "Design", organizationId: "1"),
+            .fixture(id: "2", name: "Engineering", organizationId: "1"),
+        ]
+
+        vaultRepository.fetchCollectionsResult = .success(
+            collections + [
+                .fixture(id: "3", name: "Other Org Collection", organizationId: "555"),
+                .fixture(id: "4", name: "My Items", organizationId: "1", type: .defaultUserCollection),
+                .fixture(id: nil, name: "Without ID", organizationId: "1"),
+            ],
+        )
+
+        await subject.perform(.fetchCipherOptions)
+
+        XCTAssertEqual(subject.state.collections, collections)
+        try XCTAssertFalse(XCTUnwrap(vaultRepository.fetchCollectionsIncludeReadOnly))
+    }
+
+    /// `perform(_:)` with `.fetchCipherOptions` fetches the ownership options for a cipher from the repository.
+    /// If there is a default user collection that is selected on the cipher then it's included
+    /// on the state collections.
+    @MainActor
+    func test_perform_fetchCipherOptionsDefaultCollectionIncluded() async {
+        let collections: [CollectionView] = [
+            .fixture(id: "1", name: "Design", organizationId: "1"),
+            .fixture(id: "2", name: "Engineering", organizationId: "1"),
+            .fixture(id: "4", name: "My Items", organizationId: "1", type: .defaultUserCollection),
+        ]
+        subject.state.collectionIds = ["4"]
+
+        vaultRepository.fetchCollectionsResult = .success(
+            collections + [
+                .fixture(id: "3", name: "Other Org Collection", organizationId: "555"),
+                .fixture(id: nil, name: "Without ID", organizationId: "1"),
+            ],
+        )
+
+        await subject.perform(.fetchCipherOptions)
+
+        XCTAssertEqual(subject.state.collections, collections)
+        try XCTAssertFalse(XCTUnwrap(vaultRepository.fetchCollectionsIncludeReadOnly))
+    }
+
     /// `perform(_:)` with `.fetchCipherOptions` reports an error if one occurs.
     @MainActor
     func test_perform_fetchCipherOptions_error() async {


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26394](https://bitwarden.atlassian.net/browse/PM-26394)

## 📔 Objective

Prevent displaying default user collections when editing a cipher that has not selected such default collection. Therefore the user can only change from a default collection to a non-default collection but not the other way around.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26394]: https://bitwarden.atlassian.net/browse/PM-26394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ