### PR TITLE
[PM-28339] Convert data store publisher tests to use async iterators

### DIFF
--- a/AuthenticatorBridgeKit/Tests/AuthenticatorBridgeItemServiceTests.swift
+++ b/AuthenticatorBridgeKit/Tests/AuthenticatorBridgeItemServiceTests.swift
@@ -355,7 +355,7 @@ final class AuthenticatorBridgeItemServiceTests: AuthenticatorBridgeKitTestCase 
         let initialItems = AuthenticatorBridgeItemDataView.fixtures().sorted { $0.id < $1.id }
         try await subject.insertItems(initialItems, forUserId: "userId")
 
-        var iterator = try await subject.sharedItemsPublisher().values.makeAsyncIterator()
+        var iterator = try await subject.sharedItemsPublisher().valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, initialItems)
@@ -372,7 +372,7 @@ final class AuthenticatorBridgeItemServiceTests: AuthenticatorBridgeKitTestCase 
         let initialItems = AuthenticatorBridgeItemDataView.fixtures().sorted { $0.id < $1.id }
         try await subject.insertItems(initialItems, forUserId: "userId")
 
-        var iterator = try await subject.sharedItemsPublisher().values.makeAsyncIterator()
+        var iterator = try await subject.sharedItemsPublisher().valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, initialItems)

--- a/AuthenticatorShared/Core/Vault/Services/Stores/AuthenticatorItemDataStoreTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Stores/AuthenticatorItemDataStoreTests.swift
@@ -33,7 +33,7 @@ class AuthenticatorItemDataStoreTests: BitwardenTestCase {
 
     /// `authenticatorItemPublisher(userId:)` returns a publisher for a user's authenticatorItem objects.
     func test_authenticatorItemPublisher() async throws {
-        var iterator = subject.authenticatorItemPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.authenticatorItemPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/BitwardenShared/Core/Tools/Services/GeneratorDataStoreTests.swift
+++ b/BitwardenShared/Core/Tools/Services/GeneratorDataStoreTests.swift
@@ -120,7 +120,7 @@ class GeneratorDataStoreTests: BitwardenTestCase {
     /// `passwordHistoryPublisher(userId:)` returns a publisher for a user's password history objects.
     @MainActor
     func test_passwordHistoryPublisher() async throws {
-        var iterator = subject.passwordHistoryPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.passwordHistoryPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/BitwardenShared/Core/Tools/Services/Stores/SendDataStoreTests.swift
+++ b/BitwardenShared/Core/Tools/Services/Stores/SendDataStoreTests.swift
@@ -57,7 +57,7 @@ class SendDataStoreTests: BitwardenTestCase {
 
     /// `sendPublisher(userId:)` returns a publisher for a single send.
     func test_sendPublisher() async throws {
-        var iterator = subject.sendPublisher(id: "1", userId: "1").values.makeAsyncIterator()
+        var iterator = subject.sendPublisher(id: "1", userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, .some(nil))
@@ -70,7 +70,7 @@ class SendDataStoreTests: BitwardenTestCase {
 
     /// `sendsPublisher(userId:)` returns a publisher for a user's send objects.
     func test_sendsPublisher() async throws {
-        var iterator = subject.sendsPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.sendsPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/BitwardenShared/Core/Vault/Services/Stores/CipherDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CipherDataStoreTests.swift
@@ -46,7 +46,7 @@ class CipherDataStoreTests: BitwardenTestCase {
 
     /// `cipherPublisher(userId:)` returns a publisher for a user's cipher objects.
     func test_cipherPublisher() async throws {
-        var iterator = subject.cipherPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.cipherPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/CollectionDataStoreTests.swift
@@ -34,7 +34,7 @@ class CollectionDataStoreTests: BitwardenTestCase {
 
     /// `collectionPublisher(userId:)` returns a publisher for a user's collection objects.
     func test_collectionPublisher() async throws {
-        var iterator = subject.collectionPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.collectionPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/BitwardenShared/Core/Vault/Services/Stores/FolderDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/FolderDataStoreTests.swift
@@ -68,7 +68,7 @@ class FolderDataStoreTests: BitwardenTestCase {
 
     /// `folderPublisher(userId:)` returns a publisher for a user's folder objects.
     func test_folderPublisher() async throws {
-        var iterator = subject.folderPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.folderPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/BitwardenShared/Core/Vault/Services/Stores/OrganizationDataStoreTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/OrganizationDataStoreTests.swift
@@ -45,7 +45,7 @@ class OrganizationDataStoreTests: BitwardenTestCase {
 
     /// `organizationPublisher(userId:)` returns a publisher for a user's organization objects.
     func test_organizationPublisher() async throws {
-        var iterator = subject.organizationPublisher(userId: "1").values.makeAsyncIterator()
+        var iterator = subject.organizationPublisher(userId: "1").valuesWithTimeout().makeAsyncIterator()
 
         let firstValue = try await iterator.next()
         XCTAssertEqual(firstValue, [])

--- a/TestHelpers/Extensions/Publisher+ValuesWithTimeout.swift
+++ b/TestHelpers/Extensions/Publisher+ValuesWithTimeout.swift
@@ -1,0 +1,27 @@
+import Combine
+import Foundation
+
+/// An error thrown when a publisher times out while awaiting values.
+public struct PublisherTimeoutError: Error {}
+
+public extension Publisher where Failure == Error {
+    /// Returns an async sequence of the publisher's values with a timeout.
+    ///
+    /// This is useful in tests where you want to await publisher values without risking test hangs
+    /// if the publisher never emits.
+    ///
+    /// - Parameter timeout: The maximum time interval to wait for values, in seconds. Defaults to 10 seconds.
+    /// - Returns: An async throwing publisher that emits values or throws `PublisherTimeoutError` on timeout.
+    ///
+    func valuesWithTimeout(
+        _ timeout: TimeInterval = 10,
+    ) -> AsyncThrowingPublisher<Publishers.Timeout<Self, DispatchQueue>> {
+        self
+            .timeout(
+                .seconds(timeout),
+                scheduler: DispatchQueue.main,
+                customError: { PublisherTimeoutError() },
+            )
+            .values
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28339](https://bitwarden.atlassian.net/browse/PM-28339)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

After making the changes in https://github.com/bitwarden/ios/pull/2165, some of the data store publisher tests would randomly fail. Since the data store publishers were using the background managed object context, this introduced a race condition in the tests. If the database update was made before the initial database results were published, only the most recent change would end up being published.

```
    waitFor(results.count == 2)
    XCTAssertEqual(results[0], initialItems) // this would fail because results[0] could already have `replacedItems`
    XCTAssertEqual(results[1], replacedItems)
```

I initially started adding more `waitFor` calls to wait for the initial results to be published. Converting these tests to use async iterators is similar to waiting for each result and results in a simpler and more efficient test.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28339]: https://bitwarden.atlassian.net/browse/PM-28339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ