### PR TITLE
[bre-1647] iOS CI Builds Failing With Fastlane Error

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -231,7 +231,7 @@ DEPENDENCIES
   abbrev
   csv
   dotenv
-  fastlane (= 2.229.1)
+  fastlane
   logger
   mutex_m
   ostruct


### PR DESCRIPTION
## 🎟️ Tracking

[bre-1647](https://bitwarden.atlassian.net/browse/bre-1647)

## 📔 Objective
Starting yesterday, we began seeing errors during CI Builds like [this one](https://github.com/bitwarden/ios/actions/runs/22235467746/job/64330489392#step:9:120)
```
bundler: failed to load command: fastlane (/Users/runner/work/ios/ios/vendor/bundle/ruby/3.4.0/bin/fastlane)
/Users/runner/work/ios/ios/vendor/bundle/ruby/3.4.0/gems/fastlane-2.229.0/fastlane/lib/fastlane/cli_tools_distributor.rb:126:in 'Fastlane::CLIToolsDistributor.take_off': uninitialized constant FastlaneCore::UpdateChecker (NameError)

        FastlaneCore::UpdateChecker.show_update_status('fastlane', Fastlane::VERSION)
                    ^^^^^^^^^^^^^^^
```

This was introduced by PR #2002 bumping fastlane from `2.228.0` to `2.229.0`
relevant fastlane links:
- https://github.com/fastlane/fastlane/issues/29766
- https://github.com/fastlane/fastlane/pull/29767

Bumping to `2.229.1` which has the fix included. There were other newer versions available but opted to go with the most incremental to get us working again.