### PR TITLE
[PM-31687] fix: Prevent flight recorder crash when deleting multiple logs

### DIFF
--- a/BitwardenKit/Core/Platform/Services/FlightRecorder.swift
+++ b/BitwardenKit/Core/Platform/Services/FlightRecorder.swift
@@ -340,9 +340,9 @@ public actor DefaultFlightRecorder {
             data.activeLog = nil
         }
 
-        for (index, log) in data.inactiveLogs.enumerated() {
-            guard log.expirationDate <= timeProvider.presentTime else { continue }
+        let expiredLogs = data.inactiveLogs.filter { $0.expirationDate <= timeProvider.presentTime }
 
+        for log in expiredLogs {
             Logger.flightRecorder.debug(
                 "FlightRecorder: removing expired log \(log.startDate) \(log.duration.shortDescription)",
             )
@@ -352,8 +352,10 @@ public actor DefaultFlightRecorder {
             } catch {
                 errorReporter.log(error: FlightRecorderError.removeExpiredLogError(error))
             }
+        }
 
-            data.inactiveLogs.remove(at: index)
+        data.inactiveLogs.removeAll { log in
+            expiredLogs.contains { $0.id == log.id }
         }
 
         await setFlightRecorderData(data)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31687](https://bitwarden.atlassian.net/browse/PM-31687)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a crash in the flight recorder if multiple logs need to be deleted at once. The original code had a bug where it was iterating through `data.inactiveLogs` with `enumerated()` and removing items by index during iteration. This causes array indices to shift after each removal, leading to potential crashes or skipped items.

To fix this, the expired logs are filtered out, log files are removed, and then `removeAll(where:)` is used with an ID comparison to safely remove expired logs from the array.

It fixes the following Crashlyics crash:
https://console.firebase.google.com/u/0/project/bitwarden-c2b35/crashlytics/app/ios:com.8bit.bitwarden/issues/1e3d89344debf6cc7f8754c8f0dea75b?time=7d&types=crash&sessionEventKey=8a5a649a2cf54891b8dd14d1cc962dcf_2180011112116317282

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-31687]: https://bitwarden.atlassian.net/browse/PM-31687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ