### PR TITLE
[PM-31178] feat: Archive remove confirmation and update localizations

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1282,12 +1282,10 @@
 "HiddenItems" = "Hidden items";
 "Archive" = "Archive";
 "Unarchive" = "Unarchive";
-"ItemMovedToArchive" = "Item moved to Archive";
-"ItemUnarchived" = "Item unarchived";
+"ItemMovedToArchive" = "Item moved to archive";
+"ItemMovedToVault" = "Item moved to vault";
 "SendingToArchive" = "Sending to archive…";
-"Unarchiving" = "Unarchiving…";
-"DoYouReallyWantToUnarchiveThisItem" = "Do you really want to unarchive this item?";
-"DoYouReallyWantToArchiveThisItem" = "Do you really want to archive this item?";
+"MovingItemToVault" = "Moving item to vault";
 "OrganizationNotFound" = "Organization not found.";
 "ItemsTransferred" = "Items transferred";
 "ArchiveIsEmpty" = "Archive is empty";

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -227,8 +227,8 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
         case let .unarchive(cipher):
             await performOperationAndShowToast(
                 handleDisplayToast: handleDisplayToast,
-                loadingTitle: Localizations.unarchiving,
-                toastTitle: Localizations.itemUnarchived,
+                loadingTitle: Localizations.movingItemToVault,
+                toastTitle: Localizations.itemMovedToVault,
             ) {
                 try await services.vaultRepository.unarchiveCipher(cipher)
             }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -746,9 +746,9 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         vaultRepository.unarchiveCipherResult = .success(())
         try await optionsAlert.tapAction(title: Localizations.unarchive)
 
-        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.unarchiving)
+        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.movingItemToVault)
         XCTAssertEqual(vaultRepository.unarchiveCipher, [cipherView])
-        XCTAssertEqual(toastToDisplay, Toast(title: Localizations.itemUnarchived))
+        XCTAssertEqual(toastToDisplay, Toast(title: Localizations.itemMovedToVault))
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -347,7 +347,7 @@ extension VaultGroupProcessor: CipherItemOperationDelegate {
     }
 
     func itemUnarchived() {
-        displayToastAndRefresh(toastTitle: Localizations.itemUnarchived)
+        displayToastAndRefresh(toastTitle: Localizations.itemMovedToVault)
     }
 
     // MARK: Private methods

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -144,7 +144,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertNil(subject.state.toast)
 
         subject.itemUnarchived()
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemUnarchived))
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemMovedToVault))
         waitFor(vaultRepository.fetchSyncCalled)
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupStateTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupStateTests.swift
@@ -137,28 +137,28 @@ class VaultGroupStateTests: BitwardenTestCase {
         let subjectNoPremiumArchive = VaultGroupState(
             group: .archive,
             hasPremium: false,
-            vaultFilterType: .myVault
+            vaultFilterType: .myVault,
         )
         XCTAssertTrue(subjectNoPremiumArchive.showArchivePremiumSubscriptionEndedCard)
 
         let subjectHasPremiumArchive = VaultGroupState(
             group: .archive,
             hasPremium: true,
-            vaultFilterType: .myVault
+            vaultFilterType: .myVault,
         )
         XCTAssertFalse(subjectHasPremiumArchive.showArchivePremiumSubscriptionEndedCard)
 
         let subjectNoPremiumLogin = VaultGroupState(
             group: .login,
             hasPremium: false,
-            vaultFilterType: .myVault
+            vaultFilterType: .myVault,
         )
         XCTAssertFalse(subjectNoPremiumLogin.showArchivePremiumSubscriptionEndedCard)
 
         let subjectHasPremiumLogin = VaultGroupState(
             group: .login,
             hasPremium: true,
-            vaultFilterType: .myVault
+            vaultFilterType: .myVault,
         )
         XCTAssertFalse(subjectHasPremiumLogin.showArchivePremiumSubscriptionEndedCard)
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -590,7 +590,7 @@ extension VaultListProcessor: CipherItemOperationDelegate {
     }
 
     func itemUnarchived() {
-        state.toast = Toast(title: Localizations.itemUnarchived)
+        state.toast = Toast(title: Localizations.itemMovedToVault)
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -189,7 +189,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertNil(subject.state.toast)
 
         subject.itemUnarchived()
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemUnarchived))
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemMovedToVault))
     }
 
     /// `init()` has default values set in the state.

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
@@ -77,36 +77,26 @@ class DefaultVaultItemActionHelper: VaultItemActionHelper {
             return
         }
 
-        let alert = Alert.confirmation(title: Localizations.doYouReallyWantToArchiveThisItem) { [weak self] in
-            guard let self else { return }
-
-            await performOperation(
-                loadingTitle: Localizations.sendingToArchive,
-                operation: {
-                    try await self.services.vaultRepository.archiveCipher(cipher)
-                },
-                completionHandler: completionHandler,
-            )
-        }
-        await coordinator.showAlert(alert)
+        await performOperation(
+            loadingTitle: Localizations.sendingToArchive,
+            operation: {
+                try await self.services.vaultRepository.archiveCipher(cipher)
+            },
+            completionHandler: completionHandler,
+        )
     }
 
     func unarchive(
         cipher: CipherView,
         completionHandler: @escaping () -> Void,
     ) async {
-        let alert = Alert.confirmation(title: Localizations.doYouReallyWantToUnarchiveThisItem) { [weak self] in
-            guard let self else { return }
-
-            await performOperation(
-                loadingTitle: Localizations.unarchiving,
-                operation: {
-                    try await self.services.vaultRepository.unarchiveCipher(cipher)
-                },
-                completionHandler: completionHandler,
-            )
-        }
-        await coordinator.showAlert(alert)
+        await performOperation(
+            loadingTitle: Localizations.movingItemToVault,
+            operation: {
+                try await self.services.vaultRepository.unarchiveCipher(cipher)
+            },
+            completionHandler: completionHandler,
+        )
     }
 
     // MARK: Private methods

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -98,11 +98,6 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToArchiveThisItem)
-
-        try await alert?.tapAction(title: Localizations.yes)
-
         XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.sendingToArchive)
 
         XCTAssertEqual(vaultRepository.archiveCipher.last?.id, "123")
@@ -125,38 +120,8 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToArchiveThisItem)
-
-        try await alert?.tapAction(title: Localizations.yes)
-
         XCTAssertEqual(coordinator.errorAlertsShown.count, 1)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-        XCTAssertFalse(completionCalled)
-    }
-
-    /// `archive(cipher:handleOpenURL:completionHandler:)` does not archive when the user cancels
-    /// the confirmation alert.
-    @MainActor
-    func test_archive_cancel() async throws {
-        var completionCalled = false
-        let cipher = CipherView.loginFixture(id: "123")
-
-        vaultRepository.doesActiveAccountHavePremiumResult = true
-        vaultRepository.archiveCipherResult = .success(())
-
-        await subject.archive(
-            cipher: cipher,
-            handleOpenURL: { _ in },
-            completionHandler: { completionCalled = true },
-        )
-
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToArchiveThisItem)
-
-        try await alert?.tapCancel()
-
-        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
         XCTAssertFalse(completionCalled)
     }
 
@@ -174,13 +139,7 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToUnarchiveThisItem)
-        XCTAssertNil(alert?.message)
-
-        try await alert?.tapAction(title: Localizations.yes)
-
-        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.unarchiving)
+        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.movingItemToVault)
 
         XCTAssertEqual(vaultRepository.unarchiveCipher.last?.id, "123")
         XCTAssertTrue(completionCalled)
@@ -200,36 +159,8 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToUnarchiveThisItem)
-
-        try await alert?.tapAction(title: Localizations.yes)
-
         XCTAssertEqual(coordinator.errorAlertsShown.count, 1)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-        XCTAssertFalse(completionCalled)
-    }
-
-    /// `unarchive(cipher:completionHandler:)` does not unarchive when the user cancels
-    /// the confirmation alert.
-    @MainActor
-    func test_unarchive_cancel() async throws {
-        var completionCalled = false
-        let cipher = CipherView.loginFixture(archivedDate: .now, id: "123")
-
-        vaultRepository.unarchiveCipherResult = .success(())
-
-        await subject.unarchive(
-            cipher: cipher,
-            completionHandler: { completionCalled = true },
-        )
-
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.doYouReallyWantToUnarchiveThisItem)
-
-        try await alert?.tapCancel()
-
-        XCTAssertTrue(vaultRepository.unarchiveCipher.isEmpty)
         XCTAssertFalse(completionCalled)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31178](https://bitwarden.atlassian.net/browse/PM-31178)

## 📔 Objective

Remove confirmation dialogs on archiving/unarchiving and update localizations.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31178]: https://bitwarden.atlassian.net/browse/PM-31178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ