### PR TITLE
[PM-27098] feat: Update some plurals to full-sentence forms to handle polypersonal agreement languages better

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.stringsdict
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.stringsdict
@@ -6,59 +6,59 @@
 	<key>BitwardenCouldNotDecryptXVaultItemsDescriptionLong</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@vaultitems@. Copy and share this error report with customer success to avoid additional data loss.</string>
-		<key>vaultitems</key>
+		<string>%#@BitwardenCouldNotDecryptVaultItems@ Copy and share this error report with customer success to avoid additional data loss.</string>
+		<key>BitwardenCouldNotDecryptVaultItems</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Bitwarden could not decrypt %d vault item</string>
+			<string>Bitwarden could not decrypt %d vault item.</string>
 			<key>other</key>
-			<string>Bitwarden could not decrypt %d vault items</string>
+			<string>Bitwarden could not decrypt %d vault items.</string>
 		</dict>
 	</dict>
 	<!-- A message indicating the minimum length of a master password in characters. -->
 	<key>MasterPasswordMustBeAtLeastXCharactersLong</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@masterpasswordcharacters@.</string>
-		<key>masterpasswordcharacters</key>
+		<string>%#@MasterPasswordMustBeAtLeastCharactersLong@</string>
+		<key>MasterPasswordMustBeAtLeastCharactersLong</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Master password must be at least %d character long</string>
+			<string>Master password must be at least %d character long.</string>
 			<key>other</key>
-			<string>Master password must be at least %d characters long</string>
+			<string>Master password must be at least %d characters long.</string>
 		</dict>
 	</dict>
 	<!-- A warning if we have determined that a password has been exposed in a data breach. -->
 	<key>ThisPasswordHasBeenExposedXTimesDescriptionLong</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@passwordexposedtimes@. You should change it.</string>
-		<key>passwordexposedtimes</key>
+		<string>%#@ThisPasswordHasBeenExposedTimes@ You should change it.</string>
+		<key>ThisPasswordHasBeenExposedTimes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>This password has been exposed %d time in data breaches</string>
+			<string>This password has been exposed %d time in data breaches.</string>
 			<key>other</key>
-			<string>This password has been exposed %d times in data breaches</string>
+			<string>This password has been exposed %d times in data breaches.</string>
 		</dict>
 	</dict>
 	<!-- A number of characters, as in letters/numbers/punctuation. For example, the minimum number of characters when creating a password. -->
 	<key>XCharacters</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@characters@</string>
-		<key>characters</key>
+		<string>%#@Characters@</string>
+		<key>Characters</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -74,8 +74,8 @@
 	<key>XDays</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@days@</string>
-		<key>days</key>
+		<string>%#@Days@</string>
+		<key>Days</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -91,8 +91,8 @@
 	<key>XHours</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@hours@</string>
-		<key>hours</key>
+		<string>%#@Hours@</string>
+		<key>Hours</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -108,8 +108,8 @@
 	<key>XItems</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@items@</string>
-		<key>items</key>
+		<string>%#@Items@</string>
+		<key>Items</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -125,8 +125,8 @@
 	<key>XItemsSuccessfullyImported</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@itemssuccessfullyimported@</string>
-		<key>itemssuccessfullyimported</key>
+		<string>%#@ItemsSuccessfullyImported@</string>
+		<key>ItemsSuccessfullyImported</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -142,8 +142,8 @@
 	<key>XMinutes</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@minutes@</string>
-		<key>minutes</key>
+		<string>%#@Minutes@</string>
+		<key>Minutes</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -159,8 +159,8 @@
 	<key>XSeconds</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@seconds@</string>
-		<key>seconds</key>
+		<string>%#@Seconds@</string>
+		<key>Seconds</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -176,8 +176,8 @@
 	<key>XWeeks</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@weeks@</string>
-		<key>weeks</key>
+		<string>%#@Weeks@</string>
+		<key>Weeks</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
@@ -193,17 +193,17 @@
 	<key>YourPINMustBeAtLeastXCharactersDescriptionLong</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>%#@pinmustbecharacters@. Your PIN settings will be reset if you ever fully log out of the application.</string>
-		<key>pinmustbecharacters</key>
+		<string>%#@YourPINMustBeAtLeastCharacters@ Your PIN settings will be reset if you ever fully log out of the application.</string>
+		<key>YourPINMustBeAtLeastCharacters</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>
 			<string>NSStringPluralRuleType</string>
 			<key>NSStringFormatValueTypeKey</key>
 			<string>d</string>
 			<key>one</key>
-			<string>Your PIN must be at least %d character</string>
+			<string>Your PIN must be at least %d character.</string>
 			<key>other</key>
-			<string>Your PIN must be at least %d characters</string>
+			<string>Your PIN must be at least %d characters.</string>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27098

## 📔 Objective

[As noted in comments on a previous PR](https://github.com/bitwarden/ios/pull/1999#issuecomment-3672028969), the previous form of handling plurals in strings by breaking out just the plural had some issues. The first is that CrowdIn Translation Memory would cause issues with pluralized nouns being taken out of subject/object context, which doesn't work for languages that decline nouns differently for subjects and objects. The second is that languages with [polypersonal agreement](https://en.wikipedia.org/wiki/Polypersonal_agreement) also require inflecting the verb congruently with the number of items, and we weren't allowing that.

Per that recommendation, I've pulled things out into full sentences, so that translators can provide better translations for the array of possibilities.

Nota bene: I elected even in circumstances where it is just a full sentence to leave the sentence-ending punctuation out of the pluralized forms. This allows us to remain consistent in multi-sentence situations, and for the base string to clearly indicate the sentence patterns. I'm not, however, wedded to that, I would just like to be consistent.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
