### PR TITLE
[PM-32095] ci: Run print step when test succeeds in test workflows

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -168,7 +168,7 @@ jobs:
           kill "$PYEETD_PID"
 
       - name: Print Logs Summary
-        if: failure() && steps.test.outcome == 'failure'
+        if: steps.test.outcome != 'skipped'
         run: |
           xcresultparser -f -o cli "$_TESTS_RESULT_BUNDLE_PATH"
           xcresultparser -f -o txt "$_TESTS_RESULT_BUNDLE_PATH" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
             kill "$PYEETD_PID"
 
       - name: Print Logs Summary
-        if: failure() && steps.test.outcome == 'failure'
+        if: steps.test.outcome != 'skipped'
         run: |
           xcresultparser -f -o cli "$_TESTS_RESULT_BUNDLE_PATH"
           xcresultparser -f -o txt "$_TESTS_RESULT_BUNDLE_PATH" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## 🎟️ Tracking

PM-32095

## 📔 Objective

Following a recent change, print logs step wasn't running when `test` step succeeds. The end goal stays the same, we still don't want this step to run when other steps (like Build) fail. 