### PR TITLE
[PM-32760] fix: Fix archive response upsert

### DIFF
--- a/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIService.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIService.swift
@@ -28,9 +28,9 @@ protocol CipherAPIService {
     /// Performs an API request to archive an existing cipher in the user's vault.
     ///
     /// - Parameter id: The cipher id that to be archived.
-    /// - Returns: The `EmptyResponse`.
+    /// - Returns: The `CipherDetailsResponseModel` of the cipher that was archived.
     ///
-    func archiveCipher(withID id: String) async throws -> EmptyResponse
+    func archiveCipher(withID id: String) async throws -> CipherDetailsResponseModel
 
     /// Performs an API request to add a new cipher contained within one or more collections to the
     /// user's vault.
@@ -141,9 +141,9 @@ protocol CipherAPIService {
     /// Performs an API request to unarchive a cipher in the user's vault.
     ///
     /// - Parameter id: The id of the cipher to be unarchived.
-    /// - Returns: The `EmptyResponse`.
+    /// - Returns: The `CipherDetailsResponseModel` of the cipher that was unarchived.
     ///
-    func unarchiveCipher(withID id: String) async throws -> EmptyResponse
+    func unarchiveCipher(withID id: String) async throws -> CipherDetailsResponseModel
 
     /// Performs an API request to update an existing cipher in the user's vault.
     ///
@@ -173,7 +173,7 @@ extension APIService: CipherAPIService {
         try await apiService.send(AddCipherRequest(cipher: cipher, encryptedFor: encryptedFor))
     }
 
-    func archiveCipher(withID id: String) async throws -> Networking.EmptyResponse {
+    func archiveCipher(withID id: String) async throws -> CipherDetailsResponseModel {
         try await apiService.send(ArchiveCipherRequest(id: id))
     }
 
@@ -239,7 +239,7 @@ extension APIService: CipherAPIService {
         try await apiService.send(SoftDeleteCipherRequest(id: id))
     }
 
-    func unarchiveCipher(withID id: String) async throws -> Networking.EmptyResponse {
+    func unarchiveCipher(withID id: String) async throws -> CipherDetailsResponseModel {
         try await apiService.send(UnarchiveCipherRequest(id: id))
     }
 

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/CipherAPIServiceTests.swift
@@ -140,16 +140,56 @@ class CipherAPIServiceTests: XCTestCase { // swiftlint:disable:this type_body_le
         )
     }
 
-    /// `archiveCipher()` performs the archive cipher request.
+    /// `archiveCipher()` performs the archive cipher request and decodes the response.
     func test_archiveCipher() async throws {
-        client.result = .httpSuccess(testData: .emptyResponse)
+        client.result = .httpSuccess(testData: .cipherResponse)
 
-        _ = try await subject.archiveCipher(withID: "123")
+        let response = try await subject.archiveCipher(withID: "123")
 
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertNil(client.requests[0].body)
         XCTAssertEqual(client.requests[0].method, .put)
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/ciphers/123/archive/")
+
+        XCTAssertEqual(
+            response,
+            CipherDetailsResponseModel(
+                archivedDate: nil,
+                attachments: nil,
+                card: nil,
+                collectionIds: nil,
+                creationDate: Date(timeIntervalSince1970: 1_691_656_425.345),
+                deletedDate: nil,
+                edit: true,
+                favorite: true,
+                fields: nil,
+                folderId: "folderId",
+                id: "3792af7a-4441-11ee-be56-0242ac120002",
+                identity: nil,
+                key: nil,
+                login: CipherLoginModel(
+                    autofillOnPageLoad: nil,
+                    fido2Credentials: nil,
+                    password: "encrypted password",
+                    passwordRevisionDate: nil,
+                    totp: "totp",
+                    uris: [CipherLoginUriModel(match: nil, uri: "encrypted uri", uriChecksum: nil)],
+                    username: "encrypted username",
+                ),
+                name: "encrypted name",
+                notes: nil,
+                organizationId: nil,
+                organizationUseTotp: false,
+                passwordHistory: nil,
+                permissions: nil,
+                reprompt: .none,
+                revisionDate: Date(timeIntervalSince1970: 1_691_656_425.345),
+                secureNote: nil,
+                sshKey: nil,
+                type: .login,
+                viewPassword: true,
+            ),
+        )
     }
 
     /// `bulkShareCiphers()` performs the bulk share ciphers request and decodes the response.
@@ -387,16 +427,56 @@ class CipherAPIServiceTests: XCTestCase { // swiftlint:disable:this type_body_le
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/ciphers/123/delete")
     }
 
-    /// `unarchiveCipher()` performs the unarchive cipher request.
+    /// `unarchiveCipher()` performs the unarchive cipher request and decodes the response.
     func test_unarchiveCipher() async throws {
-        client.result = .httpSuccess(testData: .emptyResponse)
+        client.result = .httpSuccess(testData: .cipherResponse)
 
-        _ = try await subject.unarchiveCipher(withID: "123")
+        let response = try await subject.unarchiveCipher(withID: "123")
 
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertNil(client.requests[0].body)
         XCTAssertEqual(client.requests[0].method, .put)
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/ciphers/123/unarchive/")
+
+        XCTAssertEqual(
+            response,
+            CipherDetailsResponseModel(
+                archivedDate: nil,
+                attachments: nil,
+                card: nil,
+                collectionIds: nil,
+                creationDate: Date(timeIntervalSince1970: 1_691_656_425.345),
+                deletedDate: nil,
+                edit: true,
+                favorite: true,
+                fields: nil,
+                folderId: "folderId",
+                id: "3792af7a-4441-11ee-be56-0242ac120002",
+                identity: nil,
+                key: nil,
+                login: CipherLoginModel(
+                    autofillOnPageLoad: nil,
+                    fido2Credentials: nil,
+                    password: "encrypted password",
+                    passwordRevisionDate: nil,
+                    totp: "totp",
+                    uris: [CipherLoginUriModel(match: nil, uri: "encrypted uri", uriChecksum: nil)],
+                    username: "encrypted username",
+                ),
+                name: "encrypted name",
+                notes: nil,
+                organizationId: nil,
+                organizationUseTotp: false,
+                passwordHistory: nil,
+                permissions: nil,
+                reprompt: .none,
+                revisionDate: Date(timeIntervalSince1970: 1_691_656_425.345),
+                secureNote: nil,
+                sshKey: nil,
+                type: .login,
+                viewPassword: true,
+            ),
+        )
     }
 
     /// `updateCipherCollections()` performs the update cipher collections request.

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/ArchiveCipherRequest.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/ArchiveCipherRequest.swift
@@ -4,7 +4,7 @@ import Networking
 /// Data model for performing an archive cipher request.
 ///
 struct ArchiveCipherRequest: Request {
-    typealias Response = EmptyResponse
+    typealias Response = CipherDetailsResponseModel
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/UnarchiveCipherRequest.swift
+++ b/BitwardenShared/Core/Vault/Services/API/Cipher/Requests/UnarchiveCipherRequest.swift
@@ -4,7 +4,7 @@ import Networking
 /// Data model for performing an unarchive cipher request.
 ///
 struct UnarchiveCipherRequest: Request {
-    typealias Response = EmptyResponse
+    typealias Response = CipherDetailsResponseModel
 
     // MARK: Properties
 

--- a/BitwardenShared/Core/Vault/Services/CipherService.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherService.swift
@@ -235,10 +235,13 @@ extension DefaultCipherService {
         let userID = try await stateService.getActiveAccountId()
 
         // Archive cipher on backend.
-        _ = try await cipherAPIService.archiveCipher(withID: id)
+        var response = try await cipherAPIService.archiveCipher(withID: id)
+
+        // The API doesn't return the collectionIds, so manually add them back.
+        response.collectionIds = cipher.collectionIds
 
         // Archive cipher on local storage
-        try await cipherDataStore.upsertCipher(cipher, userId: userID)
+        try await cipherDataStore.upsertCipher(Cipher(responseModel: response), userId: userID)
     }
 
     func bulkShareCiphersWithServer(
@@ -419,10 +422,13 @@ extension DefaultCipherService {
         let userID = try await stateService.getActiveAccountId()
 
         // Unarchive cipher from backend.
-        _ = try await cipherAPIService.unarchiveCipher(withID: id)
+        var response = try await cipherAPIService.unarchiveCipher(withID: id)
+
+        // The API doesn't return the collectionIds, so manually add them back.
+        response.collectionIds = cipher.collectionIds
 
         // Unarchive cipher from local storage
-        try await cipherDataStore.upsertCipher(cipher, userId: userID)
+        try await cipherDataStore.upsertCipher(Cipher(responseModel: response), userId: userID)
     }
 
     func updateCipherCollectionsWithServer(_ cipher: Cipher) async throws {

--- a/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CipherServiceTests.swift
@@ -74,12 +74,17 @@ class CipherServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
 
     /// `archiveCipherWithServer(id:_:)` archives the cipher in the backend and local storage.
     func test_archiveCipherWithServer() async throws {
-        client.result = .httpSuccess(testData: .emptyResponse)
+        client.result = .httpSuccess(testData: .cipherResponse)
         stateService.activeAccount = .fixture()
 
         try await subject.archiveCipherWithServer(id: "1", .fixture())
 
-        XCTAssertEqual(cipherDataStore.upsertCipherValue, .fixture())
+        var cipherResponse = try CipherDetailsResponseModel(
+            response: .success(body: APITestData.cipherResponse.data),
+        )
+        cipherResponse.collectionIds = Cipher.fixture().collectionIds
+        XCTAssertEqual(cipherDataStore.upsertCipherValue, Cipher(responseModel: cipherResponse))
+        XCTAssertEqual(cipherDataStore.upsertCipherUserId, "1")
     }
 
     /// `bulkShareCiphersWithServer(_:collectionIds:encryptedFor:)` shares multiple ciphers with the
@@ -356,12 +361,16 @@ class CipherServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
 
     /// `unarchiveCipherWithServer(id:_:)` unarchives the cipher in the backend and local storage.
     func test_unarchiveCipherWithServer() async throws {
-        client.result = .httpSuccess(testData: .emptyResponse)
+        client.result = .httpSuccess(testData: .cipherResponse)
         stateService.activeAccount = .fixture()
 
         try await subject.unarchiveCipherWithServer(id: "1", .fixture())
 
-        XCTAssertEqual(cipherDataStore.upsertCipherValue, .fixture())
+        var cipherResponse = try CipherDetailsResponseModel(
+            response: .success(body: APITestData.cipherResponse.data),
+        )
+        cipherResponse.collectionIds = Cipher.fixture().collectionIds
+        XCTAssertEqual(cipherDataStore.upsertCipherValue, Cipher(responseModel: cipherResponse))
         XCTAssertEqual(cipherDataStore.upsertCipherUserId, "1")
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32760](https://bitwarden.atlassian.net/browse/PM-32760)

## 📔 Objective

Fix [un]archive by upserting the reponse's cipher on the operation instead of the local copy of it.


[PM-32760]: https://bitwarden.atlassian.net/browse/PM-32760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ