### PR TITLE
[PM-18404] Add server version to About screen version copy-paste

### DIFF
--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -41,7 +41,4 @@ enum SettingsAction: Equatable {
 
     /// The tutorial button was tapped
     case tutorialTapped
-
-    /// The version was tapped.
-    case versionTapped
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsEffect.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsEffect.swift
@@ -4,6 +4,9 @@ import BitwardenKit
 
 /// Effects that can be processed by an `SettingsProcessor`.
 enum SettingsEffect: Equatable {
+    /// Copy the version information to the pasteboard.
+    case copyVersionInfo
+
     /// An effect for the flight recorder feature.
     case flightRecorder(FlightRecorderSettingsSectionEffect)
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -52,6 +52,8 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
 
     override func perform(_ effect: SettingsEffect) async {
         switch effect {
+        case .copyVersionInfo:
+            await copyVersionInfo()
         case let .flightRecorder(flightRecorderEffect):
             switch flightRecorderEffect {
             case let .toggleFlightRecorder(isOn):
@@ -125,16 +127,15 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             state.toast = newValue
         case .tutorialTapped:
             coordinator.navigate(to: .tutorial)
-        case .versionTapped:
-            handleVersionTapped()
         }
     }
 
     // MARK: - Private Methods
 
-    /// Prepare the text to be copied.
-    private func handleVersionTapped() {
-        services.pasteboardService.copy(services.appInfoService.appInfoString)
+    /// Copies the app's version info to the pasteboard.
+    private func copyVersionInfo() async {
+        let appInfo = await services.appInfoService.appInfoString
+        services.pasteboardService.copy(appInfo)
         state.toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo))
     }
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -62,6 +62,28 @@ class SettingsProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `perform(_:)` with `.copyVersionInfo` copies the copyright, the version string and device
+    /// info to the pasteboard.
+    @MainActor
+    func test_perform_copyVersionInfo() async {
+        await subject.perform(.copyVersionInfo)
+        XCTAssertEqual(
+            pasteboardService.copiedString,
+            """
+            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
+
+            📝 Bitwarden 1.0 (1)
+            📦 Bundle: com.8bit.bitwarden
+            📱 Device: iPhone14,2
+            🍏 System: iOS 16.4
+            """,
+        )
+        XCTAssertEqual(
+            subject.state.toast?.title,
+            Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo)).title,
+        )
+    }
+
     /// `perform(_:)` with `.flightRecorder(.toggleFlightRecorder(true))` navigates to the enable
     /// flight recorder screen when toggled on.
     @MainActor
@@ -292,26 +314,5 @@ class SettingsProcessorTests: BitwardenTestCase {
         subject.receive(.syncWithBitwardenAppTapped)
 
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.passwordManagerLink)
-    }
-
-    /// Receiving `.versionTapped` copies the copyright, the version string and device info to the pasteboard.
-    @MainActor
-    func test_receive_versionTapped() {
-        subject.receive(.versionTapped)
-        XCTAssertEqual(
-            pasteboardService.copiedString,
-            """
-            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
-
-            📝 Bitwarden 1.0 (1)
-            📦 Bundle: com.8bit.bitwarden
-            📱 Device: iPhone14,2
-            🍏 System: iOS 16.4
-            """,
-        )
-        XCTAssertEqual(
-            subject.state.toast?.title,
-            Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo)).title,
-        )
     }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView+ViewInspectorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView+ViewInspectorTests.swift
@@ -153,11 +153,12 @@ class SettingsViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .tutorialTapped)
     }
 
-    /// Tapping the version button dispatches the `.versionTapped` action.
+    /// Tapping the version button performs the `.copyVersionInfo` effect.
     @MainActor
-    func test_versionButton_tap() throws {
+    func test_versionButton_tap() async throws {
         let button = try subject.inspect().find(button: version)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .versionTapped)
+        try await waitForAsync { !self.processor.effects.isEmpty }
+        XCTAssertEqual(processor.effects.last, .copyVersionInfo)
     }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -71,7 +71,9 @@ struct SettingsView: View {
                 externalLinkRow(Localizations.privacyPolicy, action: .privacyPolicyTapped)
 
                 SettingsListItem(store.state.version) {
-                    store.send(.versionTapped)
+                    Task {
+                        await store.perform(.copyVersionInfo)
+                    }
                 } trailingContent: {
                     SharedAsset.Icons.copy24.swiftUIImage
                         .imageStyle(.rowIcon)

--- a/BitwardenKit/Core/Platform/Services/FlightRecorder.swift
+++ b/BitwardenKit/Core/Platform/Services/FlightRecorder.swift
@@ -314,7 +314,7 @@ public actor DefaultFlightRecorder {
     ///
     private func createLogFile(for log: FlightRecorderData.LogMetadata) async throws {
         let userId = await (try? stateService.getActiveAccountId()) ?? "n/a"
-        let contents = """
+        let contents = await """
         Bitwarden iOS Flight Recorder
         Log Start: \(dateFormatter.string(from: log.startDate))
         Log Duration: \(log.duration.shortDescription)

--- a/BitwardenKit/Core/Platform/Services/Mocks/MockAppInfoService.swift
+++ b/BitwardenKit/Core/Platform/Services/Mocks/MockAppInfoService.swift
@@ -2,7 +2,7 @@ import BitwardenKit
 import Foundation
 
 public class MockAppInfoService: AppInfoService {
-    public var appInfoString = """
+    public var appInfoStringValue = """
     © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
 
     📝 Bitwarden 1.0 (1)
@@ -10,7 +10,7 @@ public class MockAppInfoService: AppInfoService {
     📱 Device: iPhone14,2
     🍏 System: iOS 16.4
     """
-    public var appInfoWithoutCopyrightString = """
+    public var appInfoWithoutCopyrightStringValue = """
     📝 Bitwarden 1.0 (1)
     📦 Bundle: com.8bit.bitwarden
     📱 Device: iPhone14,2
@@ -18,6 +18,18 @@ public class MockAppInfoService: AppInfoService {
     """
     public var copyrightString = "© Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))"
     public var versionString = "1.0 (1)"
+
+    public var appInfoString: String {
+        get async {
+            appInfoStringValue
+        }
+    }
+
+    public var appInfoWithoutCopyrightString: String {
+        get async {
+            appInfoWithoutCopyrightStringValue
+        }
+    }
 
     public init() {}
 }

--- a/BitwardenKit/Core/Platform/Utilities/ErrorReportBuilder.swift
+++ b/BitwardenKit/Core/Platform/Utilities/ErrorReportBuilder.swift
@@ -82,7 +82,7 @@ public struct DefaultErrorReportBuilder {
 extension DefaultErrorReportBuilder: ErrorReportBuilder {
     public func buildShareErrorLog(for error: Error, callStack: String) async -> String {
         let userId = await (try? activeAccountStateProvider.getActiveAccountId()) ?? "n/a"
-        return """
+        return await """
         \(error as NSError)
         \(error.localizedDescription)
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutAction.swift
@@ -32,9 +32,6 @@ enum AboutAction: Equatable {
     /// The submit crash logs toggle value changed.
     case toggleSubmitCrashLogs(Bool)
 
-    /// The version was tapped.
-    case versionTapped
-
     /// The web vault button was tapped.
     case webVaultTapped
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutEffect.swift
@@ -5,6 +5,9 @@ import BitwardenKit
 /// Effects that can be processed by the `AboutProcessor`.
 ///
 enum AboutEffect: Equatable {
+    /// Copy the version information to the pasteboard.
+    case copyVersionInfo
+
     /// An effect for the Flight Recorder feature.
     case flightRecorder(FlightRecorderSettingsSectionEffect)
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessor.swift
@@ -53,6 +53,8 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
 
     override func perform(_ effect: AboutEffect) async {
         switch effect {
+        case .copyVersionInfo:
+            await copyVersionInfo()
         case let .flightRecorder(flightRecorderEffect):
             switch flightRecorderEffect {
             case let .toggleFlightRecorder(isOn):
@@ -97,8 +99,6 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
         case let .toggleSubmitCrashLogs(isOn):
             state.isSubmitCrashLogsToggleOn = isOn
             services.errorReporter.isEnabled = isOn
-        case .versionTapped:
-            handleVersionTapped()
         case .webVaultTapped:
             coordinator.showAlert(.webVaultAlert {
                 self.state.url = self.services.environmentService.webVaultURL
@@ -108,9 +108,10 @@ final class AboutProcessor: StateProcessor<AboutState, AboutAction, AboutEffect>
 
     // MARK: - Private Methods
 
-    /// Prepare the text to be copied.
-    private func handleVersionTapped() {
-        services.pasteboardService.copy(services.appInfoService.appInfoString)
+    /// Copies the app's version info to the pasteboard.
+    private func copyVersionInfo() async {
+        let appInfo = await services.appInfoService.appInfoString
+        services.pasteboardService.copy(appInfo)
         state.toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo))
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutProcessorTests.swift
@@ -76,9 +76,31 @@ class AboutProcessorTests: BitwardenTestCase {
             state: AboutState(),
         )
 
-        XCTAssertEqual(subject.state.copyrightText, "© Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))")
+        XCTAssertEqual(
+            subject.state.copyrightText,
+            "© Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))",
+        )
         XCTAssertTrue(subject.state.isSubmitCrashLogsToggleOn)
         XCTAssertEqual(subject.state.version, "1.0 (1)")
+    }
+
+    /// `perform(_:)` with `.copyVersionInfo` copies the copyright, the version string
+    /// and device info to the pasteboard.
+    @MainActor
+    func test_perform_copyVersionInfo() async {
+        await subject.perform(.copyVersionInfo)
+        XCTAssertEqual(
+            pasteboardService.copiedString,
+            """
+            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
+
+            📝 Bitwarden 1.0 (1)
+            📦 Bundle: com.8bit.bitwarden
+            📱 Device: iPhone14,2
+            🍏 System: iOS 16.4
+            """,
+        )
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo)))
     }
 
     /// `perform(_:)` with `.flightRecorder(.toggleFlightRecorder(true))` navigates to the enable
@@ -215,25 +237,6 @@ class AboutProcessorTests: BitwardenTestCase {
 
         XCTAssertTrue(subject.state.isSubmitCrashLogsToggleOn)
         XCTAssertTrue(errorReporter.isEnabled)
-    }
-
-    /// `receive(_:)` with action `.versionTapped` copies the copyright, the version string
-    /// and device info to the pasteboard.
-    @MainActor
-    func test_receive_versionTapped() {
-        subject.receive(.versionTapped)
-        XCTAssertEqual(
-            pasteboardService.copiedString,
-            """
-            © Bitwarden Inc. 2015\(String.enDash)\(Calendar.current.component(.year, from: Date.now))
-
-            📝 Bitwarden 1.0 (1)
-            📦 Bundle: com.8bit.bitwarden
-            📱 Device: iPhone14,2
-            🍏 System: iOS 16.4
-            """,
-        )
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.valueHasBeenCopied(Localizations.appInfo)))
     }
 
     /// `receive(_:)` with `.webVaultTapped` shows an alert for navigating to the web vault

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutView+ViewInspectorTests.swift
@@ -87,12 +87,13 @@ class AboutViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .learnAboutOrganizationsTapped)
     }
 
-    /// Tapping the version button dispatches the `.versionTapped` action.
+    /// Tapping the version button performs the `.copyVersionInfo` effect.
     @MainActor
-    func test_versionButton_tap() throws {
+    func test_versionButton_tap() async throws {
         let button = try subject.inspect().find(button: version)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .versionTapped)
+        try await waitForAsync { !self.processor.effects.isEmpty }
+        XCTAssertEqual(processor.effects.last, .copyVersionInfo)
     }
 
     /// Tapping the web vault button dispatches the `.webVaultTapped` action.

--- a/BitwardenShared/UI/Platform/Settings/Settings/About/AboutView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/About/AboutView.swift
@@ -83,7 +83,9 @@ struct AboutView: View {
             externalLinkRow(Localizations.learnOrg, action: .learnAboutOrganizationsTapped)
 
             SettingsListItem(store.state.version) {
-                store.send(.versionTapped)
+                Task {
+                    await store.perform(.copyVersionInfo)
+                }
             } trailingContent: {
                 SharedAsset.Icons.copy24.swiftUIImage
                     .imageStyle(.rowIcon)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18404](https://bitwarden.atlassian.net/browse/PM-18404)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds the server version and information to the About screen's version copy-paste functionality. The server version is now included when users copy app information or export a flight recorder log. The output also includes the cloud region and third party server's name, if available.

Example output:

```
📝 Bitwarden 2024.6.0 (1)
📦 Bundle: com.livefront.bitwarden
📱 Device: iPhone17,1
🍏 System: iOS 26.2
🦀 SDK: 2.0.0-3818-df9bd63
🌩️ Server: 2026.1.0 @ US
```

Bitwarden US:
```
🌩️ Server: 2026.1.0 @ US
```

Bitwarden EU:
```
🌩️ Server: 2026.1.0 @ EU
```

Third Party:
```
🌩️ Server: ThirdPartyName 2025.12.0
```



## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18404]: https://bitwarden.atlassian.net/browse/PM-18404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ