### PR TITLE
[PM-24299] Set isPreAuth when generating MP in create account flow

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepository.swift
@@ -184,7 +184,7 @@ extension DefaultGeneratorRepository: GeneratorRepository {
     // MARK: Generator
 
     func generateMasterPassword() async throws -> String {
-        try await clientService.generators(isPreAuth: false).passphrase(
+        try await clientService.generators(isPreAuth: true).passphrase(
             settings: PassphraseGeneratorRequest(
                 numWords: 3,
                 wordSeparator: "-",

--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
@@ -151,6 +151,16 @@ class GeneratorRepositoryTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_generateMasterPassword() async throws {
         let masterPassword = try await subject.generateMasterPassword()
         XCTAssertEqual(masterPassword, "PASSPHRASE")
+        XCTAssertTrue(clientService.mockGeneratorsIsPreAuth)
+        XCTAssertEqual(
+            clientService.mockGenerators.passphraseGeneratorRequest,
+            PassphraseGeneratorRequest(
+                numWords: 3,
+                wordSeparator: "-",
+                capitalize: true,
+                includeNumber: true,
+            ),
+        )
     }
 
     /// `generatePassphrase` returns the generated passphrase.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24299](https://bitwarden.atlassian.net/browse/PM-24299)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds a missing `isPreAuth` flag when generating a master password during the create account flow. Since there's no active account yet, not having this flag logs an error to Crashlytics.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-24299]: https://bitwarden.atlassian.net/browse/PM-24299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ