### PR TITLE
[PM-32095] ci: Update Test workflows summary step to list failures only

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -150,6 +150,7 @@ jobs:
           kill "$PYEETD_PID"
 
       - name: Test
+        id: test
         env:
           _SIMULATOR_ID: ${{ steps.boot-simulator.outputs.simulator-id }}
         run: |
@@ -167,7 +168,7 @@ jobs:
           kill "$PYEETD_PID"
 
       - name: Print Logs Summary
-        if: always()
+        if: failure() && steps.test.outcome == 'failure'
         run: |
           xcresultparser -f -o cli "$_TESTS_RESULT_BUNDLE_PATH"
           echo "# Test Summary" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,6 +145,7 @@ jobs:
             kill "$PYEETD_PID"
 
       - name: Test
+        id: test
         env:
           _SIMULATOR_ID: ${{ steps.boot-simulator.outputs.simulator-id }}
         run: |
@@ -162,7 +163,7 @@ jobs:
             kill "$PYEETD_PID"
 
       - name: Print Logs Summary
-        if: always()
+        if: failure() && steps.test.outcome == 'failure'
         run: |
           xcresultparser -f -o cli "$_TESTS_RESULT_BUNDLE_PATH"
           echo "# Test Summary" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32095

## 📔 Objective

After updating to xcode26 test logs stopped listing failed tests, making it harder for our team to troubleshoot flaky tests and notice ongoing patterns.  With this PR we're:

1. Changing our test logs summary step to list failed tests only, making it easier to identify what failed.
2. Change Output Summary step condition to only execute if the Test step failed, removing an unnecessary error log when other steps like Build fail instead (e.g. [run](https://github.com/bitwarden/ios/actions/runs/21917980824/attempts/1)).
