### PR TITLE
Update Claude.md to indicate that mocks don't need DocC comments

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,7 +10,7 @@ Core directives for maintaining code quality and consistency in the Bitwarden iO
 2. **Follow Code Style**: ALWAYS follow https://contributing.bitwarden.com/contributing/code-style/swift
 3. **Follow Testing Guidelines**: Analyzing or implementing tests MUST follow guidelines in `./../Docs/Testing.md`.
 4. **Best Practices**: Follow Swift / SwiftUI general best practices (value over reference types, guard clauses, extensions, protocol oriented programming)
-5. **Document Everything**: Everything in the code requires DocC documentation except for protocol properties/functions implementations as the docs for them will be in the protocol. As well, mocks do not need DocC documentation, because the docs for the public interface will be in the protocol.
+5. **Document Everything**: Everything in the code requires DocC documentation except for protocol properties/functions implementations as the docs for them will be in the protocol. Additionally, mocks do not need DocC documentation, because the docs for the public interface will be in the protocol.
 6. **Dependency Management**: Use `ServiceContainer` as established in the project
 7. **Use Established Patterns**: Leverage existing components before creating new ones
 8. **File References**: Use file:line_number format when referencing code
@@ -37,7 +37,7 @@ Core directives for maintaining code quality and consistency in the Bitwarden iO
 
 1. Follow existing code style in surrounding files
 2. Write tests alongside implementation
-3. Add DocC to everything except protocol implementations
+3. Add DocC to everything except protocol implementations and mocks
 4. Validate against architecture guidelines
 
 ### After Implementation


### PR DESCRIPTION
## 📔 Objective

This updates `CLAUDE.md` to also exclude mocks from the DocC requirements. We historically have not required documentation comments on these, because they are already documented in the original protocol, and they exist as mocks. Claude otherwise consistently generates comments on code review suggesting to document mocks, which ends up being noise.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
