### PR TITLE
[PM-26063] Move ExternalLinksConstants to BitwardenKit

### DIFF
--- a/AuthenticatorShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/AuthenticatorShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -9,7 +9,7 @@ extension ExternalLinksConstants {
     // MARK: Properties
 
     /// A link to Apple's guide on backing up iPhone.
-    static let backupInformation = URL(string: "https://support.apple.com/guide/iphone/back-up-iphone-iph3ecf67d29/ios")
+    static let backupInformation = URL(string: "https://support.apple.com/guide/iphone/back-up-iphone-iph3ecf67d29/ios")!
 
     /// A link to the password manager app within the app store.
     static let passwordManagerLink = URL(string: "https://itunes.apple.com/app/id1137397744?mt=8")!

--- a/BitwardenKit/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenKit/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -7,7 +7,7 @@ import Foundation
 public enum ExternalLinksConstants {
     // MARK: Properties
 
-    /// A link the Bitwarden's help page for the Flight Recorder.
+    /// A link to Bitwarden's help page for the Flight Recorder.
     public static let flightRecorderHelp = URL(string: "https://bitwarden.com/help/flight-recorder")!
 
     /// A link to Bitwarden's general help and feedback page.

--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -43,7 +43,7 @@ extension ExternalLinksConstants {
     /// A markdown link to Bitwarden's terms of service.
     static let termsOfService = URL(string: "https://bitwarden.com/terms/")!
 
-    /// A markdown link to Bitwarden's markting email preferences.
+    /// A markdown link to Bitwarden's marketing email preferences.
     static let unsubscribeFromMarketingEmails = URL(string: "https://bitwarden.com/email-preferences/")!
 
     /// A link to Bitwarden's help page for showing website icons.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26063](https://bitwarden.atlassian.net/browse/PM-26063)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Consolidates `ExternalLinksConstants` into `BitwardenKit`. This moves the main enum/namespace along with shared constants and leaves extensions in PM/Authenticator for defining app specific constants.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26063]: https://bitwarden.atlassian.net/browse/PM-26063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ