### PR TITLE
[PM-26063] Fix flaky test

### DIFF
--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -444,10 +444,11 @@ class ItemListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             XCTFail("There is no onExpiration closure for the first item in the factory")
             return
         }
-        onExpiration([firstItemRefreshed])
+        onExpiration([firstItem])
 
-        waitFor(!authItemRepository.refreshedTotpCodes.isEmpty)
-        XCTAssertEqual(subject.state.searchResults, authItemRepository.refreshedTotpCodes)
+        waitFor { subject.state.searchResults == [firstItemRefreshed] }
+        XCTAssertEqual(authItemRepository.refreshedTotpCodes, [firstItem])
+        XCTAssertEqual(subject.state.searchResults, [firstItemRefreshed])
     }
 
     /// `perform(_:)` with `.streamItemList` starts streaming vault items. When there are no shared


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26063](https://bitwarden.atlassian.net/browse/PM-26063)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a flaky Authenticator test. In this case, the `waitFor` was checking for a value set in the repository and the assertion was checking for a value in the state. Since the repository value is set before the state value, there was a race condition if the `waitFor` exited before the state value was set.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26063]: https://bitwarden.atlassian.net/browse/PM-26063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ