### PR TITLE
[PM-27074] Switch to using SDK's init crypto with MasterPasswordUnlock

### DIFF
--- a/BitwardenShared/Core/Auth/Extensions/BitwardenSdk+Auth.swift
+++ b/BitwardenShared/Core/Auth/Extensions/BitwardenSdk+Auth.swift
@@ -25,3 +25,13 @@ extension BitwardenSdk.InitUserCryptoMethod {
         }
     }
 }
+
+extension BitwardenSdk.MasterPasswordUnlockData {
+    init(responseModel model: MasterPasswordUnlockResponseModel) {
+        self.init(
+            kdf: model.kdf.sdkKdf,
+            masterKeyWrappedUserKey: model.masterKeyEncryptedUserKey,
+            salt: model.salt,
+        )
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Response/MasterPasswordUnlockResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/MasterPasswordUnlockResponseModel.swift
@@ -9,8 +9,8 @@ struct MasterPasswordUnlockResponseModel: Codable, Equatable, Hashable {
     let kdf: KdfConfig
 
     /// The user's encrypted user key, encrypted with the master key.
-    let masterKeyEncryptedUserKey: String?
+    let masterKeyEncryptedUserKey: String
 
     /// The cryptographic salt used in key derivation.
-    let salt: String?
+    let salt: String
 }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -937,6 +937,9 @@ extension DefaultAuthRepository: AuthRepository {
                 method: method,
             ),
         )
+
+        // Remove admin pending login request if exists
+        try await authService.setPendingAdminLoginRequest(nil, userId: nil)
     }
 
     func unlockVaultWithBiometrics() async throws {
@@ -988,7 +991,24 @@ extension DefaultAuthRepository: AuthRepository {
         let account = try await stateService.getActiveAccount()
         let encryptionKeys = try await stateService.getAccountEncryptionKeys(userId: account.profile.userId)
         guard let encUserKey = encryptionKeys.encryptedUserKey else { throw StateServiceError.noEncUserKey }
-        try await unlockVault(method: .password(password: password, userKey: encUserKey))
+
+        let masterPasswordUnlock = account.profile.userDecryptionOptions?.masterPasswordUnlock
+        let unlockMethod: InitUserCryptoMethod = if let masterPasswordUnlock {
+            .masterPasswordUnlock(
+                password: password,
+                masterPasswordUnlock: MasterPasswordUnlockData(responseModel: masterPasswordUnlock),
+            )
+        } else {
+            .password(password: password, userKey: encUserKey)
+        }
+        try await unlockVault(method: unlockMethod)
+
+        let hashedPassword = try await authService.hashPassword(
+            password: password,
+            purpose: .localAuthorization,
+        )
+        try await stateService.setMasterPasswordHash(hashedPassword)
+        await updateKdfToMinimumsIfNeeded(password: password)
     }
 
     func unlockVaultWithPIN(pin: String) async throws {
@@ -1116,27 +1136,6 @@ extension DefaultAuthRepository: AuthRepository {
         )
 
         await flightRecorder.log("[Auth] Vault unlocked, method: \(method.methodType)")
-
-        switch method {
-        case .authRequest:
-            // Remove admin pending login request if exists
-            try await authService.setPendingAdminLoginRequest(nil, userId: nil)
-        case let .password(password, _):
-            let hashedPassword = try await authService.hashPassword(
-                password: password,
-                purpose: .localAuthorization,
-            )
-            try await stateService.setMasterPasswordHash(hashedPassword)
-            await updateKdfToMinimumsIfNeeded(password: password)
-        case .decryptedKey,
-             .deviceKey,
-             .keyConnector,
-             .masterPasswordUnlock,
-             .pin,
-             .pinEnvelope:
-            // No-op: nothing extra to do.
-            break
-        }
 
         try await configurePinUnlockIfNeeded(method: method)
 
@@ -1274,7 +1273,7 @@ extension DefaultAuthRepository: AuthRepository {
                 try await stateService.setPinProtectedUserKeyToMemory(enrollPinResponse.pinProtectedUserKeyEnvelope)
                 await flightRecorder.log("[Auth] Set PIN-protected user key in memory")
             }
-        case.pinEnvelope:
+        case .pinEnvelope:
             break
         }
     }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -2115,6 +2115,63 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
+    // `unlockVaultWithPassword(_:)` unlocks the vault with the user's password using the master
+    // password unlock data.
+    func test_unlockVaultWithPassword_masterPasswordUnlockData() async throws {
+        let account = Account.fixture(profile: .fixture(
+            userDecryptionOptions: UserDecryptionOptions(
+                hasMasterPassword: true,
+                masterPasswordUnlock: MasterPasswordUnlockResponseModel(
+                    kdf: KdfConfig(kdfType: .pbkdf2sha256, iterations: 600_000),
+                    masterKeyEncryptedUserKey: "MASTER_KEY_ENCRYPTED_USER_KEY",
+                    salt: "SALT",
+                ),
+                keyConnectorOption: nil,
+                trustedDeviceOption: nil,
+            ),
+        ))
+        stateService.activeAccount = account
+        stateService.accountEncryptionKeys = [
+            "1": AccountEncryptionKeys(
+                accountKeys: .fixtureFilled(),
+                encryptedPrivateKey: "PRIVATE_KEY",
+                encryptedUserKey: "USER_KEY",
+            ),
+        ]
+
+        await assertAsyncDoesNotThrow {
+            try await subject.unlockVaultWithPassword(password: "password")
+        }
+
+        XCTAssertEqual(
+            clientService.mockCrypto.initializeUserCryptoRequest,
+            InitUserCryptoRequest(
+                userId: "1",
+                kdfParams: .pbkdf2(iterations: UInt32(600_000)),
+                email: "user@bitwarden.com",
+                privateKey: "PRIVATE_KEY",
+                signingKey: "WRAPPED_SIGNING_KEY",
+                securityState: "SECURITY_STATE",
+                method: .masterPasswordUnlock(
+                    password: "password",
+                    masterPasswordUnlock: MasterPasswordUnlockData(
+                        kdf: .pbkdf2(iterations: 600_000),
+                        masterKeyWrappedUserKey: "MASTER_KEY_ENCRYPTED_USER_KEY",
+                        salt: "SALT",
+                    ),
+                ),
+            ),
+        )
+        XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
+        XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
+        XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
+        XCTAssertEqual(stateService.masterPasswordHashes["1"], "hashed")
+
+        XCTAssertTrue(changeKdfService.needsKdfUpdateToMinimumsCalled)
+        XCTAssertFalse(changeKdfService.updateKdfToMinimumsCalled)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `logout` throws an error with no accounts.
     func test_logout_noAccounts() async {
         stateService.accounts = []

--- a/BitwardenShared/Core/Platform/Services/CryptoClientProtocol+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Services/CryptoClientProtocol+Extensions.swift
@@ -14,19 +14,10 @@ extension CryptoClientProtocol {
         encryptionKeys: AccountEncryptionKeys,
         method: InitUserCryptoMethod,
     ) async throws {
-        let kdf: KdfConfig = switch method {
-        case .password:
-            // Master password unlock should use the master password unlock data's KDF settings if
-            // available to support separate KDF settings from the user's auth method.
-            account.profile.userDecryptionOptions?.masterPasswordUnlock?.kdf ?? account.kdf
-        default:
-            account.kdf
-        }
-
         try await initializeUserCrypto(
             req: InitUserCryptoRequest(
                 userId: account.profile.userId,
-                kdfParams: kdf.sdkKdf,
+                kdfParams: account.kdf.sdkKdf,
                 email: account.profile.email,
                 privateKey: encryptionKeys.encryptedPrivateKey,
                 signingKey: encryptionKeys.accountKeys?.signatureKeyPair?.wrappedSigningKey,

--- a/BitwardenShared/Core/Platform/Services/CryptoClientProtocolExtensionsTests.swift
+++ b/BitwardenShared/Core/Platform/Services/CryptoClientProtocolExtensionsTests.swift
@@ -47,40 +47,6 @@ class CryptoClientProtocolExtensionsTests: BitwardenTestCase {
     }
 
     // `initializeUserCrypto(account:encryptionKeys:method:)` initializes the user crypto using a
-    // user's master password and their master password unlock data.
-    func test_initializeUserCrypto_masterPassword_masterPasswordUnlockData() async throws {
-        try await subject.initializeUserCrypto(
-            account: .fixture(profile: .fixture(
-                userDecryptionOptions: UserDecryptionOptions(
-                    hasMasterPassword: true,
-                    masterPasswordUnlock: MasterPasswordUnlockResponseModel(
-                        kdf: KdfConfig(kdfType: .pbkdf2sha256, iterations: 850_000),
-                        masterKeyEncryptedUserKey: nil,
-                        salt: nil,
-                    ),
-                    keyConnectorOption: nil,
-                    trustedDeviceOption: nil,
-                ),
-            )),
-            encryptionKeys: AccountEncryptionKeys(
-                accountKeys: .fixtureFilled(),
-                encryptedPrivateKey: "PRIVATE_KEY",
-                encryptedUserKey: "encryptedUserKey",
-            ),
-            method: .password(password: "password123", userKey: "userKey"),
-        )
-
-        let request = try XCTUnwrap(subject.initializeUserCryptoRequest)
-        XCTAssertEqual(request.userId, "1")
-        XCTAssertEqual(request.kdfParams, .pbkdf2(iterations: 850_000))
-        XCTAssertEqual(request.email, "user@bitwarden.com")
-        XCTAssertEqual(request.method, .password(password: "password123", userKey: "userKey"))
-        XCTAssertEqual(request.privateKey, "PRIVATE_KEY")
-        XCTAssertEqual(request.securityState, "SECURITY_STATE")
-        XCTAssertEqual(request.signingKey, "WRAPPED_SIGNING_KEY")
-    }
-
-    // `initializeUserCrypto(account:encryptionKeys:method:)` initializes the user crypto using a
     // user's PIN.
     func test_initializeUserCrypto_pin() async throws {
         try await subject.initializeUserCrypto(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27074](https://bitwarden.atlassian.net/browse/PM-27074)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The SDK added `InitUserCryptoMethod.masterPasswordUnlock` for unlocking the vault with master password unlock data, which was introduced in https://github.com/bitwarden/ios/pull/1978. This uses that method for vault unlocking if the user has master password unlock data.

This replaces the approach used in #2027.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27074]: https://bitwarden.atlassian.net/browse/PM-27074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ