### PR TITLE
[PM-31830] fix: Fix archived cipher update on non-premium user

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -880,6 +880,11 @@ extension DefaultVaultRepository: VaultRepository {
     }
 
     func updateCipher(_ cipherView: CipherView) async throws {
+        if await shouldUnarchiveCipherOnUpdate(cipherView) {
+            try await updateCipher(cipherView.update(archivedDate: nil))
+            return
+        }
+
         let cipherEncryptionContext = try await clientService.vault().ciphers().encrypt(cipherView: cipherView)
         try await cipherService.updateCipherWithServer(
             cipherEncryptionContext.cipher,
@@ -888,6 +893,11 @@ extension DefaultVaultRepository: VaultRepository {
     }
 
     func updateCipherCollections(_ cipherView: CipherView) async throws {
+        if await shouldUnarchiveCipherOnUpdate(cipherView) {
+            try await updateCipherCollections(cipherView.update(archivedDate: nil))
+            return
+        }
+
         let cipher = try await encryptAndUpdateCipher(cipherView)
         try await cipherService.updateCipherCollectionsWithServer(cipher)
     }
@@ -1022,5 +1032,19 @@ extension DefaultVaultRepository: VaultRepository {
             cipherListView: cipherListView,
             fido2CredentialAutofillView: fido2CredentialAutofillView,
         )
+    }
+
+    /// Checks whether the cipher should be unarchived when it's being updated.
+    /// - Parameter cipher: The cipher to check.
+    /// - Returns: `true` if it should be unarchived, `false` otherwise.
+    private func shouldUnarchiveCipherOnUpdate(_ cipher: CipherView) async -> Bool {
+        guard cipher.archivedDate != nil else {
+            return false
+        }
+
+        let archiveItemsFF: Bool = await configService.getFeatureFlag(.archiveVaultItems)
+        let hasPremium = await stateService.doesActiveAccountHavePremium()
+
+        return archiveItemsFF && !hasPremium
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -1423,6 +1423,82 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
     }
 
+    /// `updateCipherCollections()` unarchives the cipher when it's archived, feature flag is on,
+    /// and user doesn't have premium.
+    @MainActor
+    func test_updateCipherCollections_unarchivesNonPremiumUserWithFeatureFlag() async throws {
+        stateService.activeAccount = nonPremiumAccount
+        stateService.doesActiveAccountHavePremiumResult = false
+        configService.featureFlagsBool[.archiveVaultItems] = true
+
+        let archivedCipher = CipherView.fixture(archivedDate: .now, id: "123")
+        try await subject.updateCipherCollections(archivedCipher)
+
+        // Verify cipher was unarchived before updating collections
+        let unarchivedCipher = archivedCipher.update(archivedDate: nil)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [unarchivedCipher])
+        XCTAssertEqual(
+            cipherService.updateCipherCollectionsWithServerCiphers,
+            [Cipher(cipherView: unarchivedCipher)],
+        )
+    }
+
+    /// `updateCipherCollections()` does NOT unarchive the cipher when user has premium,
+    /// even with feature flag on.
+    @MainActor
+    func test_updateCipherCollections_doesNotUnarchivePremiumUser() async throws {
+        stateService.activeAccount = premiumAccount
+        stateService.doesActiveAccountHavePremiumResult = true
+        configService.featureFlagsBool[.archiveVaultItems] = true
+
+        let archivedCipher = CipherView.fixture(archivedDate: .now, id: "123")
+        try await subject.updateCipherCollections(archivedCipher)
+
+        // Verify cipher was NOT unarchived (kept archived)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(
+            cipherService.updateCipherCollectionsWithServerCiphers,
+            [Cipher(cipherView: archivedCipher)],
+        )
+    }
+
+    /// `updateCipherCollections()` does NOT unarchive the cipher when feature flag is off,
+    /// even for non-premium users.
+    @MainActor
+    func test_updateCipherCollections_doesNotUnarchiveWhenFeatureFlagOff() async throws {
+        stateService.activeAccount = nonPremiumAccount
+        stateService.doesActiveAccountHavePremiumResult = false
+        configService.featureFlagsBool[.archiveVaultItems] = false
+
+        let archivedCipher = CipherView.fixture(archivedDate: .now, id: "123")
+        try await subject.updateCipherCollections(archivedCipher)
+
+        // Verify cipher was NOT unarchived (kept archived)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(
+            cipherService.updateCipherCollectionsWithServerCiphers,
+            [Cipher(cipherView: archivedCipher)],
+        )
+    }
+
+    /// `updateCipherCollections()` proceeds normally when cipher is not archived.
+    @MainActor
+    func test_updateCipherCollections_notArchivedCipher() async throws {
+        stateService.activeAccount = nonPremiumAccount
+        stateService.doesActiveAccountHavePremiumResult = false
+        configService.featureFlagsBool[.archiveVaultItems] = true
+
+        let cipher = CipherView.fixture(archivedDate: nil, id: "123")
+        try await subject.updateCipherCollections(cipher)
+
+        // Verify cipher was updated normally (no changes)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(
+            cipherService.updateCipherCollectionsWithServerCiphers,
+            [Cipher(cipherView: cipher)],
+        )
+    }
+
     /// `updateCipher()` throws on encryption errors.
     func test_updateCipher_encryptError() async throws {
         clientCiphers.encryptError = BitwardenTestError.example
@@ -1440,6 +1516,71 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let cipher = CipherView.fixture(id: "123")
         try await subject.updateCipher(cipher)
 
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+    }
+
+    /// `updateCipher()` unarchives the cipher when it's archived, feature flag is on, and user doesn't have premium.
+    @MainActor
+    func test_updateCipher_unarchivesNonPremiumUserWithFeatureFlag() async throws {
+        stateService.activeAccount = nonPremiumAccount
+        stateService.doesActiveAccountHavePremiumResult = false
+        configService.featureFlagsBool[.archiveVaultItems] = true
+        client.result = .httpSuccess(testData: .cipherResponse)
+
+        let archivedCipher = CipherView.fixture(archivedDate: .now, id: "123")
+        try await subject.updateCipher(archivedCipher)
+
+        // Verify cipher was unarchived before updating
+        let unarchivedCipher = archivedCipher.update(archivedDate: nil)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [unarchivedCipher])
+        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+    }
+
+    /// `updateCipher()` does NOT unarchive the cipher when user has premium, even with feature flag on.
+    @MainActor
+    func test_updateCipher_doesNotUnarchivePremiumUser() async throws {
+        stateService.activeAccount = premiumAccount
+        stateService.doesActiveAccountHavePremiumResult = true
+        configService.featureFlagsBool[.archiveVaultItems] = true
+        client.result = .httpSuccess(testData: .cipherResponse)
+
+        let archivedCipher = CipherView.fixture(archivedDate: .now, id: "123")
+        try await subject.updateCipher(archivedCipher)
+
+        // Verify cipher was NOT unarchived (kept archived)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+    }
+
+    /// `updateCipher()` does NOT unarchive the cipher when feature flag is off, even for non-premium users.
+    @MainActor
+    func test_updateCipher_doesNotUnarchiveWhenFeatureFlagOff() async throws {
+        stateService.activeAccount = nonPremiumAccount
+        stateService.doesActiveAccountHavePremiumResult = false
+        configService.featureFlagsBool[.archiveVaultItems] = false
+        client.result = .httpSuccess(testData: .cipherResponse)
+
+        let archivedCipher = CipherView.fixture(archivedDate: .now, id: "123")
+        try await subject.updateCipher(archivedCipher)
+
+        // Verify cipher was NOT unarchived (kept archived)
+        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+    }
+
+    /// `updateCipher()` proceeds normally when cipher is not archived.
+    @MainActor
+    func test_updateCipher_notArchivedCipher() async throws {
+        stateService.activeAccount = nonPremiumAccount
+        stateService.doesActiveAccountHavePremiumResult = false
+        configService.featureFlagsBool[.archiveVaultItems] = true
+        client.result = .httpSuccess(testData: .cipherResponse)
+
+        let cipher = CipherView.fixture(archivedDate: nil, id: "123")
+        try await subject.updateCipher(cipher)
+
+        // Verify cipher was updated normally (no changes)
         XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
         XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31830](https://bitwarden.atlassian.net/browse/PM-31830)

## 📔 Objective

When user is no longer premium and they try to edit an archived cipher then it should be moved back to the normal vault upon save.


[PM-31830]: https://bitwarden.atlassian.net/browse/PM-31830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ