### PR TITLE
[PM-28540] Simplify project files with Xcodegen templates

### DIFF
--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -203,11 +203,11 @@ targets:
       base:
         ENABLE_TESTING_SEARCH_PATHS: YES
         GENERATE_INFOPLIST_FILE: YES
+    templates:
+      - MocksTarget
+    templateAttributes:
+      sourcesPath: AuthenticatorShared
     sources:
-      - path: AuthenticatorShared
-        includes:
-          - "**/Fixtures/*"
-          - "**/Mocks/*"
       - path: AuthenticatorShared/Sourcery/Generated/AutoMockable.generated.swift
         optional: true
     dependencies:

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -99,11 +99,10 @@ targets:
         ENABLE_TESTING_SEARCH_PATHS: YES
         INFOPLIST_FILE: AuthenticatorBridgeKit/MocksInfo.plist
         SWIFT_STRICT_CONCURRENCY: complete
-    sources:
-      - path: AuthenticatorBridgeKit
-        includes:
-          - "**/Fixtures/*"
-          - "**/Mocks/*"
+    templates:
+      - MocksTarget
+    templateAttributes:
+      sourcesPath: AuthenticatorBridgeKit
     dependencies:
       - target: AuthenticatorBridgeKit
       - target: BitwardenKit
@@ -135,11 +134,11 @@ targets:
       base:
         ENABLE_TESTING_SEARCH_PATHS: YES
         INFOPLIST_FILE: BitwardenKit/Application/Mocks/Support/Info.plist
+    templates:
+      - MocksTarget
+    templateAttributes:
+      sourcesPath: BitwardenKit
     sources:
-      - path: BitwardenKit
-        includes:
-          - "**/Fixtures/*"
-          - "**/Mocks/*"
       - path: BitwardenKit/Sourcery/Generated/AutoMockable.generated.swift
         optional: true
     dependencies:

--- a/project-common.yml
+++ b/project-common.yml
@@ -46,13 +46,19 @@ targetTemplates:
           - "**/__Snapshots__/*"
           - "**/GoogleService-Info.*.plist"
         buildPhase: none
+  # Adds common include/excludes for mocks targets.
+  MocksTarget:
+    sources:
+      - path: ${sourcesPath}
+        includes:
+          - "**/Fixtures/*"
+          - "**/Mocks/*"
   # Adds common include/excludes for snapshot test targets.
   SnapshotTestTarget:
     sources:
       - path: ${sourcesPath}
         includes:
           - "**/*SnapshotTests.*"
-          - "**/Fixtures/*"
           - "**/TestHelpers/*"
   # Adds the Sourcery pre-build script.
   SourceryTarget:
@@ -78,7 +84,6 @@ targetTemplates:
           - "**/*ViewInspectorTests.*"
         includes:
           - "**/*Tests.*"
-          - "**/Fixtures/*"
           - "**/TestHelpers/*"
   # Adds common include/excludes for ViewInspector test targets.
   ViewInspectorTestTarget:
@@ -86,5 +91,4 @@ targetTemplates:
       - path: ${sourcesPath}
         includes:
           - "**/*ViewInspectorTests.*"
-          - "**/Fixtures/*"
           - "**/TestHelpers/*"

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -376,11 +376,11 @@ targets:
       base:
         ENABLE_TESTING_SEARCH_PATHS: YES
         GENERATE_INFOPLIST_FILE: YES
+    templates:
+      - MocksTarget
+    templateAttributes:
+      sourcesPath: BitwardenShared
     sources:
-      - path: BitwardenShared
-        includes:
-          - "**/Fixtures/*"
-          - "**/Mocks/*"
       - path: BitwardenShared/Sourcery/Generated/AutoMockable.generated.swift
         optional: true
     dependencies:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28540](https://bitwarden.atlassian.net/browse/PM-28540)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When I added Sourcery to BitwardenKit (https://github.com/bitwarden/ios/pull/2136), I wondered if we could simplify some of the duplication in our project files.

This is an attempt at using Xcodegen's [templates](https://github.com/yonaskolb/XcodeGen/blob/master/Docs/ProjectSpec.md#target-template) to share some common logic between targets.

There's two categories of templates that I've added:

- "Sources" templates: a template that contains our common regex patterns for the source files used in different types of targets:
  - `CommonTarget`: this is meant for app or framework targets and mainly includes all files other than tests and test helpers (mocks, fixtures, etc).
  - `MocksTarget`: a target containing mocks and fixtures.
  - `TestTarget`: a unit testing target which excludes ViewInspector and snapshot tests.
  - `SnapshotTestTarget`: a test target for snapshot tests.
  - `ViewInspectorTestTarget`: a test target for ViewInspector tests.
- "Build phase" templates:
  - `SourceryTarget`: a template for a target that needs a Sourcery pre-build script.

The templates are defined in [project-common.yml](https://github.com/bitwarden/ios/blob/51342b0eb8f1e4ad710ac4ddcc9cc59f83d6046b/project-common.yml#L28).

Going forward, adding Sourcery to a target is simplified to adding `SourceryTarget` to the list of a target's templates (and adding the generated file to any test targets):

```diff
diff --git a/project-bwk.yml b/project-bwk.yml
--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -121,4 +121,5 @@
     templates:
       - CommonTarget
+      - SourceryTarget
     templateAttributes:
       sourcesPath: BitwardenKit
```

<details><summary>Diff of the project files before and after:</summary>
<p>

The only noticeable change here of the project files is the removal of the `gitignore` files, which I intentionally excluded. So even though this changes a bunch of stuff, I hope I've minimized any potential issues 🤞. 

```diff
diff -U0 before/Bitwarden.pbxproj Bitwarden.xcodeproj/project.pbxproj
--- before/Bitwarden.pbxproj	2025-11-18 16:36:29
+++ Bitwarden.xcodeproj/project.pbxproj	2025-11-19 09:25:25
@@ -3158 +3157,0 @@
-		20E4EE0C07D3EE8586C46233 /* .gitignore */ = {isa = PBXFileReference; path = .gitignore; sourceTree = "<group>"; };
@@ -4607 +4605,0 @@
-		A6C964FC3085FA0C093F0C63 /* .gitignore */ = {isa = PBXFileReference; path = .gitignore; sourceTree = "<group>"; };
@@ -7463 +7460,0 @@
-				20E4EE0C07D3EE8586C46233 /* .gitignore */,
@@ -8724 +8720,0 @@
-				A6C964FC3085FA0C093F0C63 /* .gitignore */,

diff -U0 before/Authenticator.pbxproj Authenticator.xcodeproj/project.pbxproj
--- before/Authenticator.pbxproj	2025-11-18 16:36:53
+++ Authenticator.xcodeproj/project.pbxproj	2025-11-19 09:25:25
@@ -980 +979,0 @@
-		3CEC58C44DB13461B95880A5 /* .gitignore */ = {isa = PBXFileReference; path = .gitignore; sourceTree = "<group>"; };
@@ -1008 +1006,0 @@
-		4D0217410E4A8906F80DEDD9 /* .gitignore */ = {isa = PBXFileReference; path = .gitignore; sourceTree = "<group>"; };
@@ -1209 +1206,0 @@
-		C203B0C946484B15F519EFE6 /* .gitignore */ = {isa = PBXFileReference; path = .gitignore; sourceTree = "<group>"; };
@@ -1472 +1468,0 @@
-				3CEC58C44DB13461B95880A5 /* .gitignore */,
@@ -1528 +1523,0 @@
-				C203B0C946484B15F519EFE6 /* .gitignore */,
@@ -2278 +2272,0 @@
-				4D0217410E4A8906F80DEDD9 /* .gitignore */,

diff -U0 before/BitwardenKit.pbxproj BitwardenKit.xcodeproj/project.pbxproj
--- before/BitwardenKit.pbxproj	2025-11-18 16:36:16
+++ BitwardenKit.xcodeproj/project.pbxproj	2025-11-19 09:25:23
@@ -1309 +1308,0 @@
-		DBBC174DA9DFDD9E2F708A65 /* .gitignore */ = {isa = PBXFileReference; path = .gitignore; sourceTree = "<group>"; };
@@ -1669 +1667,0 @@
-				DBBC174DA9DFDD9E2F708A65 /* .gitignore */,
```

</p>
</details> 




## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28540]: https://bitwarden.atlassian.net/browse/PM-28540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ