### PR TITLE
[PM-26735] Prevent push notification logout when changing KDF settings

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Domain/PushNotificationData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/PushNotificationData.swift
@@ -62,10 +62,30 @@ struct SyncFolderNotification: Codable, Equatable {
 
 // MARK: - UserNotification
 
-/// Additional information that can be contained in the push notification payload for certain types of notifications.
-struct UserNotification: Codable, Equatable {
+/// Additional information that can be contained in the logout push notification payload.
+struct LogoutNotification: Codable, Equatable {
+    // MARK: Types
+
+    /// The reason why a user is being logged out.
+    enum PushNotificationLogOutReason: Int, Codable, DefaultValueProvider {
+        /// The logout was triggered by a KDF setting change.
+        case kdfChange = 0
+
+        /// An unknown or unimplemented reason.
+        case unknown = -1
+
+        static var defaultValue: Self {
+            .unknown
+        }
+    }
+
+    // MARK: Properties
+
     /// The date of the notification.
     let date: Date?
+
+    /// The reason why the user is being logged out.
+    @DefaultValue var reason: PushNotificationLogOutReason
 
     /// The user id that needs to be updated.
     let userId: String

--- a/BitwardenShared/Core/Platform/Models/Domain/PushNotificationDataTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/PushNotificationDataTests.swift
@@ -39,4 +39,69 @@ class PushNotificationDataTests: BitwardenTestCase {
 
         XCTAssertNil(data)
     }
+
+    /// `data()` decodes a logout notification.
+    func test_data_logoutNotification() throws {
+        let subject = PushNotificationData(
+            contextId: nil,
+            payload: """
+            {
+                "Date": "2025-10-01T00:00:00.000Z",
+                "UserId": "12345",
+            }
+            """,
+            type: .logOut,
+        )
+
+        let data: LogoutNotification = try XCTUnwrap(subject.data())
+        XCTAssertEqual(data, LogoutNotification(
+            date: Date(year: 2025, month: 10, day: 1),
+            reason: .unknown,
+            userId: "12345",
+        ))
+    }
+
+    /// `data()` decodes a logout notification with a reason.
+    func test_data_logoutNotification_withReason() throws {
+        let subject = PushNotificationData(
+            contextId: nil,
+            payload: """
+            {
+                "Date": "2025-10-01T00:00:00.000Z",
+                "Reason": 0,
+                "UserId": "12345",
+            }
+            """,
+            type: .logOut,
+        )
+
+        let data: LogoutNotification = try XCTUnwrap(subject.data())
+        XCTAssertEqual(data, LogoutNotification(
+            date: Date(year: 2025, month: 10, day: 1),
+            reason: .kdfChange,
+            userId: "12345",
+        ))
+    }
+
+    /// `data()` decodes a logout notification with an unknown reason.
+    func test_data_logoutNotification_withReasonUnknown() throws {
+        let subject = PushNotificationData(
+            contextId: nil,
+            payload: """
+            {
+                "Date": "2025-10-01T00:00:00.000Z",
+                "Reason": -2,
+                "UserId": "12345",
+            }
+            """,
+            type: .logOut,
+        )
+
+        let data: LogoutNotification = try XCTUnwrap(subject.data())
+        XCTAssertEqual(data, LogoutNotification(
+            date: Date(year: 2025, month: 10, day: 1),
+            reason: .unknown,
+            userId: "12345",
+        ))
+    }
 }

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -689,6 +689,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             appIdService: appIdService,
             authRepository: authRepository,
             authService: authService,
+            configService: configService,
             errorReporter: errorReporter,
             notificationAPIService: apiService,
             refreshableApiService: apiService,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26735](https://bitwarden.atlassian.net/browse/PM-26735)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Prevents a logout push notification from logging the user out when changing KDF settings. When changing KDF settings, the backend will send a logout push notification with a reason of `kdfChange: 0`. If this is received by the app, and the app has the `forceUpdateKdfSettings` feature flag enabled, the user shouldn't be logged out since the new KDF settings can be used immediately following a sync.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26735]: https://bitwarden.atlassian.net/browse/PM-26735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ