### PR TITLE
[PM-31369] 🍒 fix: Logout accounts with "on app restart" timeout when app restarts

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -37,9 +37,12 @@ protocol AuthRepository: AnyObject {
 
     /// Checks the session timeout for all accounts, and locks or logs out as needed.
     ///
-    /// - Parameter handleActiveUser: A closure to handle the active user.
+    /// - Parameters:
+    ///   - isAppRestart: Whether the app has been restarted and is checking timeouts on app
+    ///     startup. Defaults to false.
+    ///   - handleActiveUser: A closure to handle the active user.
     ///
-    func checkSessionTimeouts(handleActiveUser: ((String) async -> Void)?) async
+    func checkSessionTimeouts(isAppRestart: Bool, handleActiveUser: ((String) async -> Void)?) async
 
     /// Clears the pins stored on device and in memory.
     ///
@@ -310,6 +313,14 @@ protocol AuthRepository: AnyObject {
 }
 
 extension AuthRepository {
+    /// Checks the session timeout for all accounts, and locks or logs out as needed.
+    ///
+    /// - Parameter handleActiveUser: A closure to handle the active user.
+    ///
+    func checkSessionTimeouts(handleActiveUser: ((String) async -> Void)?) async {
+        await checkSessionTimeouts(isAppRestart: false, handleActiveUser: handleActiveUser)
+    }
+
     /// Whether active user account can be locked.
     ///
     /// - Returns: `true` if active user account can be locked, `false` otherwise.
@@ -567,7 +578,7 @@ extension DefaultAuthRepository: AuthRepository {
         try await stateService.getUserHasMasterPassword(userId: userId)
     }
 
-    func checkSessionTimeouts(handleActiveUser: ((String) async -> Void)? = nil) async {
+    func checkSessionTimeouts(isAppRestart: Bool = false, handleActiveUser: ((String) async -> Void)? = nil) async {
         do {
             let accounts = try await getAccounts()
             guard !accounts.isEmpty else { return }
@@ -578,7 +589,10 @@ extension DefaultAuthRepository: AuthRepository {
                 let userId = account.userId
 
                 // Check time-based timeout
-                let shouldTimeout = try await vaultTimeoutService.hasPassedSessionTimeout(userId: userId)
+                let shouldTimeout = try await vaultTimeoutService.hasPassedSessionTimeout(
+                    userId: userId,
+                    isAppRestart: isAppRestart,
+                )
                 // Check if account can't be unlocked after restart (no master password, PIN, or biometrics)
                 let shouldLogoutDueToNoUnlockMethod = !account.isUnlocked // Account locked
                     && !account.canBeLocked // Doesn't have an unlock method

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -688,6 +688,44 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(handledUserId, beeAccount.profile.userId)
     }
 
+    /// `checkSessionTimeout()` passes the `isAppRestart` flag to `VaultTimeoutService` when the
+    /// app is restarting.
+    func test_checkSessionTimeout_onAppRestart() async {
+        stateService.accounts = [anneAccount]
+        stateService.activeAccount = anneAccount
+        stateService.timeoutAction = [anneAccount.profile.userId: .logout]
+        stateService.vaultTimeout = [anneAccount.profile.userId: .onAppRestart]
+        vaultTimeoutService.shouldSessionTimeout[anneAccount.profile.userId] = true
+        stateService.isAuthenticated[anneAccount.profile.userId] = true
+
+        var handledUserId: String?
+        await subject.checkSessionTimeouts(isAppRestart: true) { userId in
+            handledUserId = userId
+        }
+
+        XCTAssertEqual(handledUserId, anneAccount.profile.userId)
+        XCTAssertEqual(vaultTimeoutService.hasPassedSessionTimeoutIsAppRestart, true)
+    }
+
+    /// `checkSessionTimeout()` passes the `isAppRestart` flag to `VaultTimeoutService` when the
+    /// app isn't restarting.
+    func test_checkSessionTimeout_onAppRestart_notRestarting() async {
+        stateService.accounts = [anneAccount]
+        stateService.activeAccount = anneAccount
+        stateService.timeoutAction = [anneAccount.profile.userId: .logout]
+        stateService.vaultTimeout = [anneAccount.profile.userId: .onAppRestart]
+        vaultTimeoutService.shouldSessionTimeout[anneAccount.profile.userId] = false
+        stateService.isAuthenticated[anneAccount.profile.userId] = true
+
+        var handledUserId: String?
+        await subject.checkSessionTimeouts(isAppRestart: false) { userId in
+            handledUserId = userId
+        }
+
+        XCTAssertNil(handledUserId)
+        XCTAssertEqual(vaultTimeoutService.hasPassedSessionTimeoutIsAppRestart, false)
+    }
+
     /// `getProfilesState()` throws an error when the accounts are nil.
     func test_getProfilesState_empty() async {
         let state = await subject.getProfilesState(

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -12,6 +12,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var canVerifyMasterPasswordResult: Result<Bool, Error> = .success(true)
     var canVerifyMasterPasswordForUserResult: Result<[String: Bool], Error> = .success([:])
     var checkSessionTimeoutCalled = false
+    var checkSessionTimeoutIsAppRestart: Bool?
     var checkSessionTimeoutsShouldTimeoutActiveUser = false // swiftlint:disable:this identifier_name
     var clearPinsCalled = false
     var createNewSsoUserRememberDevice: Bool = false
@@ -148,8 +149,9 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
         }
     }
 
-    func checkSessionTimeouts(handleActiveUser: ((String) async -> Void)?) async {
+    func checkSessionTimeouts(isAppRestart: Bool = false, handleActiveUser: ((String) async -> Void)?) async {
         checkSessionTimeoutCalled = true
+        checkSessionTimeoutIsAppRestart = isAppRestart
         handleActiveUserClosure = handleActiveUser
         if checkSessionTimeoutsShouldTimeoutActiveUser, let activeAccount {
             await handleActiveUser?(activeAccount.profile.userId)

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultTimeoutService.swift
@@ -8,6 +8,7 @@ import Foundation
 
 class MockVaultTimeoutService: VaultTimeoutService {
     var account: Account = .fixture()
+    var hasPassedSessionTimeoutIsAppRestart: Bool?
     var lastActiveTime = [String: Date]()
     var pinUnlockAvailabilityResult: Result<[String: Bool], Error> = .success([:])
     var setLastActiveTimeError: Error?
@@ -55,7 +56,8 @@ class MockVaultTimeoutService: VaultTimeoutService {
         return try pinUnlockAvailabilityResult.get()[userId] ?? false
     }
 
-    func hasPassedSessionTimeout(userId: String) async throws -> Bool {
+    func hasPassedSessionTimeout(userId: String, isAppRestart: Bool) async throws -> Bool {
+        hasPassedSessionTimeoutIsAppRestart = isAppRestart
         if let shouldSessionTimeoutError {
             throw shouldSessionTimeoutError
         }

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -99,15 +99,32 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
         XCTAssertTrue(shouldTimeout)
     }
 
-    /// `.hasPassedSessionTimeout()` returns false for a timeout value of app restart.
-    func test_hasPassedSessionTimeout_appRestart() async throws {
+    /// `.hasPassedSessionTimeout()` returns false for a timeout value of app restart when not restarting.
+    func test_hasPassedSessionTimeout_appRestart_notRestarting() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.lastActiveTime[account.profile.userId] = .distantPast
         stateService.vaultTimeout[account.profile.userId] = .onAppRestart
 
-        let shouldTimeout = try await subject.hasPassedSessionTimeout(userId: account.profile.userId)
+        let shouldTimeout = try await subject.hasPassedSessionTimeout(
+            userId: account.profile.userId,
+            isAppRestart: false,
+        )
         XCTAssertFalse(shouldTimeout)
+    }
+
+    /// `.hasPassedSessionTimeout()` returns true for a timeout value of app restart when app is restarting.
+    func test_hasPassedSessionTimeout_appRestart_isRestarting() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.lastActiveTime[account.profile.userId] = .distantPast
+        stateService.vaultTimeout[account.profile.userId] = .onAppRestart
+
+        let shouldTimeout = try await subject.hasPassedSessionTimeout(
+            userId: account.profile.userId,
+            isAppRestart: true,
+        )
+        XCTAssertTrue(shouldTimeout)
     }
 
     /// `.hasPassedSessionTimeout()` returns true if the user should be timed out for a custom timeout value.

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -1092,6 +1092,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
             ),
         )
         XCTAssertTrue(authRepository.checkSessionTimeoutCalled)
+        XCTAssertEqual(authRepository.checkSessionTimeoutIsAppRestart, true)
     }
 
     /// `handleAndRoute(_ :)` redirects `.didTimeout` to `.complete`

--- a/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
+++ b/BitwardenShared/UI/Auth/Extensions/AuthRouter+Redirects.swift
@@ -244,7 +244,7 @@ extension AuthRouter {
 
         // Check all accounts for timeouts on startup (both time-based and "no unlock method after restart")
         var activeUserShouldTimeout = false
-        await services.authRepository.checkSessionTimeouts { _ in
+        await services.authRepository.checkSessionTimeouts(isAppRestart: true) { _ in
             activeUserShouldTimeout = true
         }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31369](https://bitwarden.atlassian.net/browse/PM-31369)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This is a cherry-pick of https://github.com/bitwarden/ios/pull/2301 to fix logout on app restart.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31369]: https://bitwarden.atlassian.net/browse/PM-31369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ