### PR TITLE
[PM-29948] Remove resetMasterPassword property

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/Fixtures/IdentityTokenResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/Fixtures/IdentityTokenResponseModel+Fixtures.swift
@@ -45,7 +45,6 @@ extension IdentityTokenResponseModel {
         keyConnectorUrl: String? = nil,
         masterPasswordPolicy: MasterPasswordPolicyResponseModel? = nil,
         privateKey: String? = "PRIVATE_KEY",
-        resetMasterPassword: Bool = false,
         twoFactorToken: String? = nil,
         userDecryptionOptions: UserDecryptionOptions? = UserDecryptionOptions(
             hasMasterPassword: true,
@@ -69,7 +68,6 @@ extension IdentityTokenResponseModel {
             keyConnectorUrl: keyConnectorUrl,
             masterPasswordPolicy: masterPasswordPolicy,
             privateKey: privateKey,
-            resetMasterPassword: resetMasterPassword,
             twoFactorToken: twoFactorToken,
             userDecryptionOptions: userDecryptionOptions,
             accessToken: accessToken,

--- a/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/IdentityTokenResponseModel.swift
@@ -39,9 +39,6 @@ struct IdentityTokenResponseModel: Equatable, JSONResponse, KdfConfigProtocol, A
     /// The user's private key.
     let privateKey: String?
 
-    /// Whether the user's master password needs to be reset.
-    let resetMasterPassword: Bool
-
     /// The two-factor authentication token.
     let twoFactorToken: String?
 

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenKeyConnector.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenKeyConnector.json
@@ -8,7 +8,6 @@
   "Key": "KEY",
   "MasterPasswordPolicy": null,
   "ForcePasswordReset": false,
-  "ResetMasterPassword": false,
   "Kdf": 0,
   "KdfIterations": 600000,
   "KdfMemory": null,

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenKeyConnectorMasterPassword.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenKeyConnectorMasterPassword.json
@@ -8,7 +8,6 @@
   "Key": "KEY",
   "MasterPasswordPolicy": null,
   "ForcePasswordReset": false,
-  "ResetMasterPassword": false,
   "Kdf": 0,
   "KdfIterations": 600000,
   "KdfMemory": null,

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenNoMasterPassword.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenNoMasterPassword.json
@@ -6,7 +6,6 @@
   "scope": "api offline_access",
   "MasterPasswordPolicy": null,
   "ForcePasswordReset": false,
-  "ResetMasterPassword": false,
   "Kdf": 0,
   "KdfIterations": 600000,
   "KdfMemory": null,

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenSuccess.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenSuccess.json
@@ -8,7 +8,6 @@
   "Key": "KEY",
   "MasterPasswordPolicy": null,
   "ForcePasswordReset": false,
-  "ResetMasterPassword": false,
   "Kdf": 0,
   "KdfIterations": 600000,
   "KdfMemory": null,

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenSuccessTwoFactorToken.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenSuccessTwoFactorToken.json
@@ -8,7 +8,6 @@
   "Key": "KEY",
   "MasterPasswordPolicy": null,
   "ForcePasswordReset": false,
-  "ResetMasterPassword": false,
   "Kdf": 0,
   "KdfIterations": 600000,
   "KdfMemory": null,

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenTrustedDevice.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenTrustedDevice.json
@@ -6,7 +6,6 @@
   "scope": "api offline_access",
   "MasterPasswordPolicy": null,
   "ForcePasswordReset": false,
-  "ResetMasterPassword": false,
   "Kdf": 0,
   "KdfIterations": 600000,
   "KdfMemory": null,

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenWithMasterPasswordPolicy.json
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Fixtures/IdentityTokenWithMasterPasswordPolicy.json
@@ -17,7 +17,6 @@
         "Object": "masterPasswordPolicy"
     },
     "ForcePasswordReset": false,
-    "ResetMasterPassword": false,
     "Kdf": 0,
     "KdfIterations": 600000,
     "KdfMemory": null,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-29948

## 📔 Objective

This removes the `resetMasterPassword` property from the `IdentityTokenResponseModel`, now that it's deprecated.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
