### PR TITLE
[PM-33252] fix: Fix update profile KDF values from User decryption options on sync

### DIFF
--- a/BitwardenShared/Core/Auth/Services/ChangeKdfService.swift
+++ b/BitwardenShared/Core/Auth/Services/ChangeKdfService.swift
@@ -98,7 +98,7 @@ class DefaultChangeKdfService: ChangeKdfService {
 
             // If the account needs a KDF update, sync the user's account and check again before
             // proceeding to ensure the local data is up-to-date.
-            try await syncService.fetchSync(forceSync: false)
+            try await syncService.fetchSync(forceSync: true)
             return try await accountNeedsKdfUpdate()
         } catch {
             errorReporter.log(error: error)

--- a/BitwardenShared/Core/Auth/Services/ChangeKdfServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/ChangeKdfServiceTests.swift
@@ -78,7 +78,7 @@ class ChangeKdfServiceTests: BitwardenTestCase {
         let needsUpdate = await subject.needsKdfUpdateToMinimums()
         XCTAssertFalse(needsUpdate)
         XCTAssertTrue(syncService.didFetchSync)
-        XCTAssertEqual(syncService.fetchSyncForceSync, false)
+        XCTAssertEqual(syncService.fetchSyncForceSync, true)
     }
 
     /// `needsKdfUpdateToMinimums()` returns false and logs an error if one occurs.
@@ -147,7 +147,7 @@ class ChangeKdfServiceTests: BitwardenTestCase {
         let needsUpdate = await subject.needsKdfUpdateToMinimums()
         XCTAssertTrue(needsUpdate)
         XCTAssertTrue(syncService.didFetchSync)
-        XCTAssertEqual(syncService.fetchSyncForceSync, false)
+        XCTAssertEqual(syncService.fetchSyncForceSync, true)
     }
 
     /// `updateKdfToMinimums(password:)` updates the user's KDF settings.

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1869,6 +1869,12 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
                 trustedDeviceOption: nil,
             )
         userDecryptionOptions.masterPasswordUnlock = masterPasswordUnlock
+
+        profile.kdfIterations = masterPasswordUnlock.kdf.iterations
+        profile.kdfType = masterPasswordUnlock.kdf.kdfType
+        profile.kdfMemory = masterPasswordUnlock.kdf.memory
+        profile.kdfParallelism = masterPasswordUnlock.kdf.parallelism
+
         profile.userDecryptionOptions = userDecryptionOptions
         state.accounts[userId]?.profile = profile
         appSettingsStore.state = state

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -2070,9 +2070,17 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         let user1 = appSettingsStore.state?.accounts["1"]
         XCTAssertEqual(user1?.profile.userDecryptionOptions?.masterPasswordUnlock, masterPasswordUnlockUser1)
+        XCTAssertEqual(user1?.profile.kdfType, .pbkdf2sha256)
+        XCTAssertEqual(user1?.profile.kdfIterations, 600_000)
+        XCTAssertNil(user1?.profile.kdfMemory)
+        XCTAssertNil(user1?.profile.kdfParallelism)
 
         let user2 = appSettingsStore.state?.accounts["2"]
         XCTAssertEqual(user2?.profile.userDecryptionOptions?.masterPasswordUnlock, masterPasswordUnlockUser2)
+        XCTAssertEqual(user2?.profile.kdfType, .argon2id)
+        XCTAssertEqual(user2?.profile.kdfIterations, 3)
+        XCTAssertEqual(user2?.profile.kdfMemory, 64)
+        XCTAssertEqual(user2?.profile.kdfParallelism, 4)
         // Ensure any existing other decryption options aren't affected.
         XCTAssertEqual(
             user2?.profile.userDecryptionOptions,


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33252](https://bitwarden.atlassian.net/browse/PM-33252)

## 📔 Objective

Fix update profile KDF values from User decryption options on sync so KDF upgrade checks are done with latest KDF values from the server. This was causing an alert to upgrade KDF to display in a loop as the iOS app was never updating the old KDF values when the server got updated from another client.


[PM-33252]: https://bitwarden.atlassian.net/browse/PM-33252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ