### PR TITLE
[PM-32095] ci: Output full test results log to the github run summary

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -171,7 +171,6 @@ jobs:
         if: failure() && steps.test.outcome == 'failure'
         run: |
           xcresultparser -f -o cli "$_TESTS_RESULT_BUNDLE_PATH"
-          echo "# Test Summary" >> "$GITHUB_STEP_SUMMARY"
           xcresultparser -f -o txt "$_TESTS_RESULT_BUNDLE_PATH" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Convert coverage to Cobertura

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,7 +166,6 @@ jobs:
         if: failure() && steps.test.outcome == 'failure'
         run: |
           xcresultparser -f -o cli "$_TESTS_RESULT_BUNDLE_PATH"
-          echo "# Test Summary" >> "$GITHUB_STEP_SUMMARY"
           xcresultparser -f -o txt "$_TESTS_RESULT_BUNDLE_PATH" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Convert coverage to Cobertura


### PR DESCRIPTION
## 🎟️ Tracking

PM-32095

## 📔 Objective

With the increase in flaky tests, in order to improve troubleshooting Test workflow failures we'll now output the whole summary to the GitHub Run Summary, making it easier to see the failing tests, matching the same output we already had in the step, without the extra clicks.