### PR TITLE
[PM-32401] fix: Prevent copy TOTP autofill action for non-premium accounts

### DIFF
--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -698,7 +698,7 @@ extension DefaultVaultRepository: VaultRepository {
     }
 
     func getTOTPKeyIfAllowedToCopy(cipher: CipherView) async throws -> String? {
-        guard let totp = cipher.login?.totp else {
+        guard let totp = cipher.login?.totp, !totp.isEmpty else {
             return nil
         }
 

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -1050,6 +1050,16 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(totpKey, "123")
     }
 
+    /// `getTOTPKeyIfAllowedToCopy(cipher:)` return `nil` when cipher has an empty TOTP key.
+    func test_getTOTPKeyIfAllowedToCopy_totpEmpty() async throws {
+        stateService.activeAccount = .fixture()
+        let totpKey = try await subject.getTOTPKeyIfAllowedToCopy(cipher: .fixture(
+            login: .fixture(totp: ""),
+            organizationUseTotp: true,
+        ))
+        XCTAssertNil(totpKey)
+    }
+
     /// `getTOTPKeyIfAllowedToCopy(cipher:)` return `nil` when cipher doesn't have TOTP key.
     func test_getTOTPKeyIfAllowedToCopy_totpNil() async throws {
         stateService.activeAccount = .fixture()

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -120,7 +120,7 @@ class AutofillHelper {
             guard appExtensionDelegate?.canAutofill ?? false,
                   let username = cipherView.login?.username, !username.isEmpty,
                   let password = cipherView.login?.password, !password.isEmpty else {
-                handleMissingValueForAutofill(cipherView: cipherView, showToast: showToast)
+                await handleMissingValueForAutofill(cipherView: cipherView, showToast: showToast)
                 return
             }
 
@@ -154,7 +154,7 @@ class AutofillHelper {
     ///   - cipherView: The `CipherView` to use for autofill.
     ///   - showToast: A closure that when called will display a toast to the user.
     ///
-    private func handleMissingValueForAutofill(cipherView: CipherView, showToast: @escaping (String) -> Void) {
+    private func handleMissingValueForAutofill(cipherView: CipherView, showToast: @escaping (String) -> Void) async {
         guard let login = cipherView.login,
               !login.username.isEmptyOrNil ||
               !login.password.isEmptyOrNil ||
@@ -180,22 +180,26 @@ class AutofillHelper {
             }))
         }
 
-        if let totp = login.totp, !totp.isEmpty {
-            alert.add(AlertAction(title: Localizations.copyTotp, style: .default) { _ in
-                do {
-                    let key = TOTPKeyModel(authenticatorKey: totp)
-                    let response = try await self.services.vaultRepository.refreshTOTPCode(for: key)
-                    if let code = response.codeModel?.code {
-                        self.services.pasteboardService.copy(code)
-                        showToast(Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp))
-                    } else {
+        do {
+            if let totp = try await services.vaultRepository.getTOTPKeyIfAllowedToCopy(cipher: cipherView) {
+                alert.add(AlertAction(title: Localizations.copyTotp, style: .default) { _ in
+                    do {
+                        let key = TOTPKeyModel(authenticatorKey: totp)
+                        let response = try await self.services.vaultRepository.refreshTOTPCode(for: key)
+                        if let code = response.codeModel?.code {
+                            self.services.pasteboardService.copy(code)
+                            showToast(Localizations.valueHasBeenCopied(Localizations.verificationCodeTotp))
+                        } else {
+                            self.coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+                        }
+                    } catch {
                         self.coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+                        self.services.errorReporter.log(error: error)
                     }
-                } catch {
-                    self.coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
-                    self.services.errorReporter.log(error: error)
-                }
-            })
+                })
+            }
+        } catch {
+            services.errorReporter.log(error: error)
         }
 
         alert.add(AlertAction(title: Localizations.cancel, style: .cancel))

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -217,6 +217,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             login: .fixture(password: "PASSWORD", username: nil, totp: "totp"),
             name: "Bitwarden Login",
         ))
+        vaultRepository.getTOTPKeyIfAllowedToCopyResult = .success("totp")
         vaultRepository.refreshTOTPCodeResult = .success(
             LoginTOTPState(
                 authKeyModel: TOTPKeyModel(authenticatorKey: .standardTotpKey),
@@ -253,6 +254,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             login: .fixture(password: "PASSWORD", username: nil, totp: "totp"),
             name: "Bitwarden Login",
         ))
+        vaultRepository.getTOTPKeyIfAllowedToCopyResult = .success("totp")
         struct GenerateTotpError: Error, Equatable {}
         vaultRepository.refreshTOTPCodeResult = .failure(GenerateTotpError())
 
@@ -262,6 +264,42 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.copyTotp)
         XCTAssertEqual(errorReporter.errors.last as? GenerateTotpError, GenerateTotpError())
+    }
+
+    /// `handleCipherForAutofill(cipherListView:)` logs an error if `getTOTPKeyIfAllowedToCopy` throws
+    /// in the missing value alert.
+    @MainActor
+    func test_handleCipherForAutofill_missingValueGetTOTPKeyError() async throws {
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: nil, totp: "totp"),
+            name: "Bitwarden Login",
+        ))
+        struct GetTOTPKeyError: Error, Equatable {}
+        vaultRepository.getTOTPKeyIfAllowedToCopyResult = .failure(GetTOTPKeyError())
+
+        let cipher = CipherListView.fixture(id: "1")
+        await subject.handleCipherForAutofill(cipherListView: cipher) { _ in }
+
+        XCTAssertEqual(errorReporter.errors.last as? GetTOTPKeyError, GetTOTPKeyError())
+    }
+
+    /// `handleCipherForAutofill(cipherListView:)` does not show Copy TOTP in the missing value alert
+    /// when the user is not authorized to use TOTP.
+    @MainActor
+    func test_handleCipherForAutofill_missingValueTotpNotAuthorized() async throws {
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: nil, totp: "totp"),
+            name: "Bitwarden Login",
+        ))
+        vaultRepository.getTOTPKeyIfAllowedToCopyResult = .success(nil)
+
+        let cipher = CipherListView.fixture(id: "1")
+        await subject.handleCipherForAutofill(cipherListView: cipher) { _ in }
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.copyPassword)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
     }
 
     /// `handleCipherForAutofill(cipherListView:)` shows an alert if the cipher is missing an


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-32401](https://bitwarden.atlassian.net/browse/PM-32401)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Similar to https://github.com/bitwarden/ios/pull/2467

This handles the case where a cipher is missing a username or password and autofill can't be performed. From the vault list, a user is given the option of copying individual fields from within a cipher. If the cipher contains a TOTP key, but the user doesn't have premium (or the org doesn't use TOTP), the "Copy TOTP" code option shouldn't be available in the menu.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="568" height="1084" alt="before" src="https://github.com/user-attachments/assets/c7d59e48-1db1-4f60-ba4a-9c6e6e6c74d5" /> | <img width="568" height="1084" alt="after" src="https://github.com/user-attachments/assets/f9ff3c38-fb3c-478c-8a21-2c0626269ab0" /> | 

[PM-32401]: https://bitwarden.atlassian.net/browse/PM-32401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ