### PR TITLE
[PM-31722] chore: Add WatchService tests

### DIFF
--- a/BitwardenShared/Core/Platform/Services/WatchService.swift
+++ b/BitwardenShared/Core/Platform/Services/WatchService.swift
@@ -38,7 +38,7 @@ class DefaultWatchService: NSObject, WatchService {
     private let organizationService: OrganizationService
 
     /// The watch connect session.
-    private var session: WCSession?
+    private var session: (any WatchSession)?
 
     /// The service used by the application to manage account state.
     private let stateService: StateService
@@ -46,6 +46,9 @@ class DefaultWatchService: NSObject, WatchService {
     /// Keep a reference to the task used to sync the watch when the ciphers change, so that
     /// it can be cancelled and recreated when the user changes.
     private var syncCiphersTask: Task<Void, Never>?
+
+    /// The factory used to create and check support for watch sessions.
+    private let watchSessionFactory: WatchSessionFactory
 
     // MARK: Initialization
 
@@ -59,6 +62,7 @@ class DefaultWatchService: NSObject, WatchService {
     ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - organizationService: The service used to manage syncing and updates to the user's organizations.
     ///   - stateService: The service used by the application to manage account state.
+    ///   - watchSessionFactory: The factory used to create and check support for watch sessions.
     ///
     init(
         cipherService: CipherService,
@@ -68,6 +72,7 @@ class DefaultWatchService: NSObject, WatchService {
         errorReporter: ErrorReporter,
         organizationService: OrganizationService,
         stateService: StateService,
+        watchSessionFactory: WatchSessionFactory = DefaultWatchSessionFactory(),
     ) {
         self.cipherService = cipherService
         self.clientService = clientService
@@ -76,6 +81,7 @@ class DefaultWatchService: NSObject, WatchService {
         self.errorReporter = errorReporter
         self.organizationService = organizationService
         self.stateService = stateService
+        self.watchSessionFactory = watchSessionFactory
         super.init()
 
         // Listen for changes in the settings and data that would require syncing with the watch.
@@ -88,8 +94,21 @@ class DefaultWatchService: NSObject, WatchService {
 
     // MARK: Methods
 
+    /// Handle messages received from the watch to listen for requests to sync.
+    ///
+    /// - Parameter message: The message received from the watch.
+    ///
+    func handleMessage(_ message: [String: Any]) async {
+        if let actionMessage = message["actionMessage"] as? String, actionMessage == "triggerSync" {
+            let userId = try? await stateService.getActiveAccountId()
+            let shouldConnect = try? await stateService.getConnectToWatch()
+            let lastUserShouldConnectToWatch = await stateService.getLastUserShouldConnectToWatch()
+            syncWithWatch(userId: userId, shouldConnect: shouldConnect ?? lastUserShouldConnectToWatch)
+        }
+    }
+
     func isSupported() -> Bool {
-        WCSession.isSupported()
+        watchSessionFactory.isSupported()
     }
 
     // MARK: Private Methods
@@ -149,26 +168,10 @@ class DefaultWatchService: NSObject, WatchService {
         return (userData, .valid)
     }
 
-    /// Handle messages received from the watch to listen for requests to sync.
-    ///
-    /// - Parameter message: The message received from the watch.
-    ///
-    private func handleMessage(_ message: [String: Any]) {
-        if let actionMessage = message["actionMessage"] as? String,
-           actionMessage == "triggerSync" {
-            Task {
-                let userId = try? await self.stateService.getActiveAccountId()
-                let shouldConnect = try? await self.stateService.getConnectToWatch()
-                let lastUserShouldConnectToWatch = await self.stateService.getLastUserShouldConnectToWatch()
-                syncWithWatch(userId: userId, shouldConnect: shouldConnect ?? lastUserShouldConnectToWatch)
-            }
-        }
-    }
-
     /// Start the session to connect to the watch.
     private func startSession() {
-        if WCSession.isSupported(), session == nil {
-            session = WCSession.default
+        if watchSessionFactory.isSupported(), session == nil {
+            session = watchSessionFactory.makeSession()
             session?.delegate = self
         }
         if session?.activationState != .activated {
@@ -183,7 +186,7 @@ class DefaultWatchService: NSObject, WatchService {
     ///   - shouldConnect: Whether the user has toggled on the connect to watch setting.
     ///
     private func syncWithWatch(ciphers: [Cipher], shouldConnect: Bool) async throws {
-        guard WCSession.isSupported() else { return }
+        guard watchSessionFactory.isSupported() else { return }
 
         // Connect the session if necessary.
         if shouldConnect, session?.activationState != .activated {
@@ -262,7 +265,9 @@ extension DefaultWatchService: WCSessionDelegate {
 
     /// Handle messages received from the watch.
     func session(_: WCSession, didReceiveMessage message: [String: Any]) {
-        handleMessage(message)
+        Task {
+            await handleMessage(message)
+        }
     }
 
     /// Handle messages received from the watch.
@@ -271,14 +276,16 @@ extension DefaultWatchService: WCSessionDelegate {
         didReceiveMessage message: [String: Any],
         replyHandler _: @escaping ([String: Any]) -> Void,
     ) {
-        handleMessage(message)
+        Task {
+            await handleMessage(message)
+        }
     }
 }
 
-// MARK: - WCSession
+// MARK: WatchSession Extension
 
-extension WCSession {
-    /// A convenience method for supreme laziness to send a state to the watch.
+extension WatchSession {
+    /// A convenience method to send an invalid state to the watch.
     ///
     /// - Parameter state: The invalid state to send.
     ///

--- a/BitwardenShared/Core/Platform/Services/WatchServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/WatchServiceTests.swift
@@ -1,0 +1,296 @@
+import BitwardenKitMocks
+import BitwardenSdk
+import Combine
+import TestHelpers
+import Testing
+import WatchConnectivity
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - WatchServiceTests
+
+@MainActor
+struct WatchServiceTests {
+    // MARK: Properties
+
+    var cipherService: MockCipherService!
+    var clientService: MockClientService!
+    var configService: MockConfigService!
+    var environmentService: MockEnvironmentService!
+    var errorReporter: MockErrorReporter!
+    var organizationService: MockOrganizationService!
+    var stateService: MockStateService!
+    var watchSession: MockWatchSession!
+    var watchSessionFactory: MockWatchSessionFactory!
+    var subject: DefaultWatchService!
+
+    // MARK: Initialization
+
+    init() async throws {
+        cipherService = MockCipherService()
+        clientService = MockClientService()
+        configService = MockConfigService()
+        environmentService = MockEnvironmentService()
+        errorReporter = MockErrorReporter()
+        organizationService = MockOrganizationService()
+        stateService = MockStateService()
+
+        watchSession = MockWatchSession()
+        watchSession.underlyingIsPaired = true
+        watchSession.underlyingIsWatchAppInstalled = true
+        watchSession.underlyingActivationState = .activated
+
+        watchSessionFactory = MockWatchSessionFactory()
+        watchSessionFactory.isSupportedReturnValue = true
+        watchSessionFactory.makeSessionReturnValue = watchSession
+
+        stateService.activeAccount = .fixture(profile: .fixture(hasPremiumPersonally: true))
+        stateService.connectToWatchSubject = CurrentValueSubject((nil, false))
+
+        // Let the sync task in DefaultWatchService start up and run the initial pass to prevent
+        // potential race conditions. This is done by waiting on `isSupported` to be called
+        // and returning false so no initial sync is run, leaving the tests in a stable place to
+        // start from.
+        await withContinuationTimeout { resume in
+            watchSessionFactory.isSupportedClosure = {
+                resume()
+                return false
+            }
+
+            subject = DefaultWatchService(
+                cipherService: cipherService,
+                clientService: clientService,
+                configService: configService,
+                environmentService: environmentService,
+                errorReporter: errorReporter,
+                organizationService: organizationService,
+                stateService: stateService,
+                watchSessionFactory: watchSessionFactory,
+            )
+        }
+        watchSessionFactory.isSupportedClosure = nil
+    }
+
+    // MARK: handleMessage Tests
+
+    /// When a `triggerSync` message is received, the service re-syncs.
+    @Test
+    func handleMessage_triggerSync_syncsCalled() async throws {
+        clientService.mockVault.clientCiphers.decryptResult = { _ in
+            .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
+        }
+        stateService.connectToWatchByUserId["1"] = true
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            cipherService.ciphersSubject.send([.fixture()])
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            Task {
+                // Simulate a message from the watch via the internal handler.
+                await subject.handleMessage(["actionMessage": "triggerSync"])
+            }
+        }
+
+        #expect(watchSession.updateApplicationContextCallsCount == 2)
+    }
+
+    // MARK: isSupported Tests
+
+    /// `isSupported()` returns `false` when the factory reports the session is not supported.
+    @Test
+    func isSupported_returnsFalse() {
+        watchSessionFactory.isSupportedReturnValue = false
+        #expect(subject.isSupported() == false)
+    }
+
+    /// `isSupported()` returns `true` when the factory reports the session is supported.
+    @Test
+    func isSupported_returnsTrue() {
+        watchSessionFactory.isSupportedReturnValue = true
+        #expect(subject.isSupported() == true)
+    }
+
+    // MARK: syncWithWatch Tests
+
+    /// `syncWithWatch()` sends a `.needLogin` state when there is no active account.
+    @Test
+    func syncWithWatch_noActiveAccount_sendsNeedLogin() async throws {
+        stateService.activeAccount = nil
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send((nil, true))
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        #expect(dto.state == .needLogin)
+    }
+
+    /// `syncWithWatch()` sends a `.needSetup` state when `shouldConnect` is `false`.
+    @Test
+    func syncWithWatch_shouldNotConnect_sendsNeedSetup() async throws {
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            // First, establish the session by syncing with shouldConnect = true.
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            // Now update with shouldConnect = false — the existing session will be used.
+            stateService.connectToWatchSubject.send(("1", false))
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        #expect(dto.state == .needSetup)
+    }
+
+    /// `syncWithWatch()` sends a `.needPremium` state when the user has no premium personally and
+    /// no qualifying org.
+    @Test
+    func syncWithWatch_noPremium_sendsNeedPremium() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(hasPremiumPersonally: false))
+        organizationService.fetchAllOrganizationsResult = .success([])
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        #expect(dto.state == .needPremium)
+    }
+
+    /// `syncWithWatch()` proceeds past the premium gate with sync when the user has premium via org.
+    @Test
+    func syncWithWatch_premiumViaOrg_proceedsToSync() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(hasPremiumPersonally: false))
+        organizationService.fetchAllOrganizationsResult = .success([
+            .fixture(enabled: true, usersGetPremium: true),
+        ])
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        // Passed premium gate; empty TOTP list results in need2FAItem.
+        #expect(dto.state == .need2FAItem)
+    }
+
+    /// `syncWithWatch()` sends a `.need2FAItem` state when there are no TOTP ciphers.
+    @Test
+    func syncWithWatch_noTotpCiphers_sendsNeed2FAItem() async throws {
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        #expect(dto.state == .need2FAItem)
+    }
+
+    /// `syncWithWatch()` sends a `.valid` state and a list of ciphers if the user has premium and
+    /// connect to watch enabled.
+    @Test
+    func syncWithWatch_validState_sendsWatchData() async throws {
+        clientService.mockVault.clientCiphers.decryptResult = { _ in
+            .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            cipherService.ciphersSubject.send([.fixture()])
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        #expect(dto.state == .valid)
+        #expect(dto.ciphers?.count == 1)
+        #expect(dto.ciphers?.first?.id == "cipher-1")
+    }
+
+    /// `syncWithWatch()` re-syncs with new data when ciphers update.
+    @Test
+    func syncWithWatch_ciphersUpdate_resyncs() async throws {
+        clientService.mockVault.clientCiphers.decryptResult = { _ in
+            .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            // Send a cipher update.
+            cipherService.ciphersSubject.send([.fixture()])
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            // Send a second cipher update.
+            cipherService.ciphersSubject.send([.fixture(), .fixture(id: "cipher-2")])
+        }
+
+        let dto = try decodedDTO(from: watchSession.updateApplicationContextReceivedApplicationContext)
+        #expect(dto.state == .valid)
+        #expect(dto.ciphers?.count == 2)
+    }
+
+    // MARK: connectToWatchPublisher Tests
+
+    /// When the publisher emits twice, only the latest sync task remains active.
+    @Test
+    func connectToWatchPublisher_newUser_cancelsPreviousTask() async throws {
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            stateService.connectToWatchSubject.send(("1", true))
+        }
+
+        await withContinuationTimeout { resume in
+            watchSession.updateApplicationContextClosure = { _ in resume() }
+
+            // Second emission should cancel the first task and create a new one.
+            stateService.connectToWatchSubject.send(("2", true))
+        }
+
+        // Each emission syncs; the second emission produces at least one additional sync.
+        #expect(watchSession.updateApplicationContextCallsCount == 2)
+    }
+
+    // MARK: Helpers
+
+    /// Decodes a `WatchDTO` from the last-sent `updateApplicationContext` call.
+    private func decodedDTO(from context: [String: Any]?) throws -> WatchDTO {
+        let sentData = try #require(context)
+        let compressedData = try #require(sentData.values.first as? NSData)
+        let decompressed = try compressedData.decompressed(using: .lzfse) as Data
+        return try MessagePackDecoder().decode(WatchDTO.self, from: decompressed)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/WatchSession.swift
+++ b/BitwardenShared/Core/Platform/Services/WatchSession.swift
@@ -1,0 +1,59 @@
+import WatchConnectivity
+
+// MARK: - WatchSession
+
+/// A protocol abstracting instance-level usage of `WCSession` to enable testability.
+///
+protocol WatchSession: AnyObject { // sourcery: AutoMockable
+    /// The current activation state of the session.
+    var activationState: WCSessionActivationState { get }
+
+    /// The delegate for the session.
+    var delegate: (any WCSessionDelegate)? { get set }
+
+    /// Whether an Apple Watch is paired with the iPhone.
+    var isPaired: Bool { get }
+
+    /// Whether the Watch app is installed on the paired watch.
+    var isWatchAppInstalled: Bool { get }
+
+    /// Activates the session.
+    func activate()
+
+    /// Sends new state information to the paired and active Apple Watch.
+    ///
+    /// - Parameter applicationContext: A dictionary of state information to send.
+    ///
+    func updateApplicationContext(_ applicationContext: [String: Any]) throws
+}
+
+// MARK: - WCSession + WatchSession
+
+extension WCSession: WatchSession {}
+
+// MARK: - WatchSessionFactory
+
+/// A factory that provides access to `WatchSession` and its static-level support check.
+///
+protocol WatchSessionFactory { // sourcery: AutoMockable
+    /// Whether the current device supports Watch sessions.
+    func isSupported() -> Bool
+
+    /// Returns the default watch session if the device supports it, otherwise `nil`.
+    func makeSession() -> (any WatchSession)?
+}
+
+// MARK: - DefaultWatchSessionFactory
+
+/// The default `WatchSessionFactory` for the production app.
+///
+struct DefaultWatchSessionFactory: WatchSessionFactory {
+    func isSupported() -> Bool {
+        WCSession.isSupported()
+    }
+
+    func makeSession() -> (any WatchSession)? {
+        guard WCSession.isSupported() else { return nil }
+        return WCSession.default
+    }
+}

--- a/BitwardenShared/Sourcery/sourcery.yml
+++ b/BitwardenShared/Sourcery/sourcery.yml
@@ -14,5 +14,5 @@ exclude:
   - Fixtures
 
 args:
-  autoMockableImports: ["BitwardenKit", "BitwardenSdk", "Combine"]
+  autoMockableImports: ["BitwardenKit", "BitwardenSdk", "Combine", "WatchConnectivity"]
   autoMockableTestableImports: ["BitwardenShared"]

--- a/TestHelpers/Support/SwiftTestingHelpers.swift
+++ b/TestHelpers/Support/SwiftTestingHelpers.swift
@@ -1,0 +1,90 @@
+// swiftlint:disable:this file_name
+
+import Foundation
+import Testing
+
+// MARK: - waitForAsync
+
+/// Wait for a condition asynchronously to be true. The test will fail if the condition isn't met
+/// before the specified timeout.
+///
+/// - Parameters:
+///   - condition: Return `true` to continue or `false` to keep waiting.
+///   - timeout: How long to wait before failing.
+///   - sourceLocation: The source location of the call site. Defaults to the location where this
+///     function is called from.
+///
+@MainActor
+public func waitForAsync(
+    _ condition: @escaping () -> Bool,
+    timeout: TimeInterval = 10.0,
+    failureMessage: Comment = "waitForAsync condition wasn't met within the time limit",
+    sourceLocation: SourceLocation = #_sourceLocation,
+) async throws {
+    let limit = Date(timeIntervalSinceNow: timeout)
+    while !condition(), limit > Date() {
+        try await Task.sleep(nanoseconds: 20_000_000)
+    }
+    #expect(condition(), failureMessage, sourceLocation: sourceLocation)
+}
+
+// MARK: - withContinuationTimeout
+
+/// Waits for a callback-based async operation to call its `resume` closure, recording a test
+/// failure if `resume` is not called within the specified time.
+///
+/// Use this instead of `withCheckedContinuation` in tests to prevent indefinite hangs when the
+/// expected callback is never called.
+///
+/// ```swift
+/// await withContinuationTimeout { resume in
+///     mockService.onComplete = { resume() }
+///     subject.performAction()
+/// }
+/// ```
+///
+/// - Parameters:
+///   - timeout: How long to wait before recording a failure. Defaults to 10 seconds.
+///   - sourceLocation: The source location of the call site. Defaults to the location where this
+///     function is called from.
+///   - body: A closure that receives a `resume` callback. Call `resume()` to unblock the wait.
+///
+@MainActor
+public func withContinuationTimeout(
+    timeout: TimeInterval = 10.0,
+    sourceLocation: SourceLocation = #_sourceLocation,
+    body: (@escaping () -> Void) -> Void,
+) async {
+    struct TimedOut: Error {}
+
+    do {
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            let stream = AsyncStream<Void> { continuation in
+                body { continuation.yield(()) }
+            }
+
+            group.addTask {
+                for await _ in stream {
+                    return
+                }
+                throw CancellationError()
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                throw TimedOut()
+            }
+
+            try await group.next()
+            group.cancelAll()
+        }
+    } catch is TimedOut {
+        Issue.record(
+            "withContinuationTimeout: callback was not called within \(timeout)s",
+            sourceLocation: sourceLocation,
+        )
+    } catch {
+        // CancellationError from the stream-iterating task, thrown after the timeout fires and
+        // the task group cancels it. Expected and safe to ignore.
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31722](https://bitwarden.atlassian.net/browse/PM-31722)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Adds an initial set of tests for `WatchService`. This includes a mock for `WCSession`, which didn't exist previously. Adding these first before fixing an issue in my next PR.

This introduces a `withContinuationTimeout` helper for tests which need to wait on a callback before proceeding. It's similar to `withCheckedContinuation` but adds a timeout. This can be used as an alternative to `waitForAsync`, and works well for waiting on mock closure calls.

```
// This will wait until `mockFunctionClosure` is called
await withContinuationTimeout { resume in
    mock.mockFunctionClosure = { resume() }

    // Trigger something that will call `mockFunctionClosure` in the mock
}
```

[PM-31722]: https://bitwarden.atlassian.net/browse/PM-31722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ