### PR TITLE
[PM-27598] Don't fill password strength indicator until minimum character limit is met

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Views/PasswordStrengthIndicator.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/PasswordStrengthIndicator.swift
@@ -17,6 +17,13 @@ struct PasswordStrengthIndicator: View {
     /// The required text count for the password
     let requiredTextCount: Int
 
+    // MARK: Computed Properties
+
+    /// Whether the entered password has met the minimum length required.
+    var hasPasswordMinimumLength: Bool {
+        passwordTextCount >= requiredTextCount
+    }
+
     // MARK: View
 
     var body: some View {
@@ -26,7 +33,7 @@ struct PasswordStrengthIndicator: View {
                     RoundedRectangle(cornerRadius: 2)
                         .fill(Color(asset: SharedAsset.Colors.strokeDivider))
 
-                    let fillWidth = passwordTextCount >= requiredTextCount
+                    let fillWidth = hasPasswordMinimumLength
                         ? geometry.size.width * passwordStrength.strengthPercent
                         : 0
                     RoundedRectangle(cornerRadius: 2)
@@ -39,7 +46,7 @@ struct PasswordStrengthIndicator: View {
 
             HStack {
                 HStack(spacing: 4) {
-                    if passwordTextCount >= requiredTextCount {
+                    if hasPasswordMinimumLength {
                         Image(asset: SharedAsset.Icons.check12)
                             .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
                             .padding(.leading, 1)
@@ -58,7 +65,7 @@ struct PasswordStrengthIndicator: View {
 
                 Spacer()
 
-                if passwordTextCount >= requiredTextCount {
+                if hasPasswordMinimumLength {
                     Text(passwordStrength.text ?? "")
                         .foregroundColor(Color(asset: passwordStrength.color))
                         .styleGuide(.footnote)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27598](https://bitwarden.atlassian.net/browse/PM-27598)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Previously, the password strength indicator and label would fill as the user entered their password. This could cause confusion if a strong password was entered that was less than the minimum number of characters. This changes the behavior to only fill the strength indicator and show the strength label after the minimum character count has been met.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/92fe9237-585c-4bad-a5c8-f58bfe3b6264" /> | <video src="https://github.com/user-attachments/assets/7ee4b5c5-8309-49d7-89fa-01efbfa3d002" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27598]: https://bitwarden.atlassian.net/browse/PM-27598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ