### PR TITLE
[PM-32845] bug:  RC Fix trusted device not remembered for new SSO users 

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Response/Fixtures/SetAccountKeysResponseModel+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/Fixtures/SetAccountKeysResponseModel+Fixtures.swift
@@ -1,0 +1,17 @@
+@testable import BitwardenShared
+
+extension SetAccountKeysResponseModel {
+    static func fixture(
+        accountKeys: PrivateKeysResponseModel? = nil,
+        key: String? = nil,
+        privateKey: String? = "PRIVATE_KEY",
+        publicKey: String? = "PUBLIC_KEY",
+    ) -> SetAccountKeysResponseModel {
+        self.init(
+            accountKeys: accountKeys,
+            key: key,
+            privateKey: privateKey,
+            publicKey: publicKey,
+        )
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Response/SetAccountKeysResponseModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/SetAccountKeysResponseModel.swift
@@ -1,0 +1,22 @@
+import Networking
+
+// MARK: - SetAccountKeysResponseModel
+
+/// API response model for the `/accounts/keys` endpoint when setting account keys.
+///
+struct SetAccountKeysResponseModel: Equatable, JSONResponse, AccountKeysResponseModelProtocol {
+    // MARK: Properties
+
+    /// The user's account keys.
+    let accountKeys: PrivateKeysResponseModel?
+
+    /// The user's key.
+    let key: String?
+
+    /// The user's private key.
+    @available(*, deprecated, message: "Use accountKeys instead when possible") // TODO: PM-24659 remove
+    let privateKey: String?
+
+    /// The user's public key.
+    let publicKey: String?
+}

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -643,14 +643,16 @@ extension DefaultAuthRepository: AuthRepository {
             rememberDevice: rememberDevice,
         )
 
-        try await accountAPIService.setAccountKeys(requestModel: KeysRequestModel(
-            encryptedPrivateKey: registrationKeys.privateKey,
-            publicKey: registrationKeys.publicKey,
-        ))
+        let setAccountKeysResponse = try await accountAPIService.setAccountKeys(
+            requestModel: KeysRequestModel(
+                encryptedPrivateKey: registrationKeys.privateKey,
+                publicKey: registrationKeys.publicKey,
+            ),
+        )
 
         try await stateService.setAccountEncryptionKeys(
             AccountEncryptionKeys(
-                accountKeys: nil,
+                accountKeys: setAccountKeysResponse.accountKeys,
                 encryptedPrivateKey: registrationKeys.privateKey,
                 encryptedUserKey: nil,
             ),

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -252,7 +252,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         client.results = [
             .httpSuccess(testData: .organizationAutoEnrollStatus),
             .httpSuccess(testData: .organizationKeys),
-            .httpSuccess(testData: .emptyResponse),
+            .httpSuccess(testData: .setAccountKeys),
             .httpSuccess(testData: .emptyResponse),
         ]
         clientService.mockAuth.makeRegisterTdeKeysResult = .success(registerTdeInput)
@@ -291,7 +291,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         client.results = [
             .httpSuccess(testData: .organizationAutoEnrollStatus),
             .httpSuccess(testData: .organizationKeys),
-            .httpSuccess(testData: .emptyResponse),
+            .httpSuccess(testData: .setAccountKeys),
             .httpSuccess(testData: .emptyResponse),
         ]
         clientService.mockAuth.makeRegisterTdeKeysResult = .success(registerTdeInput)
@@ -309,6 +309,42 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 encryptedUserKey: nil,
             ),
         )
+    }
+
+    /// `createNewSsoUser()` stores the accountKeys from the setAccountKeys response.
+    func test_createNewSsoUser_withAccountKeys() async throws {
+        let registerTdeInput = RegisterTdeKeyResponse(
+            privateKey: "privateKey",
+            publicKey: "publicKey",
+            adminReset: "adminReset",
+            deviceKey: TrustDeviceResponse(
+                deviceKey: "deviceKey",
+                protectedUserKey: "protectedUserKey",
+                protectedDevicePrivateKey: "protectedDevicePrivateKey",
+                protectedDevicePublicKey: "protectedDevicePublicKey",
+            ),
+        )
+        stateService.activeAccount = Account.fixture()
+        client.results = [
+            .httpSuccess(testData: .organizationAutoEnrollStatus),
+            .httpSuccess(testData: .organizationKeys),
+            .httpSuccess(testData: .setAccountKeysWithAccountKeys),
+            .httpSuccess(testData: .emptyResponse),
+        ]
+        clientService.mockAuth.makeRegisterTdeKeysResult = .success(registerTdeInput)
+        trustDeviceService.trustDeviceWithExistingKeysResult = .success(())
+
+        try await subject.createNewSsoUser(orgIdentifier: "Bitwarden", rememberDevice: true)
+
+        XCTAssertEqual(trustDeviceService.trustDeviceWithExistingKeysValue, registerTdeInput.deviceKey)
+        let storedKeys = stateService.accountEncryptionKeys["1"]
+        XCTAssertNotNil(storedKeys?.accountKeys)
+        XCTAssertEqual(
+            storedKeys?.accountKeys?.publicKeyEncryptionKeyPair.wrappedPrivateKey,
+            "mockWrappedPrivateKey",
+        )
+        XCTAssertEqual(storedKeys?.encryptedPrivateKey, "privateKey")
+        XCTAssertNil(storedKeys?.encryptedUserKey)
     }
 
     /// `deleteAccount()` deletes the active account and removes it from the state.

--- a/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIService.swift
@@ -67,9 +67,10 @@ protocol AccountAPIService {
 
     /// Set the account keys.
     ///
-    ///  - Parameter requestModel: The request model containing the keys to set in the account.
+    /// - Parameter requestModel: The request model containing the keys to set in the account.
+    /// - Returns: The response containing the account keys.
     ///
-    func setAccountKeys(requestModel: KeysRequestModel) async throws
+    func setAccountKeys(requestModel: KeysRequestModel) async throws -> SetAccountKeysResponseModel
 
     /// Sets the user's key from key connector.
     ///
@@ -171,8 +172,8 @@ extension APIService: AccountAPIService {
         _ = try await apiUnauthenticatedService.send(request)
     }
 
-    func setAccountKeys(requestModel: KeysRequestModel) async throws {
-        _ = try await apiService.send(SetAccountKeysRequest(body: requestModel))
+    func setAccountKeys(requestModel: KeysRequestModel) async throws -> SetAccountKeysResponseModel {
+        try await apiService.send(SetAccountKeysRequest(body: requestModel))
     }
 
     func setKeyConnectorKey(_ requestModel: SetKeyConnectorKeyRequestModel) async throws {

--- a/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
@@ -207,6 +207,84 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/accounts/request-otp")
     }
 
+    /// `setAccountKeys()` sets the user's account keys and returns the response.
+    func test_setAccountKeys() async throws {
+        let json = """
+        {
+          "key": null,
+          "publicKey": "mockPublicKey",
+          "privateKey": "mockPrivateKey",
+          "accountKeys": null
+        }
+        """.data(using: .utf8)!
+        client.result = .httpSuccess(testData: APITestData(data: json))
+
+        let response = try await subject.setAccountKeys(
+            requestModel: KeysRequestModel(
+                encryptedPrivateKey: "PRIVATE_KEY",
+                publicKey: "PUBLIC_KEY",
+            ),
+        )
+
+        let request = try XCTUnwrap(client.requests.first)
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.url.relativePath, "/api/accounts/keys")
+        XCTAssertNotNil(request.body)
+        XCTAssertEqual(response.publicKey, "mockPublicKey")
+        XCTAssertEqual(response.privateKey, "mockPrivateKey")
+    }
+
+    /// `setAccountKeys()` returns a response with accountKeys when provided.
+    func test_setAccountKeys_withAccountKeys() async throws {
+        let json = """
+        {
+          "key": "mockKey",
+          "publicKey": "mockPublicKey",
+          "privateKey": "mockPrivateKey",
+          "accountKeys": {
+            "signatureKeyPair": null,
+            "publicKeyEncryptionKeyPair": {
+              "wrappedPrivateKey": "mockWrappedPrivateKey",
+              "publicKey": "mockPublicKey",
+              "signedPublicKey": null
+            },
+            "securityState": null
+          }
+        }
+        """.data(using: .utf8)!
+        client.result = .httpSuccess(testData: APITestData(data: json))
+
+        let response = try await subject.setAccountKeys(
+            requestModel: KeysRequestModel(
+                encryptedPrivateKey: "PRIVATE_KEY",
+                publicKey: "PUBLIC_KEY",
+            ),
+        )
+
+        XCTAssertEqual(response.key, "mockKey")
+        XCTAssertEqual(response.publicKey, "mockPublicKey")
+        XCTAssertEqual(response.privateKey, "mockPrivateKey")
+        XCTAssertNotNil(response.accountKeys)
+        XCTAssertEqual(
+            response.accountKeys?.publicKeyEncryptionKeyPair.wrappedPrivateKey,
+            "mockWrappedPrivateKey",
+        )
+    }
+
+    /// `setAccountKeys()` throws an error if the request fails.
+    func test_setAccountKeys_httpFailure() async {
+        client.result = .httpFailure()
+
+        await assertAsyncThrows {
+            _ = try await subject.setAccountKeys(
+                requestModel: KeysRequestModel(
+                    encryptedPrivateKey: "PRIVATE_KEY",
+                    publicKey: "PUBLIC_KEY",
+                ),
+            )
+        }
+    }
+
     /// `setKeyConnectorKey()` sets the user's key connector key.
     func test_setKeyConnectorKey() async throws {
         client.result = .httpSuccess(testData: .emptyResponse)

--- a/BitwardenShared/Core/Auth/Services/API/Account/Fixtures/APITestData+Account.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Fixtures/APITestData+Account.swift
@@ -1,0 +1,10 @@
+import TestHelpers
+
+// swiftlint:disable missing_docs
+
+public extension APITestData {
+    static let setAccountKeys = loadFromJsonBundle(resource: "SetAccountKeys")
+    static let setAccountKeysWithAccountKeys = loadFromJsonBundle(resource: "SetAccountKeysWithAccountKeys")
+}
+
+// swiftlint:enable missing_docs

--- a/BitwardenShared/Core/Auth/Services/API/Account/Fixtures/SetAccountKeys.json
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Fixtures/SetAccountKeys.json
@@ -1,0 +1,6 @@
+{
+  "key": null,
+  "publicKey": "mockPublicKey",
+  "privateKey": "mockPrivateKey",
+  "accountKeys": null
+}

--- a/BitwardenShared/Core/Auth/Services/API/Account/Fixtures/SetAccountKeysWithAccountKeys.json
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Fixtures/SetAccountKeysWithAccountKeys.json
@@ -1,0 +1,14 @@
+{
+  "key": null,
+  "publicKey": "mockPublicKey",
+  "privateKey": "mockPrivateKey",
+  "accountKeys": {
+    "signatureKeyPair": null,
+    "publicKeyEncryptionKeyPair": {
+      "wrappedPrivateKey": "mockWrappedPrivateKey",
+      "publicKey": "mockPublicKey",
+      "signedPublicKey": null
+    },
+    "securityState": null
+  }
+}

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/SetAccountKeysRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/SetAccountKeysRequest.swift
@@ -6,7 +6,7 @@ import Networking
 /// The API request sent when submitting the account keys.
 ///
 struct SetAccountKeysRequest: Request {
-    typealias Response = EmptyResponse
+    typealias Response = SetAccountKeysResponseModel
     typealias Body = KeysRequestModel
 
     /// The body of this request.

--- a/BitwardenShared/Core/Auth/Services/KeychainRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepository.swift
@@ -491,7 +491,12 @@ extension DefaultKeychainRepository {
     }
 
     func getDeviceKey(userId: String) async throws -> String? {
-        try await getValue(for: .deviceKey(userId: userId))
+        do {
+            let value: String = try await getValue(for: .deviceKey(userId: userId))
+            return value
+        } catch KeychainServiceError.osStatusError(errSecItemNotFound), KeychainServiceError.keyNotFound {
+            return nil
+        }
     }
 
     func getRefreshToken(userId: String) async throws -> String {
@@ -499,7 +504,12 @@ extension DefaultKeychainRepository {
     }
 
     func getPendingAdminLoginRequest(userId: String) async throws -> String? {
-        try await getValue(for: .pendingAdminLoginRequest(userId: userId))
+        do {
+            let value: String = try await getValue(for: .pendingAdminLoginRequest(userId: userId))
+            return value
+        } catch KeychainServiceError.osStatusError(errSecItemNotFound), KeychainServiceError.keyNotFound {
+            return nil
+        }
     }
 
     func getUserAuthKeyValue(for item: KeychainItem) async throws -> String {

--- a/BitwardenShared/Core/Auth/Services/KeychainRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepositoryTests.swift
@@ -144,6 +144,20 @@ final class KeychainRepositoryTests: BitwardenTestCase { // swiftlint:disable:th
         )
     }
 
+    /// `deletePendingAdminLoginRequest` succeeds quietly.
+    ///
+    func test_deletePendingAdminLoginRequest_success() async throws {
+        let item = KeychainItem.pendingAdminLoginRequest(userId: "1")
+        keychainService.deleteResult = .success(())
+        let expectedQuery = await subject.keychainQueryValues(for: item)
+
+        try await subject.deletePendingAdminLoginRequest(userId: "1")
+        XCTAssertEqual(
+            keychainService.deleteQueries,
+            [expectedQuery],
+        )
+    }
+
     /// The service should generate a storage key for a` KeychainItem`.
     ///
     func test_formattedKey_biometrics() async {
@@ -202,6 +216,54 @@ final class KeychainRepositoryTests: BitwardenTestCase { // swiftlint:disable:th
         await assertAsyncThrows(error: error) {
             _ = try await subject.getAuthenticatorVaultKey(userId: "1")
         }
+    }
+
+    /// `getDeviceKey(userId:)` returns the stored device key.
+    func test_getDeviceKey() async throws {
+        keychainService.setSearchResultData(string: "DEVICE_KEY")
+        let deviceKey = try await subject.getDeviceKey(userId: "1")
+        XCTAssertEqual(deviceKey, "DEVICE_KEY")
+    }
+
+    /// `getDeviceKey(userId:)` throws an error if a non-keyNotFound error occurs.
+    func test_getDeviceKey_error() async {
+        let error = KeychainServiceError.osStatusError(-1)
+        keychainService.searchResult = .failure(error)
+        await assertAsyncThrows(error: error) {
+            _ = try await subject.getDeviceKey(userId: "1")
+        }
+    }
+
+    /// `getDeviceKey(userId:)` returns `nil` when the key is not found.
+    func test_getDeviceKey_notFound() async throws {
+        let error = KeychainServiceError.keyNotFound(KeychainItem.deviceKey(userId: "1"))
+        keychainService.searchResult = .failure(error)
+        let deviceKey = try await subject.getDeviceKey(userId: "1")
+        XCTAssertNil(deviceKey)
+    }
+
+    /// `getPendingAdminLoginRequest(userId:)` returns the stored pending admin login request.
+    func test_getPendingAdminLoginRequest() async throws {
+        keychainService.setSearchResultData(string: "PENDING_ADMIN_LOGIN_REQUEST")
+        let request = try await subject.getPendingAdminLoginRequest(userId: "1")
+        XCTAssertEqual(request, "PENDING_ADMIN_LOGIN_REQUEST")
+    }
+
+    /// `getPendingAdminLoginRequest(userId:)` throws an error if a non-keyNotFound error occurs.
+    func test_getPendingAdminLoginRequest_error() async {
+        let error = KeychainServiceError.osStatusError(-1)
+        keychainService.searchResult = .failure(error)
+        await assertAsyncThrows(error: error) {
+            _ = try await subject.getPendingAdminLoginRequest(userId: "1")
+        }
+    }
+
+    /// `getPendingAdminLoginRequest(userId:)` returns `nil` when the key is not found.
+    func test_getPendingAdminLoginRequest_notFound() async throws {
+        let error = KeychainServiceError.keyNotFound(KeychainItem.pendingAdminLoginRequest(userId: "1"))
+        keychainService.searchResult = .failure(error)
+        let request = try await subject.getPendingAdminLoginRequest(userId: "1")
+        XCTAssertNil(request)
     }
 
     /// `getRefreshToken(userId:)` returns the stored refresh token.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-32845

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
### Summary    

🍒 RC Cherry picked from #2383                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  - Store accountKeys returned from /accounts/keys endpoint when creating new SSO users                                                                                                                                                             
  - Add SetAccountKeysResponseModel to capture the response instead of discarding it                                                                                                                                                                
  - Fixes bug where trusted device selection was not persisted across app restarts for TDE users                                                                                                                                                    
                                                                                                                                                                                                                                           
###  Root Cause                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
  The /accounts/keys endpoint returns account keys in the response, but iOS was using EmptyResponse and discarding this data. The accountKeys field was always set to nil when storing encryption keys, causing the device trust state to not persist.      
  Keychain getDeviceKey was also throwing exception trying to decode literal string value of the device key as json.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                    
###  Solution                                                                                                      
                                                                                                                    
  1. Created SetAccountKeysResponseModel conforming to JSONResponse and AccountKeysResponseModelProtocol                                                                                                                                            
  2. Updated SetAccountKeysRequest to use the new response model                                                                                                                                                                                    
  3. Modified AccountAPIService.setAccountKeys() to return the response                                                                                                                                                                             
  4. Updated AuthRepository.createNewSsoUser() to store accountKeys from the response                                                                                                                                                               
                                                                                         
## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


https://github.com/user-attachments/assets/b8041f1c-bb3d-41e5-ba12-5b53a1933c2d