### PR TITLE
[PM-28227] Remove iOS version restriction on the workaround for autofill text to insert

### DIFF
--- a/BitwardenAutoFillExtension/CredentialProviderViewController.swift
+++ b/BitwardenAutoFillExtension/CredentialProviderViewController.swift
@@ -477,10 +477,9 @@ extension CredentialProviderViewController: RootNavigator {
         // HACK: [PM-28227] When opening this extension on mode `text to insert`
         // We can't use `removeFromSuperview` or the extension closes afterwards after a few seconds.
         // Therefore we have this hack to pop to root on navigation controller.
-        // iOS 26.2 changed something on the navigation from `prepareInterfaceForUserChoosingTextToInsert`
+        // iOS sometimes changes something on the navigation from `prepareInterfaceForUserChoosingTextToInsert`
         // which needs this workaround.
-        if #available(iOS 26.2, *),
-           let context,
+        if let context,
            case .autofillText = context.extensionMode,
            let navController = fromViewController as? UINavigationController {
             navController.popToRoot(animated: true)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-28227](https://bitwarden.atlassian.net/browse/PM-28227)

## 📔 Objective

Remove iOS version restriction on the workaround for autofill text to insert done in #2312 as there are users experiencing a similar behavior on older iOS versions; so we need to let the workaround work there as well.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-28227]: https://bitwarden.atlassian.net/browse/PM-28227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ