### PR TITLE
[PM-29855] fix: Update accessibility label for option button in list rows

### DIFF
--- a/BitwardenKit/UI/Platform/Settings/FlightRecorder/FlightRecorderLogs/FlightRecorderLogsView.swift
+++ b/BitwardenKit/UI/Platform/Settings/FlightRecorder/FlightRecorderLogs/FlightRecorderLogsView.swift
@@ -109,7 +109,7 @@ struct FlightRecorderLogsView: View {
                 SharedAsset.Icons.ellipsisHorizontal24.swiftUIImage
                     .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
             }
-            .accessibilityLabel(Localizations.more)
+            .accessibilityLabel(Localizations.moreOptions)
             .accessibilityIdentifier("FlightRecorderLogOptionsButton")
         }
         .accessibilityElement(children: .combine)

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 "AccountAlreadyAdded" = "Account already added";
 "SwitchToAlreadyAddedAccountConfirmation" = "Would you like to switch to it now?";
 "MasterPassword" = "Master password";
-"More" = "More";
+"MoreOptions" = "More options";
 "MyVault" = "My vault";
 "Authenticator" = "Authenticator";
 "Name" = "Name";

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -88,10 +88,10 @@ struct SendListItemRowView: View {
                 } label: {
                     buttonLabel(for: store.state.item)
                 }
-                .accessibilityIdentifier(store.state.accessibilityIdentifier)
 
                 if case let .send(sendView) = store.state.item.itemType {
                     optionsMenu(for: sendView)
+                        .accessibilityLabel(Localizations.moreOptions)
                 }
             }
             .padding(.horizontal, 16)
@@ -101,6 +101,8 @@ struct SendListItemRowView: View {
                     .padding(.leading, scaledIconWidth + 16 + 16)
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityIdentifier(store.state.accessibilityIdentifier)
     }
 
     // MARK: Private Views

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView+ViewInspectorTests.swift
@@ -147,7 +147,7 @@ class VaultGroupViewTests: BitwardenTestCase {
         let item = VaultListItem.fixture()
         let section = VaultListSection(id: "Items", items: [item], name: Localizations.items)
         processor.state.loadingState = .data([section])
-        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.moreOptions)
         try await button.tap()
         XCTAssertEqual(processor.effects.last, .morePressed(item))
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView+ViewInspectorTests.swift
@@ -282,7 +282,7 @@ class VaultListViewTests: BitwardenTestCase {
     func test_vaultItem_moreButton_tap() async throws {
         let item = VaultListItem.fixture()
         processor.state.loadingState = .data([VaultListSection(id: "1", items: [item], name: "Group")])
-        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.moreOptions)
         try await button.tap()
         XCTAssertEqual(processor.effects.last, .morePressed(item))
     }

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView+ViewInspectorTests.swift
@@ -39,7 +39,7 @@ class VaultListItemRowViewTests: BitwardenTestCase {
     /// Test that tapping the more button dispatches the `.morePressed` action.
     @MainActor
     func test_moreButton_tap() async throws {
-        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.more)
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.moreOptions)
         try await button.tap()
         XCTAssertEqual(processor.effects.last, .morePressed)
     }

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
@@ -86,7 +86,7 @@ struct VaultListItemRowView: View {
                                 SharedAsset.Icons.ellipsisHorizontal24.swiftUIImage
                                     .imageStyle(.rowIcon)
                             }
-                            .accessibilityLabel(Localizations.more)
+                            .accessibilityLabel(Localizations.moreOptions)
                             .accessibilityIdentifier("CipherOptionsButton")
                         }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-29855](https://bitwarden.atlassian.net/browse/PM-29855)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the accessibility label for the option menu's button in the vault, send, and flight recorder list to 'More options'.


[PM-29855]: https://bitwarden.atlassian.net/browse/PM-29855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ