### PR TITLE
[PM-33390] PM-33287: Change minimum numbers/special max value from 5 to 9

### DIFF
--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorProcessorTests.swift
@@ -1124,7 +1124,7 @@ class GeneratorProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         StepperField<GeneratorState>(
             accessibilityId: accessibilityId,
             keyPath: keyPath,
-            range: 0 ... 5,
+            range: 0 ... 9,
             title: Localizations.minNumbers,
             value: 1,
         )

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorState.swift
@@ -319,13 +319,13 @@ extension GeneratorState {
                     stepperField(
                         accessibilityId: "MinNumberValueLabel",
                         keyPath: \.passwordState.minimumNumber,
-                        range: 0 ... 5,
+                        range: 0 ... 9,
                         title: Localizations.minNumbers,
                     ),
                     stepperField(
                         accessibilityId: "MinSpecialValueLabel",
                         keyPath: \.passwordState.minimumSpecial,
-                        range: 0 ... 5,
+                        range: 0 ... 9,
                         title: Localizations.minSpecial,
                     ),
                     toggleField(

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorStateTests.swift
@@ -68,8 +68,8 @@ class GeneratorStateTests: BitwardenTestCase { // swiftlint:disable:this type_bo
               Toggle: a-z Value: true
               Toggle: 0-9 Value: true
               Toggle: !@#$%^&* Value: false
-              Stepper: Minimum numbers Value: 1 Range: 0...5
-              Stepper: Minimum special Value: 1 Range: 0...5
+              Stepper: Minimum numbers Value: 1 Range: 0...9
+              Stepper: Minimum special Value: 1 Range: 0...9
               Toggle: Avoid ambiguous characters Value: false
             """
         }

--- a/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Generator/Generator/GeneratorView+ViewInspectorTests.swift
@@ -180,7 +180,7 @@ class GeneratorViewTests: BitwardenTestCase {
         let field = StepperField<GeneratorState>(
             accessibilityId: "MinNumberValueLabel",
             keyPath: \.passwordState.minimumNumber,
-            range: 0 ... 5,
+            range: 0 ... 9,
             title: Localizations.minNumbers,
             value: 1,
         )


### PR DESCRIPTION
## Code changes

- Updated stepper ranges from `0...5` to `0...9` in `GeneratorState.swift`
- Updated corresponding test expectations in `GeneratorStateTests`,
  `GeneratorProcessorTests`, and `GeneratorView+ViewInspectorTests`

## Testing

- Verified in simulator that steppers now allow values up to 9
- All Generator-related unit tests pass

## 🎟️ Tracking

(https://github.com/bitwarden/ios/issues/2420)

## 📔 Objective

Fixes Issue [PM-33287]
The password generator's "Minimum numbers" and "Minimum special" steppers
had a max value of 5, while other Bitwarden clients allow up to 9.


## 📸 Screenshots

Before:

<img width="1178" height="356" alt="image" src="https://github.com/user-attachments/assets/d745288b-f146-4703-98a1-1cf0d6ea6f5c" />


After:

<img width="368" height="123" alt="Screenshot 2026-03-11 at 8 50 18 AM" src="https://github.com/user-attachments/assets/11222c56-d916-4a9c-83f3-0552bc2c744e" />


<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->


[PM-33287]: https://bitwarden.atlassian.net/browse/PM-33287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ