### PR TITLE
[PM-29444] Update cron jobs to run at midnight on Sundays

### DIFF
--- a/.github/workflows/cron-update-public-suffix-list.yml
+++ b/.github/workflows/cron-update-public-suffix-list.yml
@@ -1,8 +1,8 @@
 name: Cron / Update public suffix list
 on:
   schedule:
-    # Run weekly on Monday at 00:00 UTC
-    - cron: '0 0 * * 1'
+    # Run weekly on Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -4,7 +4,8 @@ run-name: Crowdin Pull - ${{ github.event_name == 'workflow_dispatch' && 'Manual
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 5'
+    # Run weekly on Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
 
 jobs:
   crowdin-sync:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29444

## 📔 Objective

This unifies the public suffix list and crowdin pull cron jobs to both run over the weekend, to take advantage of off-hours for the runners. More specifically, this updates them to run at midnight on Sundays (UTC).

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
