### PR TITLE
[PM-23914] Logout after updating master password

### DIFF
--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessor.swift
@@ -172,8 +172,8 @@ class UpdateMasterPasswordProcessor: StateProcessor<
             )
 
             coordinator.hideLoadingOverlay()
+            await coordinator.handleEvent(.action(.logout(userId: nil, userInitiated: false)))
             coordinator.navigate(to: .dismiss)
-            await coordinator.handleEvent(.didCompleteAuth)
         } catch let error as InputValidationError {
             coordinator.showAlert(.inputValidationAlert(error: error))
         } catch {

--- a/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/UpdateMasterPassword/UpdateMasterPasswordProcessorTests.swift
@@ -248,7 +248,7 @@ class UpdateMasterPasswordProcessorTests: BitwardenTestCase {
         XCTAssertEqual(authRepository.updateMasterPasswordPasswordHint, "NEW_PASSWORD_HINT")
         XCTAssertEqual(authRepository.updateMasterPasswordReason, .weakMasterPasswordOnLogin)
 
-        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
+        XCTAssertEqual(coordinator.events, [.action(.logout(userId: nil, userInitiated: false))])
         XCTAssertEqual(coordinator.routes, [.dismiss])
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26163](https://bitwarden.atlassian.net/browse/PM-26163)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

After a password reset and updating a master password, the user should be logged out and forced to log back in.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/3c6d6f0c-80d9-4365-9f83-53962b77831f

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26163]: https://bitwarden.atlassian.net/browse/PM-26163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ