### PR TITLE
Implement device auth key creation options fetching [PM-26177] (7/8)

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Domain/DeviceAuthKeyRecord.swift
+++ b/BitwardenShared/Core/Auth/Models/Domain/DeviceAuthKeyRecord.swift
@@ -140,6 +140,7 @@ public struct DeviceAuthKeyRecord: Codable, Equatable, Sendable {
                         rpName: rpName,
                         userDisplayName: userDisplayName,
                         discoverable: discoverable,
+                        // TODO(PM-26177): SDK will add this field
                         // hmacSecret: hmacSecret,
                         creationDate: creationDate
                     ),
@@ -198,6 +199,7 @@ public struct DeviceAuthKeyRecord: Codable, Equatable, Sendable {
                         rpName: rpName,
                         userDisplayName: userDisplayName,
                         discoverable: discoverable,
+                        // TODO(PM-26177): SDK will add this field
                         // hmacSecret: hmacSecret,
                         creationDate: creationDate
                     ),

--- a/BitwardenShared/Core/Auth/Services/DeviceAuthKeyService.swift
+++ b/BitwardenShared/Core/Auth/Services/DeviceAuthKeyService.swift
@@ -1,7 +1,9 @@
+import os.log
 import CryptoKit
 import BitwardenKit
 import BitwardenSdk
 import Foundation
+import UIKit
 
 // MARK: - DeviceAuthKeyService
 
@@ -36,7 +38,7 @@ protocol DeviceAuthKeyService { // sourcery: AutoMockable
         masterPasswordHash: String,
         overwrite: Bool,
         userId: String?,
-    ) async throws -> DeviceAuthKeyRecord
+    ) async throws
 
     /// Deletes the device auth key.
     ///
@@ -89,7 +91,7 @@ extension DeviceAuthKeyService {
     func createDeviceAuthKey(
         masterPasswordHash: String,
         overwrite: Bool,
-    ) async throws -> DeviceAuthKeyRecord {
+    ) async throws {
         try await createDeviceAuthKey(
             masterPasswordHash: masterPasswordHash,
             overwrite: overwrite,
@@ -119,13 +121,20 @@ struct DefaultDeviceAuthKeyService: DeviceAuthKeyService {
     /// The provider for the active account state.
     private let activeAccountStateProvider: ActiveAccountStateProvider
 
+    private let authAPIService: AuthAPIService
+
     private let clientService: ClientService
 
     /// Repository for managing device auth keys in the keychain.
     private let deviceAuthKeychainRepository: DeviceAuthKeychainRepository
 
+    private let environmentService: EnvironmentService
+
     /// Repository for managing keys in the keychain.
     private let keychainRepository: KeychainRepository
+
+    /// Default PRF salt input to use if none is received from WebAuthn client.
+    private static let defaultLoginWithPrfSalt = Data(SHA256.hash(data: "passwordless-login".data(using: .utf8)!))
 
     // MARK: Initializers
 
@@ -137,13 +146,17 @@ struct DefaultDeviceAuthKeyService: DeviceAuthKeyService {
     ///
     init(
         activeAccountStateProvider: ActiveAccountStateProvider,
+        authAPIService: AuthAPIService,
         clientService: ClientService,
         deviceAuthKeychainRepository: DeviceAuthKeychainRepository,
+        environmentService: EnvironmentService,
         keychainRepository: KeychainRepository,
     ) {
         self.activeAccountStateProvider = activeAccountStateProvider
+        self.authAPIService = authAPIService
         self.clientService = clientService
         self.deviceAuthKeychainRepository = deviceAuthKeychainRepository
+        self.environmentService = environmentService
         self.keychainRepository = keychainRepository
     }
 
@@ -160,7 +173,7 @@ struct DefaultDeviceAuthKeyService: DeviceAuthKeyService {
         }
 
         guard request.rpId == environmentService.webVaultURL.domain else {
-            throw DeviceAuthKeyError.invalidRequest(reason: "Requested RP ID does not match expected origin")
+            throw DeviceAuthKeyError.originMismatch
         }
 
         guard metadata.cipherId == recordIdentifier else {
@@ -196,9 +209,62 @@ struct DefaultDeviceAuthKeyService: DeviceAuthKeyService {
         masterPasswordHash: String,
         overwrite: Bool,
         userId: String?,
-    ) async throws -> DeviceAuthKeyRecord {
-        // TODO: PM-26177 to finish building out this stub
-        throw DeviceAuthKeyError.notImplemented
+    ) async throws {
+        let userId = try await activeAccountStateProvider.userIdOrActive(userId)
+        let record = try? await deviceAuthKeychainRepository.getDeviceAuthKey(userId: userId)
+        guard record == nil || overwrite else {
+            return
+        }
+        let deviceKey = try await ensureDeviceKeyIsSet(userId: userId)
+
+        // Create passkey from server options
+        let response = try await authAPIService.getWebAuthnCredentialCreationOptions(
+            SecretVerificationRequestModel(type: .masterPasswordHash(masterPasswordHash))
+        )
+        let options = response.options
+        guard options.rp.id == environmentService.webVaultURL.domain else {
+            throw DeviceAuthKeyError.originMismatch
+        }
+        let token = response.token
+        let (createdCredential, clientDataJson) = try await createPasskey(
+            options: options,
+            userId: userId,
+            deviceKey: deviceKey
+        )
+
+        // Create unlock keyset from PRF value
+        // TODO(PM-26177): Extensions will be returned in an SDK update
+        // let prfResult = createdCredential.extensions.prf!.results!.first
+        let prfResult = Data()
+        let prfKeyResponse = try await clientService.crypto().makePrfUserKeySet(prf: prfResult.base64EncodedString())
+
+        // Register the credential keyset with the server.
+        // TODO: This only returns generic names like `iPhone` on real devices.
+        // If there is a more specific name available (e.g., user-chosen),
+        // that would be helpful to disambiguate in the menu.
+        let clientName = await "Bitwarden App on \(UIDevice.current.name)"
+        guard let clientDataJsonData = clientDataJson.data(using: .utf8) else {
+            throw DeviceAuthKeyError.serialization(reason: "Failed to serialize clientDataJson to data")
+        }
+
+        let request = WebAuthnLoginSaveCredentialRequestModel(
+            deviceResponse: WebAuthnPublicKeyCredentialWithAttestationResponse(
+                id: createdCredential.credentialId.base64urlEncodedString(),
+                rawId: createdCredential.credentialId.base64urlEncodedString(),
+                response: WebAuthnAuthenticatorAttestationResponse(
+                    attestationObject: createdCredential.attestationObject.base64urlEncodedString(),
+                    clientDataJSON: clientDataJsonData.base64urlEncodedString()
+                ),
+                type: "public-key"
+            ),
+            encryptedPrivateKey: prfKeyResponse.encryptedDecapsulationKey,
+            encryptedPublicKey: prfKeyResponse.encryptedEncapsulationKey,
+            encryptedUserKey: prfKeyResponse.encapsulatedDownstreamKey,
+            name: clientName,
+            supportsPrf: true,
+            token: token
+        )
+        try await authAPIService.saveWebAuthnCredential(request)
     }
 
     func deleteDeviceAuthKey(
@@ -227,6 +293,86 @@ struct DefaultDeviceAuthKeyService: DeviceAuthKeyService {
         let resolvedUserId = try await activeAccountStateProvider.userIdOrActive(userId)
         return try await deviceAuthKeychainRepository.getDeviceAuthKey(userId: resolvedUserId)
     }
+
+    private func createPasskey(
+        options: WebAuthnPublicKeyCredentialCreationOptions,
+        userId: String,
+        deviceKey: SymmetricKey
+    ) async throws -> (MakeCredentialResult, String) {
+        let excludeCredentials: [PublicKeyCredentialDescriptor]? = if options.excludeCredentials != nil {
+            // TODO: return early if exclude credentials matches
+            try options.excludeCredentials!.map { params in
+                try PublicKeyCredentialDescriptor(
+                    ty: params.type,
+                    id: Foundation.Data(base64urlEncoded: params.id)!,
+                    transports: nil
+                )
+            }
+        } else { nil }
+
+        let credParams = options.pubKeyCredParams.map { params in
+            PublicKeyCredentialParameters(ty: params.type, alg: Int64(params.alg))
+        }
+
+        let origin = deriveWebOrigin()
+        // Manually serialize to JSON to make sure it's ordered and formatted according to the spec.
+        let clientDataJson = #"{"type":"webauthn.create","challenge":"\#(options.challenge)","origin":"\#(origin)"}"#
+        let clientDataHash = Data(SHA256.hash(data: clientDataJson.data(using: .utf8)!))
+
+        let credentialStore = DeviceAuthKeyCredentialStore(
+            clientService: clientService,
+            deviceAuthKeychainRepository: deviceAuthKeychainRepository,
+            deviceKey: deviceKey,
+            userId: userId
+        )
+        let userInterface = DeviceAuthKeyUserInterface()
+        let authenticator = try await clientService
+            .platform()
+            .fido2()
+            .deviceAuthenticator(userInterface: userInterface, credentialStore: credentialStore, deviceKey: deviceKey)
+        let credRequest = try MakeCredentialRequest(
+            clientDataHash: clientDataHash,
+            rp: PublicKeyCredentialRpEntity(id: options.rp.id, name: options.rp.name),
+            user: PublicKeyCredentialUserEntity(
+                id: Data(base64urlEncoded: options.user.id)!,
+                displayName: options.user.name,
+                name: options.user.name,
+            ),
+            pubKeyCredParams: credParams,
+            excludeList: excludeCredentials,
+            options: Options(
+                rk: true,
+                uv: .required,
+            ),
+            extensions: #"{"prf":{"eval":{"first":"\#(DefaultDeviceAuthKeyService.defaultLoginWithPrfSalt)"}}}"#,
+        )
+        let createdCredential = try await authenticator.makeCredential(request: credRequest)
+        return (createdCredential, clientDataJson)
+    }
+
+    private func deriveWebOrigin() -> String {
+        // TODO: Should we be using the web vault as the origin, and is this the best way to get it?
+        let url = environmentService.webVaultURL
+        return "\(url.scheme ?? "http")://\(url.hostWithPort!)"
+    }
+
+    private func ensureDeviceKeyIsSet(userId: String) async throws -> SymmetricKey {
+
+        if let deviceKeyB64 = try await keychainRepository.getDeviceKey(userId: userId) {
+            guard let deviceKeyData = Data(base64Encoded: deviceKeyB64) else {
+                throw DeviceAuthKeyError.missingOrInvalidKey
+            }
+            return SymmetricKey(data: deviceKeyData)
+        } else {
+            // Set if not found
+            let deviceKey = SymmetricKey(size: SymmetricKeySize(bitCount: 512))
+            let key = deviceKey.withUnsafeBytes { bytes in
+                Data(Array(bytes)).base64EncodedString()
+            }
+            try await keychainRepository.setDeviceKey(key, userId: userId)
+            return deviceKey
+        }
+    }
 }
 
 // MARK: - DeviceAuthKeyError
@@ -241,6 +387,12 @@ enum DeviceAuthKeyError: Error {
 
     /// The requested functionality has not yet been implemented.
     case notImplemented
+
+    /// The WebAuthn RP ID for the request cred did not match the expected origin.
+    case originMismatch
+
+    /// Failed to serialize some data
+    case serialization(reason: String)
 }
 
 // MARK: DeviceAuthKeyCredentialStore
@@ -347,7 +499,10 @@ final internal class DeviceAuthKeyCredentialStore: Fido2CredentialStore {
     }
 
     func saveCredential(cred: BitwardenSdk.EncryptionContext) async throws {
-        guard let fido2cred = cred.cipher.login?.fido2Credentials?[safeIndex: 0] else {
+        guard let fido2cred = cred.cipher.login?.fido2Credentials?[safeIndex: 0],
+              let userHandle = fido2cred.userHandle,
+              let userName = fido2cred.userName,
+              let userDisplayName = fido2cred.userDisplayName else {
             throw DeviceAuthKeyError.invalidCipher
         }
         let record = DeviceAuthKeyRecord(
@@ -366,9 +521,9 @@ final internal class DeviceAuthKeyCredentialStore: Fido2CredentialStore {
             keyValue: fido2cred.keyValue,
             rpId: fido2cred.rpId,
             rpName: fido2cred.rpName,
-            userDisplayName: fido2cred.userDisplayName,
-            userId: fido2cred.userHandle,
-            userName: fido2cred.userName,
+            userDisplayName: userDisplayName,
+            userId: userHandle,
+            userName: userName,
         )
 
         // The record contains encrypted data, we need to decrypt it before storing metadata


### PR DESCRIPTION
⚠️ I will be working with a mobile team member on this in a batch of PRs . If you are auto-assigned, ignore this PR.

## 🎟️ Tracking
[PM-26177](https://bitwarden.atlassian.net/browse/PM-26177)

## 📔 Objective

This implements the logic for fetching WebAuthn data from the server and creating the passkey. It depends on SDK methods that have not landed yet, so it will fail at the last step of creating the passkey for now.

Depends on #2298.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26177]: https://bitwarden.atlassian.net/browse/PM-26177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ