### PR TITLE
[PM-31717] fix: Use default keyboard for 2FA code on iPad to prevent crash

### DIFF
--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthView.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthView.swift
@@ -21,12 +21,16 @@ struct TwoFactorAuthView: View {
         case .yubiKey:
             TextFieldConfiguration.oneTimeCode(keyboardType: .default)
         default:
-            TextFieldConfiguration.oneTimeCode(
-                // WORKAROUND: Using an iPad with the floating keyboard on iOS 26 will occasionally
-                // crash on this screen when displaying the `numberPad` keyboard type. Using the
-                // default keyboard prevents this. (PM-31717)
-                keyboardType: UIDevice.current.userInterfaceIdiom == .pad ? .default : .numberPad,
-            )
+            if #available(iOS 26, *) {
+                TextFieldConfiguration.oneTimeCode(
+                    // WORKAROUND: Using an iPad with the floating keyboard on iOS 26 will occasionally
+                    // crash on this screen when displaying the `numberPad` keyboard type. Using the
+                    // default keyboard prevents this. (PM-31717)
+                    keyboardType: UIDevice.current.userInterfaceIdiom == .pad ? .default : .numberPad,
+                )
+            } else {
+                TextFieldConfiguration.oneTimeCode()
+            }
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31717](https://bitwarden.atlassian.net/browse/PM-31717)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

On an iPad, using the floating keyboard, the app will occasionally crash when displaying the floating numeric keypad. I was only able to get this to crash in one scenario:

- From the 2FA screen, tap into the verification code field
- Enter a number
- Tap outside of the field. The keyboard will hide but the field will still have focus.
- Tap back into the field. The app will crash. 

> *** Terminating app due to uncaught exception 'NSGenericException', reason: 'Unable to activate constraint with anchors <NSLayoutYAxisAnchor:0x122a8d180 "UIView:0x111306f40.top"> and <NSLayoutYAxisAnchor:0x122ab7040 "_UIRemoteKeyboardPlaceholderView:0x122a51600.bottom"> because they have no common ancestor.  Does the constraint or its anchors reference items in different view hierarchies?  That's illegal.'

I tested other fields that use the numeric keyboard (adding a card, entering a PIN), but couldn't get those to crash. As a workaround, this switches the numeric keyboard to the default keyboard for the 2FA screen on iPad.

https://console.firebase.google.com/project/bitwarden-c2b35/crashlytics/app/ios:com.8bit.bitwarden/issues/089032745ad0d02b8fdd38dd1638c1f3?time=7d&types=crash&sessionEventKey=15b3bb0cc9f748cd83134a58ea1762d4_2181062941837630275 


[PM-31717]: https://bitwarden.atlassian.net/browse/PM-31717?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ