### PR TITLE
[PM-27525] chore: Fix spellings from initial spell check run

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/CameraService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/CameraService.swift
@@ -96,7 +96,7 @@ class DefaultCameraService: NSObject {
     }
 }
 
-// MARK: - DefaultCamerAuthorizationService
+// MARK: - DefaultCameraAuthorizationService
 
 extension DefaultCameraService: CameraService {
     func checkStatus() -> CameraAuthorizationStatus {

--- a/AuthenticatorShared/Core/Platform/Services/PlatformClientService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/PlatformClientService.swift
@@ -10,7 +10,7 @@ protocol PlatformClientService: AnyObject {
 
     /// Gets the fingerprint (public key) based on `req`.
     /// - Parameter request: Request with parameters for the fingerprint.
-    /// - Returns: Fingerprint pubilc key.
+    /// - Returns: Fingerprint public key.
     func fingerprint(request req: FingerprintRequest) throws -> String
 
     /// Load feature flags into the client.

--- a/AuthenticatorShared/Core/Vault/Services/Importers/Support/Base32.swift
+++ b/AuthenticatorShared/Core/Vault/Services/Importers/Support/Base32.swift
@@ -120,7 +120,7 @@ enum Base32 {
     /// 16-bit     = 0111010011110100         = 0b0111010011110100 -> 29940
     /// desired    = ---10100--------         = 0b10100            -> 20
     ///
-    /// we can acheive this by bitshifting left by the offset (3)
+    /// we can achieve this by bitshifting left by the offset (3)
     /// then bitshifting right by (16 - numberOfBits(5)) = (11)
     /// and then the trailing 5-bits will be our desired bits
     ///
@@ -135,7 +135,7 @@ enum Base32 {
     }
 
     /// Converts a data array to an array of 5-bit values held in a `UInt8` array.
-    /// - Note: max value of any number in the resultant aray will be
+    /// - Note: max value of any number in the resultant array will be
     ///         `0b00011111` = `31` as we will be only using the 5-bits
     ///         of the `UInt8`.  If there are not enough bits in the `UInt8`
     ///         array to fill up the last 5-bit value, it should be padded

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/OTPAuthModelTests.swift
@@ -29,7 +29,7 @@ class OTPAuthModelTests: BitwardenTestCase {
         XCTAssertEqual(subject.secret, "JBSWY3DPEHPK3PXP")
     }
 
-    /// `init` choses the issuer parameter if it differs from the label
+    /// `init` chooses the issuer parameter if it differs from the label
     func test_init_issuerParameter() {
         let key = "otpauth://totp/8bit:person@bitwarden.com?secret=JBSWY3DPEHPK3PXP&issuer=Bitwarden"
         guard let subject = OTPAuthModel(otpAuthUri: key)

--- a/AuthenticatorShared/UI/Auth/AuthCoordinator.swift
+++ b/AuthenticatorShared/UI/Auth/AuthCoordinator.swift
@@ -98,7 +98,7 @@ final class AuthCoordinator: NSObject, Coordinator, HasStackNavigator, HasRouter
     /// - Parameters:
     ///   - account: The active account.
     ///   - animated: Whether to animate the transition.
-    ///   - attemptAutmaticBiometricUnlock: Whether to the processor should attempt a biometric unlock on appear.
+    ///   - attemptAutomaticBiometricUnlock: Whether to the processor should attempt a biometric unlock on appear.
     ///   - didSwitchAccountAutomatically: A flag indicating if the active account was switched automatically.
     ///
     private func showVaultUnlock() {

--- a/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Tutorial/Tutorial/TutorialProcessor.swift
@@ -2,7 +2,7 @@ import BitwardenKit
 
 // MARK: - TutorialProcessor
 
-/// The processer used to manage state and handle actions for the tutorial screen.
+/// The processor used to manage state and handle actions for the tutorial screen.
 ///
 final class TutorialProcessor: StateProcessor<TutorialState, TutorialAction, TutorialEffect> {
     // MARK: Types

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/CameraPreviewView.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/CameraPreviewView.swift
@@ -11,7 +11,7 @@ public struct CameraPreviewView {
 
     /// The UIView holding the `AVCaptureVideoPreviewLayer`.
     public class VideoPreviewView: UIView {
-        /// The layerClass, overrided to be an `AVCaptureVideoPreviewLayer`.
+        /// The layerClass, overridden to be an `AVCaptureVideoPreviewLayer`.
         override public class var layerClass: AnyClass {
             AVCaptureVideoPreviewLayer.self
         }

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessor.swift
@@ -30,10 +30,10 @@ final class ScanCodeProcessor: StateProcessor<ScanCodeState, ScanCodeAction, Sca
     /// The services used by this processor, including camera authorization and error reporting.
     private let services: Services
 
-    /// A subject cointaining the scan code results.
+    /// A subject containing the scan code results.
     private var qrScanResultSubject = CurrentValueSubject<[ScanResult], Never>([])
 
-    // MARK: Intialization
+    // MARK: Initialization
 
     /// Creates a new `ScanCodeProcessor`.
     ///

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
@@ -27,7 +27,7 @@ class EnvironmentURLDataTests: XCTestCase {
     }
 
     /// `defaultUS` returns the properly configured `EnvironmentURLData`
-    /// with the deafult Urls for united states region.
+    /// with the default Urls for united states region.
     func test_defaultUS() {
         XCTAssertEqual(
             EnvironmentURLData.defaultUS,
@@ -44,7 +44,7 @@ class EnvironmentURLDataTests: XCTestCase {
     }
 
     /// `defaultEU` returns the properly configured `EnvironmentURLData`
-    /// with the deafult Urls for europe region.
+    /// with the default Urls for europe region.
     func test_defaultEU() {
         XCTAssertEqual(
             EnvironmentURLData.defaultEU,
@@ -217,7 +217,7 @@ class EnvironmentURLDataTests: XCTestCase {
         )
     }
 
-    /// `upgradeToPremiumURL` returns the upgrate to premium URL.
+    /// `upgradeToPremiumURL` returns the upgrade to premium URL.
     func test_upgradeToPremiumURL() {
         let subject = EnvironmentURLData(
             base: URL(string: "https://vault.example.com"),

--- a/BitwardenKit/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Extensions/JSONDecoderBitwardenTests.swift
@@ -32,7 +32,7 @@ class JSONDecoderBitwardenTests: BitwardenTestCase {
         )
     }
 
-    /// `JSONDecoder.cxfDecoder` can decode URLs succesfully when they don't present schemes
+    /// `JSONDecoder.cxfDecoder` can decode URLs successfully when they don't present schemes
     /// prefixing http or https depending on if it's an IP Address on properties named "urls" and
     /// if they can be converted directly to URL or not..
     func test_cxfDecoder_decodesNoSchemeURLsSuccessfully() throws {

--- a/BitwardenKit/Core/Platform/Utilities/StackNavigator.swift
+++ b/BitwardenKit/Core/Platform/Utilities/StackNavigator.swift
@@ -128,7 +128,7 @@ public extension StackNavigator {
     ///   - navigationTitle: The navigation title to pre-populate the navigation bar so that it doesn't flash.
     ///   - searchController: If non-nil, pre-populate the navigation bar with a search bar backed by the
     ///         supplied UISearchController.
-    ///     Normal SwiftUI search contorls will not work if this value is supplied. Tracking the searchController
+    ///     Normal SwiftUI search controls will not work if this value is supplied. Tracking the searchController
     ///     behavior must be done through a UISearchControllerDelegate or a UISearchResultsUpdating object.
     ///
     func push(

--- a/BitwardenKit/UI/Platform/Application/Extensions/View+Toolbar.swift
+++ b/BitwardenKit/UI/Platform/Application/Extensions/View+Toolbar.swift
@@ -292,7 +292,7 @@ public extension View {
 
     /// A `ToolbarContent` that adjusts the navigation bar to display a large title on the leading
     /// edge of the navigation bar and hides the centered title. This has the appearance of a large
-    /// title navigation bar without the extra padding above the title and overall hight similar to
+    /// title navigation bar without the extra padding above the title and overall height similar to
     /// an inline navigation bar title.
     ///
     /// - Parameters:

--- a/BitwardenKit/UI/Platform/Application/Views/AccessoryButton.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/AccessoryButton.swift
@@ -6,13 +6,13 @@ import SwiftUI
 public struct AccessoryButton: View {
     // MARK: Types
 
-    /// A type that wraps a synchrounous or asynchrounous block that is executed by this button.
+    /// A type that wraps a synchronous or asynchronous block that is executed by this button.
     ///
     enum Action {
         /// An action run synchrounously.
         case sync(() -> Void)
 
-        /// An action run asynchrounously.
+        /// An action run asynchronously.
         case async(() async -> Void)
     }
 

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenMenuField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenMenuField.swift
@@ -440,7 +440,7 @@ private enum MenuPreviewOptions: CaseIterable, Menuable {
     .background(Color(.systemGroupedBackground))
 }
 
-#Preview("Addititional Menu") {
+#Preview("Additional Menu") {
     Group {
         BitwardenMenuField(
             title: "Animals",

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -300,7 +300,7 @@ protocol AuthRepository: AnyObject {
     ///
     func validatePassword(_ password: String) async throws -> Bool
 
-    /// Validates thes user's entered PIN.
+    /// Validates the user's entered PIN.
     /// - Parameter pin: Pin to validate.
     /// - Returns: `true` if valid, `false` otherwise.
     func validatePin(pin: String) async throws -> Bool

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -901,7 +901,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
     }
 
     /// `loginWithTwoFactorCode(email:code:method:remember:)` set forcePasswordResetReason as
-    /// weakMasterPasswordOnLogin as master password doesn't fullfil org policies.
+    /// weakMasterPasswordOnLogin as master password doesn't fulfill org policies.
     func test_loginWithTwoFactorCode_forcePasswordResetReason() async throws {
         // Set up the mock data.
         client.results = [

--- a/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsService.swift
+++ b/BitwardenShared/Core/Auth/Services/Biometrics/BiometricsService.swift
@@ -137,7 +137,7 @@ class DefaultBiometricsService: BiometricsService {
             return .noBiometrics
         }
         guard let laError = error as? LAError else {
-            // A non LAError occured
+            // A non LAError occurred
             Logger.application.log("Other error: \(error.localizedDescription)")
             return .unknownError(error.localizedDescription, biometricAuthType)
         }

--- a/BitwardenShared/Core/Auth/Services/LocalAuth/LocalAuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/LocalAuth/LocalAuthServiceTests.swift
@@ -165,7 +165,7 @@ class LocalAuthServiceTests: BitwardenTestCase {
 
     /// `evaluateDeviceOwnerPolicy(_:for:reason:)`
     /// when status is unknown error
-    func test_evaluateDeviceOwnerPolicy_statusUknownError() async throws {
+    func test_evaluateDeviceOwnerPolicy_statusUnknownError() async throws {
         let result = try await subject.evaluateDeviceOwnerPolicy(laContext, for: .unknownError(""), reason: "")
 
         XCTAssertFalse(result)

--- a/BitwardenShared/Core/Auth/Services/TrustDeviceService.swift
+++ b/BitwardenShared/Core/Auth/Services/TrustDeviceService.swift
@@ -35,19 +35,19 @@ protocol TrustDeviceService {
 
     /// Get value to decide if the device should be trusted.
     ///
-    /// - Returns: Boolean value refering to if device should be trusted.
+    /// - Returns: Boolean value referring to if device should be trusted.
     ///
     func getShouldTrustDevice() async throws -> Bool
 
-    /// Set value refering to if device should be trusted.
+    /// Set value referring to if device should be trusted.
     ///
-    /// - Parameter value: Boolean value refering to if device should be trusted.
+    /// - Parameter value: Boolean value referring to if device should be trusted.
     ///
     func setShouldTrustDevice(_ value: Bool) async throws
 
     /// Is the current device trusted.
     ///
-    /// - Returns: Boolean value refering to if device is trusted.
+    /// - Returns: Boolean value referring to if device is trusted.
     ///
     func isDeviceTrusted() async throws -> Bool
 }

--- a/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactory.swift
+++ b/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactory.swift
@@ -5,7 +5,7 @@ import BitwardenSdk
 protocol CredentialIdentityFactory {
     /// Creates the `ASCredentialIdentity` array from a `CipherView` (it may return empty).
     /// - Parameter cipher: The cipher to get the identities from.
-    /// - Returns: An array of `ASCredentialIdenitty` (password or one time code)
+    /// - Returns: An array of `ASCredentialIdentity` (password or one time code)
     @available(iOS 17.0, *)
     func createCredentialIdentities(from cipher: CipherView) async -> [ASCredentialIdentity]
 
@@ -15,7 +15,7 @@ protocol CredentialIdentityFactory {
     func tryCreatePasswordCredentialIdentity(from cipher: CipherView) -> ASPasswordCredentialIdentity?
 }
 
-/// Default implemenation of `CredentialIdentityFactory` to create credential identities.
+/// Default implementation of `CredentialIdentityFactory` to create credential identities.
 struct DefaultCredentialIdentityFactory: CredentialIdentityFactory {
     @available(iOS 17.0, *)
     func createCredentialIdentities(from cipher: CipherView) async -> [ASCredentialIdentity] {

--- a/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactoryTests.swift
@@ -116,7 +116,7 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
     }
 
     /// `createCredentialIdentities(from:)` creates only OTC credential identity
-    /// from the given cipher view when the cipher doens't have username nor password..
+    /// from the given cipher view when the cipher doesn't have username nor password..
     func test_createCredentialIdentities_otcIdentityWhenNoUsernameNorPassword() async throws {
         guard #available(iOS 18.0, *) else {
             throw XCTSkip("iOS 18.0 is required to run this test.")

--- a/BitwardenShared/Core/Autofill/Utilities/ActionExtensionHelper.swift
+++ b/BitwardenShared/Core/Autofill/Utilities/ActionExtensionHelper.swift
@@ -51,7 +51,7 @@ public class ActionExtensionHelper { // swiftlint:disable:this type_body_length
         context.providerType == Constants.UTType.appExtensionSetup
     }
 
-    /// Wether the app extension save login provider was included in the input items.
+    /// Whether the app extension save login provider was included in the input items.
     public var isProviderSaveLogin: Bool {
         context.providerType == Constants.UTType.appExtensionSaveLogin
     }

--- a/BitwardenShared/Core/Platform/Services/CameraService.swift
+++ b/BitwardenShared/Core/Platform/Services/CameraService.swift
@@ -87,7 +87,7 @@ class DefaultCameraService: NSObject {
     }
 }
 
-// MARK: - DefaultCamerAuthorizationService
+// MARK: - DefaultCameraAuthorizationService
 
 extension DefaultCameraService: CameraService {
     func checkStatusOrRequestCameraAuthorization() async -> CameraAuthorizationStatus {

--- a/BitwardenShared/Core/Platform/Services/PlatformClientService.swift
+++ b/BitwardenShared/Core/Platform/Services/PlatformClientService.swift
@@ -10,7 +10,7 @@ protocol PlatformClientService: AnyObject {
 
     /// Gets the fingerprint (public key) based on `req`.
     /// - Parameter request: Request with parameters for the fingerprint.
-    /// - Returns: Fingerprint pubilc key.
+    /// - Returns: Fingerprint public key.
     func fingerprint(request req: FingerprintRequest) throws -> String
 
     /// Load feature flags into the client.

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -103,7 +103,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     /// The repository used by the application to manage generator data for the UI layer.
     let generatorRepository: GeneratorRepository
 
-    /// The repository used by the application to manage importing credential in Credential Exhange flow.
+    /// The repository used by the application to manage importing credential in Credential Exchange flow.
     let importCiphersRepository: ImportCiphersRepository
 
     /// The service used to access & store data on the device keychain.
@@ -142,7 +142,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     /// The helper used for app rehydration.
     let rehydrationHelper: RehydrationHelper
 
-    /// The service used by the appllication to manage app review prompts related data.
+    /// The service used by the application to manage app review prompts related data.
     let reviewPromptService: ReviewPromptService
 
     /// The factory to make `SearchProcessorMediator`s.
@@ -239,7 +239,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     ///   - flightRecorder: The service used by the application for recording temporary debug logs.
     ///   - generatorRepository: The repository used by the application to manage generator data for the UI layer.
     ///   - importCiphersRepository: The repository used by the application to manage importing credential
-    ///   in Credential Exhange flow.
+    ///   in Credential Exchange flow.
     ///   - keychainRepository: The repository used to manages keychain items.
     ///   - keychainService: The service used to access & store data on the device keychain.
     ///   - languageStateService: The service for handling language state.
@@ -555,7 +555,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             timeProvider: timeProvider,
         )
 
-        let exportVaultService = DefultExportVaultService(
+        let exportVaultService = DefaultExportVaultService(
             cipherService: cipherService,
             clientService: clientService,
             configService: configService,

--- a/BitwardenShared/Core/Platform/Services/Services.swift
+++ b/BitwardenShared/Core/Platform/Services/Services.swift
@@ -220,7 +220,7 @@ protocol HasGeneratorRepository {
 /// Protocol for an object that provides a `ImportCiphersRepository`.
 ///
 protocol HasImportCiphersRepository {
-    /// The repository used by the application to manage importing credential in Credential Exhange flow.
+    /// The repository used by the application to manage importing credential in Credential Exchange flow.
     var importCiphersRepository: ImportCiphersRepository { get }
 }
 

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -93,7 +93,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     }
 
     /// `addPendingAppIntentAction(_:)` adds the pending app intent actions to a non-existing collection of actions
-    /// so it first creates the collecton and it gets added to it.
+    /// so it first creates the collection and it gets added to it.
     func test_addPendingAppIntentAction_currentNil() async {
         appSettingsStore.pendingAppIntentActions = nil
         await subject.addPendingAppIntentAction(.lockAll)

--- a/BitwardenShared/Core/Platform/Utilities/KeyManagementTypes.swift
+++ b/BitwardenShared/Core/Platform/Utilities/KeyManagementTypes.swift
@@ -11,5 +11,5 @@ typealias SignedPublicKey = String
 /// A signature key encrypted with a symmetric key.
 typealias WrappedSigningKey = EncString
 
-/// A signature public key (verifying key) in base64 encoded CoseKey format.
+/// A signature public key (verifying key) in base64 encoded CaseKey format.
 typealias VerifyingKey = String

--- a/BitwardenShared/Core/Platform/Utilities/Rehydration/RehydrationHelper.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Rehydration/RehydrationHelper.swift
@@ -8,7 +8,7 @@ protocol RehydrationHelper {
     func clearAppRehydrationState() async throws
     /// Gets the last target state for rehydartion.
     func getLastTargetState() async -> RehydrationState?
-    /// Attemps to get the saved rehydratable target if there's one and if the expiration time hasn't been reached.
+    /// Attempts to get the saved rehydratable target if there's one and if the expiration time hasn't been reached.
     func getSavedRehydratableTarget() async throws -> RehydratableTarget?
     /// Saves the rehydration state if the last view seen by the user is one that we need to save
     /// so after the user unlocks it navigates back to such screen.

--- a/BitwardenShared/Core/Platform/Utilities/ServerVersionTests.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ServerVersionTests.swift
@@ -16,7 +16,7 @@ class ServerVersionTests: BitwardenTestCase {
         XCTAssertNil(ServerVersion("2024;2-0#metadata"))
     }
 
-    /// `init(_:)` returns the struct correclty on valid format on server versions.
+    /// `init(_:)` returns the struct correctly on valid format on server versions.
     func test_init_validFormatVersions() {
         XCTAssertNotNil(ServerVersion("2024.0.0"))
         XCTAssertNotNil(ServerVersion("2024.18.1"))

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -146,21 +146,21 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `doesActiveAccountHaveVerifiedEmail()` with verified email returns true.
-    func test_doesActiveAccountHaveVerifedEmail_true() async throws {
+    func test_doesActiveAccountHaveVerifiedEmail_true() async throws {
         stateService.activeAccount = .fixture(profile: .fixture(emailVerified: true))
         let isVerified = try await subject.doesActiveAccountHaveVerifiedEmail()
         XCTAssertTrue(isVerified)
     }
 
     /// `doesActiveAccountHavePremium()` with unverified email returns false.
-    func test_doesActiveAccountHaveVerifedEmail_false() async throws {
+    func test_doesActiveAccountHaveVerifiedEmail_false() async throws {
         stateService.activeAccount = .fixture(profile: .fixture(emailVerified: false))
         let isVerified = try await subject.doesActiveAccountHaveVerifiedEmail()
         XCTAssertFalse(isVerified)
     }
 
     /// `doesActiveAccountHavePremium()` with nil verified email returns false.
-    func test_doesActiveAccountHaveVerifedEmail_nil() async throws {
+    func test_doesActiveAccountHaveVerifiedEmail_nil() async throws {
         stateService.activeAccount = .fixture(profile: .fixture(emailVerified: nil))
         let isVerified = try await subject.doesActiveAccountHaveVerifiedEmail()
         XCTAssertFalse(isVerified)

--- a/BitwardenShared/Core/Tools/Services/API/FileAPIServiceTests.swift
+++ b/BitwardenShared/Core/Tools/Services/API/FileAPIServiceTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-// MARK: - FileAPIServieTests
+// MARK: - FileAPIServiceTests
 
 class FileAPIServiceTests: BitwardenTestCase {
     // MARK: Properties

--- a/BitwardenShared/Core/Tools/Utilities/CXFCredentialsResultBuilder.swift
+++ b/BitwardenShared/Core/Tools/Utilities/CXFCredentialsResultBuilder.swift
@@ -4,7 +4,7 @@ import BitwardenSdk
 protocol CXFCredentialsResultBuilder {
     /// Builds the credentials result for the Credential Exchange flow UI.
     /// - Parameter ciphers: Ciphers to build the results.
-    /// - Returns: Returns an array to be used in the Credential Exhange UI.
+    /// - Returns: Returns an array to be used in the Credential Exchange UI.
     func build(from ciphers: [Cipher]) -> [CXFCredentialsResult]
 }
 

--- a/BitwardenShared/Core/Vault/Extensions/CipherWithArchive.swift
+++ b/BitwardenShared/Core/Vault/Extensions/CipherWithArchive.swift
@@ -22,7 +22,7 @@ extension CipherWithArchive {
     /// and remove this function.
     ///
     /// - Parameter archiveVaultItemsFeatureFlagEnabled: The `FeatureFlag.archiveVaultItems` flag value.
-    /// - Returns: `true` if hidden, `false` othewise.
+    /// - Returns: `true` if hidden, `false` otherwise.
     func isHiddenWithArchiveFF(flag archiveVaultItemsFeatureFlagEnabled: Bool) -> Bool {
         if deletedDate != nil {
             return true

--- a/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherMatchingHelper.swift
@@ -23,7 +23,7 @@ protocol CipherMatchingHelper { // sourcery: AutoMockable
 
 // MARK: DefaultCipherMatchingHelper
 
-/// Default implemenetation of `CipherMatchingHelper`.
+/// Default implementation of `CipherMatchingHelper`.
 ///
 class DefaultCipherMatchingHelper: CipherMatchingHelper {
     // MARK: Properties

--- a/BitwardenShared/Core/Vault/Helpers/VaultListDataPreparator.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListDataPreparator.swift
@@ -72,7 +72,7 @@ protocol VaultListDataPreparator { // sourcery: AutoMockable
     ) async -> VaultListPreparedData?
 
     /// Prepares search data for the autofill's data on passwords + Fido2 combined in multiple sections
-    /// vault list bulider.
+    /// vault list builder.
     /// - Parameters:
     ///   - ciphers: An array of `Cipher` objects to be processed.
     ///   - filter: A `VaultListFilter` object that defines the filtering criteria for the vault list.

--- a/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilderFactory.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilderFactory.swift
@@ -13,7 +13,7 @@ protocol VaultListSectionsBuilderFactory { // sourcery: AutoMockable
 
 // MARK: - DefaultVaultListSectionsBuilderFactory
 
-/// The default implemetnation of `VaultListSectionsBuilderFactory`.
+/// The default implementation of `VaultListSectionsBuilderFactory`.
 struct DefaultVaultListSectionsBuilderFactory: VaultListSectionsBuilderFactory {
     /// The service used by the application to handle encryption and decryption tasks.
     let clientService: ClientService

--- a/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilderTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilderTests.swift
@@ -149,7 +149,7 @@ class VaultListSectionsBuilderTests: BitwardenTestCase { // swiftlint:disable:th
         }
     }
 
-    /// `addAutofillCombinedSingleSection()` adds a vault section combinining passwords and Fido2 items.
+    /// `addAutofillCombinedSingleSection()` adds a vault section combining passwords and Fido2 items.
     func test_addAutofillCombinedSingleSection() {
         setUpSubject(withData: VaultListPreparedData(
             fido2Items: [
@@ -192,7 +192,7 @@ class VaultListSectionsBuilderTests: BitwardenTestCase { // swiftlint:disable:th
         }
     }
 
-    /// `addAutofillPasswordsSection()` adds a vault section combinining exact and fuzzy match items.
+    /// `addAutofillPasswordsSection()` adds a vault section combining exact and fuzzy match items.
     func test_addAutofillPasswordsSection() {
         setUpSubject(withData: VaultListPreparedData(
             exactMatchItems: [

--- a/BitwardenShared/Core/Vault/Models/API/CipherPermissionsModel.swift
+++ b/BitwardenShared/Core/Vault/Models/API/CipherPermissionsModel.swift
@@ -4,6 +4,6 @@ struct CipherPermissionsModel: Codable, Equatable {
     /// Whether `delete` permission is active.
     let delete: Bool
 
-    /// Whether `restore` permission is acive.
+    /// Whether `restore` permission is active.
     let restore: Bool
 }

--- a/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
@@ -10,7 +10,7 @@ enum ExportFileType: Equatable {
     /// A `.csv` file type.
     case csv
 
-    /// An encypted `.json` file type.
+    /// An encrypted `.json` file type.
     case encryptedJson(password: String)
 
     /// A `.json` file type.
@@ -103,7 +103,7 @@ extension ExportVaultService {
     }
 }
 
-class DefultExportVaultService: ExportVaultService {
+class DefaultExportVaultService: ExportVaultService {
     // MARK: Parameters
 
     /// The cipher service used by this service.

--- a/BitwardenShared/Core/Vault/Services/ExportVaultServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultServiceTests.swift
@@ -176,7 +176,7 @@ final class ExportVaultServiceTests: BitwardenTestCase { // swiftlint:disable:th
                 ),
             ),
         )
-        subject = DefultExportVaultService(
+        subject = DefaultExportVaultService(
             cipherService: cipherService,
             clientService: clientService,
             configService: configService,

--- a/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreService.swift
+++ b/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreService.swift
@@ -187,7 +187,7 @@ private extension Cipher {
 
 #if DEBUG
 
-/// A wrapper of a `Fido2CredentialStore` which adds debugging info for the `Fido2DebugginReportBuilder`.
+/// A wrapper of a `Fido2CredentialStore` which adds debugging info for the `Fido2DebuggingReportBuilder`.
 final class DebuggingFido2CredentialStoreService: Fido2CredentialStore {
     let fido2CredentialStore: Fido2CredentialStore
 

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -400,7 +400,7 @@ extension DefaultSyncService {
         let userId = try await stateService.getActiveAccountId()
         guard userId == data.userId else { return }
 
-        // If the local data is more recent than the nofication, skip the sync.
+        // If the local data is more recent than the notification, skip the sync.
         let localCipher = try await cipherService.fetchCipher(withId: data.id)
         if let localCipher, let revisionDate = data.revisionDate, localCipher.revisionDate >= revisionDate {
             return

--- a/BitwardenShared/Core/Vault/Services/TOTP/TOTPExpirationCalculatorTests.swift
+++ b/BitwardenShared/Core/Vault/Services/TOTP/TOTPExpirationCalculatorTests.swift
@@ -111,7 +111,7 @@ final class TOTPExpirationCalculatorTests: BitwardenTestCase {
         )
     }
 
-    func test_remainingSecons_roundsUp() {
+    func test_remainingSeconds_roundsUp() {
         XCTAssertEqual(
             TOTPExpirationCalculator.remainingSeconds(
                 for: Date(year: 2024, month: 1, day: 1, second: 29, nanosecond: 90_000_000),

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -244,7 +244,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             showVaultUnlock(
                 account: account,
                 animated: animated,
-                attemptAutmaticBiometricUnlock: attemptAutomaticBiometricUnlock,
+                attemptAutomaticBiometricUnlock: attemptAutomaticBiometricUnlock,
                 didSwitchAccountAutomatically: didSwitch,
             )
         case let .vaultUnlockSetup(accountSetupFlow):
@@ -816,13 +816,13 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     /// - Parameters:
     ///   - account: The active account.
     ///   - animated: Whether to animate the transition.
-    ///   - attemptAutmaticBiometricUnlock: Whether to the processor should attempt a biometric unlock on appear.
+    ///   - attemptAutomaticBiometricUnlock: Whether to the processor should attempt a biometric unlock on appear.
     ///   - didSwitchAccountAutomatically: A flag indicating if the active account was switched automatically.
     ///
     private func showVaultUnlock(
         account: Account,
         animated: Bool,
-        attemptAutmaticBiometricUnlock: Bool,
+        attemptAutomaticBiometricUnlock: Bool,
         didSwitchAccountAutomatically: Bool,
     ) {
         let processor = VaultUnlockProcessor(
@@ -831,7 +831,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             services: services,
             state: VaultUnlockState(account: account),
         )
-        processor.shouldAttemptAutomaticBiometricUnlock = attemptAutmaticBiometricUnlock
+        processor.shouldAttemptAutomaticBiometricUnlock = attemptAutomaticBiometricUnlock
         let view = VaultUnlockView(store: Store(processor: processor))
         stackNavigator?.replace(view, animated: animated)
         if didSwitchAccountAutomatically {

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -742,7 +742,7 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(delegate.erroredError as? BitwardenTestError, BitwardenTestError.example)
     }
 
-    /// `navigate(to:)` with `.webAuthnSelfHosted` handles when the server sends unparseable credentials
+    /// `navigate(to:)` with `.webAuthnSelfHosted` handles when the server sends unparsable credentials
     @MainActor
     func test_navigate_webAuthnSelfHosted_unableToDecode() throws {
         let delegate = MockWebAuthnFlowDelegate()

--- a/BitwardenShared/UI/Auth/AuthRouterTests.swift
+++ b/BitwardenShared/UI/Auth/AuthRouterTests.swift
@@ -377,7 +377,7 @@ final class AuthRouterTests: BitwardenTestCase { // swiftlint:disable:this type_
     }
 
     /// `handleAndRoute(_ :)` delivers the locked active user to `.vaultUnlock`
-    ///     thorugh  `.didLockAccount()`.
+    ///     through  `.didLockAccount()`.
     func test_handleAndRoute_didLockAccount_active() async {
         let alt = Account.fixtureAccountLogin()
         let active = Account.fixture()

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGenerator/MasterPasswordGeneratorProcessor.swift
@@ -32,7 +32,7 @@ class MasterPasswordGeneratorProcessor: StateProcessor<
     ///
     /// - Parameters:
     ///   - coordinator: The coordinator that handles navigation.
-    ///   - delegate: The delegate for the processor to notifiy saving a generated password.
+    ///   - delegate: The delegate for the processor to notify saving a generated password.
     ///   - services: The services required by this processor.
     ///
     init(

--- a/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGuidance/MasterPasswordGuidanceProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/MasterPasswordGuidance/MasterPasswordGuidanceProcessor.swift
@@ -23,7 +23,7 @@ class MasterPasswordGuidanceProcessor: StateProcessor<
     ///
     /// - Parameters:
     ///   - coordinator: The coordinator that handles navigation.
-    ///   - delegate: The delegate for the processor to notifiy saving a generated password.
+    ///   - delegate: The delegate for the processor to notify saving a generated password.
     ///
     init(
         coordinator: AnyCoordinator<AuthRoute, AuthEvent>,

--- a/BitwardenShared/UI/Auth/Login/LoginDecryptionOptions/LoginDecryptionOptionsState.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginDecryptionOptions/LoginDecryptionOptionsState.swift
@@ -19,7 +19,7 @@ struct LoginDecryptionOptionsState: Equatable {
     /// Email of the active user to be displayed
     var email: String = ""
 
-    /// Whether the remeber device toggle is on.
+    /// Whether the remember device toggle is on.
     var isRememberDeviceToggleOn: Bool = true
 
     /// The organization identifier being used during the single-sign process.

--- a/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
@@ -139,7 +139,7 @@ class LoginProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         let validationResponse = ResponseValidationErrorModel(
             error: "Invalid credentials",
-            errorDescription: "an error occured",
+            errorDescription: "an error occurred",
             errorModel: .init(
                 message: "message",
                 object: "object",

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -162,7 +162,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         )
     }
 
-    /// `perform(_:)` with `.beginDuoAuth` initates the duo auth flow.
+    /// `perform(_:)` with `.beginDuoAuth` initiates the duo auth flow.
     @MainActor
     func test_perform_beginDuoAuth_success() async {
         let expectedURL = URL(string: "bitwarden://expectedURL")!
@@ -312,7 +312,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertEqual(actualConnectorData, connectorData)
     }
 
-    /// `perform(_:)` with `.beginWebAuthn` initates the WebAuthn auth flow.
+    /// `perform(_:)` with `.beginWebAuthn` initiates the WebAuthn auth flow.
     @MainActor
     func test_perform_beginWebAuthn_success() async throws {
         environmentService.region = .unitedStates

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthState.swift
@@ -40,7 +40,7 @@ struct TwoFactorAuthState: Equatable, Sendable {
     /// Whether the remember me toggle is on.
     var isRememberMeOn = false
 
-    /// User organization idenfier if came from SSO flow
+    /// User organization identifier if came from SSO flow
     var orgIdentifier: String?
 
     /// The text to display in the detailed instructions.

--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserVerificationMediatorTests.swift
@@ -92,9 +92,9 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase { // swiftlint:disab
     /// `checkUser(userVerificationPreference:credential:)`  with each preference,
     /// account has been unlocked in current transaction.
     func test_checkUser_anyPreferenceUnlockedCurrentTransaction() async throws {
-        try await checkUser_verified_when_unlockedCurrentTransation(.discouraged)
-        try await checkUser_verified_when_unlockedCurrentTransation(.preferred)
-        try await checkUser_verified_when_unlockedCurrentTransation(.required)
+        try await checkUser_verified_when_unlockedCurrentTransaction(.discouraged)
+        try await checkUser_verified_when_unlockedCurrentTransaction(.preferred)
+        try await checkUser_verified_when_unlockedCurrentTransaction(.required)
     }
 
     /// `checkUser(userVerificationPreference:credential:)`  with each preference,
@@ -183,7 +183,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase { // swiftlint:disab
     }
 
     /// `checkUser(userVerificationPreference:credential:)`  with preference required,
-    /// reprompt none and unable to perform perform device local auth, pin nor master passwrod verifications.
+    /// reprompt none and unable to perform perform device local auth, pin nor master password verifications.
     func test_checkUser_requiredUnableToPerform() async throws {
         userVerificationRunner.verifyInQueueResult = .success(.unableToPerform)
 
@@ -365,7 +365,7 @@ class Fido2UserVerificationMediatorTests: BitwardenTestCase { // swiftlint:disab
         )
     }
 
-    private func checkUser_verified_when_unlockedCurrentTransation(
+    private func checkUser_verified_when_unlockedCurrentTransaction(
         _ userVerificationPreference: BitwardenSdk.Verification,
         file: StaticString = #filePath,
         line: UInt = #line,

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -244,7 +244,7 @@ public class AppProcessor {
         await checkIfLockedAndPerformNavigation(route: route)
     }
 
-    /// Perpares the current environment configuration by loading the URLs for the active account
+    /// Prepares the current environment configuration by loading the URLs for the active account
     /// and getting the current server config.
     public func prepareEnvironmentConfig() async {
         await services.environmentService.loadURLsForActiveAccount()

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -211,7 +211,7 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(coordinator.events, [.didTimeout(userId: "1")])
     }
 
-    /// `init()` subscribes to will enter foreground events ands completes the user's autofill setup
+    /// `init()` subscribes to will enter foreground events and completes the user's autofill setup
     /// process if autofill is enabled and they previously choose to set it up later.
     @MainActor
     func test_init_appForeground_completeAutofillAccountSetup() async throws {

--- a/BitwardenShared/UI/Platform/Application/Extensions/View+Backport.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View+Backport.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 // MARK: - View
 
-/// Extension of `View` to have the `backport` object availalbe to ease
+/// Extension of `View` to have the `backport` object available to ease
 /// with available APIs.
 ///
 /// Adapted from https://davedelong.com/blog/2021/10/09/simplifying-backwards-compatibility-in-swift/

--- a/BitwardenShared/UI/Platform/Application/Utilities/PendingAppIntentActionMediatorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Utilities/PendingAppIntentActionMediatorTests.swift
@@ -90,8 +90,8 @@ class PendingAppIntentActionMediatorTests: BitwardenTestCase {
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
     }
 
-    /// `executePendingAppIntentActions()` with `.lockAll` with no delegate locks all vaults but doens't inform
-    /// to the delegate.
+    /// `executePendingAppIntentActions()` with `.lockAll` with no delegate locks all vaults but
+    /// doesn't inform the delegate.
     func test_executePendingAppIntentActions_lockAllNoDelegate() async throws {
         stateService.activeAccount = .fixture()
         stateService.pendingAppIntentActions = [.lockAll]

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
@@ -94,7 +94,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
     /// Perform with `.deleteAccount` presents the OTP code verification alert.
     /// If the error is that user verification failed
     /// And the user does not have a master password
-    /// Then display an invalid verification code mesage
+    /// Then display an invalid verification code message
     @MainActor
     func test_perform_deleteAccount_serverError_otpIncorrect() async throws {
         authRepository.hasMasterPasswordResult = .success(false)
@@ -122,7 +122,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
     /// Perform with `.deleteAccount` presents the master password prompt alert.
     /// If the error is that user verification failed
     /// And the user has a master password
-    /// Then display an invalid master password mesage
+    /// Then display an invalid master password message
     @MainActor
     func test_perform_deleteAccount_serverError_passwordIncorrect() async throws {
         authRepository.deleteAccountResult = .failure(

--- a/BitwardenShared/UI/Tools/ExportCXF/ExportCXFRoute.swift
+++ b/BitwardenShared/UI/Tools/ExportCXF/ExportCXFRoute.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - ExportCXFRoute
 
-/// A route to specific screens in the Credential Exhange export flow.
+/// A route to specific screens in the Credential Exchange export flow.
 public enum ExportCXFRoute: Equatable, Hashable {
     /// A route to dismiss the screen currently presented modally.
     case dismiss

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFState.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFState.swift
@@ -16,7 +16,7 @@ struct ImportCXFState: Equatable, Sendable {
         /// The import flow is in progress.
         case importing
 
-        /// The import flow succeded.
+        /// The import flow succeeded.
         case success(totalImportedCredentials: Int, importedResults: [CXFCredentialsResult])
 
         /// The import flow failed.

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXFRoute.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXFRoute.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // MARK: - ImportCXFRoute
 
-/// A route to specific screens in the Credential Exhange import flow.
+/// A route to specific screens in the Credential Exchange import flow.
 public enum ImportCXFRoute: Equatable, Hashable {
     /// A route to dismiss the screen currently presented modally.
     case dismiss

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -319,7 +319,7 @@ class AlertVaultTests: BitwardenTestCase { // swiftlint:disable:this type_body_l
     }
 
     /// `static moreOptions(canCopyTotp:cipherView:hasMasterPassword:id:showEdit:action:)` returns
-    /// the appropirate options for `.sshKey` type
+    /// the appropriate options for `.sshKey` type
     @MainActor
     func test_moreOptions_sshKey() async throws { // swiftlint:disable:this function_body_length
         var capturedAction: MoreOptionsAction?

--- a/BitwardenShared/UI/Vault/Helpers/TextAutofillHelperFactory.swift
+++ b/BitwardenShared/UI/Vault/Helpers/TextAutofillHelperFactory.swift
@@ -8,7 +8,7 @@ protocol TextAutofillHelperFactory {
     func create(delegate: TextAutofillHelperDelegate) -> TextAutofillHelper
 }
 
-/// Default implemenation of `TextAutofillHelperFactory`.
+/// Default implementation of `TextAutofillHelperFactory`.
 struct DefaultTextAutofillHelperFactory: TextAutofillHelperFactory {
     // MARK: Properties
 

--- a/BitwardenShared/UI/Vault/Helpers/TextAutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/TextAutofillHelperTests.swift
@@ -283,7 +283,7 @@ class TextAutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this typ
 
     /// `handleCipherForAutofill(cipherView:)` shows options with custom fields
     /// and user selects one custom field to autofill it when `viewPassword` is `false` so hidden fields are
-    /// not avaialble.
+    /// not available.
     @MainActor
     func test_handleCipherForAutofill_optionsWithCustomFieldsNotViewPassword() async throws {
         let optionsHelper = MockTextAutofillOptionsHelper()

--- a/BitwardenShared/UI/Vault/Helpers/TextAutofillOptionsHelper/IdentityTextAutofillOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/TextAutofillOptionsHelper/IdentityTextAutofillOptionsHelperTests.swift
@@ -326,7 +326,7 @@ class IdentityTextAutofillOptionsHelperTests: BitwardenTestCase { // swiftlint:d
     }
 
     /// `getTextAutofillOptions(cipherView:)` returns all options when
-    /// we have all of the values available exept from phone.
+    /// we have all of the values available except from phone.
     func test_getTextAutofillOptions_phoneNil() async {
         let cipher = CipherView.fixture(
             identity: .fixture(
@@ -352,7 +352,7 @@ class IdentityTextAutofillOptionsHelperTests: BitwardenTestCase { // swiftlint:d
     }
 
     /// `getTextAutofillOptions(cipherView:)` returns all options when
-    /// we have all of the values available exept from phone being empty.
+    /// we have all of the values available except from phone being empty.
     func test_getTextAutofillOptions_phoneEmpty() async {
         let cipher = CipherView.fixture(
             identity: .fixture(

--- a/BitwardenShared/UI/Vault/Helpers/TextAutofillOptionsHelper/SSHKeyTextAutofillOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/TextAutofillOptionsHelper/SSHKeyTextAutofillOptionsHelperTests.swift
@@ -108,7 +108,7 @@ class SSHKeyTextAutofillOptionsHelperTests: BitwardenTestCase {
 
     /// `getTextAutofillOptions(cipherView:)` returns options when
     /// we have all of the values available except fingerprint empty.
-    func test_getTextAutofillOptions_fingeprintEmpty() async {
+    func test_getTextAutofillOptions_fingerprintEmpty() async {
         let cipher = CipherView.fixture(
             sshKey: .fixture(
                 privateKey: "privateKey",

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListEffect.swift
@@ -6,7 +6,7 @@ import BitwardenSdk
 ///
 enum VaultAutofillListEffect: Equatable {
     /// Triggered when `excludedCredentialFound` state changed.
-    case excludedCredentialFoundChaged
+    case excludedCredentialFoundChanged
 
     /// Fido2 flow should be initialized if needed..
     case initFido2

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -288,10 +288,10 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         )
     }
 
-    /// `perform(_:)` with `.excludedCredentialFoundChaged` updates the state with the excluded credential
+    /// `perform(_:)` with `.excludedCredentialFoundChanged` updates the state with the excluded credential
     /// vault list section.
     @MainActor
-    func test_perform_excludedCredentialFoundChaged() async throws {
+    func test_perform_excludedCredentialFoundChanged() async throws {
         let cipher = CipherView.fixture(login: .fixture(fido2Credentials: [.fixture()]))
         subject.state.excludedCredentialIdFound = cipher.id
         vaultRepository.cipherDetailsSubject.send(cipher)
@@ -309,7 +309,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         )
 
         let task = Task {
-            await subject.perform(.excludedCredentialFoundChaged)
+            await subject.perform(.excludedCredentialFoundChanged)
         }
         defer { task.cancel() }
 
@@ -328,11 +328,11 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         XCTAssertEqual(firstItem.id, cipher.id)
     }
 
-    /// `perform(_:)` with `.excludedCredentialFoundChaged` updates the state with the excluded credential
+    /// `perform(_:)` with `.excludedCredentialFoundChanged` updates the state with the excluded credential
     /// vault list section but then sets `excludedCredentialFound` to `nil` in state when cipher
     /// has no Fido2 credentials.
     @MainActor
-    func test_perform_excludedCredentialFoundChaged_cipherHasNoFido2Credentials() async throws {
+    func test_perform_excludedCredentialFoundChanged_cipherHasNoFido2Credentials() async throws {
         let cipher = CipherView.fixture(login: .fixture(fido2Credentials: [.fixture()]))
         subject.state.excludedCredentialIdFound = cipher.id
         vaultRepository.cipherDetailsSubject.send(cipher)
@@ -350,7 +350,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         )
 
         let task = Task {
-            await subject.perform(.excludedCredentialFoundChaged)
+            await subject.perform(.excludedCredentialFoundChanged)
         }
         defer { task.cancel() }
 
@@ -375,16 +375,16 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         }
     }
 
-    /// `perform(_:)` with `.excludedCredentialFoundChaged` throws when getting the excluded credential cipher
+    /// `perform(_:)` with `.excludedCredentialFoundChanged` throws when getting the excluded credential cipher
     /// from the publisher so it shows an error and cancels the extension flow.
     @MainActor
-    func test_perform_excludedCredentialFoundChaged_cipherPublisherThrows() async throws {
+    func test_perform_excludedCredentialFoundChanged_cipherPublisherThrows() async throws {
         let cipher = CipherView.fixture()
         subject.state.excludedCredentialIdFound = cipher.id
         vaultRepository.cipherDetailsSubject.send(completion: .failure(BitwardenTestError.example))
 
         let task = Task {
-            await subject.perform(.excludedCredentialFoundChaged)
+            await subject.perform(.excludedCredentialFoundChanged)
         }
         defer { task.cancel() }
 
@@ -415,7 +415,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         XCTAssertTrue(appExtensionDelegate.didCancelCalled)
     }
 
-    /// `perform(_:)` with `.excludedCredentialFoundChaged` throws when creating the excluded credential cipher
+    /// `perform(_:)` with `.excludedCredentialFoundChanged` throws when creating the excluded credential cipher
     /// section so it shows an error and cancels the extension flow.
     @MainActor
     func test_informExcludedCredentialFound_creatingExcludeCredentialSectionThrows() async throws {
@@ -425,7 +425,7 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         vaultRepository.createAutofillListExcludedCredentialSectionResult = .failure(BitwardenTestError.example)
 
         let task = Task {
-            await subject.perform(.excludedCredentialFoundChaged)
+            await subject.perform(.excludedCredentialFoundChanged)
         }
         defer { task.cancel() }
 

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+TotpTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+TotpTests.swift
@@ -368,7 +368,7 @@ class VaultAutofillListProcessorTotpTests: BitwardenTestCase { // swiftlint:disa
     @MainActor
     func test_refreshTOTPCodes_searchItemsEmpty() throws {
         // WORKAROUND: initialize `configuredTOTPRefreshSchedulingItems` with something so `waitFor`
-        // doens't have race condition issues.
+        // doesn't have race condition issues.
         totpExpirationManagerForSearchItems.configuredTOTPRefreshSchedulingItems = [
             VaultListItem(id: "1", itemType: .cipher(.fixture())),
         ]

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -128,7 +128,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
 
     override func perform(_ effect: VaultAutofillListEffect) async {
         switch effect {
-        case .excludedCredentialFoundChaged:
+        case .excludedCredentialFoundChanged:
             if let cipherIdFound = state.excludedCredentialIdFound {
                 await updateExcludedCredentialSection(from: cipherIdFound)
             }
@@ -322,7 +322,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
         }
     }
 
-    /// Initilaizes the TOTP expiration managers so the TOTP codes are refreshed automatically.
+    /// Initializes the TOTP expiration managers so the TOTP codes are refreshed automatically.
     func initTotpExpirationManagers() {
         vaultItemsTotpExpirationManager = services.totpExpirationManagerFactory.create(
             onExpiration: { [weak self] expiredItems in

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -110,7 +110,7 @@ private struct VaultAutofillListSearchableView: View {
                 await store.perform(.search(store.state.searchText))
             }
             .task(id: store.state.excludedCredentialIdFound) {
-                await store.perform(.excludedCredentialFoundChaged)
+                await store.perform(.excludedCredentialFoundChanged)
             }
             .toast(
                 store.binding(

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/CameraPreviewView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/CameraPreviewView.swift
@@ -11,7 +11,7 @@ public struct CameraPreviewView {
 
     /// The UIView holding the `AVCaptureVideoPreviewLayer`.
     public class VideoPreviewView: UIView {
-        /// The layerClass, overrided to be an `AVCaptureVideoPreviewLayer`.
+        /// The layerClass, overridden to be an `AVCaptureVideoPreviewLayer`.
         override public class var layerClass: AnyClass {
             AVCaptureVideoPreviewLayer.self
         }

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
@@ -21,7 +21,7 @@ final class ManualEntryProcessor: StateProcessor<ManualEntryState, ManualEntryAc
     /// The services used by this processor, including camera authorization and error reporting.
     private let services: Services
 
-    // MARK: Intialization
+    // MARK: Initialization
 
     /// Creates a new `ManualEntryProcessor`.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ScanCodeProcessor.swift
@@ -30,10 +30,10 @@ final class ScanCodeProcessor: StateProcessor<ScanCodeState, ScanCodeAction, Sca
     /// The services used by this processor, including camera authorization and error reporting.
     private let services: Services
 
-    /// A subject cointaining the scan code results.
+    /// A subject containing the scan code results.
     private var qrScanResultSubject = CurrentValueSubject<[ScanResult], Never>([])
 
-    // MARK: Intialization
+    // MARK: Initialization
 
     /// Creates a new `ScanCodeProcessor`.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState+HeaderTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState+HeaderTests.swift
@@ -359,7 +359,7 @@ class CipherItemStateHeaderTests: BitwardenTestCase { // swiftlint:disable:this 
         }
     }
 
-    /// `getter:totalHeaderAdditionalItems` returns 0 when cipher doesn't belong to an organzation.
+    /// `getter:totalHeaderAdditionalItems` returns 0 when cipher doesn't belong to an organization.
     func test_totalHeaderAdditionalItems_noOrganization() throws {
         let state = try XCTUnwrap(
             CipherItemState(
@@ -370,7 +370,7 @@ class CipherItemStateHeaderTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(state.totalHeaderAdditionalItems, 0)
     }
 
-    /// `getter:totalHeaderAdditionalItems` returns 1 when cipher belongs to an organzation
+    /// `getter:totalHeaderAdditionalItems` returns 1 when cipher belongs to an organization
     /// but not to collections nor folder.
     func test_totalHeaderAdditionalItems_organizationButNoCollectionNoFolder() throws {
         let state = try XCTUnwrap(
@@ -382,7 +382,7 @@ class CipherItemStateHeaderTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(state.totalHeaderAdditionalItems, 1)
     }
 
-    /// `getter:totalHeaderAdditionalItems` returns 4 when cipher belongs to an organzation
+    /// `getter:totalHeaderAdditionalItems` returns 4 when cipher belongs to an organization
     /// and to 3 collections but not to a folder.
     func test_totalHeaderAdditionalItems_organizationCollectionsNoFolder() throws {
         let state = try XCTUnwrap(
@@ -394,7 +394,7 @@ class CipherItemStateHeaderTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(state.totalHeaderAdditionalItems, 4)
     }
 
-    /// `getter:totalHeaderAdditionalItems` returns 5 when cipher belongs to an organzation,
+    /// `getter:totalHeaderAdditionalItems` returns 5 when cipher belongs to an organization,
     /// to 3 collections and a folder.
     func test_totalHeaderAdditionalItems_organizationCollectionsFolder() throws {
         let state = try XCTUnwrap(
@@ -410,7 +410,7 @@ class CipherItemStateHeaderTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(state.totalHeaderAdditionalItems, 5)
     }
 
-    /// `getter:totalHeaderAdditionalItems` returns 2 when cipher belongs to an organzation,
+    /// `getter:totalHeaderAdditionalItems` returns 2 when cipher belongs to an organization,
     /// no collections and a folder.
     func test_totalHeaderAdditionalItems_organizationFolderAndNoCollections() throws {
         let state = try XCTUnwrap(

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/LoginViewUpdateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/LoginViewUpdateTests.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import BitwardenShared
 
 final class LoginViewUpdateTests: BitwardenTestCase {
-    // MARK: Propteries
+    // MARK: Properties
 
     var loginState: LoginItemState!
     var subject: BitwardenSdk.LoginView!

--- a/Configs/Common-bwa.xcconfig
+++ b/Configs/Common-bwa.xcconfig
@@ -5,7 +5,7 @@ BASE_BUNDLE_ID = $(ORGANIZATION_IDENTIFIER).authenticator
 SHARED_APP_GROUP_IDENTIFIER = group.${ORGANIZATION_IDENTIFIER}.bitwarden-authenticator
 APPICON_NAME = AppIcon
 
-// The above code signing settings can be overriden by adding a Local-bwa.xcconfig
+// The above code signing settings can be overridden by adding a Local-bwa.xcconfig
 // file in the Configs directory.
 //
 // As an example, add the file Local-bwa.xcconfig with the following contents:

--- a/Configs/Common-bwpm.xcconfig
+++ b/Configs/Common-bwpm.xcconfig
@@ -6,7 +6,7 @@ BASE_BUNDLE_ID = $(ORGANIZATION_IDENTIFIER).bitwarden
 APPICON_NAME = AppIcon
 BMPW_BUNDLE_DISPLAY_NAME = Bitwarden
 
-// The above code signing settings can be overriden by adding a Local-bwpm.xcconfig
+// The above code signing settings can be overridden by adding a Local-bwpm.xcconfig
 // file in the Configs directory.
 //
 // As an example, add the file Local-bwpm.xcconfig with the following contents:

--- a/Configs/Common-bwth.xcconfig
+++ b/Configs/Common-bwth.xcconfig
@@ -5,7 +5,7 @@ BASE_BUNDLE_ID = $(ORGANIZATION_IDENTIFIER).testharness
 SHARED_APP_GROUP_IDENTIFIER = group.${ORGANIZATION_IDENTIFIER}.testharness
 APPICON_NAME = AppIcon
 
-// The above code signing settings can be overriden by adding a Local-bwth.xcconfig
+// The above code signing settings can be overridden by adding a Local-bwth.xcconfig
 // file in the Configs directory.
 //
 // As an example, add the file Local-bwth.xcconfig with the following contents:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27525](https://bitwarden.atlassian.net/browse/PM-27524)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes most spelling errors identified by https://github.com/bitwarden/ios/pull/2319.

There's a few that remain and most of them are keys within our localization files, which didn't seem worth it to change since it will require retranslating any existing translations.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-27525]: https://bitwarden.atlassian.net/browse/PM-27525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ