### PR TITLE
[BWA-227] chore: Update Authenticator app icons

### DIFF
--- a/Authenticator/Application/Support/AppIcon-Beta.icon/icon.json
+++ b/Authenticator/Application/Support/AppIcon-Beta.icon/icon.json
@@ -2,7 +2,7 @@
   "fill-specializations" : [
     {
       "value" : {
-        "solid" : "srgb:0.09020,0.36471,0.86275,1.00000"
+        "solid" : "srgb:0.00784,0.05882,0.40392,1.00000"
       }
     },
     {
@@ -140,6 +140,11 @@
       "layers" : [
         {
           "fill-specializations" : [
+            {
+              "value" : {
+                "solid" : "srgb:0.00000,0.77255,0.85882,1.00000"
+              }
+            },
             {
               "appearance" : "dark",
               "value" : {

--- a/Authenticator/Application/Support/AppIcon-Dev.icon/icon.json
+++ b/Authenticator/Application/Support/AppIcon-Dev.icon/icon.json
@@ -2,7 +2,7 @@
   "fill-specializations" : [
     {
       "value" : {
-        "solid" : "srgb:0.09020,0.36471,0.86275,1.00000"
+        "solid" : "srgb:0.00784,0.05882,0.40392,1.00000"
       }
     },
     {
@@ -139,7 +139,13 @@
       "hidden" : false,
       "layers" : [
         {
+          "blend-mode" : "normal",
           "fill-specializations" : [
+            {
+              "value" : {
+                "solid" : "srgb:0.00000,0.77255,0.85882,1.00000"
+              }
+            },
             {
               "appearance" : "dark",
               "value" : {
@@ -147,6 +153,7 @@
               }
             }
           ],
+          "glass" : true,
           "image-name" : "Authenticator - Light - focus.svg",
           "name" : "Authenticator - Light - focus"
         }

--- a/Authenticator/Application/Support/AppIcon.icon/icon.json
+++ b/Authenticator/Application/Support/AppIcon.icon/icon.json
@@ -2,7 +2,7 @@
   "fill-specializations" : [
     {
       "value" : {
-        "solid" : "srgb:0.09020,0.36471,0.86275,1.00000"
+        "solid" : "srgb:0.00784,0.05882,0.40392,1.00000"
       }
     },
     {
@@ -179,12 +179,18 @@
         {
           "fill-specializations" : [
             {
+              "value" : {
+                "solid" : "srgb:0.00000,0.77255,0.85882,1.00000"
+              }
+            },
+            {
               "appearance" : "dark",
               "value" : {
                 "solid" : "extended-gray:1.00000,1.00000"
               }
             }
           ],
+          "hidden" : false,
           "image-name" : "Authenticator.svg",
           "name" : "Authenticator"
         }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[BWA-227](https://bitwarden.atlassian.net/browse/BWA-227)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates Authenticator's app icons to be consistent with Android.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

<img width="568" height="1084" alt="Screenshot 2026-02-25 at 11 42 34 AM" src="https://github.com/user-attachments/assets/aaa0cb1c-9711-47fe-8479-bc1e2d33149b" />


[BWA-227]: https://bitwarden.atlassian.net/browse/BWA-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ