### PR TITLE
[PM-33231] fix: Fix keyboard being shown on sync with browser from login screen

### DIFF
--- a/BitwardenShared/UI/Platform/Application/Extensions/View.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View.swift
@@ -175,6 +175,8 @@ private struct KeyboardDismissOnAppearView: UIViewRepresentable {
     func makeUIView(context: Context) -> UIView {
         let view = UIView(frame: .zero)
         view.backgroundColor = .clear
+
+        /// Wait a bit so the animation ends and also until the keyboard is actually shown to be dismissed.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
             view.window?.endEditing(true)
         }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33231](https://bitwarden.atlassian.net/browse/PM-33231)

## 📔 Objective

Fix keyboard being shown on sync with browser from login screen request.
The proposed fix here is just wait a bit to dismiss the keyboard so it has time to be shown first.


[PM-33231]: https://bitwarden.atlassian.net/browse/PM-33231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ