### PR TITLE
[PM-26063] Add flight recorder to Authenticator's settings

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/AppModule.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppModule.swift
@@ -56,3 +56,17 @@ extension DefaultAppModule: AppModule {
         ).asAnyCoordinator()
     }
 }
+
+// MARK: - DefaultAppModule + FlightRecorderModule
+
+extension DefaultAppModule: FlightRecorderModule {
+    public func makeFlightRecorderCoordinator(
+        stackNavigator: StackNavigator,
+    ) -> AnyCoordinator<FlightRecorderRoute, Void> {
+        FlightRecorderCoordinator(
+            services: services,
+            stackNavigator: stackNavigator,
+        )
+        .asAnyCoordinator()
+    }
+}

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -18,6 +18,9 @@ enum SettingsAction: Equatable {
     /// The export items button was tapped.
     case exportItemsTapped
 
+    /// An action for the Flight Recorder feature.
+    case flightRecorder(FlightRecorderSettingsSectionAction)
+
     /// The help center button was tapped.
     case helpCenterTapped
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsEffect.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsEffect.swift
@@ -4,11 +4,17 @@ import BitwardenKit
 
 /// Effects that can be processed by an `SettingsProcessor`.
 enum SettingsEffect: Equatable {
+    /// An effect for the flight recorder feature.
+    case flightRecorder(FlightRecorderSettingsSectionEffect)
+
     /// The view appeared so the initial data should be loaded.
     case loadData
 
     /// The session timeout value was changed.
     case sessionTimeoutValueChanged(SessionTimeoutValue)
+
+    /// Stream the active flight recorder log.
+    case streamFlightRecorderLog
 
     /// Unlock with Biometrics was toggled.
     case toggleUnlockWithBiometrics(Bool)

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -22,6 +22,9 @@ struct SettingsState: Equatable {
     /// The current default save option.
     var defaultSaveOption: DefaultSaveOption = .none
 
+    /// The state for the Flight Recorder feature.
+    var flightRecorderState = FlightRecorderSettingsSectionState()
+
     /// The current default save option.
     var sessionTimeoutValue: SessionTimeoutValue = .never
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView+ViewInspectorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView+ViewInspectorTests.swift
@@ -73,6 +73,34 @@ class SettingsViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .exportItemsTapped)
     }
 
+    /// The flight recorder toggle turns logging on and off.
+    @MainActor
+    func test_flightRecorder_toggle_tap() async throws {
+        let toggle = try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.flightRecorder)
+
+        try toggle.tap()
+        try await waitForAsync { !self.processor.effects.isEmpty }
+        XCTAssertEqual(processor.effects, [.flightRecorder(.toggleFlightRecorder(true))])
+        processor.effects.removeAll()
+
+        processor.state.flightRecorderState.activeLog = FlightRecorderData.LogMetadata(
+            duration: .eightHours,
+            startDate: .now,
+        )
+        try toggle.tap()
+        try await waitForAsync { !self.processor.effects.isEmpty }
+        XCTAssertEqual(processor.effects, [.flightRecorder(.toggleFlightRecorder(false))])
+    }
+
+    /// Tapping the flight recorder view recorded logs button dispatches the
+    /// `.viewFlightRecorderLogsTapped` action.
+    @MainActor
+    func test_flightRecorder_viewRecordedLogsButton_tap() throws {
+        let button = try subject.inspect().find(button: Localizations.viewRecordedLogs)
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .flightRecorder(.viewLogsTapped))
+    }
+
     /// Tapping the help center button dispatches the `.helpCenterTapped` action.
     @MainActor
     func test_helpCenterButton_tap() throws {

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -49,13 +49,24 @@ struct SettingsView: View {
         .task {
             await store.perform(.loadData)
         }
+        .task {
+            await store.perform(.streamFlightRecorderLog)
+        }
     }
 
     // MARK: Private views
 
     /// The about section containing privacy policy and version information.
     @ViewBuilder private var aboutSection: some View {
-        SectionView(Localizations.about) {
+        SectionView(Localizations.about, contentSpacing: 8) {
+            FlightRecorderSettingsSectionView(
+                store: store.child(
+                    state: \.flightRecorderState,
+                    mapAction: { .flightRecorder($0) },
+                    mapEffect: { .flightRecorder($0) },
+                ),
+            )
+
             ContentBlock(dividerLeadingPadding: 16) {
                 externalLinkRow(Localizations.privacyPolicy, action: .privacyPolicyTapped)
 

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -11,6 +11,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
 
     /// The module types required by this coordinator for creating child coordinators.
     typealias Module = FileSelectionModule
+        & FlightRecorderModule
         & TutorialModule
 
     typealias Services = HasAppInfoService
@@ -23,6 +24,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
         & HasErrorAlertServices.ErrorAlertServices
         & HasErrorReporter
         & HasExportItemsService
+        & HasFlightRecorder
         & HasImportItemsService
         & HasPasteboardService
         & HasStateService
@@ -81,6 +83,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
             stackNavigator?.dismiss()
         case .exportItems:
             showExportItems()
+        case let .flightRecorder(flightRecorderRoute):
+            showFlightRecorder(route: flightRecorderRoute)
         case .importItems:
             showImportItems()
         case let .importItemsFileSelection(route):
@@ -130,6 +134,17 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator {
         let view = ExportItemsView(store: Store(processor: processor))
         let navController = UINavigationController(rootViewController: UIHostingController(rootView: view))
         stackNavigator?.present(navController)
+    }
+
+    /// Shows a flight recorder view.
+    ///
+    /// - Parameter route: A `FlightRecorderRoute` to navigate to.
+    ///
+    private func showFlightRecorder(route: FlightRecorderRoute) {
+        guard let stackNavigator else { return }
+        let coordinator = module.makeFlightRecorderCoordinator(stackNavigator: stackNavigator)
+        coordinator.start()
+        coordinator.navigate(to: route)
     }
 
     /// Presents an activity controller for importing items.

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -69,6 +69,16 @@ class SettingsCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(navigationController.viewControllers.first is UIHostingController<ExportItemsView>)
     }
 
+    /// `navigate(to:)` with `.flightRecorder` starts flight recorder coordinator and navigates to
+    /// the enable flight recorder view.
+    @MainActor
+    func test_navigateTo_flightRecorder() throws {
+        subject.navigate(to: .flightRecorder(.enableFlightRecorder))
+
+        XCTAssertTrue(module.flightRecorderCoordinator.isStarted)
+        XCTAssertEqual(module.flightRecorderCoordinator.routes.last, .enableFlightRecorder)
+    }
+
     /// `navigate(to:)` with `.selectLanguage()` presents the select language view.
     @MainActor
     func test_navigateTo_selectLanguage() throws {

--- a/AuthenticatorShared/UI/Platform/Settings/SettingsRoute.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/SettingsRoute.swift
@@ -11,6 +11,9 @@ public enum SettingsRoute: Equatable, Hashable {
     /// A route to the export items view.
     case exportItems
 
+    /// A route to a Flight Recorder view.
+    case flightRecorder(FlightRecorderRoute)
+
     /// A route to the import items view.
     case importItems
 

--- a/GlobalTestHelpers-bwa/MockAppModule.swift
+++ b/GlobalTestHelpers-bwa/MockAppModule.swift
@@ -9,6 +9,7 @@ class MockAppModule:
     AuthModule,
     DebugMenuModule,
     FileSelectionModule,
+    FlightRecorderModule,
     ItemListModule,
     TutorialModule,
     TabModule {
@@ -18,6 +19,7 @@ class MockAppModule:
     var debugMenuCoordinator = MockCoordinator<DebugMenuRoute, Void>()
     var fileSelectionDelegate: FileSelectionDelegate?
     var fileSelectionCoordinator = MockCoordinator<FileSelectionRoute, FileSelectionEvent>()
+    var flightRecorderCoordinator = MockCoordinator<FlightRecorderRoute, Void>()
     var itemListCoordinator = MockCoordinator<ItemListRoute, ItemListEvent>()
     var tabCoordinator = MockCoordinator<TabRoute, Void>()
     var tutorialCoordinator = MockCoordinator<TutorialRoute, TutorialEvent>()
@@ -53,6 +55,12 @@ class MockAppModule:
     ) -> AnyCoordinator<FileSelectionRoute, FileSelectionEvent> {
         fileSelectionDelegate = delegate
         return fileSelectionCoordinator.asAnyCoordinator()
+    }
+
+    func makeFlightRecorderCoordinator(
+        stackNavigator _: StackNavigator,
+    ) -> AnyCoordinator<FlightRecorderRoute, Void> {
+        flightRecorderCoordinator.asAnyCoordinator()
     }
 
     func makeItemListCoordinator(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26063](https://bitwarden.atlassian.net/browse/PM-26063)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the Flight Recorder options to Authenticator's settings view. This allows for enabling/disabling Flight Recorder and viewing the list of any logs.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/8ff42184-5947-4ad5-9134-b611cb65dc59

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26063]: https://bitwarden.atlassian.net/browse/PM-26063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ