### PR TITLE
[PM-33571] llm: Add requirements refinement and planning skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -30,12 +30,12 @@ The app follows a layered architecture: Views send Actions/Effects to a Store, w
 ### Code Organization
 
 `Bitwarden/`, `Authenticator/` — app targets
-`BitwardenShared/`, `AuthenticatorShared/`, `BitwardenKit/` — shared frameworks; each has `Core/` + `UI/` with fixed subdirs: `Auth/`, `Autofill/`, `Platform/`, `Tools/`, `Vault/`
+`BitwardenShared/`, `AuthenticatorShared/`, `BitwardenKit/` — shared frameworks; each has `Core/` + `UI/` with fixed subdirs (see `Docs/Architecture.md` [Architecture Structure] for canonical domain list)
 `AuthenticatorBridgeKit/`, `BitwardenResources/`, `Networking/` — support frameworks
 `BitwardenAutoFillExtension/`, `BitwardenActionExtension/`, `BitwardenShareExtension/`, `BitwardenWatchApp/` — extensions
 `Docs/`, `Scripts/`, `TestPlans/`, `Configs/`, `Sourcery/Templates/`, `project-*.yml` — configuration
 
-**CRITICAL**: Do NOT add new top-level subdirectories to `Core/` or `UI/`. Fixed: `Auth/`, `Autofill/`, `Platform/`, `Tools/`, `Vault/`.
+**CRITICAL**: Do NOT add new top-level subdirectories to `Core/` or `UI/`. The fixed subdirectories are defined in `Docs/Architecture.md` under [Architecture Structure].
 
 For key principles (unidirectional data flow, dependency injection, coordinator navigation, zero-knowledge), core patterns (Coordinator/Processor/State/View/Action/Effect files), adding new features, adding services/repositories, and common patterns, see `Docs/Architecture.md`.
 

--- a/.claude/commands/plan-ios-work.md
+++ b/.claude/commands/plan-ios-work.md
@@ -18,7 +18,7 @@ If `$ARGUMENTS` is a description, use it directly as the requirements source.
 Invoke the `refining-ios-requirements` skill to:
 - Extract structured requirements and acceptance criteria
 - Perform gap analysis (error states, edge cases, extensions, accessibility)
-- Map to iOS domain (Auth/Autofill/Platform/Tools/Vault)
+- Map to iOS domain (see `Docs/Architecture.md` Architecture Structure for domain list)
 
 **Pause here**: Present requirements to user and confirm accuracy before proceeding.
 

--- a/.claude/skills/planning-ios-implementation/SKILL.md
+++ b/.claude/skills/planning-ios-implementation/SKILL.md
@@ -14,12 +14,17 @@ Use this skill to design a complete implementation plan before writing code. Out
 
 ## Step 1: Classify the Change
 
-Determine what type of change this is:
-- **New feature** (new screen + full file-set): Coordinator, Processor, State, Action, Effect, View, Route
-- **Enhancement** (modify existing screen): Identify which existing files change
-- **New service/repository**: Protocol + Default implementation + Has* protocol + Mock
-- **Bug fix**: Identify root cause file(s)
-- **Data model change**: CoreData schema + migration if needed
+Determine the change type to guide scope and planning depth:
+
+| Type | Description | Typical Scope |
+|------|-------------|---------------|
+| **New Feature** | Entirely new functionality, screens, or flows | New files + modifications, multi-phase |
+| **Enhancement** | Extending existing feature with new capabilities | Mostly modifications, 1-2 phases |
+| **Bug Fix** | Correcting incorrect behavior | Targeted modifications, single phase |
+| **Refactoring** | Restructuring without behavior change | Modifications only, migration-aware |
+| **Infrastructure** | Build, CI, tooling, or dependency changes | Config files, minimal code changes |
+
+State the classification and rationale before proceeding.
 
 ## Step 2: Explore Existing Patterns
 
@@ -68,14 +73,14 @@ Models, CoreData entities (if needed), service protocols, repository protocols
 ### Phase 2: Service/Repository Implementations
 Default<Name>Service/Repository — business logic, SDK calls, network
 
-### Phase 3: Processor + State
+### Phase 3: DI Wiring
+ServiceContainer extensions, Has* protocol additions
+
+### Phase 4: Processor + State
 StateProcessor subclass, State struct, Action enum, Effect enum
 
-### Phase 4: View + Coordinator
+### Phase 5: View + Coordinator
 SwiftUI View with store.binding, Coordinator with routes, navigation wiring
-
-### Phase 5: DI Wiring
-ServiceContainer extensions, Has* protocol additions
 
 ### Phase 6: Tests
 ProcessorTests (action/effect paths), ServiceTests (business logic), ViewTests (snapshots if UI)
@@ -85,7 +90,7 @@ ProcessorTests (action/effect paths), ServiceTests (business logic), ViewTests (
 
 Identify risks and mitigations:
 - **Security**: Does this touch vault data, auth tokens, or Keychain? → Security review required
-- **Extensions**: Does this affect AutoFill/Action extensions? → Memory limit check needed
+- **Extensions**: Does this affect AutoFill/Action/Share extensions? → Memory limit check needed
 - **Multi-account**: Does this need per-account isolation? → CoreData userId scoping
 - **SDK dependency**: Does this require BitwardenSdk changes? → Coordinate with SDK team
 

--- a/.claude/skills/refining-ios-requirements/SKILL.md
+++ b/.claude/skills/refining-ios-requirements/SKILL.md
@@ -41,7 +41,7 @@ Identify unstated requirements the ticket may have missed:
 
 **Platform concerns**
 - App extension impact (AutoFill, Action, Share — memory limits apply)
-- watchOS companion impact (if vault data is involved)
+- watchOS companion impact (if vault data is involved, especially TOTP data)
 - Offline mode behavior
 
 **Accessibility**
@@ -51,12 +51,7 @@ Identify unstated requirements the ticket may have missed:
 
 ## Step 4: Map to iOS Domain
 
-Determine which Bitwarden iOS domain(s) are involved:
-- **Auth/**: Authentication, login, unlock, key derivation
-- **Autofill/**: Credential provider, autofill flows
-- **Platform/**: Cross-cutting concerns, services, utilities
-- **Tools/**: Generator, Send, Import/Export
-- **Vault/**: Cipher management, folders, collections
+Determine which Bitwarden iOS domain(s) are involved. Read `Docs/Architecture.md` (Architecture Structure section) for the canonical domain list and descriptions.
 
 Determine which app(s) are affected:
 - **BitwardenShared**: Password Manager
@@ -88,7 +83,7 @@ Determine which app(s) are affected:
 1. [Question for product/design]
 
 ### Scope
-- **Domain**: [Auth / Autofill / Platform / Tools / Vault]
+- **Domain**: [from Architecture Structure domain list]
 - **App(s)**: [Password Manager / Authenticator / Both]
 - **Extensions affected**: [AutoFill / Action / Share / Watch / None]
 - **Out of scope**: [explicit exclusions]

--- a/.claude/skills/reviewing-changes/reference/ios-architecture-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/ios-architecture-patterns.md
@@ -26,7 +26,7 @@ Bitwarden-specific structural constraints that reviewers must verify. These are 
 ## Domain Folder Constraints
 
 - [ ] No new top-level subdirectories added to `Core/` or `UI/`
-- [ ] Fixed subdirectories only: `Auth/`, `Autofill/`, `Platform/`, `Tools/`, `Vault/`
+- [ ] Fixed subdirectories only (see `Docs/Architecture.md` Architecture Structure for canonical list)
 - [ ] New files placed in the correct domain folder (Auth vs Vault vs Platform)
 
 ## File-Set Completeness

--- a/Docs/Architecture.md
+++ b/Docs/Architecture.md
@@ -69,6 +69,7 @@ Most of the app's functionality is implemented in the `BitwardenShared` and `Aut
 
 - `Auth`
 - `Autofill`
+- `Billing`
 - `Platform`
 - `Tools`
 - `Vault`
@@ -382,7 +383,7 @@ Test files are co-located with the code they test, maintaining the same folder s
 
 - Makes it easy to find tests for a given type
 - Ensures tests evolve alongside the code
-- Reinforces the architectural boundaries (Auth, Autofill, Platform, Tools, Vault)
+- Reinforces the architectural boundaries (see [Architecture Structure](#architecture-structure) for domain list)
 
 ### Dependency Mocking
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33571

## 📔 Objective

Adds two new Claude skills and a command for the planning phase of iOS feature development.

**What changed:**

- **`skills/refining-ios-requirements`** — Ingests Jira/Confluence tickets via MCP, extracts structured requirements and acceptance criteria, performs gap analysis (error states, edge cases, multi-account, extension memory, accessibility), and maps work to the correct iOS domain (Auth/Autofill/Platform/Tools/Vault). Produces a structured requirements doc and pauses for user confirmation before proceeding.

- **`skills/planning-ios-implementation`** — Classifies the change type (new feature, enhancement, service, bug fix), explores existing codebase patterns, lists all files to create/modify with domain placement, produces dependency-ordered implementation phases (Core → Services → Processors → Views → DI → Tests), and assesses risks (security, extensions, multi-account, SDK).

- **`/plan-ios-work` command** — Orchestrates both skills end-to-end: ingests a ticket via MCP, refines requirements, confirms with user, plans implementation, and saves the design doc to `.claude/outputs/plans/<ticket-id>.md`.

- **CLAUDE.md** — Compresses the directory tree listing from 45 to 5 lines; removes the Auth/Authorization detail section (now discoverable via the `refining-ios-requirements` skill); removes the redundant Core Directives numbered list (covered by the DO/DON'T section and `Docs/` pointers); replaces the external style guide URL with local `Docs/Architecture.md` and `Docs/Testing.md` references.