### PR TITLE
[PM-28150] fix: Prevent active user biometrics from being disabled when inactive user logs out

### DIFF
--- a/BitwardenKit/Core/Platform/Services/ActiveAccountStateProvider.swift
+++ b/BitwardenKit/Core/Platform/Services/ActiveAccountStateProvider.swift
@@ -12,3 +12,16 @@ public protocol ActiveAccountStateProvider: AnyObject { // sourcery: AutoMockabl
     ///
     func getActiveAccountId() async throws -> String
 }
+
+public extension ActiveAccountStateProvider {
+    /// Returns the provided user ID if it exists, otherwise fetches the active account's ID.
+    ///
+    /// - Parameter maybeId: The optional user ID to check.
+    /// - Returns: The user ID if provided, otherwise the active account's ID.
+    /// - Throws: An error if fetching the active account ID fails.
+    ///
+    func userIdOrActive(_ maybeId: String?) async throws -> String {
+        if let maybeId { return maybeId }
+        return try await getActiveAccountId()
+    }
+}

--- a/BitwardenKit/Core/Platform/Services/BiometricsStateService.swift
+++ b/BitwardenKit/Core/Platform/Services/BiometricsStateService.swift
@@ -3,19 +3,24 @@
 /// A protocol for a service that provides state management functionality around biometrics.
 ///
 public protocol BiometricsStateService: ActiveAccountStateProvider {
-    /// Get the active user's Biometric Authentication Preference.
+    /// Get a user's Biometric Authentication Preference.
     ///
+    /// - Parameter userId: The user ID for the user to get the biometric authentication preference.
+    ///     Defaults to the active user if nil.
     /// - Returns: A `Bool` indicating the user's preference for using biometric authentication.
     ///     If `true`, the device should attempt biometric authentication for authorization events.
     ///     If `false`, the device should not attempt biometric authentication for authorization events.
     ///
-    func getBiometricAuthenticationEnabled() async throws -> Bool
+    func getBiometricAuthenticationEnabled(userId: String?) async throws -> Bool
 
-    /// Sets the user's Biometric Authentication Preference.
+    /// Sets a user's Biometric Authentication Preference.
     ///
-    /// - Parameter isEnabled: A `Bool` indicating the user's preference for using biometric authentication.
+    /// - Parameters:
+    ///   - isEnabled: A `Bool` indicating the user's preference for using biometric authentication.
     ///     If `true`, the device should attempt biometric authentication for authorization events.
     ///     If `false`, the device should not attempt biometric authentication for authorization events.
+    ///   - userId: The user ID for the user to set the biometric authentication preference.
+    ///     Defaults to the active user if nil.
     ///
-    func setBiometricAuthenticationEnabled(_ isEnabled: Bool?) async throws
+    func setBiometricAuthenticationEnabled(_ isEnabled: Bool?, userId: String?) async throws
 }

--- a/BitwardenKit/Core/Platform/Services/Mocks/MockBiometricsStateService.swift
+++ b/BitwardenKit/Core/Platform/Services/Mocks/MockBiometricsStateService.swift
@@ -2,10 +2,20 @@ import BitwardenKit
 import TestHelpers
 
 public class MockBiometricsStateService: BiometricsStateService {
+    // swiftlint:disable identifier_name
+
     public var activeAccountIdError: Error?
     public var activeAccountIdResult = Result<String, Error>.failure(BitwardenTestError.mock("Mock error not set"))
-    public var biometricAuthenticationEnabledResult: Result<Bool, Error> = .success(false)
+
+    public var getBiometricAuthenticationEnabledActiveAccount: Bool = false
+    public var getBiometricAuthenticationEnabledByUserId = [String: Bool]()
+    public var getBiometricAuthenticationEnabledError: Error?
+
+    public var setBiometricAuthenticationEnabledActiveAccount: Bool?
+    public var setBiometricAuthenticationEnabledByUserId = [String: Bool]()
     public var setBiometricAuthenticationEnabledError: Error?
+
+    // swiftlint:enable identifier_name
 
     public init() {}
 
@@ -16,14 +26,27 @@ public class MockBiometricsStateService: BiometricsStateService {
         return try activeAccountIdResult.get()
     }
 
-    public func getBiometricAuthenticationEnabled() async throws -> Bool {
-        try biometricAuthenticationEnabledResult.get()
+    public func getBiometricAuthenticationEnabled(userId: String?) async throws -> Bool {
+        if let getBiometricAuthenticationEnabledError {
+            throw getBiometricAuthenticationEnabledError
+        }
+        guard let userId else {
+            return getBiometricAuthenticationEnabledActiveAccount
+        }
+        guard let value = getBiometricAuthenticationEnabledByUserId[userId] else {
+            throw BitwardenTestError.mock("Mock error not user for userId \(userId)")
+        }
+        return value
     }
 
-    public func setBiometricAuthenticationEnabled(_ isEnabled: Bool?) async throws {
+    public func setBiometricAuthenticationEnabled(_ isEnabled: Bool?, userId: String?) async throws {
         if let setBiometricAuthenticationEnabledError {
             throw setBiometricAuthenticationEnabledError
         }
-        biometricAuthenticationEnabledResult = .success(isEnabled ?? false)
+        guard let userId else {
+            setBiometricAuthenticationEnabledActiveAccount = isEnabled
+            return
+        }
+        setBiometricAuthenticationEnabledByUserId[userId] = isEnabled
     }
 }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -558,7 +558,7 @@ extension DefaultAuthRepository: AuthRepository {
             try? isPinUnlockAvailable(userId: userId)
         ) ?? false
         let isUnlockWithBiometricOn: Bool = await (
-            try? biometricsRepository.getBiometricUnlockStatus().isEnabled
+            try? biometricsRepository.getBiometricUnlockStatus(userId: userId).isEnabled
         ) ?? false
         return hasMasterPassword || isUnlockWithPinOn || isUnlockWithBiometricOn
     }
@@ -785,7 +785,7 @@ extension DefaultAuthRepository: AuthRepository {
 
         // Clear all user data.
         try await stateService.setSyncToAuthenticator(false, userId: userId)
-        try await biometricsRepository.setBiometricUnlockKey(authKey: nil)
+        try await biometricsRepository.setBiometricUnlockKey(authKey: nil, userId: userId)
         try await keychainService.deleteItems(for: userId)
         await vaultTimeoutService.remove(userId: userId)
 

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -162,7 +162,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_canBeLocked_hasFaceId() async {
         stateService.userHasMasterPassword["1"] = false
         stateService.pinProtectedUserKeyValue["1"] = "123"
-        biometricsRepository.biometricUnlockStatus = .success(.available(.faceID, enabled: true))
+        biometricsRepository.getBiometricUnlockStatusByUserId["1"] = .available(.faceID, enabled: true)
         let result = await subject.canBeLocked(userId: "1")
         XCTAssertTrue(result)
     }
@@ -170,7 +170,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `.canBeLocked(userId:)` should true when user has master password.
     func test_canBeLocked_hasMasterPassword() async {
         stateService.userHasMasterPassword["1"] = true
-        biometricsRepository.biometricUnlockStatus = .success(.notAvailable)
+        biometricsRepository.getBiometricUnlockStatusByUserId["1"] = .notAvailable
         let result = await subject.canBeLocked(userId: "1")
         XCTAssertTrue(result)
     }
@@ -179,7 +179,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_canBeLocked_hasPin() async {
         stateService.userHasMasterPassword["1"] = false
         stateService.pinProtectedUserKeyValue["1"] = "123"
-        biometricsRepository.biometricUnlockStatus = .success(.available(.faceID, enabled: true))
+        biometricsRepository.getBiometricUnlockStatusByUserId["1"] = .available(.faceID, enabled: true)
         let result = await subject.canBeLocked(userId: "1")
         XCTAssertTrue(result)
     }
@@ -188,7 +188,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_canBeLocked_hasNothing() async {
         stateService.userHasMasterPassword["1"] = false
         stateService.pinProtectedUserKeyValue = [:]
-        biometricsRepository.biometricUnlockStatus = .success(.notAvailable)
+        biometricsRepository.getBiometricUnlockStatusByUserId["1"] = .notAvailable
         let result = await subject.canBeLocked(userId: "1")
         XCTAssertFalse(result)
     }
@@ -439,7 +439,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let key = "userKey"
         clientService.mockCrypto.getUserEncryptionKeyResult = .success(key)
         try await subject.allowBioMetricUnlock(true)
-        XCTAssertEqual(biometricsRepository.capturedUserAuthKey, key)
+        XCTAssertEqual(biometricsRepository.setBiometricUnlockKeyActiveUser, key)
     }
 
     /// `allowBioMetricUnlock(:)` throws an error if required.
@@ -449,7 +449,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let key = "userKey"
         clientService.mockCrypto.getUserEncryptionKeyResult = .success(key)
         try await subject.allowBioMetricUnlock(false)
-        XCTAssertNil(biometricsRepository.capturedUserAuthKey)
+        XCTAssertNil(biometricsRepository.setBiometricUnlockKeyActiveUser)
     }
 
     /// `allowBioMetricUnlock(:)` throws an error if required.
@@ -457,7 +457,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         biometricsRepository.setBiometricUnlockKeyError = nil
         clientService.mockCrypto.getUserEncryptionKeyResult = .failure(BiometricsServiceError.getAuthKeyFailed)
         try await subject.allowBioMetricUnlock(false)
-        XCTAssertNil(biometricsRepository.capturedUserAuthKey)
+        XCTAssertNil(biometricsRepository.setBiometricUnlockKeyActiveUser)
     }
 
     /// `checkSessionTimeout()` locks an account when the session timeout action is lock.
@@ -2563,7 +2563,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.accounts = [account]
         stateService.activeAccount = account
         vaultTimeoutService.isClientLocked[account.profile.userId] = false
-        biometricsRepository.capturedUserAuthKey = "Value"
+        biometricsRepository.setBiometricUnlockKeyByUserId["1"] = "Value"
         biometricsRepository.setBiometricUnlockKeyError = nil
         stateService.pinProtectedUserKeyValue["1"] = "1"
         stateService.encryptedPinByUserId["1"] = "1"
@@ -2572,7 +2572,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         try await subject.logout(userInitiated: true)
 
         XCTAssertEqual([account.profile.userId], stateService.accountsLoggedOut)
-        XCTAssertNil(biometricsRepository.capturedUserAuthKey)
+        XCTAssertNil(biometricsRepository.setBiometricUnlockKeyByUserId["1"])
         XCTAssertEqual(keychainService.deleteItemsForUserIds, ["1"])
         XCTAssertTrue(stateService.logoutAccountUserInitiated)
         XCTAssertEqual(vaultTimeoutService.removedIds, [anneAccount.profile.userId])
@@ -2587,7 +2587,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.accounts = [account]
         stateService.activeAccount = account
         vaultTimeoutService.isClientLocked[account.profile.userId] = false
-        biometricsRepository.capturedUserAuthKey = "Value"
+        biometricsRepository.setBiometricUnlockKeyByUserId["1"] = "Value"
         biometricsRepository.setBiometricUnlockKeyError = nil
         stateService.pinProtectedUserKeyValue["1"] = "1"
         stateService.encryptedPinByUserId["1"] = "1"
@@ -2596,7 +2596,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         try await subject.logout(userInitiated: true)
 
         XCTAssertEqual([account.profile.userId], stateService.accountsLoggedOut)
-        XCTAssertNil(biometricsRepository.capturedUserAuthKey)
+        XCTAssertNil(biometricsRepository.setBiometricUnlockKeyByUserId["1"])
         XCTAssertEqual(keychainService.deleteItemsForUserIds, ["1"])
         XCTAssertTrue(stateService.logoutAccountUserInitiated)
         XCTAssertEqual(vaultTimeoutService.removedIds, [anneAccount.profile.userId])
@@ -2610,7 +2610,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.accounts = [account]
         stateService.activeAccount = nil
         vaultTimeoutService.isClientLocked[account.profile.userId] = false
-        biometricsRepository.capturedUserAuthKey = "Value"
+        biometricsRepository.setBiometricUnlockKeyByUserId["1"] = "Value"
         biometricsRepository.setBiometricUnlockKeyError = nil
         stateService.pinProtectedUserKeyValue["1"] = "1"
         stateService.encryptedPinByUserId["1"] = "1"
@@ -2621,7 +2621,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         }
 
         XCTAssertEqual([], stateService.accountsLoggedOut)
-        XCTAssertNotNil(biometricsRepository.capturedUserAuthKey)
+        XCTAssertNotNil(biometricsRepository.setBiometricUnlockKeyByUserId["1"])
         XCTAssertEqual(keychainService.deleteItemsForUserIds, [])
         XCTAssertFalse(stateService.logoutAccountUserInitiated)
         XCTAssertEqual(vaultTimeoutService.removedIds, [])

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsRepository.swift
@@ -35,20 +35,44 @@ protocol BiometricsRepository: AnyObject {
 
     /// Returns the status for user BiometricAuthentication.
     ///
+    /// - Parameter userId: The user ID for the user to get biometric unlock status. Defaults to the active user if nil.
     /// - Returns: The a `BiometricAuthorizationStatus`.
     ///
-    func getBiometricUnlockStatus() async throws -> BiometricsUnlockStatus
+    func getBiometricUnlockStatus(userId: String?) async throws -> BiometricsUnlockStatus
 
     /// Attempts to retrieve a user's auth key with biometrics.
     ///
     func getUserAuthKey() async throws -> String
 
+    /// Sets the biometric unlock preference for a user.
+    ///
+    /// If permissions have not been requested, this request should trigger the system permissions dialog.
+    ///
+    /// - Parameters:
+    ///   - authKey: An optional `String` representing the user auth key. If nil, Biometric Unlock is disabled.
+    ///   - userId: The user ID for the user to set biometric unlock. Defaults to the active user if nil.
+    ///
+    func setBiometricUnlockKey(authKey: String?, userId: String?) async throws
+}
+
+extension BiometricsRepository {
+    /// Returns the status for the active user's BiometricAuthentication.
+    ///
+    /// - Returns: The a `BiometricAuthorizationStatus`.
+    ///
+    func getBiometricUnlockStatus() async throws -> BiometricsUnlockStatus {
+        try await getBiometricUnlockStatus(userId: nil)
+    }
+
     /// Sets the biometric unlock preference for the active user.
-    ///   If permissions have not been requested, this request should trigger the system permisisons dialog.
+    ///
+    /// If permissions have not been requested, this request should trigger the system permissions dialog.
     ///
     /// - Parameter authKey: An optional `String` representing the user auth key. If nil, Biometric Unlock is disabled.
     ///
-    func setBiometricUnlockKey(authKey: String?) async throws
+    func setBiometricUnlockKey(authKey: String?) async throws {
+        try await setBiometricUnlockKey(authKey: authKey, userId: nil)
+    }
 }
 
 // MARK: - DefaultBiometricsRepository
@@ -92,24 +116,25 @@ class DefaultBiometricsRepository: BiometricsRepository {
         biometricsService.getBiometricAuthenticationType()
     }
 
-    func setBiometricUnlockKey(authKey: String?) async throws {
+    func setBiometricUnlockKey(authKey: String?, userId: String?) async throws {
+        let userId = try await stateService.userIdOrActive(userId)
         guard let authKey,
               try await biometricsService.evaluateBiometricPolicy() else {
-            try await stateService.setBiometricAuthenticationEnabled(false)
-            try? await deleteUserAuthKey()
+            try await stateService.setBiometricAuthenticationEnabled(false, userId: userId)
+            try? await deleteUserAuthKey(userId: userId)
             return
         }
 
-        try await setUserBiometricAuthKey(value: authKey)
-        try await stateService.setBiometricAuthenticationEnabled(true)
+        try await setUserBiometricAuthKey(value: authKey, userId: userId)
+        try await stateService.setBiometricAuthenticationEnabled(true, userId: userId)
     }
 
-    func getBiometricUnlockStatus() async throws -> BiometricsUnlockStatus {
+    func getBiometricUnlockStatus(userId: String?) async throws -> BiometricsUnlockStatus {
         let biometryStatus = biometricsService.getBiometricAuthStatus()
         if case .lockedOut = biometryStatus {
             throw BiometricsServiceError.biometryLocked
         }
-        let hasEnabledBiometricUnlock = try await stateService.getBiometricAuthenticationEnabled()
+        let hasEnabledBiometricUnlock = try await stateService.getBiometricAuthenticationEnabled(userId: userId)
         switch biometryStatus {
         case let .authorized(type):
             return .available(type, enabled: hasEnabledBiometricUnlock)
@@ -163,13 +188,13 @@ class DefaultBiometricsRepository: BiometricsRepository {
 // MARK: Private Methods
 
 extension DefaultBiometricsRepository {
-    /// Attempts to delete the active user's AuthKey from the keychain.
+    /// Attempts to delete a user's AuthKey from the keychain.
     ///
-    private func deleteUserAuthKey() async throws {
-        let id = try await stateService.getActiveAccountId()
-
+    /// - Parameter userId: The user ID for the user to delete the auth key.
+    ///
+    private func deleteUserAuthKey(userId: String) async throws {
         do {
-            try await keychainRepository.deleteUserBiometricAuthKey(userId: id)
+            try await keychainRepository.deleteUserBiometricAuthKey(userId: userId)
         } catch {
             throw BiometricsServiceError.deleteAuthKeyFailed
         }
@@ -177,13 +202,13 @@ extension DefaultBiometricsRepository {
 
     /// Attempts to save an auth key to the keychain with biometrics.
     ///
-    /// - Parameter value: The key to be stored.
+    /// - Parameters:
+    ///   - value: The key to be stored.
+    ///   - userId: The user ID for the user to set the auth key.
     ///
-    private func setUserBiometricAuthKey(value: String) async throws {
-        let id = try await stateService.getActiveAccountId()
-
+    private func setUserBiometricAuthKey(value: String, userId: String) async throws {
         do {
-            try await keychainRepository.setUserBiometricAuthKey(userId: id, value: value)
+            try await keychainRepository.setUserBiometricAuthKey(userId: userId, value: value)
         } catch {
             throw BiometricsServiceError.setAuthKeyFailed
         }

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockBiometricsRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockBiometricsRepository.swift
@@ -1,29 +1,47 @@
 @testable import BitwardenShared
 
 class MockBiometricsRepository: BiometricsRepository {
-    var biometricUnlockStatus: Result<BiometricsUnlockStatus, Error> = .success(.notAvailable)
-    var capturedUserAuthKey: String?
-    var didDeleteKey: Bool = false
     var getBiometricAuthenticationTypeResult: BitwardenShared.BiometricAuthenticationType?
+
+    var biometricUnlockStatus: Result<BiometricsUnlockStatus, Error>?
+    var getBiometricUnlockStatusError: Error?
+    var getBiometricUnlockStatusActiveUser = BiometricsUnlockStatus.notAvailable
+    var getBiometricUnlockStatusByUserId = [String: BiometricsUnlockStatus]()
+
     var getUserAuthKeyResult: Result<String, Error> = .success("UserAuthKey")
+
+    var setBiometricUnlockKeyActiveUser: String?
+    var setBiometricUnlockKeyByUserId = [String: String]()
     var setBiometricUnlockKeyError: Error?
 
     func getBiometricAuthenticationType() -> BitwardenShared.BiometricAuthenticationType? {
         getBiometricAuthenticationTypeResult
     }
 
-    func getBiometricUnlockStatus() async throws -> BitwardenShared.BiometricsUnlockStatus {
-        try biometricUnlockStatus.get()
+    func getBiometricUnlockStatus(userId: String?) async throws -> BitwardenShared.BiometricsUnlockStatus {
+        if let getBiometricUnlockStatusError {
+            throw getBiometricUnlockStatusError
+        }
+        if let biometricUnlockStatus {
+            // TODO: PM-31189 Legacy mock value, update all tests to use getBiometricUnlockStatusByUserId
+            return try biometricUnlockStatus.get()
+        }
+        guard let userId else {
+            return getBiometricUnlockStatusActiveUser
+        }
+        return getBiometricUnlockStatusByUserId[userId] ?? .notAvailable
     }
 
     func getUserAuthKey() async throws -> String {
         try getUserAuthKeyResult.get()
     }
 
-    func setBiometricUnlockKey(authKey: String?) async throws {
-        capturedUserAuthKey = authKey
-        if let setBiometricUnlockKeyError {
-            throw setBiometricUnlockKeyError
+    func setBiometricUnlockKey(authKey: String?, userId: String?) async throws {
+        if let setBiometricUnlockKeyError { throw setBiometricUnlockKeyError }
+        guard let userId else {
+            setBiometricUnlockKeyActiveUser = authKey
+            return
         }
+        setBiometricUnlockKeyByUserId[userId] = authKey
     }
 }

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -2414,13 +2414,13 @@ struct AccountVolatileData {
 // MARK: Biometrics
 
 extension DefaultStateService: BiometricsStateService {
-    func getBiometricAuthenticationEnabled() async throws -> Bool {
-        let userId = try getActiveAccountUserId()
+    func getBiometricAuthenticationEnabled(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.isBiometricAuthenticationEnabled(userId: userId)
     }
 
-    func setBiometricAuthenticationEnabled(_ isEnabled: Bool?) async throws {
-        let userId = try getActiveAccountUserId()
+    func setBiometricAuthenticationEnabled(_ isEnabled: Bool?, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setBiometricAuthenticationEnabled(isEnabled, for: userId)
     }
 }

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -845,15 +845,15 @@ class MockStateService: StateService, ActiveAccountStateProvider { // swiftlint:
 // MARK: Biometrics
 
 extension MockStateService {
-    func getBiometricAuthenticationEnabled() async throws -> Bool {
-        guard let activeAccount else { throw StateServiceError.noActiveAccount }
+    func getBiometricAuthenticationEnabled(userId: String?) async throws -> Bool {
+        let userId = try unwrapUserId(userId)
         try getBiometricAuthenticationEnabledResult.get()
-        return biometricsEnabled[activeAccount.profile.userId] ?? false
+        return biometricsEnabled[userId] ?? false
     }
 
-    func setBiometricAuthenticationEnabled(_ isEnabled: Bool?) async throws {
-        guard let activeAccount else { throw StateServiceError.noActiveAccount }
+    func setBiometricAuthenticationEnabled(_ isEnabled: Bool?, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
         try setBiometricAuthenticationEnabledResult.get()
-        biometricsEnabled[activeAccount.profile.userId] = isEnabled
+        biometricsEnabled[userId] = isEnabled
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -212,7 +212,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         let hasMasterPassword = try await stateService.getUserHasMasterPassword(userId: userId)
         let timeoutAction = try await stateService.getTimeoutAction(userId: userId)
         guard hasMasterPassword else {
-            let isBiometricsEnabled = try await biometricsRepository.getBiometricUnlockStatus().isEnabled
+            let isBiometricsEnabled = try await biometricsRepository.getBiometricUnlockStatus(userId: userId).isEnabled
             let isPinEnabled = try await isPinUnlockAvailable(userId: userId)
             if isPinEnabled || isBiometricsEnabled {
                 return timeoutAction

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -323,9 +323,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
         stateService.timeoutAction["1"] = .lock
         stateService.userHasMasterPassword["1"] = false
-        biometricsRepository.biometricUnlockStatus = .success(
-            .available(.faceID, enabled: true),
-        )
+        biometricsRepository.getBiometricUnlockStatusByUserId["1"] = .available(.faceID, enabled: true)
 
         var timeoutAction = try await subject.sessionTimeoutAction(userId: "1")
         XCTAssertEqual(timeoutAction, .lock)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28150](https://bitwarden.atlassian.net/browse/PM-28150)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes an issue where the active user's biometrics setting can be cleared/disabled when an inactive user is logged out.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/72b49ff4-52e4-4f3e-a5be-cbd2ccd50671" /> | <video src="https://github.com/user-attachments/assets/16dfc9ee-d97d-4678-9451-2264aa3b71bc" /> | 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28150]: https://bitwarden.atlassian.net/browse/PM-28150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ