### PR TITLE
[PM-28339] Move FetchedResultsSubscription's initial fetch into background

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/FetchedResultsPublisher.swift
+++ b/BitwardenKit/Core/Platform/Utilities/FetchedResultsPublisher.swift
@@ -147,7 +147,9 @@ private final class FetchedResultsSubscription<SubscriberType, ResultType, Outpu
                     }
                 }
             } catch {
-                subscriber.receive(completion: .failure(error))
+                self.queue.async {
+                    self.subscriber?.receive(completion: .failure(error))
+                }
             }
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28339](https://bitwarden.atlassian.net/browse/PM-28339)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When `FetchedResultsSubscription` is initialized, it performs an initial fetch of the fetch request. If the subscription is created on the main thread, which is often the case when subscribing to data in a processor, this occurs on the main thread. The fetch itself occurs on a background context (https://github.com/bitwarden/ios/pull/2165), but `performFetch()` is synchronous and waits for the results. After adding the serial queue in the previous PR, this is an easy thing to also move into the background.

Overall Summary:
| Metric | Baseline | After Change | Δ (%) |
|--------|--------|--------|--------|
| Hitch Duration (ms) | 150.5 | 86.7 | -43% |
| Avg Hitch Duration (ms) | 44.6 | 34.7 | -22% |
| Max Hitch Duration (ms) | 80 | 60 | -25% |

<details><summary>Run Details</summary>
<p>

Baseline:
| Duration (ms) | Average (ms) | Max (ms) |
|--------|--------|--------|
| 291.7 | 58.3 | 133.3 |
| 65.7 | 32.9 | 50 |
| 183.4 | 61.1 | 100 |
| 133.3 | 44.5 | 66.7 |
| 78.3 | 26.1 | 50 |

After Change
| Duration (ms) | Average (ms) | Max (ms) |
|--------|--------|--------|
| 91.7 | 30.6 | 66.7 |
| 91.7 | 22.9 | 50 |
| 91.7 | 22.9 | 50 |
| 66.7 | 66.7 | 66.7 |
| 91.7 | 30.6 | 66.7 |

</p>
</details> 

This was a result of profiling 5 runs before and after on startup on an iPhone 13 Pro.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28339]: https://bitwarden.atlassian.net/browse/PM-28339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ