### PR TITLE
[PM-33862] chore: Don't log to Crashlytics when receiving a login request for a logged out account

### DIFF
--- a/BitwardenShared/Core/Platform/Services/NotificationService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationService.swift
@@ -335,12 +335,20 @@ class DefaultNotificationService: NotificationService {
     private func handleLoginRequest(_ notificationData: PushNotificationData, userId: String) async throws {
         let data: LoginRequestNotification = try notificationData.data()
 
+        // Get the email of the account that the login request is coming from.
+        let loginSourceAccount: Account
+        do {
+            loginSourceAccount = try await stateService.getAccount(userId: data.userId)
+        } catch StateServiceError.noAccounts {
+            await flightRecorder.log(
+                "[Notification] Received login request notification but account (\(data.userId)) not found",
+            )
+            return
+        }
+        let loginSourceEmail = loginSourceAccount.profile.email
+
         // Save the notification data.
         await stateService.setLoginRequest(data)
-
-        // Get the email of the account that the login request is coming from.
-        let loginSourceAccount = try await stateService.getAccount(userId: data.userId)
-        let loginSourceEmail = loginSourceAccount.profile.email
 
         // Assemble the data to add to the in-app banner notification.
         let loginRequestData = try? JSONEncoder().encode(LoginRequestPushNotification(
@@ -422,14 +430,19 @@ class DefaultNotificationService: NotificationService {
             // Get the user id of the source of the login request.
             let loginSourceAccount = try await stateService.getAccount(userId: loginRequestData.userId)
 
-            // Get the active account for comparison.
-            let activeAccount = try await stateService.getActiveAccount()
+            // Get the active account ID for comparison.
+            let activeAccountId = try await stateService.getActiveAccountId()
 
             // If the notification banner was tapped but it's for a different account, switch
             // to that account automatically.
-            if activeAccount.profile.userId != loginSourceAccount.profile.userId {
+            if activeAccountId != loginSourceAccount.profile.userId {
                 await delegate?.switchAccountsForLoginRequest(to: loginSourceAccount, showAlert: false)
             }
+        } catch StateServiceError.noAccounts {
+            let userId = loginRequestData.userId
+            await flightRecorder.log(
+                "[Notification] Notification tapped for login request but account (\(userId)) not found",
+            )
         } catch {
             errorReporter.log(error: error)
         }

--- a/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
@@ -426,6 +426,33 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertTrue(syncService.didFetchSync)
     }
 
+    /// `messageReceived(_:notificationDismissed:notificationTapped:)` logs to the flight recorder
+    /// when a login request push notification is received for an account that doesn't exist.
+    @MainActor
+    func test_messageReceived_loginRequest_accountNotFound() async throws {
+        stateService.setIsAuthenticated()
+        appSettingsStore.appId = "10"
+        let loginRequestNotification = LoginRequestNotification(id: "requestId", userId: "unknownUser")
+        let notificationData = try JSONEncoder().encode(loginRequestNotification)
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
+            "data": [
+                "type": NotificationType.authRequest.rawValue,
+                "payload": String(data: notificationData, encoding: .utf8) ?? "",
+            ],
+        ]
+
+        await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: nil)
+
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+        XCTAssertEqual(
+            flightRecorder.logMessages,
+            [
+                "[Notification] Received push notification, type: authRequest",
+                "[Notification] Received login request notification but account (unknownUser) not found",
+            ],
+        )
+    }
+
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` tells
     /// the delegate to show the switch account alert if it's a login request for a non-active account.
     @MainActor
@@ -696,7 +723,8 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles errors.
     @MainActor
     func test_messageReceived_notificationTapped_error() async throws {
-        // Set up the mock data.
+        stateService.accounts = [.fixture()]
+        stateService.getActiveAccountIdError = BitwardenTestError.example
         let loginRequest = LoginRequestPushNotification(
             timeoutInMinutes: 15,
             userId: Account.fixture().profile.userId,
@@ -706,11 +734,32 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
             "notificationData": String(data: testData, encoding: .utf8) ?? "",
         ]
 
-        // Test.
         await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: true)
 
-        // Confirm the results.
-        XCTAssertEqual(errorReporter.errors.last as? StateServiceError, .noAccounts)
+        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+    }
+
+    /// `messageReceived(_:notificationDismissed:notificationTapped:)` logs the account not found
+    /// error to the flight recorder when a tapped notification references an unknown account.
+    @MainActor
+    func test_messageReceived_notificationTapped_error_accountNotFound() async throws {
+        let loginRequest = LoginRequestPushNotification(
+            timeoutInMinutes: 15,
+            userId: Account.fixture().profile.userId,
+        )
+        let testData = try JSONEncoder().encode(loginRequest)
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
+            "notificationData": String(data: testData, encoding: .utf8) ?? "",
+        ]
+
+        await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: true)
+
+        let userId = Account.fixture().profile.userId
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+        XCTAssertEqual(
+            flightRecorder.logMessages,
+            ["[Notification] Notification tapped for login request but account (\(userId)) not found"],
+        )
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-33862](https://bitwarden.atlassian.net/browse/PM-33862)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates `NotificationService` to avoid logging an error to Crashlytics if a login with device push notification is received for a previously logged out account.

These errors will still be logged to the flight recorder, but this reduces noise around this error in Crashlytics.

Flight recorder logs:

Receiving a login request notification for logged out user:
> [Notification] Received login request notification but account (<user ID>) not found

Tapping a login request notification for logged out user:
> [Notification] Notification tapped for login request but account (<user ID>) not found

This would previously log to Crashlytics as BitwardenShared.StateServiceError (0)
https://console.firebase.google.com/u/1/project/bitwarden-c2b35/crashlytics/app/ios:com.8bit.bitwarden/issues/cf447a52d81b82d362cebe514c3a608a?time=90d&sessionEventKey=f09b0fd51a3644f8b5e260f1c9afd074_2197055048938026635



[PM-33862]: https://bitwarden.atlassian.net/browse/PM-33862?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ