### PR TITLE
[PM-28184] Update feature flag used for no logout on KDF change

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -19,6 +19,9 @@ extension FeatureFlag: @retroactive CaseIterable {
 
     /// Flag to enable/disable forced KDF updates.
     static let forceUpdateKdfSettings = FeatureFlag(rawValue: "pm-18021-force-update-kdf-settings")
+    
+    /// Flag to enable/disable not logging out when a user's KDF settings are changed.
+    static let noLogoutOnKdfChange = FeatureFlag(rawValue: "pm-23995-no-logout-on-kdf-change")
 
     public static var allCases: [FeatureFlag] {
         [
@@ -27,6 +30,7 @@ extension FeatureFlag: @retroactive CaseIterable {
             .cipherKeyEncryption,
             .enableCipherKeyEncryption,
             .forceUpdateKdfSettings,
+            .noLogoutOnKdfChange,
         ]
     }
 }

--- a/BitwardenShared/Core/Platform/Services/NotificationService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationService.swift
@@ -226,9 +226,9 @@ class DefaultNotificationService: NotificationService {
                 guard let data: LogoutNotification = notificationData.data() else { return }
 
                 if data.reason == .kdfChange,
-                   // TODO: PM-26960 Remove user ID check with forceUpdateKdfSettings feature flag.
+                   // TODO: PM-26960 Remove user ID check with noLogoutOnKdfChange feature flag.
                    data.userId == userId,
-                   await configService.getFeatureFlag(.forceUpdateKdfSettings) {
+                   await configService.getFeatureFlag(.noLogoutOnKdfChange) {
                     // Don't log the user out for KDF changes.
                     break
                 }

--- a/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
@@ -502,12 +502,12 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertTrue(delegate.routeToLandingCalled)
     }
 
-    /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles logout requests and will route
-    /// to the landing screen if the logged-out account was the currently active account.
+    /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles logout requests and
+    /// doesn't route to the landing screen if the logout reason was because of a KDF change.
     @MainActor
     func test_messageReceived_logout_activeUser_kdfChange() async throws {
         let activeAccount = Account.fixture()
-        configService.featureFlagsBool[.forceUpdateKdfSettings] = true
+        configService.featureFlagsBool[.noLogoutOnKdfChange] = true
         stateService.setIsAuthenticated()
         stateService.accounts = [activeAccount]
 
@@ -532,9 +532,9 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles logout requests and will route
     /// to the landing screen if the logged-out account was the currently active account.
     @MainActor
-    func test_messageReceived_logout_activeUser_kdfChange_forceUpdateKdfSettingsOff() async throws {
+    func test_messageReceived_logout_activeUser_kdfChange_noLogoutOnKdfChangeOff() async throws {
         let activeAccount = Account.fixture()
-        configService.featureFlagsBool[.forceUpdateKdfSettings] = false
+        configService.featureFlagsBool[.noLogoutOnKdfChange] = false
         stateService.setIsAuthenticated()
         stateService.accounts = [activeAccount]
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28184](https://bitwarden.atlassian.net/browse/PM-28184)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the feature flag used for checking if the user should not logged out when receiving a logout push notification because the user's KDF settings have changed (#2041). `pm-18021-force-update-kdf-settings` was being used previously, but `pm-23995-no-logout-on-kdf-change` should be used instead.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28184]: https://bitwarden.atlassian.net/browse/PM-28184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ