### PR TITLE
[PM-27143] Add default bundle for APITestData in each framework

### DIFF
--- a/AuthenticatorBridgeKit/Tests/TestHelpers/Support/BitwardenTestCase.swift
+++ b/AuthenticatorBridgeKit/Tests/TestHelpers/Support/BitwardenTestCase.swift
@@ -1,9 +1,4 @@
 import TestHelpers
 import XCTest
 
-open class BitwardenTestCase: BaseBitwardenTestCase {
-    @MainActor
-    override open class func setUp() {
-        TestDataHelpers.defaultBundle = Bundle(for: Self.self)
-    }
-}
+open class BitwardenTestCase: BaseBitwardenTestCase {}

--- a/AuthenticatorShared/Core/Platform/Services/API/Fixtures/APITestData+Authenticator.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/Fixtures/APITestData+Authenticator.swift
@@ -1,0 +1,12 @@
+import TestHelpers
+
+/// `APITestData` helpers that load the resource from the `AuthenticatorShared` bundle.
+extension APITestData {
+    static func loadFromBundle(resource: String, extension: String) -> APITestData {
+        loadFromBundle(resource: resource, extension: `extension`, bundle: .authenticatorShared)
+    }
+
+    static func loadFromJsonBundle(resource: String) -> APITestData {
+        loadFromJsonBundle(resource: resource, bundle: .authenticatorShared)
+    }
+}

--- a/AuthenticatorShared/Core/Platform/Services/API/Fixtures/AuthenticatorSharedBundleFinder.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/Fixtures/AuthenticatorSharedBundleFinder.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+class AuthenticatorSharedBundleFinder {
+    static let bundle = Bundle(for: AuthenticatorSharedBundleFinder.self)
+}
+
+public extension Bundle {
+    /// The bundle for the `AuthenticatorShared` target.
+    static let authenticatorShared = AuthenticatorSharedBundleFinder.bundle
+}

--- a/BitwardenKit/Application/TestHelpers/Support/BitwardenTestCase.swift
+++ b/BitwardenKit/Application/TestHelpers/Support/BitwardenTestCase.swift
@@ -7,8 +7,6 @@ open class BitwardenTestCase: BaseBitwardenTestCase {
     override open class func setUp() {
         // Apply default appearances for snapshot tests.
         UI.applyDefaultAppearances()
-
-        TestDataHelpers.defaultBundle = Bundle(for: Self.self)
     }
 
     /// Executes any logic that should be applied before each test runs.

--- a/BitwardenKit/Core/Auth/Services/API/Account/Fixtures/APITestData+Account.swift
+++ b/BitwardenKit/Core/Auth/Services/API/Account/Fixtures/APITestData+Account.swift
@@ -14,111 +14,70 @@ public extension APITestData {
     // MARK: Create Account
 
     /// Test data of an invalid model state with no validation errors.
-    static let createAccountNilValidationErrors = loadFromJsonBundle(
-        resource: "CreateAccountNilValidationErrors",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let createAccountNilValidationErrors = loadFromJsonBundle(resource: "CreateAccountNilValidationErrors")
 
     /// Test data with a validation error of "User verification failed."
-    static let deleteAccountRequestFailure = loadFromJsonBundle(
-        resource: "DeleteAccountRequestFailure",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let deleteAccountRequestFailure = loadFromJsonBundle(resource: "DeleteAccountRequestFailure")
 
     /// Test data with several leaked passwords.
-    static let hibpLeakedPasswords = loadFromBundle(
-        resource: "hibpLeakedPasswords",
-        extension: "txt",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let hibpLeakedPasswords = loadFromBundle(resource: "hibpLeakedPasswords", extension: "txt")
 
     /// Test data with an invalid username/password error.
-    static let responseValidationError = loadFromJsonBundle(
-        resource: "ResponseValidationError",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let responseValidationError = loadFromJsonBundle(resource: "ResponseValidationError")
 
     // MARK: Pre-Login
 
     /// Test data for prelogin success.
-    static let preLoginSuccess = loadFromJsonBundle(
-        resource: "PreLoginSuccess",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let preLoginSuccess = loadFromJsonBundle(resource: "PreLoginSuccess")
 
     // MARK: Register Finish
 
     /// Test data with a validation error of "Email 'j@a.com' is already taken."
-    static let registerFinishAccountAlreadyExists = loadFromJsonBundle(
-        resource: "RegisterFinishAccountAlreadyExists",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let registerFinishAccountAlreadyExists = loadFromJsonBundle(resource: "RegisterFinishAccountAlreadyExists")
 
     /// Test data with a validation error of
     /// "The field MasterPasswordHint must be a string with a maximum length of 50."
-    static let registerFinishHintTooLong = loadFromJsonBundle(
-        resource: "RegisterFinishHintTooLong",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let registerFinishHintTooLong = loadFromJsonBundle(resource: "RegisterFinishHintTooLong")
 
     /// Test data with a validation error of "The Email field is not a supported e-mail address format."
-    static let registerFinishInvalidEmailFormat = loadFromJsonBundle(
-        resource: "RegisterFinishInvalidEmailFormat",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let registerFinishInvalidEmailFormat = loadFromJsonBundle(resource: "RegisterFinishInvalidEmailFormat")
 
     /// Test data of a request to create an account for `example@email.com`
-    static let registerFinishRequest = loadFromJsonBundle(
-        resource: "RegisterFinishRequest",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let registerFinishRequest = loadFromJsonBundle(resource: "RegisterFinishRequest")
 
     /// Test data of a successful account creation.
-    static let registerFinishSuccess = loadFromJsonBundle(
-        resource: "RegisterFinishSuccess",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let registerFinishSuccess = loadFromJsonBundle(resource: "RegisterFinishSuccess")
 
     // MARK: Request Password Hint
 
     /// Test data for a failure for password hint.
-    static let passwordHintFailure = loadFromJsonBundle(
-        resource: "PasswordHintFailure",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let passwordHintFailure = loadFromJsonBundle(resource: "PasswordHintFailure")
 
     // MARK: Start Registration
 
     /// Test data with a validation error of "Email 'j@a.com' is already taken."
     static let startRegistrationEmailAlreadyExists = loadFromJsonBundle(
         resource: "StartRegistrationEmailAlreadyExists",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
     )
 
     /// Test data with a validation error of "The field Email must be a string with a maximum length of 256."
     static let startRegistrationEmailExceedsMaxLength = loadFromJsonBundle(
         resource: "StartRegistrationEmailExceedsMaxLength",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
     )
 
     /// Test data with a validation error of
     static let startRegistrationInvalidEmailFormat = loadFromJsonBundle(
         resource: "StartRegistrationInvalidEmailFormat",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
     )
 
     /// Test data for success with a registration start.
     static let startRegistrationSuccess = loadFromBundle(
         resource: "StartRegistrationSuccess",
         extension: "txt",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
     )
 
     // MARK: Verify Email Token
 
     /// Test data indicating that the verify email token link has expired.
-    static let verifyEmailTokenExpiredLink = loadFromJsonBundle(
-        resource: "VerifyEmailTokenExpiredLink",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let verifyEmailTokenExpiredLink = loadFromJsonBundle(resource: "VerifyEmailTokenExpiredLink")
 }

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+BitwardenKitMocks.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+BitwardenKitMocks.swift
@@ -1,0 +1,12 @@
+import TestHelpers
+
+/// `APITestData` helpers that load the resource from the `BitwardenKitMocks` bundle.
+extension APITestData {
+    static func loadFromBundle(resource: String, extension: String) -> APITestData {
+        loadFromBundle(resource: resource, extension: `extension`, bundle: .bitwardenKitMocks)
+    }
+
+    static func loadFromJsonBundle(resource: String) -> APITestData {
+        loadFromJsonBundle(resource: resource, bundle: .bitwardenKitMocks)
+    }
+}

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+Config.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+Config.swift
@@ -3,8 +3,5 @@ import TestHelpers
 
 public extension APITestData {
     /// A valid server configuration to produce a `ConfigResponseModel`.
-    static let validServerConfig = loadFromJsonBundle(
-        resource: "ValidServerConfig",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let validServerConfig = loadFromJsonBundle(resource: "ValidServerConfig")
 }

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+Error.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+Error.swift
@@ -3,8 +3,5 @@ import TestHelpers
 
 public extension APITestData {
     /// A standard Bitwarden error message of "You do not have permissions to edit this."
-    static let bitwardenErrorMessage = loadFromJsonBundle(
-        resource: "BitwardenErrorMessage",
-        bundle: BitwardenKitMocksBundleFinder.bundle,
-    )
+    static let bitwardenErrorMessage = loadFromJsonBundle(resource: "BitwardenErrorMessage")
 }

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/BitwardenKitMocksBundleFinder.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/BitwardenKitMocksBundleFinder.swift
@@ -3,3 +3,8 @@ import Foundation
 class BitwardenKitMocksBundleFinder {
     static let bundle = Bundle(for: BitwardenKitMocksBundleFinder.self)
 }
+
+public extension Bundle {
+    /// The bundle for the `BitwardenKitMocks` target.
+    static let bitwardenKitMocks = BitwardenKitMocksBundleFinder.bundle
+}

--- a/BitwardenShared/Core/Platform/Services/API/Fixtures/APITestData+BitwardenShared.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Fixtures/APITestData+BitwardenShared.swift
@@ -1,0 +1,12 @@
+import TestHelpers
+
+/// `APITestData` helpers that load the resource from the `BitwardenShared` bundle.
+extension APITestData {
+    static func loadFromBundle(resource: String, extension: String) -> APITestData {
+        loadFromBundle(resource: resource, extension: `extension`, bundle: .bitwardenShared)
+    }
+
+    static func loadFromJsonBundle(resource: String) -> APITestData {
+        loadFromJsonBundle(resource: resource, bundle: .bitwardenShared)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/Fixtures/BitwardenSharedBundleFinder.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Fixtures/BitwardenSharedBundleFinder.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+class BitwardenSharedBundleFinder {
+    static let bundle = Bundle(for: BitwardenSharedBundleFinder.self)
+}
+
+public extension Bundle {
+    /// The bundle for the `BitwardenShared` target.
+    static let bitwardenShared = BitwardenSharedBundleFinder.bundle
+}

--- a/BitwardenShared/Core/Vault/Services/Fixtures/CXF+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Services/Fixtures/CXF+Fixtures.swift
@@ -5,5 +5,8 @@ import TestHelpers
 /// Fixtures for Credential Exchange flows.
 enum CXFFixtures {
     /// Fixture to be used on export flow with two basic-auth ciphers.
-    static let twoBasicAuthCiphers = TestDataHelpers.loadUTFStringFromJsonBundle(resource: "cxfTwoBasicAuthCiphers")
+    static let twoBasicAuthCiphers = TestDataHelpers.loadUTFStringFromJsonBundle(
+        resource: "cxfTwoBasicAuthCiphers",
+        bundle: .bitwardenShared,
+    )
 }

--- a/GlobalTestHelpers-bwa/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers-bwa/Support/BitwardenTestCase.swift
@@ -10,8 +10,6 @@ open class BitwardenTestCase: BaseBitwardenTestCase {
     override open class func setUp() {
         // Apply default appearances for snapshot tests.
         UI.applyDefaultAppearances()
-
-        TestDataHelpers.defaultBundle = Bundle(for: Self.self)
     }
 
     /// Executes any logic that should be applied before each test runs.

--- a/GlobalTestHelpers/Support/BitwardenTestCase.swift
+++ b/GlobalTestHelpers/Support/BitwardenTestCase.swift
@@ -8,8 +8,6 @@ open class BitwardenTestCase: BaseBitwardenTestCase {
     override open class func setUp() {
         // Apply default appearances for snapshot tests.
         UI.applyDefaultAppearances()
-
-        TestDataHelpers.defaultBundle = Bundle(for: Self.self)
     }
 
     /// Executes any logic that should be applied before each test runs.

--- a/TestHelpers/API/APITestData.swift
+++ b/TestHelpers/API/APITestData.swift
@@ -12,13 +12,13 @@ public struct APITestData {
     }
 
     /// Loads test data from a provided file in the test class's bundle.
-    public static func loadFromBundle(resource: String, extension: String, bundle: Bundle? = nil) -> APITestData {
+    public static func loadFromBundle(resource: String, extension: String, bundle: Bundle) -> APITestData {
         let data = TestDataHelpers.loadFromBundle(resource: resource, extension: `extension`, bundle: bundle)
         return APITestData(data: data)
     }
 
     /// Loads test data from a provided JSON file in the test class's bundle.
-    public static func loadFromJsonBundle(resource: String, bundle: Bundle? = nil) -> APITestData {
+    public static func loadFromJsonBundle(resource: String, bundle: Bundle) -> APITestData {
         loadFromBundle(resource: resource, extension: "json", bundle: bundle)
     }
 }

--- a/TestHelpers/API/TestDataHelpers.swift
+++ b/TestHelpers/API/TestDataHelpers.swift
@@ -3,34 +3,27 @@ import Foundation
 /// A type that wraps fixture data for use in mocking responses during tests.
 ///
 public enum TestDataHelpers {
-    /// The default bundle to try loading files from.
-    public static var defaultBundle: Bundle?
-
     /// Loads the data from the provided file.
-    public static func loadFromBundle(resource: String, extension: String, bundle: Bundle? = nil) -> Data {
-        let resolvedBundle = bundle ?? defaultBundle
-        guard let resolvedBundle else {
-            fatalError("Default test data bundle from not set properly in the test case.")
-        }
-        guard let url = resolvedBundle.url(forResource: resource, withExtension: `extension`) else {
+    public static func loadFromBundle(resource: String, extension: String, bundle: Bundle) -> Data {
+        guard let url = bundle.url(forResource: resource, withExtension: `extension`) else {
             // swiftlint:disable:next line_length
-            fatalError("Unable to locate file \(resource).\(`extension`) in the bundle \(resolvedBundle.bundleURL.lastPathComponent).")
+            fatalError("Unable to locate file \(resource).\(`extension`) in the bundle \(bundle.bundleURL.lastPathComponent).")
         }
         do {
             return try Data(contentsOf: url)
         } catch {
             // swiftlint:disable:next line_length
-            fatalError("Unable to load data from \(resource).\(`extension`) in the bundle \(resolvedBundle.bundleURL.lastPathComponent). Error: \(error)")
+            fatalError("Unable to load data from \(resource).\(`extension`) in the bundle \(bundle.bundleURL.lastPathComponent). Error: \(error)")
         }
     }
 
     /// Convenience function for loading data from a JSON file.
-    public static func loadFromJsonBundle(resource: String, bundle: Bundle? = nil) -> Data {
+    public static func loadFromJsonBundle(resource: String, bundle: Bundle) -> Data {
         loadFromBundle(resource: resource, extension: "json", bundle: bundle)
     }
 
     /// Convenience function for loading a JSON file into a UTF-8 string.
-    public static func loadUTFStringFromJsonBundle(resource: String, bundle: Bundle? = nil) -> String? {
+    public static func loadUTFStringFromJsonBundle(resource: String, bundle: Bundle) -> String? {
         let data = loadFromJsonBundle(resource: resource, bundle: bundle)
         return String(data: data, encoding: .utf8)
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27143](https://bitwarden.atlassian.net/browse/PM-27143)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

I looked into creating separate frameworks for AuthenticatorSharedMocks and BitwardenSharedMocks, but I ran into the issue where the fixtures in `APITestData` can't be found in the default bundle. This results in having to specify a bundle for each fixture definition.

Here's one idea around simplifying this.

1. TestDataHelpers no longer allows for an optional `Bundle` / default bundle fallback. This means each `APITestData` fixture will need to specify a bundle.

```diff
- public static func loadFromBundle(resource: String, extension: String, bundle: Bundle? = nil) -> Data {
+ public static func loadFromBundle(resource: String, extension: String, bundle: Bundle) -> Data {
```

2. But we could add per-framework helpers which specify the framework's bundle.

```
/// `APITestData` helpers that load the resource from the `BitwardenKitMocks` bundle.
extension APITestData {
    static func loadFromBundle(resource: String, extension: String) -> APITestData {
        loadFromBundle(resource: resource, extension: `extension`, bundle: .bitwardenKitMocks)
    }

    static func loadFromJsonBundle(resource: String) -> APITestData {
        loadFromJsonBundle(resource: resource, bundle: .bitwardenKitMocks)
    }
}

public extension Bundle {
    /// The bundle for the `BitwardenKitMocks` target.
    static let bitwardenKitMocks = BitwardenKitMocksBundleFinder.bundle
}
```

This needs to be specified in each framework with fixtures (BitwardenKitMocks, AuthenticatorSharedTests, BitwardenSharedTests), but essentially provides a default bundle for the framework.

This also fixes the Swift 6 warning around using `TestDataHelpers.defaultBundle`.

```
⚠️ Reference to static property 'defaultBundle' is not concurrency-safe because it involves shared mutable state; this is an error in the Swift 6 language mode
```

I also considered updating `TestDataHelpers` to search through a whitelisted set of bundles to find any file matching the resource name. I think this would work as well, and would negate the need for per-framework helpers, but it felt better to be explicit about which bundle we expect the fixture to be in.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27143]: https://bitwarden.atlassian.net/browse/PM-27143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ