### PR TITLE
[PM-30147] Fix crash by adding weak self on FetchedResultsSubscription

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/FetchedResultsPublisher.swift
+++ b/BitwardenKit/Core/Platform/Utilities/FetchedResultsPublisher.swift
@@ -137,17 +137,19 @@ private final class FetchedResultsSubscription<SubscriberType, ResultType, Outpu
 
         controller?.delegate = self
 
-        context.perform {
+        context.perform { [weak self] in
+            guard let self else { return }
+
             do {
-                try self.controller?.performFetch()
-                if self.controller?.fetchedObjects != nil {
-                    self.queue.async {
+                try controller?.performFetch()
+                if controller?.fetchedObjects != nil {
+                    queue.async {
                         self.hasChangesToSend = true
                         self.fulfillDemand()
                     }
                 }
             } catch {
-                self.queue.async {
+                queue.async {
                     self.subscriber?.receive(completion: .failure(error))
                 }
             }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-30147](https://bitwarden.atlassian.net/browse/PM-30147)

## 📔 Objective

Added weak self for context perform on `FetchedResultsSubscription` to see if that fixes a crash happening sometimes when fetching CoreData.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30147]: https://bitwarden.atlassian.net/browse/PM-30147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ