### PR TITLE
[PM-33930] fix: Exclude items with invalid keys from TOTP section count

### DIFF
--- a/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
@@ -337,10 +337,17 @@ class DefaultVaultListPreparedDataBuilder: VaultListPreparedDataBuilder { // swi
     }
 
     func incrementTOTPCount(cipher: CipherListView) async -> VaultListPreparedDataBuilder {
-        if await shouldIncludeTOTP(cipher: cipher) {
-            preparedData.totpItemsCount += 1
-        }
+        guard await shouldIncludeTOTP(cipher: cipher) else { return self }
 
+        // Ensure the TOTP key is valid by generating a TOTP code. The count shouldn't be
+        // incremented for invalid keys since they are filtered out from the list.
+        let isValidKey = await (try? clientService.vault().generateTOTPCode(
+            for: cipher,
+            date: timeProvider.presentTime,
+        )) != nil
+        guard isValidKey else { return self }
+
+        preparedData.totpItemsCount += 1
         return self
     }
 

--- a/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilderTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilderTests.swift
@@ -392,6 +392,18 @@ class VaultListPreparedDataBuilderTests: BitwardenTestCase { // swiftlint:disabl
         XCTAssertEqual(preparedData.totpItemsCount, 0)
     }
 
+    /// `incrementTOTPCount(cipher:)` does not increment the TOTP items count when the TOTP key
+    /// is present but invalid (code generation fails).
+    func test_incrementTOTPCount_doesNotIncrementWhenTOTPCodeIsInvalid() async {
+        let cipher = CipherListView.fixture(type: .login(.fixture(totp: "otpauth://totp")))
+        stateService.doesActiveAccountHavePremiumResult = true
+        clientService.mockVault.generateTOTPCodeResult = .failure(BitwardenTestError.example)
+
+        let preparedData = await subject.incrementTOTPCount(cipher: cipher).build()
+
+        XCTAssertEqual(preparedData.totpItemsCount, 0)
+    }
+
     /// `incrementTOTPCount(cipher:)` increments the TOTP items count when cipher is in an organization
     ///  with TOTP enabled.
     func test_incrementTOTPCount_incrementsWhenOrgHasTotpEnabled() async {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-33930](https://bitwarden.atlassian.net/browse/PM-33930)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The "Verification codes" section count on the main vault screen was inflated when a login had a TOTP key set but the key was invalid (e.g. `otpauth://totp` with no secret).

`incrementTOTPCount` only checked whether the cipher had a TOTP key and the user had access — it didn't validate that the key could actually produce a code. The list-building path (`totpItem(for:)`) does attempt code generation and silently drops failures, so the two paths diverged, causing the displayed count to be higher than the number of items shown in the list.

`incrementTOTPCount` now attempts TOTP code generation (matching the validation already performed by `totpItem(for:)`) and skips the count increment if generation fails.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/566d92e7-bcf7-4ea5-bf56-b7cd5d7ba733" /> | <video src="https://github.com/user-attachments/assets/9ff10398-15cd-4ebd-9d85-f06413d0456b" /> | 








[PM-33930]: https://bitwarden.atlassian.net/browse/PM-33930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ