### PR TITLE
[PM-22159] fix: Add wildcard label to release.yml to fix missing PRs in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -26,6 +26,7 @@ changelog:
         - t:ci
         - t:docs
         - t:misc
+        - '*'
     - title: '📦 Dependency Updates'
       labels:
         - dependencies


### PR DESCRIPTION
## 🎟️ Tracking

PM-22159 

## 📔 Objective

Fixes PRs missing in release notes due to lack of type label, by adding them to a catch all category. 

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes
