### PR TITLE
[PM-33231] [RC] fix: Dismiss keyboard on sync with browser view

### DIFF
--- a/BitwardenShared/UI/Auth/Login/SyncWithBrowser/SyncWithBrowserView.swift
+++ b/BitwardenShared/UI/Auth/Login/SyncWithBrowser/SyncWithBrowserView.swift
@@ -52,6 +52,7 @@ struct SyncWithBrowserView: View {
         .padding(.top, 12)
         .frame(maxWidth: .infinity)
         .scrollView()
+        .dismissKeyboardOnAppear()
         .task {
             await store.perform(.appeared)
         }

--- a/BitwardenShared/UI/Platform/Application/Extensions/View.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View.swift
@@ -2,6 +2,8 @@ import BitwardenKit
 import BitwardenResources
 import SwiftUI
 
+// MARK: - View
+
 /// Helper functions extended off the `View` protocol.
 ///
 extension View {
@@ -114,6 +116,13 @@ extension View {
         .hidden(hidden)
     }
 
+    /// Dismisses the keyboard when the view appears.
+    /// Safe for use in both app targets and app extensions.
+    ///
+    func dismissKeyboardOnAppear() -> some View {
+        background(KeyboardDismissOnAppearView())
+    }
+
     /// Returns a floating action button positioned at the bottom-right corner of the screen.
     ///
     /// - Parameters:
@@ -154,4 +163,23 @@ extension View {
         .padding([.trailing, .bottom], 16)
         .hidden(hidden)
     }
+}
+
+// MARK: - KeyboardDismissOnAppearView
+
+/// A transparent UIViewRepresentable that dismisses the keyboard when it appears.
+/// Uses `window?.endEditing(true)` to avoid `UIApplication.shared`, making it
+/// safe for use in both app targets and app extensions.
+///
+private struct KeyboardDismissOnAppearView: UIViewRepresentable {
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView(frame: .zero)
+        view.backgroundColor = .clear
+        DispatchQueue.main.async {
+            view.window?.endEditing(true)
+        }
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {}
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33231](https://bitwarden.atlassian.net/browse/PM-33231)

## 📔 Objective

🍒 Cherry picked from #2415 
Dismiss keyboard on sync with browser view in case the previous view showed it.


[PM-33231]: https://bitwarden.atlassian.net/browse/PM-33231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ