### PR TITLE
[PM-29709] Fix vault migration endpoint

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Request/BulkShareCiphersRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/BulkShareCiphersRequestModel.swift
@@ -7,7 +7,7 @@ struct BulkShareCiphersRequestModel: JSONRequestBody {
     // MARK: Properties
 
     /// The ciphers to share with the organization.
-    let ciphers: [CipherCreateRequestModel]
+    let ciphers: [CipherRequestModel]
 
     /// The collection identifiers to share the ciphers with.
     let collectionIds: [String]
@@ -22,7 +22,7 @@ extension BulkShareCiphersRequestModel {
     ///   - encryptedFor: The user ID who encrypted the ciphers.
     ///
     init(ciphers: [Cipher], collectionIds: [String], encryptedFor: String?) {
-        self.ciphers = ciphers.map { CipherCreateRequestModel(cipher: $0, encryptedFor: encryptedFor) }
+        self.ciphers = ciphers.map { CipherRequestModel(cipher: $0, encryptedFor: encryptedFor, includeId: true) }
         self.collectionIds = collectionIds
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
@@ -29,6 +29,11 @@ struct CipherRequestModel: JSONRequestBody {
     /// The folder identifier.
     let folderId: String?
 
+    /// The cipher's identifier.
+    ///
+    /// - Note: This is only included for bulk share operations where the ID needs to be in the request body.
+    let id: String?
+
     /// Identity data if the cipher is a identity.
     let identity: CipherIdentityModel?
 
@@ -73,7 +78,9 @@ extension CipherRequestModel {
     /// - Parameters:
     ///   - cipher: The `Cipher` used to initialize a `CipherRequestModel`.
     ///   - encryptedFor: The user ID who encrypted the `cipher`.
-    init(cipher: Cipher, encryptedFor: String? = nil) {
+    ///   - includeId: Whether to include the cipher's ID in the request model. Defaults to `false`.
+    ///
+    init(cipher: Cipher, encryptedFor: String? = nil, includeId: Bool = false) {
         self.init(
             attachments2: cipher.attachments?.reduce(into: [String: AttachmentRequestModel]()) { result, attachment in
                 guard let id = attachment.id else { return }
@@ -84,6 +91,7 @@ extension CipherRequestModel {
             favorite: cipher.favorite,
             fields: cipher.fields?.map(CipherFieldModel.init),
             folderId: cipher.folderId,
+            id: includeId ? cipher.id : nil,
             identity: cipher.identity.map(CipherIdentityModel.init),
             lastKnownRevisionDate: cipher.revisionDate,
             login: cipher.login.map(CipherLoginModel.init),

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/BulkShareCiphersRequestTests.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/BulkShareCiphersRequestTests.swift
@@ -44,32 +44,22 @@ class BulkShareCiphersRequestTests: BitwardenTestCase {
             {
               "ciphers" : [
                 {
-                  "cipher" : {
-                    "encryptedFor" : "user-1",
-                    "favorite" : false,
-                    "lastKnownRevisionDate" : 720403200,
-                    "name" : "Bitwarden",
-                    "reprompt" : 0,
-                    "type" : 1
-                  },
-                  "collectionIds" : [
-                    "1",
-                    "2"
-                  ]
+                  "encryptedFor" : "user-1",
+                  "favorite" : false,
+                  "id" : "123",
+                  "lastKnownRevisionDate" : 720403200,
+                  "name" : "Bitwarden",
+                  "reprompt" : 0,
+                  "type" : 1
                 },
                 {
-                  "cipher" : {
-                    "encryptedFor" : "user-1",
-                    "favorite" : false,
-                    "lastKnownRevisionDate" : 720403200,
-                    "name" : "Bitwarden",
-                    "reprompt" : 0,
-                    "type" : 1
-                  },
-                  "collectionIds" : [
-                    "1",
-                    "2"
-                  ]
+                  "encryptedFor" : "user-1",
+                  "favorite" : false,
+                  "id" : "456",
+                  "lastKnownRevisionDate" : 720403200,
+                  "name" : "Bitwarden",
+                  "reprompt" : 0,
+                  "type" : 1
                 }
               ],
               "collectionIds" : [

--- a/BitwardenShared/Core/Vault/Services/CipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherService.swift
@@ -222,17 +222,17 @@ extension DefaultCipherService {
     ) async throws {
         let userId = try await stateService.getActiveAccountId()
 
-        // Create a dictionary for quick lookup of original ciphers by ID.
-        let ciphersById = Dictionary(uniqueKeysWithValues: ciphers.compactMap { cipher in
-            cipher.id.map { ($0, cipher) }
-        })
-
         // Share the ciphers with the backend.
         let response = try await cipherAPIService.bulkShareCiphers(
             ciphers,
             collectionIds: collectionIds,
             encryptedFor: encryptedFor,
         )
+
+        // Create a dictionary for quick lookup of original ciphers by ID.
+        let ciphersById = Dictionary(uniqueKeysWithValues: ciphers.compactMap { cipher in
+            cipher.id.map { ($0, cipher) }
+        })
 
         // Update ciphers in local storage.
         for cipherResponse in response.data {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-29709

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
This pull request updates the bulk cipher sharing functionality to ensure cipher IDs are included in the request payload, which is necessary for proper identification during bulk operations. The changes primarily affect the request model and its initialization, as well as related tests and the service layer.

**Bulk Share Model and Request Model Updates:**

* The `BulkShareCiphersRequestModel` now uses `CipherRequestModel` instead of `CipherCreateRequestModel` for its `ciphers` property, allowing for inclusion of cipher IDs in bulk share requests.
* The initializer for `BulkShareCiphersRequestModel` passes `includeId: true` to `CipherRequestModel`, ensuring each cipher's ID is included in the request.
* The `CipherRequestModel` struct adds an optional `id` field, with documentation noting its use for bulk share operations.
* The `CipherRequestModel` initializer gains a new `includeId` parameter, defaulting to `false`, and sets the `id` field accordingly. [[1]](diffhunk://#diff-e5913cdba04fac8a65783e78455f7c1dad1fe941810b3420961301ab604f4525L76-R83) [[2]](diffhunk://#diff-e5913cdba04fac8a65783e78455f7c1dad1fe941810b3420961301ab604f4525R94)

**Testing and Service Layer Adjustments:**

* The bulk share ciphers request tests are updated to expect the cipher IDs in the JSON payload, verifying the new request format.
* The cipher service code is refactored to move the dictionary creation for cipher ID lookup after the API call, ensuring consistency with the updated request flow.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
