### PR TITLE
[PM-28339] Remove nested LazyVStacks to improve scroll performance

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -132,7 +132,7 @@ private struct MainSendListView: View {
     /// interface, and a message indicating that no results were found.
     @ViewBuilder private var search: some View {
         if store.state.searchText.isEmpty || !store.state.searchResults.isEmpty {
-            LazyVStack(spacing: 0) {
+            VStack(spacing: 0) {
                 if !store.state.searchResults.isEmpty {
                     sendItemSectionView(
                         sectionName: nil,
@@ -149,7 +149,7 @@ private struct MainSendListView: View {
     /// The list for this view, displayed when there is content to display.
     @ViewBuilder
     private func list(sections: [SendListSection]) -> some View {
-        LazyVStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 16) {
             if store.state.isSendDisabled {
                 InfoContainer(Localizations.sendDisabledWarning)
             }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -142,7 +142,7 @@ private struct VaultAutofillListSearchableView: View {
     /// A view for displaying a list of sections with ciphers.
     @ViewBuilder
     private func cipherCombinedListView(_ sections: [VaultListSection]) -> some View {
-        LazyVStack(spacing: 16) {
+        VStack(spacing: 16) {
             ForEach(sections) { section in
                 VaultListSectionView(
                     section: section,

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -249,7 +249,7 @@ private struct SearchableVaultListView: View {
     ///
     @ViewBuilder
     private func vaultContents(with sections: [VaultListSection]) -> some View {
-        LazyVStack(spacing: 20) {
+        VStack(spacing: 20) {
             vaultFilterRow
 
             ForEach(sections) { section in


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28339](https://bitwarden.atlassian.net/browse/PM-28339)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

In the vault and send list views, we have nested LazyVStacks. There was a LazyVStack for the list of sections and then each section had a LazyVStack containing the section's items. With a large number of vault items, this would occasionally lead to scrolling hitch issues. I think generally the recommendation is to use LazyVStack at the top-level of the scroll view. However, since we often have a few number of sections in the scroll view, and the sections can contain a large number of items, it seems to be more performant to keep a VStack at the top-level and use LazyVStack within each section.

Overall Summary:
| Metric | Baseline | After Change | Δ (%) |
|--------|--------|--------|--------|
| Hitch Duration (ms) | 839 | 554 | **-34%** |
| Avg Hitch Duration (ms) | 18.5 | 16.5 | -11% |
| Max Hitch Duration (ms) | 650.1 | 100 | **-85%** |

<details><summary>Run Details</summary>
<p>

Baseline:
| Duration (ms) | Average (ms) | Max (ms) |
|--------|--------|--------|
| 839 | 15.8 | 75 |
| 697.8 | 15.9 | 66.7 |
| 554.2 | 18.5 | 66.7 |
| 1400 | 45.17 | 658.4 |
| 1310 | 56.9 | 650.1 | 

After Change
| Duration (ms) | Average (ms) | Max (ms) |
|--------|--------|--------|
| 554.2 | 15.4 | 50 |
| 600.1 | 16.7 | 50 |
| 550.8 | 17.8 | 100 |
| 428.8 | 16.5 | 50 |
| 670.9 | 15.6 | 100 | 

</p>
</details> 

This was a result of profiling 5 runs before and after on an iPhone 13 Pro. Given that this involves manually scrolling the list, I tried to be as consistent as possible, but there is some variation. In the Baseline, there were two outliers which increased some of the before numbers, but these haven't been reproduced after making the changes.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28339]: https://bitwarden.atlassian.net/browse/PM-28339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ