### PR TITLE
[PM-32781] Restrict Claude Code attribution from commits and PRs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,8 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  },
   "extraKnownMarketplaces": {
     "bitwarden-marketplace": {
       "source": {


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32781

## 📔 Objective

Prevent Claude Code from appending co-author attribution trailers to commits and attribution text to pull request descriptions by setting `attribution.commit` and `attribution.pr` to empty strings in `.claude/settings.json`.