### PR TITLE
[PM-33557] fix: Remove "Why am I seeing this?" link button on Sync with browser view

### DIFF
--- a/BitwardenShared/UI/Auth/Login/SyncWithBrowser/SyncWithBrowserView.swift
+++ b/BitwardenShared/UI/Auth/Login/SyncWithBrowser/SyncWithBrowserView.swift
@@ -40,13 +40,6 @@ struct SyncWithBrowserView: View {
                 }
                 .buttonStyle(.secondary())
             }
-
-            Button {
-                openURL(ExternalLinksConstants.aboutOrganizations)
-            } label: {
-                Text(Localizations.whyAmISeeingThis)
-            }
-            .buttonStyle(.bitwardenBorderless)
         }
         .padding(.horizontal, 16)
         .padding(.top, 12)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33557](https://bitwarden.atlassian.net/browse/PM-33557)

## 📔 Objective

Remove "Why am I seeing this?" link button on Sync with browser view as there's no good docs page to link to yet.

[PM-33557]: https://bitwarden.atlassian.net/browse/PM-33557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ