### PR TITLE
[PM-27045] Explicitly specify unlock method

### DIFF
--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -217,9 +217,9 @@ struct SettingsView: View {
     private func biometricsToggleText(_ biometryType: BiometricAuthenticationType) -> String {
         switch biometryType {
         case .faceID:
-            Localizations.unlockWith(Localizations.faceID)
+            Localizations.unlockWithFaceID
         case .touchID:
-            Localizations.unlockWith(Localizations.touchID)
+            Localizations.unlockWithTouchID
         }
     }
 

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -182,9 +182,11 @@
 "SyncVaultNow" = "Sync vault now";
 "TouchID" = "Touch ID";
 "TwoStepLogin" = "Two-step login";
-"UnlockWith" = "Unlock with %1$@";
+"UnlockWithBiometrics" = "Unlock with biometrics";
+"UnlockWithFaceID" = "Unlock with Face ID";
+"UnlockWithTouchID" = "Unlock with Touch ID";
+"UnlockWithOpticID" = "Unlock with Optic ID";
 "UnlockWithPIN" = "Unlock with PIN code";
-"UnlockWithUnknownBiometrics" = "Unlock with biometrics";
 "Validating" = "Validating";
 "VerificationCode" = "Verification code";
 "ViewItem" = "View item";

--- a/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupState.swift
+++ b/BitwardenShared/UI/Auth/VaultUnlockSetup/VaultUnlockSetupState.swift
@@ -61,13 +61,13 @@ struct VaultUnlockSetupState: Equatable {
             case let .biometrics(type):
                 switch type {
                 case .faceID:
-                    Localizations.unlockWith(Localizations.faceID)
+                    Localizations.unlockWithFaceID
                 case .opticID:
-                    Localizations.unlockWith(Localizations.opticID)
+                    Localizations.unlockWithOpticID
                 case .touchID:
-                    Localizations.unlockWith(Localizations.touchID)
+                    Localizations.unlockWithTouchID
                 case .unknown:
-                    Localizations.unlockWithUnknownBiometrics
+                    Localizations.unlockWithBiometrics
                 }
             case .pin:
                 Localizations.unlockWithPIN

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView+ViewInspectorTests.swift
@@ -104,11 +104,11 @@ class AccountSecurityViewTests: BitwardenTestCase {
     func test_biometricsToggle() throws {
         processor.state.biometricUnlockStatus = .available(.faceID, enabled: false)
         _ = try subject.inspect().find(
-            toggleWithAccessibilityLabel: Localizations.unlockWith(Localizations.faceID),
+            toggleWithAccessibilityLabel: Localizations.unlockWithFaceID,
         )
         processor.state.biometricUnlockStatus = .available(.touchID, enabled: true)
         _ = try subject.inspect().find(
-            toggleWithAccessibilityLabel: Localizations.unlockWith(Localizations.touchID),
+            toggleWithAccessibilityLabel: Localizations.unlockWithTouchID,
         )
     }
 
@@ -118,7 +118,7 @@ class AccountSecurityViewTests: BitwardenTestCase {
         processor.state.biometricUnlockStatus = .notAvailable
         XCTAssertNil(
             try? subject.inspect().find(
-                toggleWithAccessibilityLabel: Localizations.unlockWith(Localizations.faceID),
+                toggleWithAccessibilityLabel: Localizations.unlockWithFaceID,
             ),
         )
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
@@ -255,13 +255,13 @@ struct AccountSecurityView: View {
     private func biometricsToggleText(_ biometryType: BiometricAuthenticationType) -> String {
         switch biometryType {
         case .faceID:
-            Localizations.unlockWith(Localizations.faceID)
+            Localizations.unlockWithFaceID
         case .opticID:
-            Localizations.unlockWith(Localizations.opticID)
+            Localizations.unlockWithOpticID
         case .touchID:
-            Localizations.unlockWith(Localizations.touchID)
+            Localizations.unlockWithTouchID
         case .unknown:
-            Localizations.unlockWithUnknownBiometrics
+            Localizations.unlockWithBiometrics
         }
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27045

## 📔 Objective

This updates how we handle "Unlock with" strings under the hood to explicitly specify them, rather than having a variable.

There is broader work that could be done to consolidate the `BiometricsService` and `BiometricsRepository` into `BitwardenKit` and unify how those work, but that is captured in another ticket.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
