### PR TITLE
[PM-26063] Move DefaultValue and DefaultFalse into BitwardenKit

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/DefaultFalse.swift
+++ b/BitwardenKit/Core/Platform/Utilities/DefaultFalse.swift
@@ -2,11 +2,11 @@
 /// useful for decoding a boolean value which may not be present in the response.
 ///
 @propertyWrapper
-struct DefaultFalse: Codable, Hashable {
+public struct DefaultFalse: Codable, Hashable {
     // MARK: Properties
 
     /// The wrapped value.
-    var wrappedValue: Bool
+    public var wrappedValue: Bool
 
     // MARK: Initialization
 
@@ -14,27 +14,27 @@ struct DefaultFalse: Codable, Hashable {
     ///
     /// - Parameter wrappedValue: The value that is contained in the property wrapper.
     ///
-    init(wrappedValue: Bool) {
+    public init(wrappedValue: Bool) {
         self.wrappedValue = wrappedValue
     }
 
     // MARK: Decodable
 
-    init(from decoder: any Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         wrappedValue = try container.decode(Bool.self)
     }
 
     // MARK: Encodable
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         try wrappedValue.encode(to: encoder)
     }
 }
 
 // MARK: - KeyedDecodingContainer
 
-extension KeyedDecodingContainer {
+public extension KeyedDecodingContainer {
     /// When decoding a `DefaultFalse` wrapped value, if the property doesn't exist, default to `false`.
     ///
     /// - Parameters:

--- a/BitwardenKit/Core/Platform/Utilities/DefaultFalseTests.swift
+++ b/BitwardenKit/Core/Platform/Utilities/DefaultFalseTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import BitwardenShared
+@testable import BitwardenKit
 
 class DefaultFalseTests: BitwardenTestCase {
     // MARK: Types

--- a/BitwardenKit/Core/Platform/Utilities/DefaultValue.swift
+++ b/BitwardenKit/Core/Platform/Utilities/DefaultValue.swift
@@ -5,7 +5,7 @@ import OSLog
 /// A protocol for defining a default value for a `Decodable` type if an invalid or missing value
 /// is received.
 ///
-protocol DefaultValueProvider: Decodable {
+public protocol DefaultValueProvider: Decodable {
     /// The default value to use if the value to decode is invalid or missing.
     static var defaultValue: Self { get }
 }
@@ -17,17 +17,27 @@ protocol DefaultValueProvider: Decodable {
 /// decoding failure if an invalid value is received.
 ///
 @propertyWrapper
-struct DefaultValue<T: DefaultValueProvider> {
+public struct DefaultValue<T: DefaultValueProvider> {
     // MARK: Properties
 
     /// The wrapped value.
-    let wrappedValue: T
+    public let wrappedValue: T
+
+    // MARK: Initialization
+
+    /// Creates a new `DefaultValue` with the specified wrapped value.
+    ///
+    /// - Parameter wrappedValue: The value to wrap.
+    ///
+    public init(wrappedValue: T) {
+        self.wrappedValue = wrappedValue
+    }
 }
 
 // MARK: - Decodable
 
 extension DefaultValue: Decodable {
-    init(from decoder: any Decoder) throws {
+    public init(from decoder: any Decoder) throws {
         let container = try decoder.singleValueContainer()
         do {
             wrappedValue = try container.decode(T.self)
@@ -62,7 +72,7 @@ extension DefaultValue: Decodable {
 // MARK: - Encodable
 
 extension DefaultValue: Encodable where T: Encodable {
-    func encode(to encoder: any Encoder) throws {
+    public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(wrappedValue)
     }
@@ -78,7 +88,7 @@ extension DefaultValue: Hashable where T: Hashable {}
 
 // MARK: - KeyedDecodingContainer
 
-extension KeyedDecodingContainer {
+public extension KeyedDecodingContainer {
     /// When decoding a `DefaultValue` wrapped value, if the property doesn't exist, default to the
     /// type's default value.
     ///

--- a/BitwardenKit/Core/Platform/Utilities/DefaultValueTests.swift
+++ b/BitwardenKit/Core/Platform/Utilities/DefaultValueTests.swift
@@ -1,6 +1,6 @@
 import XCTest
 
-@testable import BitwardenShared
+@testable import BitwardenKit
 
 class DefaultValueTests: BitwardenTestCase {
     // MARK: Types

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 import Networking
 

--- a/BitwardenShared/Core/Platform/Models/Domain/PushNotificationData.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/PushNotificationData.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 // MARK: - PushNotificationData

--- a/BitwardenShared/Core/Vault/Models/API/CipherSecureNoteModel.swift
+++ b/BitwardenShared/Core/Vault/Models/API/CipherSecureNoteModel.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 /// API model for a cipher secure note.
 ///
 struct CipherSecureNoteModel: Codable, Equatable {

--- a/BitwardenShared/Core/Vault/Models/Domain/Organization.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Organization.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 /// A domain model containing the details of an organization.
 ///
 public struct Organization: Equatable, Hashable, Sendable {

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherRepromptType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherRepromptType.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 /// An enum describing if the user should be re-prompted prior to using the cipher password.
 ///
 enum CipherRepromptType: Int, Codable {

--- a/BitwardenShared/Core/Vault/Models/Enum/CollectionType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CollectionType.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 /// An enum describing the type of collection assigned to user(s) or group(s).
 ///
 enum CollectionType: Int, Codable {

--- a/BitwardenShared/Core/Vault/Models/Enum/SecureNoteType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/SecureNoteType.swift
@@ -1,3 +1,5 @@
+import BitwardenKit
+
 /// An enum describing the type of secure note.
 ///
 enum SecureNoteType: Int, Codable {

--- a/BitwardenShared/Core/Vault/Models/Response/CipherDetailsResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/CipherDetailsResponseModel.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 import Networking
 

--- a/BitwardenShared/Core/Vault/Models/Response/CollectionDetailsResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/CollectionDetailsResponseModel.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 /// API response model for collection details.

--- a/BitwardenShared/Core/Vault/Models/Response/ProfileOrganizationResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/ProfileOrganizationResponseModel.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 /// API response model for a profile organization.

--- a/BitwardenShared/Core/Vault/Models/Response/ProfileResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/ProfileResponseModel.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 /// API response model for a user profile.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26063](https://bitwarden.atlassian.net/browse/PM-26063)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Moves the DefaultValue and DefaultFalse property wrappers into BitwardenKit in preparation for moving the Flight Recorder.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26063]: https://bitwarden.atlassian.net/browse/PM-26063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ