### PR TITLE
[PM-26973] Consolidate Crowdin destination paths for iOS resources

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -7,11 +7,11 @@ files:
     translation: "/Bitwarden/Application/Support/AppShortcutsLocalizations/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved
   - source: "/BitwardenResources/Localizations/en.lproj/Localizable.strings"
-    dest: "/ios-resources/%original_file_name%"
+    dest: "/ios/%original_file_name%"
     translation: "/BitwardenResources/Localizations/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved
   - source: "/BitwardenResources/Localizations/en.lproj/Localizable.stringsdict"
-    dest: "/ios-resources/%original_file_name%"
+    dest: "/ios/%original_file_name%"
     translation: "/BitwardenResources/Localizations/%osx_code%/%original_file_name%"
     update_option: update_as_unapproved
   - source: "/BitwardenWatchApp/Localization/en.lproj/Localizable.strings"


### PR DESCRIPTION
## 🎟️ Tracking

PM-26973

## 📔 Objective

Simplify and consolidate Crowdin folder structure by updating the destination path for iOS resource files from `/ios-resources/` to `/ios/`.


## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
