### PR TITLE
[PM-30147] Weakify self to fix crash by background search

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/FetchedResultsPublisher.swift
+++ b/BitwardenKit/Core/Platform/Utilities/FetchedResultsPublisher.swift
@@ -137,18 +137,18 @@ private final class FetchedResultsSubscription<SubscriberType, ResultType, Outpu
 
         controller?.delegate = self
 
-        context.perform {
+        context.perform { [weak self] in
             do {
-                try self.controller?.performFetch()
-                if self.controller?.fetchedObjects != nil {
-                    self.queue.async {
-                        self.hasChangesToSend = true
-                        self.fulfillDemand()
+                try self?.controller?.performFetch()
+                if self?.controller?.fetchedObjects != nil {
+                    self?.queue.async {
+                        self?.hasChangesToSend = true
+                        self?.fulfillDemand()
                     }
                 }
             } catch {
-                self.queue.async {
-                    self.subscriber?.receive(completion: .failure(error))
+                self?.queue.async {
+                    self?.subscriber?.receive(completion: .failure(error))
                 }
             }
         }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-30147

## 📔 Objective

This weakifies `self` in the `FetchedResultsSubscription` initializer. This is similar to https://github.com/bitwarden/ios/pull/2215 but simply keeps it weak throughout. The 2215 change still gave me crashes, but this doesn't, though I'm a little uncertain as to why.

This modifies the code introduces in https://github.com/bitwarden/ios/pull/2193.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
