### PR TITLE
[PM-29258] Update security stamp change to cause a hard logout

### DIFF
--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -514,11 +514,11 @@ extension AppProcessor {
     private func logOutAutomatically(userId: String? = nil) async {
         coordinator?.hideLoadingOverlay()
         do {
-            try await services.authRepository.logout(userId: userId, userInitiated: false)
+            try await services.authRepository.logout(userId: userId, userInitiated: true)
         } catch {
             services.errorReporter.log(error: error)
         }
-        await coordinator?.handleEvent(.didLogout(userId: userId, userInitiated: false))
+        await coordinator?.handleEvent(.didLogout(userId: userId, userInitiated: true))
     }
 
     /// Starts timer to send organization events regularly

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -1385,9 +1385,9 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         XCTAssertTrue(authRepository.logoutCalled)
         XCTAssertEqual(authRepository.logoutUserId, "1")
-        XCTAssertFalse(authRepository.logoutUserInitiated)
+        XCTAssertTrue(authRepository.logoutUserInitiated)
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.events, [.didLogout(userId: "1", userInitiated: false)])
+        XCTAssertEqual(coordinator.events, [.didLogout(userId: "1", userInitiated: true)])
     }
 
     /// `securityStampChanged(userId:)` throws logging the user out which is logged and notifies the coordinator.
@@ -1401,7 +1401,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertTrue(authRepository.logoutCalled)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.events, [.didLogout(userId: "1", userInitiated: false)])
+        XCTAssertEqual(coordinator.events, [.didLogout(userId: "1", userInitiated: true)])
     }
 
     /// `onRefreshTokenError(error:)` logs the user out and notifies the coordinator when a 401 is
@@ -1414,9 +1414,9 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         XCTAssertTrue(authRepository.logoutCalled)
         XCTAssertEqual(authRepository.logoutUserId, nil)
-        XCTAssertFalse(authRepository.logoutUserInitiated)
+        XCTAssertTrue(authRepository.logoutUserInitiated)
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: false)])
+        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: true)])
     }
 
     /// `onRefreshTokenError(error:)` logs the user out and notifies the coordinator a 403 is
@@ -1429,9 +1429,9 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         XCTAssertTrue(authRepository.logoutCalled)
         XCTAssertEqual(authRepository.logoutUserId, nil)
-        XCTAssertFalse(authRepository.logoutUserInitiated)
+        XCTAssertTrue(authRepository.logoutUserInitiated)
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: false)])
+        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: true)])
     }
 
     /// `onRefreshTokenError(error:)` logs the user out and notifies the coordinator when error is `.invalidGrant`.
@@ -1443,9 +1443,9 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         XCTAssertTrue(authRepository.logoutCalled)
         XCTAssertEqual(authRepository.logoutUserId, nil)
-        XCTAssertFalse(authRepository.logoutUserInitiated)
+        XCTAssertTrue(authRepository.logoutUserInitiated)
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: false)])
+        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: true)])
     }
 
     /// `onRefreshTokenError(error:)` throws logging the user out which is logged and notifies the coordinator
@@ -1460,7 +1460,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertTrue(authRepository.logoutCalled)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: false)])
+        XCTAssertEqual(coordinator.events, [.didLogout(userId: nil, userInitiated: true)])
     }
 
     /// `onRefreshTokenError(error:)` doesn't perform log out when error is not `.invalidGrant`.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-29258](https://bitwarden.atlassian.net/browse/PM-29258)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Use a hard logout instead of soft logout when the security stamp changes. This matches the behavior when receiving a logout push notification as a result of the security stamp changing.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-29258]: https://bitwarden.atlassian.net/browse/PM-29258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ