### PR TITLE
[PM-27039] Add loading overlay when setting up autofill extension

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1302,3 +1302,4 @@
 "YourPremiumSubscriptionEndedArchiveDescriptionLong" = "To regain access to your archive, restart your Premium subscription. If you edit details for an archived item before restarting, it’ll be moved back into your vault.";
 "RestartPremium" = "Restart Premium";
 "ThisItemIsArchivedSavingChangesWillRestoreItToYourVault" = "This item is archived. Saving changes will restore it to your vault.";
+"SettingUpAutofill" = "Setting up Autofill…";

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionActivation/ExtensionActivationProcessorTests.swift
@@ -1,4 +1,6 @@
+import BitwardenKit
 import BitwardenKitMocks
+import BitwardenResources
 import XCTest
 
 @testable import BitwardenShared
@@ -11,6 +13,7 @@ class ExtensionActivationProcessorTests: BitwardenTestCase {
     var appExtensionDelegate: MockAppExtensionDelegate!
     var autofillCredentialService: MockAutofillCredentialService!
     var configService: MockConfigService!
+    var coordinator: MockCoordinator<ExtensionSetupRoute, Void>!
     var subject: ExtensionActivationProcessor!
 
     // MARK: Setup & Teardown
@@ -21,8 +24,10 @@ class ExtensionActivationProcessorTests: BitwardenTestCase {
         appExtensionDelegate = MockAppExtensionDelegate()
         autofillCredentialService = MockAutofillCredentialService()
         configService = MockConfigService()
+        coordinator = MockCoordinator<ExtensionSetupRoute, Void>()
         subject = ExtensionActivationProcessor(
             appExtensionDelegate: appExtensionDelegate,
+            coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 autofillCredentialService: autofillCredentialService,
                 configService: configService,
@@ -37,6 +42,7 @@ class ExtensionActivationProcessorTests: BitwardenTestCase {
         appExtensionDelegate = nil
         autofillCredentialService = nil
         configService = nil
+        coordinator = nil
         subject = nil
     }
 
@@ -48,6 +54,8 @@ class ExtensionActivationProcessorTests: BitwardenTestCase {
         await subject.perform(.appeared)
 
         XCTAssertTrue(autofillCredentialService.updateCredentialsInStoreCalled)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.settingUpAutofill)])
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
     }
 
     /// `receive(_:)` with `.cancelTapped` notifies the delegate to cancel the extension.

--- a/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionSetupCoordinator.swift
+++ b/BitwardenShared/UI/Platform/ExtensionSetup/ExtensionSetupCoordinator.swift
@@ -64,6 +64,7 @@ final class ExtensionSetupCoordinator: Coordinator, HasStackNavigator {
     private func showExtensionActivation(extensionType: ExtensionActivationType) {
         let processor = ExtensionActivationProcessor(
             appExtensionDelegate: appExtensionDelegate,
+            coordinator: asAnyCoordinator(),
             services: services,
             state: ExtensionActivationState(extensionType: extensionType),
         )


### PR DESCRIPTION
## 🎟️ Tracking

[PM-27039](https://bitwarden.atlassian.net/browse/PM-27039)

## 📔 Objective

Add loading overlay when setting up autofill extension to account for large vaults.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27039]: https://bitwarden.atlassian.net/browse/PM-27039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ