### PR TITLE
[PM-33914] fix: Remove org event to avoid blank log entry.

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/EventType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/EventType.swift
@@ -48,5 +48,4 @@ public enum EventType: Int, Codable, Sendable {
     case organizationClientExportedVault = 1602
 
     case organizationItemOrganizationAccepted = 1618
-    case organizationItemOrganizationDeclined = 1619
 }

--- a/BitwardenShared/UI/Vault/MigrateToMyItems/MigrateToMyItemsProcessor.swift
+++ b/BitwardenShared/UI/Vault/MigrateToMyItems/MigrateToMyItemsProcessor.swift
@@ -129,10 +129,6 @@ final class MigrateToMyItemsProcessor: StateProcessor<
         do {
             try await services.authRepository.revokeSelfFromOrganization(organizationId: state.organizationId)
             coordinator.hideLoadingOverlay()
-            await services.eventService.collect(
-                eventType: .organizationItemOrganizationDeclined,
-                organizationId: state.organizationId,
-            )
             delegate?.didLeaveOrganization()
         } catch {
             coordinator.hideLoadingOverlay()

--- a/BitwardenShared/UI/Vault/MigrateToMyItems/MigrateToMyItemsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/MigrateToMyItems/MigrateToMyItemsProcessorTests.swift
@@ -103,7 +103,7 @@ class MigrateToMyItemsProcessorTests: BitwardenTestCase {
 
         XCTAssertTrue(authRepository.revokeSelfFromOrganizationCalled)
         XCTAssertEqual(authRepository.revokeSelfFromOrganizationOrganizationId, "org-123")
-        XCTAssertEqual(eventService.collectEventType, .organizationItemOrganizationDeclined)
+        XCTAssertNil(eventService.collectEventType)
         XCTAssertTrue(delegate.didLeaveOrganizationCalled)
         XCTAssertTrue(coordinator.alertShown.isEmpty)
     }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33914](https://bitwarden.atlassian.net/browse/PM-33914)

## 📔 Objective

Removes an org event log from the iOS client to avoid duplicate entries. This event is logged server-side.



[PM-33913]: https://bitwarden.atlassian.net/browse/PM-33913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PM-33914]: https://bitwarden.atlassian.net/browse/PM-33914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ