### PR TITLE
[PM-32575] [RC] feat: Update SSO cookies acquired try again dialog message

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1322,3 +1322,4 @@
 "WhoCanView" = "Who can view";
 "SharingWithSpecificPeopleIsPremiumFeatureDescriptionLong" = "Sharing with specific people is a Premium feature. Your current plan does not include access to this feature.";
 "SsoCookiesCleared" = "SSO cookies cleared";
+"YourRequestWasInterruptedBecauseTheAppNeededToReAuthenticatePleaseTryAgain" = "Your request was interrupted because the app needed to re-authenticate. Please try again.";

--- a/BitwardenShared/Core/Platform/Services/API/Handlers/SSOCookieVendorResponseHandler.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Handlers/SSOCookieVendorResponseHandler.swift
@@ -53,7 +53,7 @@ struct SSOCookieVendorResponseHandler: ResponseHandler {
         throw ServerError.error(
             errorResponse: ErrorResponseModel(
                 validationErrors: nil,
-                message: Localizations.tryAgain,
+                message: Localizations.yourRequestWasInterruptedBecauseTheAppNeededToReAuthenticatePleaseTryAgain,
             ),
         )
     }

--- a/BitwardenShared/Core/Platform/Services/API/Handlers/SSOCookieVendorResponseHandlerTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/Handlers/SSOCookieVendorResponseHandlerTests.swift
@@ -153,7 +153,10 @@ class SSOCookieVendorResponseHandlerTests: BitwardenTestCase {
             XCTFail("Expected ServerError.error, got \(String(describing: thrownError))")
             return
         }
-        XCTAssertEqual(errorResponse.message, Localizations.tryAgain)
+        XCTAssertEqual(
+            errorResponse.message,
+            Localizations.yourRequestWasInterruptedBecauseTheAppNeededToReAuthenticatePleaseTryAgain,
+        )
     }
 
     /// `handle(_:for:retryWith:)` throws the underlying error when `acquireCookie` fails with


### PR DESCRIPTION
## 🎟️ Tracking

[PM-32575](https://bitwarden.atlassian.net/browse/PM-32575)

## 📔 Objective

🍒 Cherry picked from #2409.
Update SSO cookies acquired try again dialog message.

## 📸 Screenshots

<img width="314" alt="Cookies acquired try again message" src="https://github.com/user-attachments/assets/0efa9e03-7b7b-4bfb-acfb-fabf4cc5e465" />



[PM-32575]: https://bitwarden.atlassian.net/browse/PM-32575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ