### PR TITLE
[PM-34062] [RC] fix: Fix dismiss sync with browser automatically

### DIFF
--- a/BitwardenShared/UI/Platform/GlobalModal/GlobalModalCoordinator.swift
+++ b/BitwardenShared/UI/Platform/GlobalModal/GlobalModalCoordinator.swift
@@ -51,9 +51,14 @@ public final class GlobalModalCoordinator: NSObject, Coordinator, HasStackNaviga
     ) {
         switch route {
         case let .dismissWithAction(onDismiss):
-            stackNavigator?.dismiss(animated: true, completion: {
-                onDismiss?.action()
-            })
+            // PM-34062 Sometimes it doesn't get dismissed because it tries to do it before coming back
+            // from the browser to the view. So we wait a bit here and execute this on
+            // main thread to handle the edge case.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+                self?.stackNavigator?.dismiss(animated: true, completion: {
+                    onDismiss?.action()
+                })
+            }
         case .syncWithBrowser:
             showSyncWithBrowser()
         }

--- a/BitwardenShared/UI/Platform/GlobalModal/GlobalModalCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/GlobalModal/GlobalModalCoordinatorTests.swift
@@ -1,0 +1,72 @@
+import BitwardenKit
+import BitwardenKitMocks
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - GlobalModalCoordinatorTests
+
+class GlobalModalCoordinatorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var stackNavigator: MockStackNavigator!
+    var subject: GlobalModalCoordinator!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        stackNavigator = MockStackNavigator()
+        subject = GlobalModalCoordinator(
+            services: ServiceContainer.withMocks(),
+            stackNavigator: stackNavigator,
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        stackNavigator = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `navigate(to:)` with `.dismissWithAction(nil)` dismisses the view without calling an action.
+    @MainActor
+    func test_navigate_dismissWithAction_nilAction() async throws {
+        subject.navigate(to: .dismissWithAction(nil))
+
+        try await waitForAsync { self.stackNavigator.actions.last?.type == .dismissedWithCompletionHandler }
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .dismissedWithCompletionHandler)
+    }
+
+    /// `navigate(to:)` with `.dismissWithAction(_)` dismisses the view and calls the dismiss action.
+    @MainActor
+    func test_navigate_dismissWithAction_withAction() async throws {
+        var actionCalled = false
+        let dismissAction = DismissAction { actionCalled = true }
+
+        subject.navigate(to: .dismissWithAction(dismissAction))
+
+        try await waitForAsync { actionCalled }
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .dismissedWithCompletionHandler)
+        XCTAssertTrue(actionCalled)
+    }
+
+    /// `navigate(to:)` with `.syncWithBrowser` replaces the stack with the sync with browser view.
+    @MainActor
+    func test_navigate_syncWithBrowser() throws {
+        subject.navigate(to: .syncWithBrowser)
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .replaced)
+        XCTAssertTrue(action.view is SyncWithBrowserView)
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34062](https://bitwarden.atlassian.net/browse/PM-34062)

## 📔 Objective

🍒 RC Cherry pick from #2484.

Fix dismiss sync with browser when the action to dismiss was being executed before it went back form the browser to the app which prevented the dismiss navigation.


[PM-34062]: https://bitwarden.atlassian.net/browse/PM-34062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ