### PR TITLE
[PM-18404] fix: Prevent SDK version script from breaking SwiftUI previews

### DIFF
--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -128,7 +128,9 @@ targets:
     preBuildScripts:
       - name: Generate SDK Version Info
         path: Scripts/generate-sdk-version-info.sh
-        basedOnDependencyAnalysis: false
+        basedOnDependencyAnalysis: true
+        inputFiles:
+          - $(SRCROOT)/project-common.yml
         outputFiles:
           - $(SRCROOT)/BitwardenKit/Core/Platform/Utilities/SDKVersionInfo.swift
     dependencies:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-18404](https://bitwarden.atlassian.net/browse/PM-18404)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

It appears that the SwiftUI previews build will restart if any of the source files are modified as part of the build. #2250 adding a built script to generate a file with the SDK version in it. This was running for each build, so SwiftUI previews would see that the file was modified and restart the build, looping indefinitely. 

This fixes that by adding `project-common.yml`, which is where the SDK version is read from, to the build script's input file list. Now the build script will only run when `project-common.yml` is modified for incremental builds.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-18404]: https://bitwarden.atlassian.net/browse/PM-18404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ