### PR TITLE
[PM-30386] Fix failing date-based tests

### DIFF
--- a/BitwardenKit/Core/Platform/Services/AppInfoServiceTests.swift
+++ b/BitwardenKit/Core/Platform/Services/AppInfoServiceTests.swift
@@ -47,7 +47,7 @@ class AppInfoServiceTests: BitwardenTestCase {
         XCTAssertEqual(
             subject.appInfoString,
             """
-            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
+            © Bitwarden Inc. 2015–2025
 
             📝 Bitwarden 1.0 (1)
             📦 Bundle: com.8bit.bitwarden
@@ -64,7 +64,7 @@ class AppInfoServiceTests: BitwardenTestCase {
         XCTAssertEqual(
             subject.appInfoString,
             """
-            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
+            © Bitwarden Inc. 2015–2025
 
             📝 Bitwarden 1.0 (1)
             📦 Bundle: Unknown
@@ -86,7 +86,7 @@ class AppInfoServiceTests: BitwardenTestCase {
         XCTAssertEqual(
             subject.appInfoString,
             """
-            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
+            © Bitwarden Inc. 2015–2025
 
             📝 Bitwarden 1.0 (1)
             📦 Bundle: com.8bit.bitwarden
@@ -112,7 +112,7 @@ class AppInfoServiceTests: BitwardenTestCase {
         XCTAssertEqual(
             subject.appInfoString,
             """
-            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
+            © Bitwarden Inc. 2015–2025
 
             📝 Bitwarden 1.0 (1)
             📦 Bundle: com.8bit.bitwarden
@@ -148,7 +148,7 @@ class AppInfoServiceTests: BitwardenTestCase {
 
     /// `copyrightString` returns the app's formatted copyright string.
     func test_copyrightString() {
-        XCTAssertEqual(subject.copyrightString, "© Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))")
+        XCTAssertEqual(subject.copyrightString, "© Bitwarden Inc. 2015–2025")
 
         timeProvider.timeConfig = .mockTime(Date(year: 2020, month: 1, day: 2))
         XCTAssertEqual(subject.copyrightString, "© Bitwarden Inc. 2015–2020")


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-30386](https://bitwarden.atlassian.net/browse/PM-30386)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Reverts a few changes from https://github.com/bitwarden/ios/pull/2223 since the tests were using a mocked date.

https://github.com/bitwarden/ios/blob/87a2fcf2ace54872abdae13327ed490d702de841/BitwardenKit/Core/Platform/Services/AppInfoServiceTests.swift#L22

I debated whether the mocked date should be removed, but that seems like the better approach. And now that the values in the test aren't the current year, this should be more obvious in the future that the date value is mocked.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-30386]: https://bitwarden.atlassian.net/browse/PM-30386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ