### PR TITLE
[PM-33230] [RC] fix: Remove error alert on known devices check

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServerCommunicationConfigClientSingletonTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ServerCommunicationConfigClientSingletonTests.swift
@@ -274,8 +274,6 @@ class ServerCommunicationConfigClientSingletonTests: BitwardenTestCase { // swif
     func test_configPublisher_ssoCookieVendor_usesCookieDomainAsHostname() async throws {
         let cookieDomain = "example.com"
         let hostname = "example.com"
-        let mockSdkClient = MockServerCommunicationConfigClient()
-        clientService.mockPlatform.serverCommunicationConfigResult = mockSdkClient
         sdkRepositoryFactory.makeServerCommunicationConfigRepositoryReturnValue =
             SdkServerCommunicationConfigRepository(serverCommunicationConfigStateService: stateService)
 
@@ -283,9 +281,9 @@ class ServerCommunicationConfigClientSingletonTests: BitwardenTestCase { // swif
             makeMetaServerConfig(communication: makeSSOCommunicationSettings(cookieDomain: cookieDomain)),
         )
 
-        try await waitForAsync { mockSdkClient.setCommunicationTypeCallsCount == 1 }
+        try await waitForAsync { self.serverCommunicationConfigClient.setCommunicationTypeCallsCount > 0 }
 
-        XCTAssertEqual(mockSdkClient.setCommunicationTypeReceivedHostname, hostname)
+        XCTAssertEqual(serverCommunicationConfigClient.setCommunicationTypeReceivedHostname, hostname)
         XCTAssertTrue(errorReporter.errors.isEmpty)
     }
 
@@ -293,8 +291,6 @@ class ServerCommunicationConfigClientSingletonTests: BitwardenTestCase { // swif
     @MainActor
     func test_configPublisher_ssoCookieVendor_nilCookieDomain_fallsBackToWebVaultHost() async throws {
         let expectedHostname = try XCTUnwrap(environmentService.webVaultURL.host)
-        let mockSdkClient = MockServerCommunicationConfigClient()
-        clientService.mockPlatform.serverCommunicationConfigResult = mockSdkClient
         sdkRepositoryFactory.makeServerCommunicationConfigRepositoryReturnValue =
             SdkServerCommunicationConfigRepository(serverCommunicationConfigStateService: stateService)
 
@@ -302,9 +298,9 @@ class ServerCommunicationConfigClientSingletonTests: BitwardenTestCase { // swif
             makeMetaServerConfig(communication: makeSSOCommunicationSettings(cookieDomain: nil)),
         )
 
-        try await waitForAsync { mockSdkClient.setCommunicationTypeCallsCount == 1 }
+        try await waitForAsync { self.serverCommunicationConfigClient.setCommunicationTypeCallsCount > 0 }
 
-        XCTAssertEqual(mockSdkClient.setCommunicationTypeReceivedHostname, expectedHostname)
+        XCTAssertEqual(serverCommunicationConfigClient.setCommunicationTypeReceivedHostname, expectedHostname)
         XCTAssertTrue(errorReporter.errors.isEmpty)
     }
 

--- a/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessor.swift
@@ -156,7 +156,7 @@ class LoginProcessor: StateProcessor<LoginState, LoginAction, LoginEffect> {
             )
             state.isLoginWithDeviceVisible = isKnownDevice
         } catch {
-            await handleErrorResponse(error)
+            services.errorReporter.log(error: error)
         }
     }
 

--- a/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift
@@ -9,8 +9,6 @@ import XCTest
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
-// swiftlint:disable file_length
-
 // MARK: - LoginProcessorTests
 
 class LoginProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
@@ -70,7 +68,8 @@ class LoginProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     // MARK: Tests
 
-    /// `perform(_:)` with `.appeared` and an error occurs does not update the login with button visibility.
+    /// `perform(_:)` with `.appeared` and an error occurs does not update the login with button visibility,
+    /// and only logs the error without showing an alert.
     @MainActor
     func test_perform_appeared_failure() async throws {
         subject.state.isLoginWithDeviceVisible = false
@@ -82,96 +81,8 @@ class LoginProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.loading)])
         XCTAssertFalse(subject.state.isLoginWithDeviceVisible)
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
-    }
-
-    /// `perform(_:)` with `.appeared` and an error occurs with an unofficial server and the error isn't expected.
-    @MainActor
-    func test_perform_appeared_failure_unofficialServer() async throws {
-        configService.configMocker.withResult(
-            ServerConfig(
-                date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: nil,
-                    featureStates: [:],
-                    gitHash: "75238191",
-                    server: .init(name: "Vaultwarden", url: "example.com"),
-                    version: "2024.4.0",
-                ),
-            ),
-        )
-        subject.state.isLoginWithDeviceVisible = false
-        client.results = [
-            .httpFailure(BitwardenTestError.example),
-        ]
-        await subject.perform(.appeared)
-
-        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.loading)])
-        XCTAssertFalse(subject.state.isLoginWithDeviceVisible)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .networkResponseError(
-                BitwardenTestError.example,
-                isOfficialBitwardenServer: false,
-            ),
-        )
-        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
-    }
-
-    /// `perform(_:)` with `.appeared` and an error occurs with an unofficial server but the error is expected.
-    @MainActor
-    func test_perform_appeared_failure_supportedErrorWithUnofficialServer() async throws {
-        configService.configMocker.withResult(
-            ServerConfig(
-                date: Date(year: 2024, month: 2, day: 14, hour: 7, minute: 50, second: 0),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: nil,
-                    featureStates: [:],
-                    gitHash: "75238191",
-                    server: .init(name: "Vaultwarden", url: "example.com"),
-                    version: "2024.4.0",
-                ),
-            ),
-        )
-        subject.state.isLoginWithDeviceVisible = false
-
-        let validationResponse = ResponseValidationErrorModel(
-            error: "Invalid credentials",
-            errorDescription: "an error occurred",
-            errorModel: .init(
-                message: "message",
-                object: "object",
-            ),
-        )
-
-        client.results = [
-            .httpFailure(
-                ServerError.validationError(
-                    validationErrorResponse: validationResponse,
-                ),
-            ),
-        ]
-
-        await subject.perform(.appeared)
-
-        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-        XCTAssertEqual(coordinator.loadingOverlaysShown, [.init(title: Localizations.loading)])
-        XCTAssertFalse(subject.state.isLoginWithDeviceVisible)
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .networkResponseError(
-                ServerError.validationError(validationErrorResponse: validationResponse),
-                isOfficialBitwardenServer: false,
-            ),
-        )
-        XCTAssertEqual(
-            errorReporter.errors.last as? ServerError,
-            .validationError(validationErrorResponse: validationResponse),
-        )
     }
 
     /// `perform(_:)` with `.appeared` and a true result shows the login with device button.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33230](https://bitwarden.atlassian.net/browse/PM-33230)

## 📔 Objective

🍒 Cherry picked for RC from: #2414.
Known devices check in login shouldn't display an alert error if it fails.

[PM-33230]: https://bitwarden.atlassian.net/browse/PM-33230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ