### PR TITLE
 [PM-26177] feat: Add base64url Data extensions

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/Data.swift
+++ b/BitwardenKit/Core/Platform/Extensions/Data.swift
@@ -11,8 +11,7 @@ public extension Data {
     ///   - base64urlEncoded: A base64url-encoded string.
     ///
     init?(base64urlEncoded str: String) throws {
-        // .ignoreUnknownCharacters allows unpadded strings as a side effect.
-        try self.init(base64Encoded: str.urlDecoded(), options: .ignoreUnknownCharacters)
+        try self.init(base64Encoded: str.urlDecoded())
     }
 
     // MARK: Functions

--- a/BitwardenKit/Core/Platform/Extensions/DataTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/DataTests.swift
@@ -26,11 +26,11 @@ class DataTests: BitwardenTestCase {
 
     /// `Data(base64urlEncoded:)` decodes an unpadded base64url-encoded String into Data.
     func test_fromBase64urlString_unpadded() {
-        let subject = "9031WCEDOh6ZUGV_-wvUSw"
+        let subject = "-_4"
         XCTAssertEqual(
             try XCTUnwrap(Data(base64urlEncoded: subject)),
             // swiftformat:disable:next numberFormatting
-            Data([0xf7, 0x4d, 0xf5, 0x58, 0x21, 0x03, 0x3a, 0x1e, 0x99, 0x50, 0x65, 0x7f, 0xfb, 0x0b, 0xd4, 0x4b]),
+            Data([0xfb, 0xfe]),
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-26177](https://bitwarden.atlassian.net/browse/PM-26177)

## 📔 Objective

Adds extensions to the Data object for handling base64url, which is used extensively throughout WebAuthn.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26177]: https://bitwarden.atlassian.net/browse/PM-26177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ