### PR TITLE
[PM-31654] fix: Update archive unavailable alert button style

### DIFF
--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -16,14 +16,17 @@ extension Alert {
     static func archiveUnavailable(
         action: @escaping () -> Void,
     ) -> Alert {
-        Alert(
+        let preferredAction = AlertAction(title: Localizations.upgradeToPremium, style: .default) { _ in action() }
+        let alert = Alert(
             title: Localizations.archiveUnavailable,
             message: Localizations.archivingItemsIsAPremiumFeatureDescriptionLong,
             alertActions: [
-                AlertAction(title: Localizations.upgradeToPremium, style: .default) { _, _ in action() },
+                preferredAction,
                 AlertAction(title: Localizations.cancel, style: .cancel),
             ],
         )
+        alert.preferredAction = preferredAction
+        return alert
     }
 
     /// Returns an alert for when the "Specific People" Send feature is unavailable due to

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -20,6 +20,8 @@ class AlertVaultTests: BitwardenTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(subject.alertActions[1].title, Localizations.cancel)
         XCTAssertEqual(subject.alertActions[1].style, .cancel)
 
+        XCTAssertEqual(subject.preferredAction, subject.alertActions[0])
+
         try await subject.tapAction(title: Localizations.upgradeToPremium)
         XCTAssertTrue(called)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31654](https://bitwarden.atlassian.net/browse/PM-31654)

## 📔 Objective

Update archive unavailable alert button style to set it as preferred so it's displayed as primary style.

## 📸 Screenshots


<img width="314" alt="Archive unavailable dialog style" src="https://github.com/user-attachments/assets/c746d1e5-ae08-4bed-b775-e9d06ca78bd0" />


[PM-31654]: https://bitwarden.atlassian.net/browse/PM-31654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ