### PR TITLE
[PM-33981] feat: Add device management UI components

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Device/DeviceAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Device/DeviceAPIService.swift
@@ -1,5 +1,6 @@
 // MARK: - DeviceAPIService
 
+// sourcery: AutoMockable
 /// A protocol for an API service used to make device requests.
 ///
 protocol DeviceAPIService {

--- a/BitwardenShared/Core/Auth/Services/API/Device/DeviceAPIService.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Device/DeviceAPIService.swift
@@ -1,9 +1,8 @@
 // MARK: - DeviceAPIService
 
-// sourcery: AutoMockable
 /// A protocol for an API service used to make device requests.
 ///
-protocol DeviceAPIService {
+protocol DeviceAPIService { // sourcery: AutoMockable
     /// Retrieves the current device by its app identifier.
     ///
     /// - Parameter appId: The unique app identifier for this device.

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -27,9 +27,6 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     /// The service used by the application to make API requests.
     let apiService: APIService
 
-    /// Overrides `deviceAPIService` for testing. Set via `ServiceContainer.withMocks(deviceAPIService:)`.
-    var deviceAPIServiceOverride: DeviceAPIService?
-
     /// Helper used to know app context.
     let appContextHelper: AppContextHelper
 
@@ -92,6 +89,9 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
 
     /// The service to get server-specified configuration
     public let configService: ConfigService
+
+    /// The service used by the application to make device API requests.
+    let deviceAPIService: DeviceAPIService
 
     /// The service to make and use the device auth key.
     let deviceAuthKeyService: DeviceAuthKeyService
@@ -266,6 +266,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     ///     for mTLS authentication.
     ///   - clientService: The service used by the application to handle encryption and decryption tasks.
     ///   - configService: The service to get server-specified configuration.
+    ///   - deviceAPIService: The service used by the application to make device API requests.
     ///   - deviceAuthKeyService: The service to make and use the device auth key.
     ///   - environmentService: The service used by the application to manage the environment settings.
     ///   - errorReportBuilder: A helper for building an error report containing the details of an
@@ -342,6 +343,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         clientCertificateService: ClientCertificateService,
         clientService: ClientService,
         configService: ConfigService,
+        deviceAPIService: DeviceAPIService,
         deviceAuthKeyService: DeviceAuthKeyService,
         environmentService: EnvironmentService,
         errorReportBuilder: ErrorReportBuilder,
@@ -412,6 +414,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         self.clientCertificateService = clientCertificateService
         self.clientService = clientService
         self.configService = configService
+        self.deviceAPIService = deviceAPIService
         self.deviceAuthKeyService = deviceAuthKeyService
         self.environmentService = environmentService
         self.errorReportBuilder = errorReportBuilder
@@ -1173,6 +1176,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             clientCertificateService: clientCertificateService,
             clientService: clientService,
             configService: configService,
+            deviceAPIService: apiService,
             deviceAuthKeyService: deviceAuthKeyService,
             environmentService: environmentService,
             errorReportBuilder: errorReportBuilder,
@@ -1271,10 +1275,6 @@ extension ServiceContainer {
 
     var configAPIService: ConfigAPIService {
         apiService
-    }
-
-    var deviceAPIService: DeviceAPIService {
-        deviceAPIServiceOverride ?? apiService
     }
 
     var fileAPIService: FileAPIService {

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -27,6 +27,9 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
     /// The service used by the application to make API requests.
     let apiService: APIService
 
+    /// Overrides `deviceAPIService` for testing. Set via `ServiceContainer.withMocks(deviceAPIService:)`.
+    var deviceAPIServiceOverride: DeviceAPIService?
+
     /// Helper used to know app context.
     let appContextHelper: AppContextHelper
 
@@ -1271,7 +1274,7 @@ extension ServiceContainer {
     }
 
     var deviceAPIService: DeviceAPIService {
-        apiService
+        deviceAPIServiceOverride ?? apiService
     }
 
     var fileAPIService: FileAPIService {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
@@ -34,6 +34,7 @@ extension ServiceContainer {
         clientCertificateService: ClientCertificateService = MockClientCertificateService(),
         clientService: ClientService = MockClientService(),
         configService: ConfigService = MockConfigService(),
+        deviceAPIService: DeviceAPIService = MockDeviceAPIService(),
         deviceAuthKeyService: DeviceAuthKeyService = MockDeviceAuthKeyService(),
         environmentService: EnvironmentService = MockEnvironmentService(),
         errorReportBuilder: ErrorReportBuilder = MockErrorReportBuilder(),
@@ -96,7 +97,7 @@ extension ServiceContainer {
             actualSearchProcessorMediatorFactory = factoryMock
         }
 
-        return ServiceContainer(
+        let container = ServiceContainer(
             apiService: APIService(
                 client: httpClient,
                 environmentService: environmentService,
@@ -170,5 +171,7 @@ extension ServiceContainer {
             vaultTimeoutService: vaultTimeoutService,
             watchService: watchService,
         )
+        container.deviceAPIServiceOverride = deviceAPIService
+        return container
     }
 }

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
@@ -34,7 +34,7 @@ extension ServiceContainer {
         clientCertificateService: ClientCertificateService = MockClientCertificateService(),
         clientService: ClientService = MockClientService(),
         configService: ConfigService = MockConfigService(),
-        deviceAPIService: DeviceAPIService = MockDeviceAPIService(),
+        deviceAPIService: DeviceAPIService? = nil,
         deviceAuthKeyService: DeviceAuthKeyService = MockDeviceAuthKeyService(),
         environmentService: EnvironmentService = MockEnvironmentService(),
         errorReportBuilder: ErrorReportBuilder = MockErrorReportBuilder(),
@@ -97,11 +97,12 @@ extension ServiceContainer {
             actualSearchProcessorMediatorFactory = factoryMock
         }
 
+        let apiService = APIService(
+            client: httpClient,
+            environmentService: environmentService,
+        )
         return ServiceContainer(
-            apiService: APIService(
-                client: httpClient,
-                environmentService: environmentService,
-            ),
+            apiService: apiService,
             appContextHelper: appContextHelper,
             appIDService: AppIDService(appIDSettingsStore: appIDSettingsStore),
             appInfoService: appInfoService,
@@ -123,7 +124,7 @@ extension ServiceContainer {
             clientCertificateService: clientCertificateService,
             clientService: clientService,
             configService: configService,
-            deviceAPIService: deviceAPIService,
+            deviceAPIService: deviceAPIService ?? apiService,
             deviceAuthKeyService: deviceAuthKeyService,
             environmentService: environmentService,
             errorReportBuilder: errorReportBuilder,

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/ServiceContainer+Mocks.swift
@@ -97,7 +97,7 @@ extension ServiceContainer {
             actualSearchProcessorMediatorFactory = factoryMock
         }
 
-        let container = ServiceContainer(
+        return ServiceContainer(
             apiService: APIService(
                 client: httpClient,
                 environmentService: environmentService,
@@ -123,6 +123,7 @@ extension ServiceContainer {
             clientCertificateService: clientCertificateService,
             clientService: clientService,
             configService: configService,
+            deviceAPIService: deviceAPIService,
             deviceAuthKeyService: deviceAuthKeyService,
             environmentService: environmentService,
             errorReportBuilder: errorReportBuilder,
@@ -171,7 +172,5 @@ extension ServiceContainer {
             vaultTimeoutService: vaultTimeoutService,
             watchService: watchService,
         )
-        container.deviceAPIServiceOverride = deviceAPIService
-        return container
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityAction.swift
@@ -21,6 +21,9 @@ enum AccountSecurityAction: Equatable {
     /// The logout button was pressed.
     case logout
 
+    /// The manage devices button was tapped.
+    case manageDevicesTapped
+
     /// The pending login requests button was tapped.
     case pendingLoginRequestsTapped
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -99,6 +99,8 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
             coordinator.navigate(to: .deleteAccount)
         case .logout:
             showLogoutConfirmation()
+        case .manageDevicesTapped:
+            coordinator.navigate(to: .deviceManagement)
         case .pendingLoginRequestsTapped:
             coordinator.navigate(to: .pendingLoginRequests)
         case let .sessionTimeoutActionChanged(newValue):
@@ -180,6 +182,8 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
             }
 
             state.isAuthenticatorSyncEnabled = try await services.stateService.getSyncToAuthenticator()
+
+            state.isManageDevicesEnabled = await services.configService.getFeatureFlag(.manageDevices)
 
             if state.biometricUnlockStatus.isEnabled || state.isUnlockWithPINCodeOn {
                 await completeAccountSetupVaultUnlockIfNeeded()

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -86,6 +86,9 @@ struct AccountSecurityState: Equatable {
     /// Whether the user has enabled the sync with the authenticator app..
     var isAuthenticatorSyncEnabled = false
 
+    /// Whether the manage devices feature is enabled.
+    var isManageDevicesEnabled = false
+
     /// Whether the timeout action policy is in effect.
     var isPolicyTimeoutActionEnabled = false
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
@@ -21,7 +21,9 @@ struct AccountSecurityView: View {
         VStack(spacing: 16) {
             setUpUnlockActionCard
 
-            pendingLoginRequests
+            if !store.state.isManageDevicesEnabled {
+                pendingLoginRequests
+            }
 
             if store.state.showUnlockOptions {
                 unlockOptionsSection
@@ -80,23 +82,35 @@ struct AccountSecurityView: View {
     private var otherSection: some View {
         SectionView(Localizations.other) {
             ContentBlock(dividerLeadingPadding: 16) {
-                SettingsListItem(
-                    Localizations.accountFingerprintPhrase,
-                    accessibilityIdentifier: "AccountFingerprintPhraseLabel",
-                ) {
-                    Task {
-                        await store.perform(.accountFingerprintPhrasePressed)
+                if store.state.isManageDevicesEnabled {
+                    SettingsListItem(
+                        Localizations.manageDevices,
+                        accessibilityIdentifier: "ManageDevicesLabel"
+                    ) {
+                        store.send(.manageDevicesTapped)
+                    } trailingContent: {
+                        Image(asset: SharedAsset.Icons.chevronRight16)
+                            .imageStyle(.accessoryIcon16)
                     }
                 }
 
                 SettingsListItem(
                     Localizations.twoStepLogin,
-                    accessibilityIdentifier: "TwoStepLoginLinkItemView",
+                    accessibilityIdentifier: "TwoStepLoginLinkItemView"
                 ) {
                     store.send(.twoStepLoginPressed)
                 } trailingContent: {
                     Image(asset: SharedAsset.Icons.externalLink24)
                         .imageStyle(.rowIcon)
+                }
+
+                SettingsListItem(
+                    Localizations.accountFingerprintPhrase,
+                    accessibilityIdentifier: "AccountFingerprintPhraseLabel"
+                ) {
+                    Task {
+                        await store.perform(.accountFingerprintPhrasePressed)
+                    }
                 }
 
                 if store.state.isLockNowVisible {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementAction.swift
@@ -1,0 +1,16 @@
+import BitwardenKit
+
+// MARK: - DeviceManagementAction
+
+/// Actions that can be processed by a `DeviceManagementProcessor`.
+///
+enum DeviceManagementAction: Equatable {
+    /// A device was tapped.
+    case deviceTapped(DeviceListItem)
+
+    /// Dismiss the sheet.
+    case dismiss
+
+    /// The toast was shown or hidden.
+    case toastShown(Toast?)
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementEffect.swift
@@ -1,0 +1,8 @@
+// MARK: - DeviceManagementEffect
+
+/// Effects that can be processed by a `DeviceManagementProcessor`.
+///
+enum DeviceManagementEffect: Equatable {
+    /// Load the device data.
+    case loadData
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessor.swift
@@ -15,7 +15,6 @@ final class DeviceManagementProcessor: StateProcessor<
 
     typealias Services = HasAppIDService
         & HasAuthService
-        & HasConfigService
         & HasDeviceAPIService
         & HasErrorReporter
         & HasTimeProvider
@@ -96,8 +95,6 @@ final class DeviceManagementProcessor: StateProcessor<
                 currentDeviceTask,
                 pendingRequestsTask,
             )
-
-            state.currentDeviceId = currentDevice.id
 
             // Create device list items and mark current session.
             var deviceItems = devices.map { device in

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessor.swift
@@ -1,0 +1,184 @@
+import BitwardenKit
+import BitwardenResources
+import Foundation
+
+// MARK: - DeviceManagementProcessor
+
+/// The processor used to manage state and handle actions for the `DeviceManagementView`.
+///
+final class DeviceManagementProcessor: StateProcessor<
+    DeviceManagementState,
+    DeviceManagementAction,
+    DeviceManagementEffect,
+> {
+    // MARK: Types
+
+    typealias Services = HasAppIDService
+        & HasAuthService
+        & HasConfigService
+        & HasDeviceAPIService
+        & HasErrorReporter
+        & HasTimeProvider
+
+    // MARK: Properties
+
+    /// The `Coordinator` that handles navigation.
+    private let coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>
+
+    /// The services used by the processor.
+    private let services: Services
+
+    // MARK: Initialization
+
+    /// Initializes a `DeviceManagementProcessor`.
+    ///
+    /// - Parameters:
+    ///   - coordinator: The coordinator used for navigation.
+    ///   - services: The services used by the processor.
+    ///   - state: The initial state of the processor.
+    ///
+    init(
+        coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>,
+        services: Services,
+        state: DeviceManagementState,
+    ) {
+        self.coordinator = coordinator
+        self.services = services
+
+        super.init(state: state)
+    }
+
+    // MARK: Methods
+
+    override func perform(_ effect: DeviceManagementEffect) async {
+        switch effect {
+        case .loadData:
+            await loadData()
+        }
+    }
+
+    override func receive(_ action: DeviceManagementAction) {
+        switch action {
+        case let .deviceTapped(device):
+            handleDeviceTapped(device)
+        case .dismiss:
+            coordinator.navigate(to: .dismiss, context: self)
+        case let .toastShown(newValue):
+            state.toast = newValue
+        }
+    }
+
+    // MARK: Private Methods
+
+    /// Handles when a device is tapped.
+    ///
+    /// - Parameter device: The device that was tapped.
+    ///
+    private func handleDeviceTapped(_ device: DeviceListItem) {
+        guard let pendingRequest = device.pendingRequest else { return }
+        coordinator.navigate(to: .loginRequest(pendingRequest), context: self)
+    }
+
+    /// Loads the device data.
+    ///
+    private func loadData() async {
+        do {
+            // Get the current device's app ID.
+            let appId = await services.appIDService.getOrCreateAppID()
+
+            // Fetch all devices and the current device in parallel.
+            async let devicesTask = services.deviceAPIService.getDevices()
+            async let currentDeviceTask = services.deviceAPIService.getCurrentDevice(appId: appId)
+            async let pendingRequestsTask = services.authService.getPendingLoginRequests()
+
+            let (devices, currentDevice, pendingRequests) = try await (
+                devicesTask,
+                currentDeviceTask,
+                pendingRequestsTask,
+            )
+
+            state.currentDeviceId = currentDevice.id
+
+            // Create device list items and mark current session.
+            var deviceItems = devices.map { device in
+                var item = DeviceListItem(device: device, timeProvider: services.timeProvider)
+                item.isCurrentSession = device.id == currentDevice.id
+                return item
+            }
+
+            // Match pending requests to devices.
+            deviceItems = matchPendingRequestsToDevices(deviceItems, pendingRequests: pendingRequests)
+
+            // Sort devices: current session first, then pending requests, then by activity.
+            deviceItems.sort { lhs, rhs in
+                // Current session always first.
+                if lhs.isCurrentSession != rhs.isCurrentSession {
+                    return lhs.isCurrentSession
+                }
+                // Devices with pending requests second.
+                if lhs.hasPendingRequest != rhs.hasPendingRequest {
+                    return lhs.hasPendingRequest
+                }
+                // Sort by last activity date descending, with nil dates last.
+                switch (lhs.lastActivityDate, rhs.lastActivityDate) {
+                case let (lhsDate?, rhsDate?):
+                    return lhsDate > rhsDate
+                case (nil, _?):
+                    return false
+                case (_?, nil):
+                    return true
+                case (nil, nil):
+                    // Fall back to creation date.
+                    return lhs.firstLogin > rhs.firstLogin
+                }
+            }
+
+            state.loadingState = .data(deviceItems)
+        } catch {
+            state.loadingState = .data([])
+            await coordinator.showErrorAlert(error: error)
+            services.errorReporter.log(error: error)
+        }
+    }
+
+    /// Matches the most recent pending login request to its corresponding device.
+    ///
+    /// - Parameters:
+    ///   - devices: The list of device items.
+    ///   - pendingRequests: The list of pending login requests.
+    /// - Returns: The updated list of device items with the most recent pending request matched.
+    ///
+    private func matchPendingRequestsToDevices(
+        _ devices: [DeviceListItem],
+        pendingRequests: [LoginRequest],
+    ) -> [DeviceListItem] {
+        var updatedDevices = devices
+
+        // Sort pending requests by creation date descending to get most recent first.
+        let sortedRequests = pendingRequests.sorted { $0.creationDate > $1.creationDate }
+
+        for request in sortedRequests {
+            // Try to match by device platform name.
+            if let index = updatedDevices.firstIndex(where: { device in
+                device.deviceType.platform.lowercased() == request.requestDeviceType.lowercased()
+            }) {
+                // Only set if no pending request has been set yet (keeps the most recent).
+                if updatedDevices[index].pendingRequest == nil {
+                    updatedDevices[index].pendingRequest = request
+                }
+            }
+        }
+
+        return updatedDevices
+    }
+}
+
+// MARK: - LoginRequestDelegate
+
+extension DeviceManagementProcessor: LoginRequestDelegate {
+    /// Update the data and display a success toast after a login request has been answered.
+    func loginRequestAnswered(approved: Bool) {
+        Task { await loadData() }
+        state.toast = Toast(title: approved ? Localizations.loginApproved : Localizations.logInDenied)
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessorTests.swift
@@ -1,0 +1,216 @@
+import BitwardenKit
+import BitwardenKitMocks
+import BitwardenResources
+import TestHelpers
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - DeviceManagementProcessorTests
+
+class DeviceManagementProcessorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var authService: MockAuthService!
+    var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
+    var deviceAPIService: MockDeviceAPIService!
+    var errorReporter: MockErrorReporter!
+    var timeProvider: MockTimeProvider!
+    var subject: DeviceManagementProcessor!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        authService = MockAuthService()
+        coordinator = MockCoordinator<SettingsRoute, SettingsEvent>()
+        deviceAPIService = MockDeviceAPIService()
+        errorReporter = MockErrorReporter()
+        timeProvider = MockTimeProvider(.mockTime(Date(timeIntervalSince1970: 1_718_000_000)))
+
+        subject = DeviceManagementProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                authService: authService,
+                deviceAPIService: deviceAPIService,
+                errorReporter: errorReporter,
+                timeProvider: timeProvider,
+            ),
+            state: DeviceManagementState(),
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        authService = nil
+        coordinator = nil
+        deviceAPIService = nil
+        errorReporter = nil
+        timeProvider = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `perform(.loadData)` loads devices and marks the current session correctly.
+    @MainActor
+    func test_perform_loadData_success() async throws {
+        let currentDevice = DeviceResponse.fixture(id: "device-id-1")
+        let otherDevice = DeviceResponse.fixture(id: "device-id-2", isTrusted: false)
+        deviceAPIService.getDevicesReturnValue = [currentDevice, otherDevice]
+        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
+        authService.getPendingLoginRequestResult = .success([])
+
+        await subject.perform(.loadData)
+
+        let items = try XCTUnwrap(subject.state.loadingState.data)
+        XCTAssertEqual(items.count, 2)
+        XCTAssertTrue(items.first(where: { $0.id == "device-id-1" })?.isCurrentSession == true)
+        XCTAssertFalse(items.first(where: { $0.id == "device-id-2" })?.isCurrentSession == true)
+    }
+
+    /// `perform(.loadData)` sorts devices: current session first, then pending requests, then by activity.
+    @MainActor
+    func test_perform_loadData_sorting() async throws {
+        let currentDevice = DeviceResponse.fixture(
+            id: "current",
+            lastActivityDate: Date(timeIntervalSince1970: 1_717_900_000),
+        )
+        let pendingDevice = DeviceResponse.fixture(
+            id: "pending",
+            isTrusted: false,
+            lastActivityDate: Date(timeIntervalSince1970: 1_717_800_000),
+            type: .chromeExtension,
+        )
+        let oldDevice = DeviceResponse.fixture(
+            id: "old",
+            isTrusted: false,
+            lastActivityDate: Date(timeIntervalSince1970: 1_600_000_000),
+            type: .macOsDesktop,
+        )
+        let pendingRequest = LoginRequest.fixture(requestDeviceType: "Chrome")
+
+        deviceAPIService.getDevicesReturnValue = [oldDevice, pendingDevice, currentDevice]
+        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
+        authService.getPendingLoginRequestResult = .success([pendingRequest])
+
+        await subject.perform(.loadData)
+
+        let items = try XCTUnwrap(subject.state.loadingState.data)
+        XCTAssertEqual(items.count, 3)
+        XCTAssertEqual(items[0].id, "current") // current session first
+        XCTAssertEqual(items[1].id, "pending") // pending request second
+        XCTAssertEqual(items[2].id, "old") // oldest last
+    }
+
+    /// `perform(.loadData)` assigns the most recent pending request when multiple exist for the same platform.
+    @MainActor
+    func test_perform_loadData_matchesMostRecentPendingRequest() async throws {
+        let chromeDevice = DeviceResponse.fixture(id: "chrome", type: .chromeExtension)
+        let currentDevice = DeviceResponse.fixture(id: "current")
+        let olderRequest = LoginRequest.fixture(
+            creationDate: Date(timeIntervalSince1970: 1_000_000),
+            id: "older",
+            requestDeviceType: "Chrome",
+        )
+        let newerRequest = LoginRequest.fixture(
+            creationDate: Date(timeIntervalSince1970: 2_000_000),
+            id: "newer",
+            requestDeviceType: "Chrome",
+        )
+
+        deviceAPIService.getDevicesReturnValue = [chromeDevice, currentDevice]
+        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
+        authService.getPendingLoginRequestResult = .success([olderRequest, newerRequest])
+
+        await subject.perform(.loadData)
+
+        let items = try XCTUnwrap(subject.state.loadingState.data)
+        let chromeItem = try XCTUnwrap(items.first(where: { $0.id == "chrome" }))
+        XCTAssertEqual(chromeItem.pendingRequest?.id, "newer")
+    }
+
+    /// `perform(.loadData)` sets loading state to empty and reports the error on failure.
+    @MainActor
+    func test_perform_loadData_error() async {
+        deviceAPIService.getDevicesThrowableError = BitwardenTestError.example
+        deviceAPIService.getCurrentDeviceThrowableError = BitwardenTestError.example
+        authService.getPendingLoginRequestResult = .success([])
+
+        await subject.perform(.loadData)
+
+        XCTAssertEqual(subject.state.loadingState, .data([]))
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
+        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+    }
+
+    /// `receive(.deviceTapped)` navigates to the login request when the device has a pending request.
+    @MainActor
+    func test_receive_deviceTapped_withPendingRequest() {
+        let request = LoginRequest.fixture()
+        var device = DeviceListItem.fixture()
+        device.pendingRequest = request
+
+        subject.receive(.deviceTapped(device))
+
+        XCTAssertEqual(coordinator.routes.last, .loginRequest(request))
+        XCTAssertNotNil(coordinator.contexts.last as? DeviceManagementProcessor)
+    }
+
+    /// `receive(.deviceTapped)` does nothing when the device has no pending request.
+    @MainActor
+    func test_receive_deviceTapped_noPendingRequest() {
+        subject.receive(.deviceTapped(.fixture()))
+
+        XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+
+    /// `receive(.dismiss)` dismisses the view.
+    @MainActor
+    func test_receive_dismiss() {
+        subject.receive(.dismiss)
+
+        XCTAssertEqual(coordinator.routes.last, .dismiss)
+    }
+
+    /// `receive(.toastShown)` updates and clears the toast state.
+    @MainActor
+    func test_receive_toastShown() {
+        subject.receive(.toastShown(Toast(title: "test")))
+        XCTAssertEqual(subject.state.toast, Toast(title: "test"))
+
+        subject.receive(.toastShown(nil))
+        XCTAssertNil(subject.state.toast)
+    }
+
+    /// `loginRequestAnswered(approved: true)` shows the approved toast and reloads.
+    @MainActor
+    func test_loginRequestAnswered_approved() {
+        deviceAPIService.getDevicesReturnValue = []
+        deviceAPIService.getCurrentDeviceReturnValue = .fixture()
+        authService.getPendingLoginRequestResult = .success([])
+
+        let task = Task { subject.loginRequestAnswered(approved: true) }
+        waitFor(deviceAPIService.getDevicesCalled)
+        task.cancel()
+
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.loginApproved))
+    }
+
+    /// `loginRequestAnswered(approved: false)` shows the denied toast and reloads.
+    @MainActor
+    func test_loginRequestAnswered_denied() {
+        deviceAPIService.getDevicesReturnValue = []
+        deviceAPIService.getCurrentDeviceReturnValue = .fixture()
+        authService.getPendingLoginRequestResult = .success([])
+
+        let task = Task { subject.loginRequestAnswered(approved: false) }
+        waitFor(deviceAPIService.getDevicesCalled)
+        task.cancel()
+
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.logInDenied))
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessorTests.swift
@@ -1,29 +1,29 @@
 import BitwardenKit
 import BitwardenKitMocks
 import BitwardenResources
+import Foundation
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
 // MARK: - DeviceManagementProcessorTests
 
-class DeviceManagementProcessorTests: BitwardenTestCase {
+@MainActor
+struct DeviceManagementProcessorTests {
     // MARK: Properties
 
-    var authService: MockAuthService!
-    var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
-    var deviceAPIService: MockDeviceAPIService!
-    var errorReporter: MockErrorReporter!
-    var timeProvider: MockTimeProvider!
-    var subject: DeviceManagementProcessor!
+    let authService: MockAuthService
+    let coordinator: MockCoordinator<SettingsRoute, SettingsEvent>
+    let deviceAPIService: MockDeviceAPIService
+    let errorReporter: MockErrorReporter
+    let timeProvider: MockTimeProvider
+    let subject: DeviceManagementProcessor
 
-    // MARK: Setup & Teardown
+    // MARK: Initialization
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         authService = MockAuthService()
         coordinator = MockCoordinator<SettingsRoute, SettingsEvent>()
         deviceAPIService = MockDeviceAPIService()
@@ -42,22 +42,11 @@ class DeviceManagementProcessorTests: BitwardenTestCase {
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
-
-        authService = nil
-        coordinator = nil
-        deviceAPIService = nil
-        errorReporter = nil
-        timeProvider = nil
-        subject = nil
-    }
-
     // MARK: Tests
 
-    /// `perform(.loadData)` loads devices and marks the current session correctly.
-    @MainActor
-    func test_perform_loadData_success() async throws {
+    /// `perform(_:)` loads devices and marks the current session correctly.
+    @Test
+    func perform_loadData_success() async throws {
         let currentDevice = DeviceResponse.fixture(id: "device-id-1")
         let otherDevice = DeviceResponse.fixture(id: "device-id-2", isTrusted: false)
         deviceAPIService.getDevicesReturnValue = [currentDevice, otherDevice]
@@ -66,15 +55,15 @@ class DeviceManagementProcessorTests: BitwardenTestCase {
 
         await subject.perform(.loadData)
 
-        let items = try XCTUnwrap(subject.state.loadingState.data)
-        XCTAssertEqual(items.count, 2)
-        XCTAssertTrue(items.first(where: { $0.id == "device-id-1" })?.isCurrentSession == true)
-        XCTAssertFalse(items.first(where: { $0.id == "device-id-2" })?.isCurrentSession == true)
+        let items = try #require(subject.state.loadingState.data)
+        #expect(items.count == 2)
+        #expect(items.first(where: { $0.id == "device-id-1" })?.isCurrentSession == true)
+        #expect(items.first(where: { $0.id == "device-id-2" })?.isCurrentSession == false)
     }
 
-    /// `perform(.loadData)` sorts devices: current session first, then pending requests, then by activity.
-    @MainActor
-    func test_perform_loadData_sorting() async throws {
+    /// `perform(_:)` sorts devices: current session first, then pending requests, then by activity.
+    @Test
+    func perform_loadData_sorting() async throws {
         let currentDevice = DeviceResponse.fixture(
             id: "current",
             lastActivityDate: Date(timeIntervalSince1970: 1_717_900_000),
@@ -99,16 +88,16 @@ class DeviceManagementProcessorTests: BitwardenTestCase {
 
         await subject.perform(.loadData)
 
-        let items = try XCTUnwrap(subject.state.loadingState.data)
-        XCTAssertEqual(items.count, 3)
-        XCTAssertEqual(items[0].id, "current") // current session first
-        XCTAssertEqual(items[1].id, "pending") // pending request second
-        XCTAssertEqual(items[2].id, "old") // oldest last
+        let items = try #require(subject.state.loadingState.data)
+        #expect(items.count == 3)
+        #expect(items[0].id == "current") // current session first
+        #expect(items[1].id == "pending") // pending request second
+        #expect(items[2].id == "old") // oldest last
     }
 
-    /// `perform(.loadData)` assigns the most recent pending request when multiple exist for the same platform.
-    @MainActor
-    func test_perform_loadData_matchesMostRecentPendingRequest() async throws {
+    /// `perform(_:)` assigns the most recent pending request when multiple exist for the same platform.
+    @Test
+    func perform_loadData_matchesMostRecentPendingRequest() async throws {
         let chromeDevice = DeviceResponse.fixture(id: "chrome", type: .chromeExtension)
         let currentDevice = DeviceResponse.fixture(id: "current")
         let olderRequest = LoginRequest.fixture(
@@ -128,89 +117,87 @@ class DeviceManagementProcessorTests: BitwardenTestCase {
 
         await subject.perform(.loadData)
 
-        let items = try XCTUnwrap(subject.state.loadingState.data)
-        let chromeItem = try XCTUnwrap(items.first(where: { $0.id == "chrome" }))
-        XCTAssertEqual(chromeItem.pendingRequest?.id, "newer")
+        let items = try #require(subject.state.loadingState.data)
+        let chromeItem = try #require(items.first(where: { $0.id == "chrome" }))
+        #expect(chromeItem.pendingRequest?.id == "newer")
     }
 
-    /// `perform(.loadData)` sets loading state to empty and reports the error on failure.
-    @MainActor
-    func test_perform_loadData_error() async {
+    /// `perform(_:)` sets loading state to empty and reports the error on failure.
+    @Test
+    func perform_loadData_error() async {
         deviceAPIService.getDevicesThrowableError = BitwardenTestError.example
         deviceAPIService.getCurrentDeviceThrowableError = BitwardenTestError.example
         authService.getPendingLoginRequestResult = .success([])
 
         await subject.perform(.loadData)
 
-        XCTAssertEqual(subject.state.loadingState, .data([]))
-        XCTAssertEqual(coordinator.errorAlertsShown.last as? BitwardenTestError, .example)
-        XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
+        #expect(subject.state.loadingState == .data([]))
+        #expect(coordinator.errorAlertsShown.last as? BitwardenTestError == .example)
+        #expect(errorReporter.errors.last as? BitwardenTestError == .example)
     }
 
-    /// `receive(.deviceTapped)` navigates to the login request when the device has a pending request.
-    @MainActor
-    func test_receive_deviceTapped_withPendingRequest() {
+    /// `receive(_:)` navigates to the login request when the device has a pending request.
+    @Test
+    func receive_deviceTapped_withPendingRequest() {
         let request = LoginRequest.fixture()
         var device = DeviceListItem.fixture()
         device.pendingRequest = request
 
         subject.receive(.deviceTapped(device))
 
-        XCTAssertEqual(coordinator.routes.last, .loginRequest(request))
-        XCTAssertNotNil(coordinator.contexts.last as? DeviceManagementProcessor)
+        #expect(coordinator.routes.last == .loginRequest(request))
+        #expect(coordinator.contexts.last is DeviceManagementProcessor)
     }
 
-    /// `receive(.deviceTapped)` does nothing when the device has no pending request.
-    @MainActor
-    func test_receive_deviceTapped_noPendingRequest() {
+    /// `receive(_:)` does nothing when the device has no pending request.
+    @Test
+    func receive_deviceTapped_noPendingRequest() {
         subject.receive(.deviceTapped(.fixture()))
 
-        XCTAssertTrue(coordinator.routes.isEmpty)
+        #expect(coordinator.routes.isEmpty)
     }
 
-    /// `receive(.dismiss)` dismisses the view.
-    @MainActor
-    func test_receive_dismiss() {
+    /// `receive(_:)` dismisses the view.
+    @Test
+    func receive_dismiss() {
         subject.receive(.dismiss)
 
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        #expect(coordinator.routes.last == .dismiss)
     }
 
-    /// `receive(.toastShown)` updates and clears the toast state.
-    @MainActor
-    func test_receive_toastShown() {
+    /// `receive(_:)` updates and clears the toast state.
+    @Test
+    func receive_toastShown() {
         subject.receive(.toastShown(Toast(title: "test")))
-        XCTAssertEqual(subject.state.toast, Toast(title: "test"))
+        #expect(subject.state.toast == Toast(title: "test"))
 
         subject.receive(.toastShown(nil))
-        XCTAssertNil(subject.state.toast)
+        #expect(subject.state.toast == nil)
     }
 
-    /// `loginRequestAnswered(approved: true)` shows the approved toast and reloads.
-    @MainActor
-    func test_loginRequestAnswered_approved() {
+    /// `loginRequestAnswered(approved:)` shows the approved toast and triggers a reload.
+    @Test
+    func loginRequestAnswered_approved() async throws {
         deviceAPIService.getDevicesReturnValue = []
         deviceAPIService.getCurrentDeviceReturnValue = .fixture()
         authService.getPendingLoginRequestResult = .success([])
 
-        let task = Task { subject.loginRequestAnswered(approved: true) }
-        waitFor(deviceAPIService.getDevicesCalled)
-        task.cancel()
+        subject.loginRequestAnswered(approved: true)
 
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.loginApproved))
+        #expect(subject.state.toast == Toast(title: Localizations.loginApproved))
+        try await waitForAsync { deviceAPIService.getDevicesCalled }
     }
 
-    /// `loginRequestAnswered(approved: false)` shows the denied toast and reloads.
-    @MainActor
-    func test_loginRequestAnswered_denied() {
+    /// `loginRequestAnswered(approved:)` shows the denied toast and triggers a reload.
+    @Test
+    func loginRequestAnswered_denied() async throws {
         deviceAPIService.getDevicesReturnValue = []
         deviceAPIService.getCurrentDeviceReturnValue = .fixture()
         authService.getPendingLoginRequestResult = .success([])
 
-        let task = Task { subject.loginRequestAnswered(approved: false) }
-        waitFor(deviceAPIService.getDevicesCalled)
-        task.cancel()
+        subject.loginRequestAnswered(approved: false)
 
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.logInDenied))
+        #expect(subject.state.toast == Toast(title: Localizations.logInDenied))
+        try await waitForAsync { deviceAPIService.getDevicesCalled }
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementState.swift
@@ -1,0 +1,18 @@
+import BitwardenKit
+
+// MARK: - DeviceManagementState
+
+/// The state used to present the `DeviceManagementView`.
+///
+struct DeviceManagementState: Equatable, Sendable {
+    // MARK: Properties
+
+    /// The loading state of the device management screen.
+    var loadingState: LoadingState<[DeviceListItem]> = .loading(nil)
+
+    /// A toast message to show in the view.
+    var toast: Toast?
+
+    /// The ID of the current device.
+    var currentDeviceId: String?
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementState.swift
@@ -12,7 +12,4 @@ struct DeviceManagementState: Equatable, Sendable {
 
     /// A toast message to show in the view.
     var toast: Toast?
-
-    /// The ID of the current device.
-    var currentDeviceId: String?
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView+ViewInspectorTests.swift
@@ -1,0 +1,57 @@
+// swiftlint:disable:this file_name
+import BitwardenKit
+import BitwardenKitMocks
+import BitwardenResources
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - DeviceManagementViewTests
+
+class DeviceManagementViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var processor: MockProcessor<DeviceManagementState, DeviceManagementAction, DeviceManagementEffect>!
+    var subject: DeviceManagementView!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        processor = MockProcessor(state: DeviceManagementState())
+        subject = DeviceManagementView(store: Store(processor: processor))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        processor = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// Tapping the cancel toolbar button dispatches the `.dismiss` action.
+    @MainActor
+    func test_cancelButton_tap() throws {
+        let button = try subject.inspect().findCancelToolbarButton()
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .dismiss)
+    }
+
+    /// Tapping a device row with a pending request dispatches the `.deviceTapped` action.
+    @MainActor
+    func test_deviceRow_tap_withPendingRequest() throws {
+        let request = LoginRequest.fixture()
+        var device = DeviceListItem.fixture(id: "device-1")
+        device.pendingRequest = request
+        processor.state.loadingState = .data([device])
+
+        let row = try subject.inspect().find(viewWithAccessibilityIdentifier: "DeviceRowCell")
+        try row.callOnTapGesture()
+
+        XCTAssertEqual(processor.dispatchedActions.last, .deviceTapped(device))
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView.swift
@@ -1,0 +1,134 @@
+import BitwardenKit
+import BitwardenResources
+import SwiftUI
+
+// MARK: - DeviceManagementView
+
+/// A view that shows all the logged-in devices and allows the user to manage them.
+///
+struct DeviceManagementView: View {
+    // MARK: Properties
+
+    /// The `Store` for this view.
+    @ObservedObject var store: Store<DeviceManagementState, DeviceManagementAction, DeviceManagementEffect>
+
+    // MARK: View
+
+    var body: some View {
+        LoadingView(state: store.state.loadingState) { devices in
+            if devices.isEmpty {
+                empty
+                    .scrollView(centerContentVertically: true)
+            } else {
+                devicesList(devices)
+                    .scrollView()
+            }
+        }
+        .navigationBar(title: Localizations.manageDevices, titleDisplayMode: .inline)
+        .toolbar {
+            cancelToolbarItem {
+                store.send(.dismiss)
+            }
+        }
+        .task {
+            await store.perform(.loadData)
+        }
+        .refreshable { [weak store] in
+            await store?.perform(.loadData)
+        }
+        .toast(store.binding(
+            get: \.toast,
+            send: DeviceManagementAction.toastShown,
+        ))
+    }
+
+    // MARK: Private Views
+
+    /// The empty view.
+    private var empty: some View {
+        VStack(spacing: 20) {
+            Image(decorative: Asset.Images.Illustrations.devices)
+                .resizable()
+                .frame(width: 100, height: 100)
+
+            Text(Localizations.noDevicesFound)
+                .styleGuide(.body)
+                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    /// The list of devices.
+    ///
+    /// - Parameter devices: The devices to display.
+    ///
+    private func devicesList(_ devices: [DeviceListItem]) -> some View {
+        VStack(spacing: 24) {
+            ContentBlock(dividerLeadingPadding: 16) {
+                ForEach(devices) { device in
+                    DeviceRow(
+                        device: device,
+                        hasDivider: device != devices.last,
+                        onTap: {
+                            store.send(.deviceTapped(device))
+                        },
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Empty") {
+    DeviceManagementView(store: Store(processor: StateProcessor(state: DeviceManagementState(
+        loadingState: .data([]),
+    ))))
+}
+
+#Preview("Devices") {
+    DeviceManagementView(store: Store(processor: StateProcessor(state: DeviceManagementState(
+        loadingState: .data([
+            DeviceListItem(
+                activityStatus: .today,
+                deviceType: .iOS,
+                displayName: "iPhone 15 Pro",
+                firstLogin: Date(),
+                id: "1",
+                identifier: "abc123",
+                isCurrentSession: true,
+                isTrusted: true,
+                lastActivityDate: Date(),
+                pendingRequest: nil,
+            ),
+            DeviceListItem(
+                activityStatus: .thisWeek,
+                deviceType: .chromeExtension,
+                displayName: "Chrome Extension",
+                firstLogin: Date().addingTimeInterval(-86400 * 30),
+                id: "2",
+                identifier: "def456",
+                isCurrentSession: false,
+                isTrusted: false,
+                lastActivityDate: Date().addingTimeInterval(-86400 * 3),
+                pendingRequest: nil,
+            ),
+            DeviceListItem(
+                activityStatus: .overThirtyDaysAgo,
+                deviceType: .macOsDesktop,
+                displayName: "macOS",
+                firstLogin: Date().addingTimeInterval(-86400 * 90),
+                id: "3",
+                identifier: "ghi789",
+                isCurrentSession: false,
+                isTrusted: true,
+                lastActivityDate: Date().addingTimeInterval(-86400 * 45),
+                pendingRequest: nil,
+            ),
+        ]),
+    ))))
+}
+#endif

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
@@ -54,6 +54,7 @@ struct DeviceRow: View {
 
                     Image(asset: SharedAsset.Icons.chevronRight16)
                         .imageStyle(.accessoryIcon16)
+                        .accessibilityHidden(true)
                 }
             }
             .padding(16)
@@ -70,6 +71,8 @@ struct DeviceRow: View {
                 onTap()
             }
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(device.hasPendingRequest ? .isButton : [])
         .accessibilityIdentifier("DeviceRowCell")
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
@@ -1,0 +1,207 @@
+import BitwardenKit
+import BitwardenResources
+import SwiftUI
+
+// MARK: - DeviceRow
+
+/// A row displaying device information in the device management list.
+///
+struct DeviceRow: View {
+    // MARK: Properties
+
+    /// The device to display.
+    let device: DeviceListItem
+
+    /// Whether to show a divider below the row.
+    let hasDivider: Bool
+
+    /// The action to perform when the device is tapped (for pending requests).
+    let onTap: () -> Void
+
+    // MARK: View
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center) {
+                VStack(alignment: .leading, spacing: 4) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        // Device name
+                        Text(device.displayName)
+                            .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                            .styleGuide(.bodySemibold)
+                            .accessibilityIdentifier("DeviceNameLabel")
+
+                        if device.isTrusted {
+                            Text(Localizations.trusted)
+                                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                                .styleGuide(.subheadline)
+                                .accessibilityIdentifier("TrustedLabel")
+                        }
+                    }
+                    .padding(.bottom, 4)
+
+                    badgeRow
+
+                    if device.lastActivityDate != nil {
+                        recentlyActiveRow
+                    }
+
+                    firstLoginRow
+                }
+
+                if device.hasPendingRequest {
+                    Spacer()
+
+                    Image(asset: SharedAsset.Icons.chevronRight16)
+                        .imageStyle(.accessoryIcon16)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if hasDivider {
+                Divider().padding(.leading, 16)
+            }
+        }
+        .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if device.hasPendingRequest {
+                onTap()
+            }
+        }
+        .accessibilityIdentifier("DeviceRowCell")
+    }
+
+    // MARK: Private Views
+
+    /// The badge row showing current session or pending request.
+    @ViewBuilder private var badgeRow: some View {
+        if device.isCurrentSession {
+            statusIndicator(
+                text: Localizations.currentSession,
+                color: SharedAsset.Colors.badgeSuccessForeground.swiftUIColor,
+            )
+        }
+
+        if device.hasPendingRequest {
+            statusIndicator(
+                text: Localizations.pendingRequest,
+                color: SharedAsset.Colors.badgeWarningForeground.swiftUIColor,
+            )
+        }
+    }
+
+    /// The recently active row with bold label and regular date.
+    private var recentlyActiveRow: some View {
+        HStack(spacing: 4) {
+            Text(Localizations.recentlyActiveLabel)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .styleGuide(.subheadlineSemibold)
+
+            Text(device.activityStatus.localizedString)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .styleGuide(.subheadline)
+        }
+        .accessibilityIdentifier("RecentlyActiveRow")
+    }
+
+    /// The first login row with bold label and regular date.
+    private var firstLoginRow: some View {
+        HStack(spacing: 4) {
+            Text(Localizations.firstLoginLabel)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .styleGuide(.subheadlineSemibold)
+
+            Text(formattedDateTime(device.firstLogin))
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .styleGuide(.subheadline)
+        }
+        .accessibilityIdentifier("FirstLoginRow")
+    }
+
+    // MARK: Private Methods
+
+    /// Creates a status indicator with a colored dot and label.
+    private func statusIndicator(text: String, color: Color) -> some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+
+            Text(text)
+                .styleGuide(.subheadline)
+                .foregroundStyle(color)
+        }
+    }
+
+    /// Formats a date for display with date and time.
+    private func formattedDateTime(_ date: Date?) -> String {
+        guard let date else { return Localizations.unknown }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Device Row - Current Session") {
+    DeviceRow(
+        device: DeviceListItem(
+            activityStatus: .today,
+            deviceType: .iOS,
+            displayName: "iPhone 15 Pro",
+            firstLogin: Date(),
+            id: "1",
+            identifier: "abc123",
+            isCurrentSession: true,
+            isTrusted: true,
+            lastActivityDate: Date(),
+            pendingRequest: nil,
+        ),
+        hasDivider: true,
+        onTap: {},
+    )
+}
+
+#Preview("Device Row - Pending Request") {
+    DeviceRow(
+        device: DeviceListItem(
+            activityStatus: .thisWeek,
+            deviceType: .chromeExtension,
+            displayName: "Chrome Extension",
+            firstLogin: Date().addingTimeInterval(-86400 * 30),
+            id: "2",
+            identifier: "def456",
+            isCurrentSession: false,
+            isTrusted: false,
+            lastActivityDate: Date().addingTimeInterval(-86400 * 3),
+            pendingRequest: nil,
+        ),
+        hasDivider: false,
+        onTap: {},
+    )
+}
+
+#Preview("Device Row - Trusted Not Current") {
+    DeviceRow(
+        device: DeviceListItem(
+            activityStatus: .lastWeek,
+            deviceType: .macOsDesktop,
+            displayName: "macOS Desktop",
+            firstLogin: Date().addingTimeInterval(-86400 * 60),
+            id: "3",
+            identifier: "ghi789",
+            isCurrentSession: false,
+            isTrusted: true,
+            lastActivityDate: Date().addingTimeInterval(-86400 * 10),
+            pendingRequest: nil,
+        ),
+        hasDivider: true,
+        onTap: {},
+    )
+}
+#endif

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
@@ -138,11 +138,20 @@ struct DeviceRow: View {
     /// Formats a date for display with date and time.
     private func formattedDateTime(_ date: Date?) -> String {
         guard let date else { return Localizations.unknown }
+        return DeviceRow.dateTimeFormatter.string(from: date)
+    }
+}
+
+// MARK: - Private Static Helpers
+
+private extension DeviceRow {
+    /// Shared formatter for device activity dates.
+    static let dateTimeFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.timeStyle = .short
-        return formatter.string(from: date)
-    }
+        return formatter
+    }()
 }
 
 // MARK: - Previews

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -65,6 +65,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
 
     typealias Services = HasASSettingsMediator
         & HasAccountAPIService
+        & HasAppIDService
         & HasAppInfoService
         & HasAuthRepository
         & HasAuthService
@@ -72,6 +73,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasBillingService
         & HasBiometricsRepository
         & HasConfigService
+        & HasDeviceAPIService
         & HasEnvironmentService
         & HasErrorAlertServices.ErrorAlertServices
         & HasErrorReporter
@@ -170,6 +172,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             showAutoFill()
         case .deleteAccount:
             showDeleteAccount()
+        case .deviceManagement:
+            showDeviceManagement()
         case .dismiss:
             stackNavigator?.dismiss()
         case .exportVault:
@@ -347,6 +351,17 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             state: DeleteAccountState(),
         )
         stackNavigator?.present(DeleteAccountView(store: Store(processor: processor)))
+    }
+
+    /// Shows the device management screen.
+    ///
+    private func showDeviceManagement() {
+        let processor = DeviceManagementProcessor(
+            coordinator: asAnyCoordinator(),
+            services: services,
+            state: DeviceManagementState(),
+        )
+        stackNavigator?.present(DeviceManagementView(store: Store(processor: processor)))
     }
 
     /// Shows the export vault screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
@@ -32,6 +32,9 @@ public enum SettingsRoute: Equatable, Hashable {
     /// A route to the delete account screen.
     case deleteAccount
 
+    /// A route to the device management screen.
+    case deviceManagement
+
     /// A route that dismisses the current view.
     case dismiss
 


### PR DESCRIPTION
Depends on: https://github.com/bitwarden/ios/pull/2489

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33981

## 📔 Objective

Add the Device Management screen UI components including:
- `DeviceManagementView` - Main view with device list and empty state
- `DeviceManagementProcessor` - Handles loading devices, matching pending requests, and sorting
- `DeviceManagementState`, `DeviceManagementAction`, `DeviceManagementEffect` - State management
- `DeviceRow` - Individual device cell with status indicators