### PR TITLE
disable claude attribution

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,5 +6,9 @@
         "repo": "bitwarden/ai-plugins"
       }
     }
+  },
+  "attribution": {
+    "commit": "",
+    "pr": ""
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32797

## 📔 Objective

Disable attribution messages output by Claude when it commits or writes a PR.
