### PR TITLE
[PM-33370] [RC] fix: Fix [un]archive flow on missing cipher key case

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -864,7 +864,13 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             ),
         )
 
+        let cipherEncryptionMediator = DefaultCipherEncryptionMediator(
+            cipherService: cipherService,
+            clientService: clientService,
+        )
+
         let vaultRepository = DefaultVaultRepository(
+            cipherEncryptionMediator: cipherEncryptionMediator,
             cipherService: cipherService,
             clientService: clientService,
             collectionHelper: collectionHelper,

--- a/BitwardenShared/Core/Vault/Helpers/CipherEncryptionMediator.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherEncryptionMediator.swift
@@ -1,0 +1,101 @@
+import BitwardenSdk
+
+/// A mediator that helps with some cipher operations involving encryption.
+protocol CipherEncryptionMediator { // sourcery: AutoMockable
+    /// Encrypts the cipher. If the cipher was migrated by the SDK (e.g. added a cipher key), the
+    /// cipher will be updated locally and on the server.
+    ///
+    /// - Parameter cipherView: The cipher to encrypt.
+    /// - Returns: The encrypted cipher.
+    ///
+    func encryptAndUpdateCipher(_ cipherView: CipherView) async throws -> Cipher
+
+    /// Sets the delegate to use.
+    /// - Parameter delegate: The delegate to use.
+    func setDelegate(_ delegate: CipherEncryptionMediatorDelegate)
+
+    /// Checks if `cipherView` lacks a cipher key and if so tries to update it with the server
+    /// returning the updated version.
+    ///
+    /// - Parameter cipherView: The cipher to check and update.
+    /// - Returns: The updated cipher with the key if the operation has been done,
+    /// otherwise the original cipher is returned.
+    /// - Remark: Use this instead of `encryptAndUpdateCipher` when you need to keep updating a cipher view after
+    /// this is run; e.g. archiving. This will only fetch the cipher again if the cipher key has been updated.
+    func updateCipherKeyIfNeeded(_ cipherView: CipherView) async throws -> CipherView
+}
+
+/// A delegate to be used by the `CipherEncryptionMediator`.
+protocol CipherEncryptionMediatorDelegate: AnyObject { // sourcery: AutoMockable
+    /// Attempt to fetch a cipher with the given id.
+    ///
+    /// - Parameter id: The id of the cipher to find.
+    /// - Returns: The cipher if it was found and `nil` if not.
+    ///
+    func fetchCipher(withId id: String) async throws -> CipherView?
+}
+
+/// Default implementation of `CipherEncryptionMediator`.
+class DefaultCipherEncryptionMediator: CipherEncryptionMediator {
+    // MARK: Properties
+
+    /// The service used to manage syncing and updates to the user's ciphers.
+    private let cipherService: CipherService
+
+    /// The service that handles common client functionality such as encryption and decryption.
+    private let clientService: ClientService
+
+    /// The delegate to be used by the `CipherEncryptionMediator`.
+    private weak var delegate: CipherEncryptionMediatorDelegate?
+
+    /// Initializes a `DefaultCipherEncryptionMediator`.
+    /// - Parameters:
+    ///   - cipherService: The service used to manage syncing and updates to the user's ciphers.
+    ///   - clientService: The service that handles common client functionality such as encryption and decryption.
+    init(cipherService: CipherService, clientService: ClientService) {
+        self.cipherService = cipherService
+        self.clientService = clientService
+    }
+
+    // MARK: Methods
+
+    func encryptAndUpdateCipher(_ cipherView: CipherView) async throws -> Cipher {
+        let cipherEncryptionContext = try await clientService.vault().ciphers().encrypt(cipherView: cipherView)
+
+        let didAddCipherKey = cipherView.key == nil && cipherEncryptionContext.cipher.key != nil
+        if didAddCipherKey {
+            try await cipherService.updateCipherWithServer(
+                cipherEncryptionContext.cipher,
+                encryptedFor: cipherEncryptionContext.encryptedFor,
+            )
+        }
+
+        return cipherEncryptionContext.cipher
+    }
+
+    func setDelegate(_ delegate: CipherEncryptionMediatorDelegate) {
+        self.delegate = delegate
+    }
+
+    func updateCipherKeyIfNeeded(_ cipherView: CipherView) async throws -> CipherView {
+        guard let cipherId = cipherView.id, cipherView.key == nil else {
+            return cipherView
+        }
+
+        let cipherEncryptionContext = try await clientService.vault().ciphers().encrypt(cipherView: cipherView)
+        guard cipherEncryptionContext.cipher.key != nil else {
+            return cipherView
+        }
+
+        try await cipherService.updateCipherWithServer(
+            cipherEncryptionContext.cipher,
+            encryptedFor: cipherEncryptionContext.encryptedFor,
+        )
+
+        guard let updatedCipherView = try await delegate?.fetchCipher(withId: cipherId) else {
+            return cipherView
+        }
+
+        return updatedCipherView
+    }
+}

--- a/BitwardenShared/Core/Vault/Helpers/CipherEncryptionMediatorTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherEncryptionMediatorTests.swift
@@ -1,0 +1,223 @@
+import BitwardenSdk
+import TestHelpers
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - CipherEncryptionMediatorTests
+
+class CipherEncryptionMediatorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var cipherService: MockCipherService!
+    var clientService: MockClientService!
+    var delegate: MockCipherEncryptionMediatorDelegate!
+    var subject: DefaultCipherEncryptionMediator!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        cipherService = MockCipherService()
+        clientService = MockClientService()
+        delegate = MockCipherEncryptionMediatorDelegate()
+
+        subject = DefaultCipherEncryptionMediator(
+            cipherService: cipherService,
+            clientService: clientService,
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        cipherService = nil
+        clientService = nil
+        delegate = nil
+        subject = nil
+    }
+
+    // MARK: Tests - encryptAndUpdateCipher
+
+    /// `encryptAndUpdateCipher(_:)` calls `updateCipherWithServer` when the cipher view has no key
+    /// and encryption adds one, then returns the encrypted cipher.
+    func test_encryptAndUpdateCipher_cipherViewHasNoKey_encryptionAddsKey_updatesWithServer() async throws {
+        let cipherView = CipherView.fixture(key: nil)
+        let encryptedCipher = Cipher.fixture(key: "encryptedKey")
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+
+        let result = try await subject.encryptAndUpdateCipher(cipherView)
+
+        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [encryptedCipher])
+        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "userId")
+        XCTAssertEqual(result, encryptedCipher)
+    }
+
+    /// `encryptAndUpdateCipher(_:)` skips `updateCipherWithServer` when the cipher view already has
+    /// a key (no migration needed).
+    func test_encryptAndUpdateCipher_cipherViewHasKey_doesNotUpdateWithServer() async throws {
+        let cipherView = CipherView.fixture(key: "existingKey")
+
+        let result = try await subject.encryptAndUpdateCipher(cipherView)
+
+        XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
+        XCTAssertEqual(clientService.mockVault.clientCiphers.encryptedCiphers, [cipherView])
+        XCTAssertNotNil(result)
+    }
+
+    /// `encryptAndUpdateCipher(_:)` skips `updateCipherWithServer` when neither the cipher view
+    /// nor the encrypted result has a key.
+    func test_encryptAndUpdateCipher_cipherViewHasNoKey_encryptedCipherHasNoKey_doesNotUpdateWithServer() async throws {
+        let cipherView = CipherView.fixture(key: nil)
+        let encryptedCipher = Cipher.fixture(key: nil)
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+
+        let result = try await subject.encryptAndUpdateCipher(cipherView)
+
+        XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
+        XCTAssertEqual(result, encryptedCipher)
+    }
+
+    /// `encryptAndUpdateCipher(_:)` rethrows errors from the SDK encryption call.
+    func test_encryptAndUpdateCipher_encryptThrows_throwsError() async throws {
+        let cipherView = CipherView.fixture(key: nil)
+        clientService.mockVault.clientCiphers.encryptError = BitwardenTestError.example
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await self.subject.encryptAndUpdateCipher(cipherView)
+        }
+    }
+
+    /// `encryptAndUpdateCipher(_:)` rethrows errors from the server update call.
+    func test_encryptAndUpdateCipher_updateWithServerThrows_throwsError() async throws {
+        let cipherView = CipherView.fixture(key: nil)
+        let encryptedCipher = Cipher.fixture(key: "encryptedKey")
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+        cipherService.updateCipherWithServerResult = .failure(BitwardenTestError.example)
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await self.subject.encryptAndUpdateCipher(cipherView)
+        }
+    }
+
+    // MARK: Tests - updateCipherKeyIfNeeded
+
+    /// `updateCipherKeyIfNeeded(_:)` returns the original cipher view early when it already has a key.
+    func test_updateCipherKeyIfNeeded_cipherViewHasKey_returnsOriginal() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: "existingKey")
+
+        let result = try await subject.updateCipherKeyIfNeeded(cipherView)
+
+        XCTAssertEqual(result, cipherView)
+        XCTAssertTrue(clientService.mockVault.clientCiphers.encryptedCiphers.isEmpty)
+        XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` returns the original cipher view early when the cipher has no id.
+    func test_updateCipherKeyIfNeeded_cipherViewHasNoId_returnsOriginal() async throws {
+        let cipherView = CipherView.fixture(id: nil, key: nil)
+
+        let result = try await subject.updateCipherKeyIfNeeded(cipherView)
+
+        XCTAssertEqual(result, cipherView)
+        XCTAssertTrue(clientService.mockVault.clientCiphers.encryptedCiphers.isEmpty)
+        XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` returns the original cipher view when the encrypted result
+    /// still has no key — the SDK did not migrate it.
+    func test_updateCipherKeyIfNeeded_encryptedCipherHasNoKey_returnsOriginal() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: nil)
+        let encryptedCipher = Cipher.fixture(key: nil)
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+
+        let result = try await subject.updateCipherKeyIfNeeded(cipherView)
+
+        XCTAssertEqual(result, cipherView)
+        XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` updates the server and returns the freshly fetched cipher view
+    /// when the SDK adds a key during encryption.
+    func test_updateCipherKeyIfNeeded_encryptionAddsKey_updatesServerAndReturnsUpdatedView() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: nil)
+        let encryptedCipher = Cipher.fixture(key: "encryptedKey")
+        let updatedCipherView = CipherView.fixture(id: "1", key: "decryptedKey")
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+        delegate.fetchCipherReturnValue = updatedCipherView
+        subject.setDelegate(delegate)
+
+        let result = try await subject.updateCipherKeyIfNeeded(cipherView)
+
+        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [encryptedCipher])
+        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "userId")
+        XCTAssertEqual(delegate.fetchCipherReceivedId, "1")
+        XCTAssertEqual(result, updatedCipherView)
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` returns the original cipher view when the delegate returns `nil`
+    /// after the server update.
+    func test_updateCipherKeyIfNeeded_encryptionAddsKey_delegateReturnsNil_returnsOriginal() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: nil)
+        let encryptedCipher = Cipher.fixture(key: "encryptedKey")
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+        delegate.fetchCipherReturnValue = nil
+        subject.setDelegate(delegate)
+
+        let result = try await subject.updateCipherKeyIfNeeded(cipherView)
+
+        XCTAssertEqual(result, cipherView)
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` returns the original cipher view when no delegate has been set.
+    func test_updateCipherKeyIfNeeded_encryptionAddsKey_noDelegate_returnsOriginal() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: nil)
+        let encryptedCipher = Cipher.fixture(key: "encryptedKey")
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+
+        let result = try await subject.updateCipherKeyIfNeeded(cipherView)
+
+        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [encryptedCipher])
+        XCTAssertEqual(result, cipherView)
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` rethrows errors from the SDK encryption call.
+    func test_updateCipherKeyIfNeeded_encryptThrows_throwsError() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: nil)
+        clientService.mockVault.clientCiphers.encryptError = BitwardenTestError.example
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await self.subject.updateCipherKeyIfNeeded(cipherView)
+        }
+    }
+
+    /// `updateCipherKeyIfNeeded(_:)` rethrows errors from the server update call.
+    func test_updateCipherKeyIfNeeded_updateWithServerThrows_throwsError() async throws {
+        let cipherView = CipherView.fixture(id: "1", key: nil)
+        let encryptedCipher = Cipher.fixture(key: "encryptedKey")
+        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
+        )
+        cipherService.updateCipherWithServerResult = .failure(BitwardenTestError.example)
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            _ = try await self.subject.updateCipherKeyIfNeeded(cipherView)
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -322,6 +322,9 @@ extension VaultRepository {
 class DefaultVaultRepository {
     // MARK: Properties
 
+    /// The mediator that helps with some cipher operations involving encryption.
+    private let cipherEncryptionMediator: CipherEncryptionMediator
+
     /// The service used to manage syncing and updates to the user's ciphers.
     private let cipherService: CipherService
 
@@ -375,6 +378,7 @@ class DefaultVaultRepository {
     /// Initialize a `DefaultVaultRepository`.
     ///
     /// - Parameters:
+    ///   - cipherEncryptionMediator: The mediator that helps with some cipher operations involving encryption.
     ///   - cipherService: The service used to manage syncing and updates to the user's ciphers.
     ///   - clientService: The service that handles common client functionality such as encryption and decryption.
     ///   - collectionHelper: The helper functions for collections.
@@ -393,6 +397,7 @@ class DefaultVaultRepository {
     ///   - vaultTimeoutService: The service used by the application to manage vault access.
     ///
     init(
+        cipherEncryptionMediator: CipherEncryptionMediator,
         cipherService: CipherService,
         clientService: ClientService,
         collectionHelper: CollectionHelper,
@@ -410,6 +415,7 @@ class DefaultVaultRepository {
         vaultListDirectorStrategyFactory: VaultListDirectorStrategyFactory,
         vaultTimeoutService: VaultTimeoutService,
     ) {
+        self.cipherEncryptionMediator = cipherEncryptionMediator
         self.cipherService = cipherService
         self.clientService = clientService
         self.collectionHelper = collectionHelper
@@ -426,29 +432,11 @@ class DefaultVaultRepository {
         self.timeProvider = timeProvider
         self.vaultListDirectorStrategyFactory = vaultListDirectorStrategyFactory
         self.vaultTimeoutService = vaultTimeoutService
+
+        self.cipherEncryptionMediator.setDelegate(self)
     }
 
     // MARK: Private
-
-    /// Encrypts the cipher. If the cipher was migrated by the SDK (e.g. added a cipher key), the
-    /// cipher will be updated locally and on the server.
-    ///
-    /// - Parameter cipherView: The cipher to encrypt.
-    /// - Returns: The encrypted cipher.
-    ///
-    private func encryptAndUpdateCipher(_ cipherView: CipherView) async throws -> Cipher {
-        let cipherEncryptionContext = try await clientService.vault().ciphers().encrypt(cipherView: cipherView)
-
-        let didAddCipherKey = cipherView.key == nil && cipherEncryptionContext.cipher.key != nil
-        if didAddCipherKey {
-            try await cipherService.updateCipherWithServer(
-                cipherEncryptionContext.cipher,
-                encryptedFor: cipherEncryptionContext.encryptedFor,
-            )
-        }
-
-        return cipherEncryptionContext.cipher
-    }
 
     /// Downloads, re-encrypts, and re-uploads an attachment without an attachment key so that it
     /// can be shared to an organization.
@@ -508,8 +496,11 @@ extension DefaultVaultRepository: VaultRepository {
         guard let id = cipher.id else {
             throw CipherAPIServiceError.updateMissingId
         }
-        let archivedCipher = cipher.update(archivedDate: timeProvider.presentTime)
-        let encryptCipher = try await encryptAndUpdateCipher(archivedCipher)
+
+        let updatedCipher = try await cipherEncryptionMediator.updateCipherKeyIfNeeded(cipher)
+
+        let archivedCipher = updatedCipher.update(archivedDate: timeProvider.presentTime)
+        let encryptCipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(archivedCipher)
         try await cipherService.archiveCipherWithServer(id: id, encryptCipher)
     }
 
@@ -522,7 +513,7 @@ extension DefaultVaultRepository: VaultRepository {
 
         for cipher in ciphers {
             // Ensure the cipher has a cipher key.
-            let encryptedCipher = try await encryptAndUpdateCipher(cipher)
+            let encryptedCipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(cipher)
             var cipherView = try await clientService.vault().ciphers().decrypt(cipher: encryptedCipher)
 
             // Migrate any attachments without an encryption key.
@@ -801,7 +792,7 @@ extension DefaultVaultRepository: VaultRepository {
     func restoreCipher(_ cipher: BitwardenSdk.CipherView) async throws {
         guard let id = cipher.id else { throw CipherAPIServiceError.updateMissingId }
         let restoredCipher = cipher.update(deletedDate: nil)
-        let encryptCipher = try await encryptAndUpdateCipher(restoredCipher)
+        let encryptCipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(restoredCipher)
         try await cipherService.restoreCipherWithServer(id: id, encryptCipher)
     }
 
@@ -817,7 +808,7 @@ extension DefaultVaultRepository: VaultRepository {
         )
 
         // Encrypt the attachment.
-        let cipher = try await encryptAndUpdateCipher(cipherView)
+        let cipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(cipherView)
         let attachment = try await clientService.vault().attachments().encryptBuffer(
             cipher: cipher,
             attachment: attachmentView,
@@ -834,7 +825,7 @@ extension DefaultVaultRepository: VaultRepository {
 
     func shareCipher(_ cipherView: CipherView, newOrganizationId: String, newCollectionIds: [String]) async throws {
         // Ensure the cipher has a cipher key.
-        let encryptedCipher = try await encryptAndUpdateCipher(cipherView)
+        let encryptedCipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(cipherView)
         var cipherView = try await clientService.vault().ciphers().decrypt(cipher: encryptedCipher)
 
         if let attachments = cipherView.attachments {
@@ -866,7 +857,7 @@ extension DefaultVaultRepository: VaultRepository {
     func softDeleteCipher(_ cipher: CipherView) async throws {
         guard let id = cipher.id else { throw CipherAPIServiceError.updateMissingId }
         let softDeletedCipher = cipher.update(deletedDate: timeProvider.presentTime)
-        let encryptedCipher = try await encryptAndUpdateCipher(softDeletedCipher)
+        let encryptedCipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(softDeletedCipher)
         try await cipherService.softDeleteCipherWithServer(id: id, encryptedCipher)
     }
 
@@ -874,8 +865,11 @@ extension DefaultVaultRepository: VaultRepository {
         guard let id = cipher.id else {
             throw CipherAPIServiceError.updateMissingId
         }
-        let archivedCipher = cipher.update(archivedDate: nil)
-        let encryptCipher = try await encryptAndUpdateCipher(archivedCipher)
+
+        let updatedCipher = try await cipherEncryptionMediator.updateCipherKeyIfNeeded(cipher)
+
+        let unarchivedCipher = updatedCipher.update(archivedDate: nil)
+        let encryptCipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(unarchivedCipher)
         try await cipherService.unarchiveCipherWithServer(id: id, encryptCipher)
     }
 
@@ -898,7 +892,7 @@ extension DefaultVaultRepository: VaultRepository {
             return
         }
 
-        let cipher = try await encryptAndUpdateCipher(cipherView)
+        let cipher = try await cipherEncryptionMediator.encryptAndUpdateCipher(cipherView)
         try await cipherService.updateCipherCollectionsWithServer(cipher)
     }
 
@@ -1047,4 +1041,8 @@ extension DefaultVaultRepository: VaultRepository {
 
         return archiveItemsFF && !hasPremium
     }
-} // swiftlint:disable:this file_length
+}
+
+extension DefaultVaultRepository: CipherEncryptionMediatorDelegate {}
+
+// swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -12,6 +12,7 @@ import XCTest
 class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
+    var cipherEncryptionMediator: MockCipherEncryptionMediator!
     var cipherService: MockCipherService!
     var client: MockHTTPClient!
     var clientCiphers: MockClientCiphers!
@@ -39,8 +40,16 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     // MARK: Setup & Teardown
 
-    override func setUp() {
+    override func setUp() { // swiftlint:disable:this function_body_length
         super.setUp()
+
+        cipherEncryptionMediator = MockCipherEncryptionMediator()
+        cipherEncryptionMediator.encryptAndUpdateCipherClosure = { cipherView in
+            Cipher(cipherView: cipherView)
+        }
+        cipherEncryptionMediator.updateCipherKeyIfNeededClosure = { cipherView in
+            cipherView
+        }
 
         cipherService = MockCipherService()
         client = MockHTTPClient()
@@ -69,6 +78,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         vaultListDirectorStrategyFactory.makeSearchStrategyReturnValue = vaultListSearchDirectorStrategy
 
         subject = DefaultVaultRepository(
+            cipherEncryptionMediator: cipherEncryptionMediator,
             cipherService: cipherService,
             clientService: clientService,
             collectionHelper: collectionHelper,
@@ -91,6 +101,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     override func tearDown() {
         super.tearDown()
 
+        cipherEncryptionMediator = nil
         cipherService = nil
         client = nil
         clientCiphers = nil
@@ -151,24 +162,14 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService.activeAccount = .fixtureAccountLogin()
         let cipherView: CipherView = .fixture(id: "123")
         cipherService.archiveCipherResult = .success(())
+
         try await subject.archiveCipher(cipherView)
+
         XCTAssertNil(cipherView.archivedDate)
         XCTAssertNotNil(cipherService.archiveCipher?.archivedDate)
         XCTAssertEqual(cipherService.archiveCipherId, "123")
-    }
-
-    /// `archiveCipher(_:cipher:)` updates the cipher on the server if the SDK adds a cipher key.
-    func test_archiveCipher_updatesMigratedCipher() async throws {
-        stateService.activeAccount = .fixture()
-        let cipherView = CipherView.fixture()
-        let cipher = Cipher.fixture(key: "new key")
-        clientCiphers.encryptCipherResult = .success(EncryptionContext(encryptedFor: "1", cipher: cipher))
-
-        try await subject.archiveCipher(cipherView)
-
-        XCTAssertEqual(cipherService.archiveCipher, cipher)
-        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [cipher])
-        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+        XCTAssertNil(cipherEncryptionMediator.updateCipherKeyIfNeededReceivedCipherView?.archivedDate)
+        XCTAssertNotNil(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView?.archivedDate)
     }
 
     /// `bulkShareCiphers()` ensures cipher keys, prepares ciphers and calls the cipher service.
@@ -188,7 +189,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.bulkShareCiphers(ciphers, newOrganizationId: "org-123", newCollectionIds: ["col-1", "col-2"])
 
         // Verify ciphers were encrypted (to ensure cipher key).
-        XCTAssertEqual(clientCiphers.encryptedCiphers.count, 2)
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherCallsCount, 2)
 
         // Verify bulk share was called.
         XCTAssertEqual(cipherService.bulkShareCiphersWithServerCiphers.last, encryptionContexts.map(\.cipher))
@@ -1420,7 +1421,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.updateCipherCollections(cipher)
 
         XCTAssertEqual(cipherService.updateCipherCollectionsWithServerCiphers, [Cipher(cipherView: cipher)])
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, cipher)
     }
 
     /// `updateCipherCollections()` unarchives the cipher when it's archived, feature flag is on,
@@ -1436,7 +1437,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         // Verify cipher was unarchived before updating collections
         let unarchivedCipher = archivedCipher.update(archivedDate: nil)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [unarchivedCipher])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, unarchivedCipher)
         XCTAssertEqual(
             cipherService.updateCipherCollectionsWithServerCiphers,
             [Cipher(cipherView: unarchivedCipher)],
@@ -1455,7 +1456,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.updateCipherCollections(archivedCipher)
 
         // Verify cipher was NOT unarchived (kept archived)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, archivedCipher)
         XCTAssertEqual(
             cipherService.updateCipherCollectionsWithServerCiphers,
             [Cipher(cipherView: archivedCipher)],
@@ -1474,7 +1475,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.updateCipherCollections(archivedCipher)
 
         // Verify cipher was NOT unarchived (kept archived)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, archivedCipher)
         XCTAssertEqual(
             cipherService.updateCipherCollectionsWithServerCiphers,
             [Cipher(cipherView: archivedCipher)],
@@ -1492,7 +1493,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.updateCipherCollections(cipher)
 
         // Verify cipher was updated normally (no changes)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, cipher)
         XCTAssertEqual(
             cipherService.updateCipherCollectionsWithServerCiphers,
             [Cipher(cipherView: cipher)],
@@ -1666,24 +1667,13 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService.activeAccount = .fixtureAccountLogin()
         let cipherView: CipherView = .fixture(deletedDate: .now, id: "123")
         cipherService.restoreWithServerResult = .success(())
+
         try await subject.restoreCipher(cipherView)
+
         XCTAssertNotNil(cipherView.deletedDate)
         XCTAssertNil(cipherService.restoredCipher?.deletedDate)
         XCTAssertEqual(cipherService.restoredCipherId, "123")
-    }
-
-    /// `restoreCipher(_:cipher:)` updates the cipher on the server if the SDK adds a cipher key.
-    func test_restoreCipher_updatesMigratedCipher() async throws {
-        stateService.activeAccount = .fixture()
-        let cipherView = CipherView.fixture(deletedDate: .now)
-        let cipher = Cipher.fixture(key: "new key")
-        clientCiphers.encryptCipherResult = .success(EncryptionContext(encryptedFor: "1", cipher: cipher))
-
-        try await subject.restoreCipher(cipherView)
-
-        XCTAssertEqual(cipherService.restoredCipher, cipher)
-        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [cipher])
-        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView?.id, "123")
     }
 
     /// `saveAttachment(cipherView:fileData:fileName:)` saves the attachment to the cipher.
@@ -1692,36 +1682,16 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         let cipherView = CipherView.fixture()
         let updatedCipher = try await subject.saveAttachment(
-            cipherView: .fixture(),
+            cipherView: cipherView,
             fileData: Data(),
             fileName: "Pineapple on pizza",
         )
 
         // Ensure all the steps completed as expected.
-        XCTAssertEqual(clientService.mockVault.clientCiphers.encryptedCiphers, [.fixture()])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, cipherView)
         XCTAssertEqual(clientService.mockVault.clientAttachments.encryptedBuffers, [Data()])
         XCTAssertEqual(cipherService.saveAttachmentWithServerCipher, Cipher(cipherView: cipherView))
         XCTAssertEqual(updatedCipher.id, "42")
-    }
-
-    /// `saveAttachment(cipherView:fileData:fileName:)` updates the cipher on the server if the SDK adds a cipher key.
-    func test_saveAttachment_updatesMigratedCipher() async throws {
-        cipherService.saveAttachmentWithServerResult = .success(.fixture(id: "42"))
-        let cipher = Cipher.fixture(key: "new key")
-        clientCiphers.encryptCipherResult = .success(EncryptionContext(encryptedFor: "1", cipher: cipher))
-
-        let updatedCipher = try await subject.saveAttachment(
-            cipherView: .fixture(),
-            fileData: Data(),
-            fileName: "Pineapple on pizza",
-        )
-
-        XCTAssertEqual(clientService.mockVault.clientCiphers.encryptedCiphers, [.fixture()])
-        XCTAssertEqual(clientService.mockVault.clientAttachments.encryptedBuffers, [Data()])
-        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [cipher])
-        XCTAssertEqual(cipherService.saveAttachmentWithServerCipher, cipher)
-        XCTAssertEqual(updatedCipher.id, "42")
-        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
     }
 
     /// `softDeleteCipher()` throws on id errors.
@@ -1740,23 +1710,13 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService.activeAccount = .fixtureAccountLogin()
         let cipherView: CipherView = .fixture(id: "123")
         cipherService.softDeleteWithServerResult = .success(())
+
         try await subject.softDeleteCipher(cipherView)
+
         XCTAssertNil(cipherView.deletedDate)
         XCTAssertNotNil(cipherService.softDeleteCipher?.deletedDate)
         XCTAssertEqual(cipherService.softDeleteCipherId, "123")
-    }
-
-    /// `softDeleteCipher(_:cipher:)` updates the cipher on the server if the SDK adds a cipher key.
-    func test_softDeleteCipher_updatesMigratedCipher() async throws {
-        stateService.activeAccount = .fixture()
-        let cipherView = CipherView.fixture(deletedDate: .now)
-        let cipher = Cipher.fixture(key: "new key")
-        clientCiphers.encryptCipherResult = .success(EncryptionContext(encryptedFor: "1", cipher: cipher))
-
-        try await subject.softDeleteCipher(cipherView)
-
-        XCTAssertEqual(cipherService.softDeleteCipher, cipher)
-        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [cipher])
+        XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView?.id, "123")
     }
 
     /// `vaultListPublisher(filter:)` makes a strategy and builds the vault list sections.
@@ -1836,24 +1796,14 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService.activeAccount = .fixtureAccountLogin()
         let cipherView: CipherView = .fixture(archivedDate: .now, id: "123")
         cipherService.unarchiveCipherResult = .success(())
+
         try await subject.unarchiveCipher(cipherView)
+
         XCTAssertNotNil(cipherView.archivedDate)
         XCTAssertNil(cipherService.unarchiveCipher?.archivedDate)
         XCTAssertEqual(cipherService.unarchiveCipherId, "123")
-    }
-
-    /// `unarchiveCipher(_:cipher:)` updates the cipher on the server if the SDK adds a cipher key.
-    func test_unarchiveCipher_updatesMigratedCipher() async throws {
-        stateService.activeAccount = .fixture()
-        let cipherView = CipherView.fixture(archivedDate: .now)
-        let cipher = Cipher.fixture(key: "new key")
-        clientCiphers.encryptCipherResult = .success(EncryptionContext(encryptedFor: "1", cipher: cipher))
-
-        try await subject.unarchiveCipher(cipherView)
-
-        XCTAssertEqual(cipherService.unarchiveCipher, cipher)
-        XCTAssertEqual(cipherService.updateCipherWithServerCiphers, [cipher])
-        XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
+        XCTAssertNotNil(cipherEncryptionMediator.updateCipherKeyIfNeededReceivedCipherView?.archivedDate)
+        XCTAssertNil(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView?.archivedDate)
     }
 
     // MARK: Private


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33370](https://bitwarden.atlassian.net/browse/PM-33370)

## 📔 Objective

🍒 RC cherry picked from #2436.

When a cipher was missing its `Key` and the user wanted to archive it, the cipher's archived date was being updated before the cipher mission key update to server, therefore the cipher was being updated to the server with the archive change which was causing the actual server call for archive to fail given that the cipher on server had already been changed with an archived date given the previous endpoint call for missing key update.

Additionally, flows for cipher key handling have been extracted to a new `CipherEncryptionMediator` file so it's easier to test and we reduce duplication on tests for the same behavior on different operations.


[PM-33370]: https://bitwarden.atlassian.net/browse/PM-33370?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ