### PR TITLE
[PM-32767] fix: Update localized strings for organization level Session Timeout Settings 

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1292,6 +1292,8 @@
 "ThisSettingIsManagedByYourOrganization" = "This setting is managed by your organization.";
 "YourOrganizationHasSetTheDefaultSessionTimeoutToX" = "Your organization has set the default session timeout to %1$@.";
 "YourOrganizationHasSetTheMaximumSessionTimeoutToX" = "Your organization has set the maximum session timeout to %1$@.";
+"YourOrganizationHasSetTheDefaultSessionTimeoutToNever" = "Your organization has set the default session timeout to never.";
+"YourOrganizationHasSetTheDefaultSessionTimeoutToAppRestart" = "Your organization has set the default session timeout to on app restart.";
 "YourOrganizationHasSetTheMaximumSessionTimeoutToXAndY" = "Your organization has set the maximum session timeout to %1$@ and %2$@.";
 "HiddenItems" = "Hidden items";
 "Archive" = "Archive";

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessorTests.swift
@@ -219,7 +219,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         )
         XCTAssertEqual(
             subject.state.policyTimeoutMessage,
-            Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToX("never"),
+            Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToNever,
         )
     }
 
@@ -261,7 +261,7 @@ class AccountSecurityProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         )
         XCTAssertEqual(
             subject.state.policyTimeoutMessage,
-            Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToX("on app restart"),
+            Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToAppRestart,
         )
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -240,18 +240,16 @@ struct AccountSecurityState: Equatable {
     /// - `nil`: Returns `nil` if no policy is in effect
     ///
     var policyTimeoutCustomMessage: String? {
-        guard isPolicyTimeoutEnabled, let policy = policyTimeoutType else { return nil }
+        guard isPolicyTimeoutEnabled, let policyTimeoutType else { return nil }
         switch policyTimeoutType {
         case .custom:
             return customTimeoutMessage
         case .immediately:
             return Localizations.thisSettingIsManagedByYourOrganization
         case .never:
-            return Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToX(policy.timeoutType)
+            return Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToNever
         case .onAppRestart:
-            return Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToX(policy.timeoutType)
-        default:
-            return customTimeoutMessage
+            return Localizations.yourOrganizationHasSetTheDefaultSessionTimeoutToAppRestart
         }
     }
 


### PR DESCRIPTION
Separates the variable-driven localization for 'never' and 'on app restart' session timeout settings into two separate strings.


## 🎟️ Tracking

[PM-32767 ](https://bitwarden.atlassian.net/browse/PM-32767?atlOrigin=eyJpIjoiMTYyM2RhOTQ2ZTU0NGQ4OGFmZTUwNGU1NjI3MzlhNzUiLCJwIjoiaiJ9)

## 📔 Objective

Fixes #2379 
> An issue in which Polish and English are combined into one Polish-localized string due to the way variable-driven localized strings function.

## 📸 Screenshots

(I did not know how to set up an org and add my test user to it yet)