### PR TITLE
[PM-32359] fix: Include archived ciphers in file exports

### DIFF
--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepository.swift
@@ -103,7 +103,7 @@ class DefaultExportCXFCiphersRepository: ExportCXFCiphersRepository {
     }
 
     func getAllCiphersToExportCXF() async throws -> [Cipher] {
-        try await exportVaultService.fetchAllCiphersToExport()
+        try await exportVaultService.fetchAllCiphersToExport(includeArchivedItems: false)
     }
 
     @available(iOS 26.0, *)

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
@@ -117,6 +117,7 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(result[0].id, "1")
         XCTAssertEqual(result[1].id, "2")
+        XCTAssertEqual(exportVaultService.fetchAllCiphersIncludeArchived, false)
     }
 
     /// `getAllCiphersToExportCXF()` throws when fetching ciphers throws.

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockExportVaultService.swift
@@ -9,7 +9,9 @@ import XCTest
 class MockExportVaultService: ExportVaultService {
     var didClearFiles = false
     var exportVaultContentsFormat: ExportFileType?
+    var exportVaultContentsIncludeArchived: Bool?
     var exportVaultContentResult: Result<String, Error> = .failure(BitwardenTestError.example)
+    var fetchAllCiphersToExportIncludeArchived: Bool?
     var fetchAllCiphersToExportResult: Result<[BitwardenSdk.Cipher], Error> = .success([])
     var mockFileName: String = "mockExport.json"
     var writeToFileResult: Result<URL, Error> = .failure(BitwardenTestError.example)
@@ -18,13 +20,18 @@ class MockExportVaultService: ExportVaultService {
         didClearFiles = true
     }
 
-    func exportVaultFileContents(format: BitwardenShared.ExportFileType) async throws -> String {
+    func exportVaultFileContents(
+        format: BitwardenShared.ExportFileType,
+        includeArchivedItems: Bool,
+    ) async throws -> String {
         exportVaultContentsFormat = format
+        exportVaultContentsIncludeArchived = includeArchivedItems
         return try exportVaultContentResult.get()
     }
 
-    func fetchAllCiphersToExport() async throws -> [BitwardenSdk.Cipher] {
-        try fetchAllCiphersToExportResult.get()
+    func fetchAllCiphersToExport(includeArchivedItems: Bool) async throws -> [BitwardenSdk.Cipher] {
+        fetchAllCiphersToExportIncludeArchived = includeArchivedItems
+        return try fetchAllCiphersToExportResult.get()
     }
 
     func generateExportFileName(

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
@@ -151,6 +151,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(exportService.exportVaultContentsFormat, .encryptedJson(password: "file password"))
         XCTAssertEqual(coordinator.routes.last, .shareURL(testURL))
         XCTAssertEqual(eventService.collectEventType, .userClientExportedVault)
+        XCTAssertEqual(exportService.exportVaultContentsIncludeArchived, true)
     }
 
     /// `.receive()` with  `.exportVaultTapped` logs an error on export failure.
@@ -279,6 +280,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
 
         XCTAssertEqual(coordinator.routes.last, .shareURL(testURL))
         XCTAssertEqual(eventService.collectEventType, .userClientExportedVault)
+        XCTAssertEqual(exportService.exportVaultContentsIncludeArchived, true)
     }
 
     /// `.receive()` with  `.exportVaultTapped` clears the user's master password after exporting


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-32359](https://bitwarden.atlassian.net/browse/PM-32359)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates file exports to include archived items. Archived items are still excluded from CXP exports.

[PM-32359]: https://bitwarden.atlassian.net/browse/PM-32359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ