### PR TITLE
[PM-26762] chore: Update NetworkingTests to strict concurrency

### DIFF
--- a/Networking/Tests/NetworkingTests/HTTPServiceTests.swift
+++ b/Networking/Tests/NetworkingTests/HTTPServiceTests.swift
@@ -11,8 +11,8 @@ class HTTPServiceTests: XCTestCase {
 
     // MARK: Setup & Teardown
 
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
 
         client = MockHTTPClient()
 
@@ -22,8 +22,8 @@ class HTTPServiceTests: XCTestCase {
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         client = nil
         subject = nil

--- a/Networking/Tests/NetworkingTests/RequestBodyTests.swift
+++ b/Networking/Tests/NetworkingTests/RequestBodyTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class RequestBodyTests: XCTestCase {
     struct TestRequestBodyJSON: JSONRequestBody {
-        static var encoder = JSONEncoder()
+        static let encoder = JSONEncoder()
 
         let name = "john"
     }

--- a/Networking/Tests/NetworkingTests/Support/URLProtocolMocking.swift
+++ b/Networking/Tests/NetworkingTests/Support/URLProtocolMocking.swift
@@ -2,7 +2,10 @@ import Foundation
 
 /// An object that manages mock responses for `MockURLProtocol`.
 ///
-class URLProtocolMocking {
+/// This class conforms to `@unchecked Sendable` because all mutable state is
+/// protected by a private DispatchQueue that ensures thread-safe access.
+///
+final class URLProtocolMocking: @unchecked Sendable {
     typealias Response = Result<(URLResponse, Data), Error>
 
     // MARK: Properties

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -260,6 +260,7 @@ targets:
     settings:
       base:
         INFOPLIST_FILE: Networking/Tests/NetworkingTests/Support/Info.plist
+        SWIFT_STRICT_CONCURRENCY: complete
     sources:
       - path: Networking
         includes:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-26762](https://bitwarden.atlassian.net/browse/PM-26762)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the `NetworkingTests` target to use strict concurrency.

## ⏰ Reminders before review

- Contributor guidelines followed
- All formatters and local linters executed and passed
- Written new unit and / or integration tests where applicable
- Protected functional changes with optionality (feature flags)
- Used internationalization (i18n) for all UI strings
- CI builds passed
- Communicated to DevOps any deployment requirements
- Updated any necessary documentation (Confluence, contributing docs) or informed the documentation team

## 🦮 Reviewer guidelines

<!-- Suggested interactions but feel free to use (or not) as you desire! -->

- 👍 (`:+1:`) or similar for great changes
- 📝 (`:memo:`) or ℹ️ (`:information_source:`) for notes or general info
- ❓ (`:question:`) for questions
- 🤔 (`:thinking:`) or 💭 (`:thought_balloon:`) for more open inquiry that's not quite a confirmed issue and could potentially benefit from discussion
- 🎨 (`:art:`) for suggestions / improvements
- ❌ (`:x:`) or ⚠️ (`:warning:`) for more significant problems or concerns needing attention
- 🌱 (`:seedling:`) or ♻️ (`:recycle:`) for future improvements or indications of technical debt
- ⛏ (`:pick:`) for minor or nitpick changes


[PM-26762]: https://bitwarden.atlassian.net/browse/PM-26762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ