### PR TITLE
[PM-33572] llm: Add implementing-ios-code skill with Swift templates

### DIFF
--- a/.claude/skills/implementing-ios-code/SKILL.md
+++ b/.claude/skills/implementing-ios-code/SKILL.md
@@ -28,7 +28,12 @@ Implement from the bottom up:
 **Data Models** (if needed)
 - Request/Response types in `Core/<Domain>/Models/Request/` and `Response/`
 - Enum types in `Core/<Domain>/Models/Enum/`
-- CoreData entities only if persistence is needed (add to `Bitwarden.xcdatamodeld`)
+
+**Persistence** (if needed)
+- Vault sync data → CoreData via `DataStore` (add entities to `Bitwarden.xcdatamodeld`)
+- Non-sensitive settings → `AppSettingsStore` (backed by UserDefaults)
+- Credentials/keys → `KeychainRepository`
+- All three are exposed through `StateService`. Prefer adding a separate protocol over extending `StateService`, `AppSettingsStore`, or `KeychainRepository` directly, to maintain interface segregation.
 
 **Services / Repositories**
 - Define protocol with `// sourcery: AutoMockable`
@@ -58,7 +63,7 @@ After creating a new service/repository:
 
 Before finishing:
 - [ ] Vault data? → Must use `BitwardenSdk` for all encryption/decryption
-- [ ] Storing credentials? → Must use `KeychainRepository`, not `UserDefaults`
+- [ ] Storing credentials? → Must use `KeychainRepository`, not `AppSettingsStore`
 - [ ] User input? → Must validate via `InputValidator`
 - [ ] Surfacing errors? → Sensitive errors must implement `NonLoggableError`
 - [ ] Running in an extension? → Check Argon2id memory if KDF is involved
@@ -67,4 +72,4 @@ Before finishing:
 
 All new public types and methods require DocC (`///`) documentation.
 Exceptions: protocol property/function implementations (docs live in the protocol), mock classes.
-Use `// MARK: -` sections to organize code within files.
+Use pragma marks to organize code. `// MARK: -` is used to denote different objects in the same file; `// MARK:` is used to denote different sections within an object.

--- a/.claude/skills/implementing-ios-code/templates.md
+++ b/.claude/skills/implementing-ios-code/templates.md
@@ -9,7 +9,6 @@ When adding a new screen, create these files (replace `<Feature>` throughout):
 
 ```
 BitwardenShared/UI/<Domain>/<Feature>/
-├── <Feature>Coordinator.swift
 ├── <Feature>Processor.swift
 ├── <Feature>State.swift
 ├── <Feature>Action.swift
@@ -18,6 +17,8 @@ BitwardenShared/UI/<Domain>/<Feature>/
 ```
 
 Add a new case to the **parent** Coordinator's existing `Route` enum rather than creating a new `Route` file.
+
+**When to create a new Coordinator:** Most screens do NOT need their own coordinator. A single coordinator typically manages an entire feature flow with many routes (e.g., `AuthCoordinator` handles ~30 screens). Only create a new child coordinator when the flow introduces a new navigation container (e.g., a new modal or tab) or becomes complex enough to warrant isolation. When in doubt, add a route to the parent coordinator.
 
 ---
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33572

## 📔 Objective

Adds a Claude skill for implementing Bitwarden iOS features following established patterns.

**What changed:**

- **`skills/implementing-ios-code/SKILL.md`** — Step-by-step implementation workflow: determines scope from a design doc, builds the Core layer first (models, services, repositories), then the full UI file-set (Coordinator, Processor, State, Action, Effect, View), wires DI into `ServiceContainer`, runs a security checklist (zero-knowledge, Keychain, InputValidator, NonLoggableError, extension memory), and ensures DocC documentation. References `Docs/Architecture.md` as authoritative and does not duplicate it.

- **`skills/implementing-ios-code/templates.md`** — Minimal copy-paste skeletons derived from actual codebase files: Coordinator, Processor, State/Action/Effect, View (with `store.binding` and `store.perform`), Service (protocol + `Default*` + `Has*` + `// sourcery: AutoMockable`), and Repository. Each template notes the source file it was based on.