### PR TITLE
Ignore local Claude review files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ Authenticator/Application/Support/Settings.bundle/Acknowledgements.latest_result
 
 # AI
 .claude/settings.local.json
+review-*.md


### PR DESCRIPTION
## 📔 Objective

This updates our `.gitignore` to also ignore the `review-*.md` files that Claude generates when running the [review plugin](https://github.com/bitwarden/ai-plugins) locally.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
