### PR TITLE
[PM-26964] Fix failing test in DebuggingFido2CredentialStoreServiceTests

### DIFF
--- a/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreServiceTests.swift
@@ -345,6 +345,7 @@ class DebuggingFido2CredentialStoreServiceTests: BitwardenTestCase {
         super.setUp()
 
         fido2CredentialStore = MockFido2CredentialStore()
+        Fido2DebuggingReportBuilder.builder.report = Fido2DebuggingReport()
 
         subject = DebuggingFido2CredentialStoreService(
             fido2CredentialStore: fido2CredentialStore,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26964](https://bitwarden.atlassian.net/browse/PM-26964)

## 📔 Objective

Fix failing test by re-creating the Fido2 report object on each test setup.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26964]: https://bitwarden.atlassian.net/browse/PM-26964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ