### PR TITLE
[PM-32358] fix: Add master password reprompt for archive and unarchive

### DIFF
--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -139,12 +139,14 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             return
         }
 
-        await performOperationAndShowToast(
-            handleDisplayToast: handleDisplayToast,
-            loadingTitle: Localizations.sendingToArchive,
-            toastTitle: Localizations.itemMovedToArchive,
-        ) {
-            try await services.vaultRepository.archiveCipher(cipher)
+        await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipher) {
+            await self.performOperationAndShowToast(
+                handleDisplayToast: handleDisplayToast,
+                loadingTitle: Localizations.sendingToArchive,
+                toastTitle: Localizations.itemMovedToArchive,
+            ) {
+                try await self.services.vaultRepository.archiveCipher(cipher)
+            }
         }
     }
 
@@ -225,12 +227,14 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
         case let .launch(url):
             handleOpenURL(url.sanitized)
         case let .unarchive(cipher):
-            await performOperationAndShowToast(
-                handleDisplayToast: handleDisplayToast,
-                loadingTitle: Localizations.movingItemToVault,
-                toastTitle: Localizations.itemMovedToVault,
-            ) {
-                try await services.vaultRepository.unarchiveCipher(cipher)
+            await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+                await self.performOperationAndShowToast(
+                    handleDisplayToast: handleDisplayToast,
+                    loadingTitle: Localizations.movingItemToVault,
+                    toastTitle: Localizations.itemMovedToVault,
+                ) {
+                    try await self.services.vaultRepository.unarchiveCipher(cipher)
+                }
             }
         case let .view(id):
             await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-32358](https://bitwarden.atlassian.net/browse/PM-32358)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds master password reprompt if necessary before archiving or unarchiving a cipher.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

https://github.com/user-attachments/assets/1e89ff34-1532-46ae-9157-f27c5c86b1a5



[PM-32358]: https://bitwarden.atlassian.net/browse/PM-32358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ