### PR TITLE
[PM-29856] fix: Update generator segmented control normal state

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Appearance/UI.swift
+++ b/BitwardenKit/UI/Platform/Application/Appearance/UI.swift
@@ -135,6 +135,21 @@ public enum UI {
         UISearchBar.appearance().setImage(tintedImage, for: .clear, state: .normal)
         UISearchBar.appearance().setImage(SharedAsset.Icons.search16.image, for: .search, state: .normal)
 
+        UISegmentedControl.appearance().setTitleTextAttributes(
+            [
+                .font: UIFontMetrics(forTextStyle: .callout).scaledFont(for: FontFamily.DMSans.regular.font(size: 13)),
+                .foregroundColor: SharedAsset.Colors.textSecondary.color,
+            ],
+            for: .normal,
+        )
+        UISegmentedControl.appearance().setTitleTextAttributes(
+            [
+                .font: UIFontMetrics(forTextStyle: .callout).scaledFont(for: FontFamily.DMSans.semiBold.font(size: 13)),
+                .foregroundColor: SharedAsset.Colors.textInteraction.color,
+            ],
+            for: .selected,
+        )
+
         // Adjust the appearance of `UITextView` for `BitwardenUITextField` instances on iOS 15.
         UITextView.appearance().isScrollEnabled = false
         UITextView.appearance().backgroundColor = .clear

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenSegmentedControl.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenSegmentedControl.swift
@@ -51,7 +51,7 @@ struct BitwardenSegmentedControl<T: Menuable & Identifiable>: View {
                         self.selection = selection
                     } label: {
                         Text(selection.localizedName)
-                            .styleGuide(.callout, weight: .semibold)
+                            .styleGuide(.callout, weight: isSelected ? .semibold : .regular)
                     }
                     .accessibility(if: isSelected, addTraits: .isSelected)
                     .accessibilityIdentifier(selection.accessibilityId)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-29856](https://bitwarden.atlassian.net/browse/PM-29856)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the segmented control to better distinguish between the selected and unselected states.

- The unselected segment's font weight was updated to regular from semibold.
- On iOS 26+, the selected segment's text color was updated to blue to better match the designs.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

iOS 26+:

| Before | After |
|--------|--------|
| <img width="568" height="1084" alt="segmented control iOS 26 before" src="https://github.com/user-attachments/assets/ea3de126-cc0f-45e6-b17b-3a00451fa97a" /> | <img width="568" height="1084" alt="segmented control iOS 26 after" src="https://github.com/user-attachments/assets/d8d9e88e-3d7b-440c-b13b-a63dce94af9e" /> | 

Pre-iOS 26:

| Before | After |
|--------|--------|
| <img width="568" height="1084" alt="segmented control iOS 18 before" src="https://github.com/user-attachments/assets/f1203455-18c3-48ac-a1ca-5acd75a885e9" /> | <img width="568" height="1084" alt="segmented control iOS 18 after" src="https://github.com/user-attachments/assets/94eb8397-70ba-4d74-b34a-fd957ec85b91" /> | 

[PM-29856]: https://bitwarden.atlassian.net/browse/PM-29856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ