### PR TITLE
[PM-31837] fix: Enforce policy session timeout action on Key connector

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -663,6 +663,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             clientService: clientService,
             configService: configService,
             errorReporter: errorReporter,
+            policyService: policyService,
             sharedTimeoutService: sharedTimeoutService,
             stateService: stateService,
             timeProvider: timeProvider,

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutService.swift
@@ -129,6 +129,9 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     /// The service used by the application to report non-fatal errors.
     private let errorReporter: ErrorReporter
 
+    /// The service for managing the polices for the user.
+    private let policyService: PolicyService
+
     /// A service that manages account timeout between apps.
     private let sharedTimeoutService: SharedTimeoutService
 
@@ -153,6 +156,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
     ///   - clientService: The service that handles common client functionality such as encryption and decryption.
     ///   - configService: The service to get server-specified configuration.
     ///   - errorReporter: The service used by the application to report non-fatal errors.
+    ///   - policyService: The service for managing the polices for the user.
     ///   - sharedTimeoutService: The service that manages account timeout between apps.
     ///   - stateService: The StateService used by DefaultVaultTimeoutService.
     ///   - timeProvider: Provides the current time.
@@ -163,6 +167,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         clientService: ClientService,
         configService: ConfigService,
         errorReporter: ErrorReporter,
+        policyService: PolicyService,
         sharedTimeoutService: SharedTimeoutService,
         stateService: StateService,
         timeProvider: TimeProvider,
@@ -172,6 +177,7 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         self.clientService = clientService
         self.configService = configService
         self.errorReporter = errorReporter
+        self.policyService = policyService
         self.sharedTimeoutService = sharedTimeoutService
         self.stateService = stateService
         self.timeProvider = timeProvider
@@ -237,14 +243,20 @@ class DefaultVaultTimeoutService: VaultTimeoutService {
         guard hasMasterPassword else {
             let isBiometricsEnabled = try await biometricsRepository.getBiometricUnlockStatus(userId: userId).isEnabled
             let isPinEnabled = try await isPinUnlockAvailable(userId: userId)
-            if isPinEnabled || isBiometricsEnabled {
-                return timeoutAction
-            } else {
+            guard isPinEnabled || isBiometricsEnabled else {
                 // If the user doesn't have a master password and hasn't enabled a pin or
                 // biometrics, their timeout action needs to be logout.
                 try await stateService.setTimeoutAction(action: .logout, userId: userId)
                 return .logout
             }
+
+            // If there's a policy for session timeout action active, then it's forced.
+            if let policy = try await policyService.fetchTimeoutPolicyValues(),
+               let policyTimeoutAction = policy.timeoutAction {
+                return policyTimeoutAction
+            }
+
+            return timeoutAction
         }
         return timeoutAction
     }

--- a/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/VaultTimeoutServiceTests.swift
@@ -1,5 +1,6 @@
 import AuthenticatorBridgeKit
 import AuthenticatorBridgeKitMocks
+import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
 import Combine
@@ -18,6 +19,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
     var clientService: MockClientService!
     var configService: MockConfigService!
     var errorReporter: MockErrorReporter!
+    var policyService: MockPolicyService!
     var sharedTimeoutService: MockSharedTimeoutService!
     var stateService: MockStateService!
     var subject: DefaultVaultTimeoutService!
@@ -35,6 +37,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
         clientService = MockClientService()
         configService = MockConfigService()
         errorReporter = MockErrorReporter()
+        policyService = MockPolicyService()
         sharedTimeoutService = MockSharedTimeoutService()
         stateService = MockStateService()
         timeProvider = MockTimeProvider(
@@ -53,6 +56,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
             clientService: clientService,
             configService: configService,
             errorReporter: errorReporter,
+            policyService: policyService,
             sharedTimeoutService: sharedTimeoutService,
             stateService: stateService,
             timeProvider: timeProvider,
@@ -68,6 +72,7 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
         clientService = nil
         configService = nil
         errorReporter = nil
+        policyService = nil
         subject = nil
         stateService = nil
         timeProvider = nil
@@ -373,6 +378,51 @@ final class VaultTimeoutServiceTests: BitwardenTestCase { // swiftlint:disable:t
         stateService.timeoutAction["1"] = .logout
         timeoutAction = try await subject.sessionTimeoutAction(userId: "1")
         XCTAssertEqual(timeoutAction, .logout)
+    }
+
+    /// `sessionTimeoutAction()` returns the policy-forced timeout action when the user doesn't
+    /// have a master password, has biometrics enabled, and a policy specifies a timeout action.
+    func test_sessionTimeoutAction_noMasterPassword_biometricsEnabled_policyForcesLogout() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+        stateService.timeoutAction["1"] = .lock
+        stateService.userHasMasterPassword["1"] = false
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        policyService.fetchTimeoutPolicyValuesResult = .success(
+            SessionTimeoutPolicy(timeoutAction: .logout, timeoutType: nil, timeoutValue: nil),
+        )
+
+        let timeoutAction = try await subject.sessionTimeoutAction(userId: "1")
+        XCTAssertEqual(timeoutAction, .logout)
+    }
+
+    /// `sessionTimeoutAction()` returns the policy-forced timeout action when the user doesn't
+    /// have a master password, has pin unlock enabled, and a policy specifies a timeout action.
+    func test_sessionTimeoutAction_noMasterPassword_pinEnabled_policyForcesLock() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+        stateService.timeoutAction["1"] = .logout
+        stateService.userHasMasterPassword["1"] = false
+        stateService.pinProtectedUserKeyValue["1"] = "KEY"
+        policyService.fetchTimeoutPolicyValuesResult = .success(
+            SessionTimeoutPolicy(timeoutAction: .lock, timeoutType: nil, timeoutValue: nil),
+        )
+
+        let timeoutAction = try await subject.sessionTimeoutAction(userId: "1")
+        XCTAssertEqual(timeoutAction, .lock)
+    }
+
+    /// `sessionTimeoutAction()` returns the stored timeout action when the user doesn't have a
+    /// master password, has biometrics enabled, and the policy has no timeout action set.
+    func test_sessionTimeoutAction_noMasterPassword_biometricsEnabled_policyNoAction() async throws {
+        stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
+        stateService.timeoutAction["1"] = .lock
+        stateService.userHasMasterPassword["1"] = false
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        policyService.fetchTimeoutPolicyValuesResult = .success(
+            SessionTimeoutPolicy(timeoutAction: nil, timeoutType: nil, timeoutValue: nil),
+        )
+
+        let timeoutAction = try await subject.sessionTimeoutAction(userId: "1")
+        XCTAssertEqual(timeoutAction, .lock)
     }
 
     /// `sessionTimeoutAction()` throws errors.


### PR DESCRIPTION
## 🎟️ Tracking

[PM-31837](https://bitwarden.atlassian.net/browse/PM-31837)

## 📔 Objective

On Key connector accounts (or any account without master password) there was a bug that it was not enforcing the policy for session timeout action when PIN or Biometrics was getting enabled; and always defaulting to "Log out".
This was because the first time the user logs in, they haven't PIN nor Biometrics set up therefore the flow saves "Log out" as the fallback and then when it was checking this again after enabling any of unlock mechanism mentioned it was just returning the last session timeout action saved instead of verifying whether there was a policy in place.
So it now checks for policies.


[PM-31837]: https://bitwarden.atlassian.net/browse/PM-31837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ