### PR TITLE
[PM-33981] feat: Integrate device management into Account Security

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityAction.swift
@@ -21,6 +21,9 @@ enum AccountSecurityAction: Equatable {
     /// The logout button was pressed.
     case logout
 
+    /// The manage devices button was tapped.
+    case manageDevicesTapped
+
     /// The pending login requests button was tapped.
     case pendingLoginRequestsTapped
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityProcessor.swift
@@ -99,6 +99,8 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
             coordinator.navigate(to: .deleteAccount)
         case .logout:
             showLogoutConfirmation()
+        case .manageDevicesTapped:
+            coordinator.navigate(to: .deviceManagement)
         case .pendingLoginRequestsTapped:
             coordinator.navigate(to: .pendingLoginRequests)
         case let .sessionTimeoutActionChanged(newValue):
@@ -180,6 +182,8 @@ final class AccountSecurityProcessor: StateProcessor<// swiftlint:disable:this t
             }
 
             state.isAuthenticatorSyncEnabled = try await services.stateService.getSyncToAuthenticator()
+
+            state.isManageDevicesEnabled = await services.configService.getFeatureFlag(.manageDevices)
 
             if state.biometricUnlockStatus.isEnabled || state.isUnlockWithPINCodeOn {
                 await completeAccountSetupVaultUnlockIfNeeded()

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityState.swift
@@ -86,6 +86,9 @@ struct AccountSecurityState: Equatable {
     /// Whether the user has enabled the sync with the authenticator app..
     var isAuthenticatorSyncEnabled = false
 
+    /// Whether the manage devices feature is enabled.
+    var isManageDevicesEnabled = false
+
     /// Whether the timeout action policy is in effect.
     var isPolicyTimeoutActionEnabled = false
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/AccountSecurityView.swift
@@ -21,7 +21,9 @@ struct AccountSecurityView: View {
         VStack(spacing: 16) {
             setUpUnlockActionCard
 
-            pendingLoginRequests
+            if !store.state.isManageDevicesEnabled {
+                pendingLoginRequests
+            }
 
             if store.state.showUnlockOptions {
                 unlockOptionsSection
@@ -80,23 +82,35 @@ struct AccountSecurityView: View {
     private var otherSection: some View {
         SectionView(Localizations.other) {
             ContentBlock(dividerLeadingPadding: 16) {
-                SettingsListItem(
-                    Localizations.accountFingerprintPhrase,
-                    accessibilityIdentifier: "AccountFingerprintPhraseLabel",
-                ) {
-                    Task {
-                        await store.perform(.accountFingerprintPhrasePressed)
+                if store.state.isManageDevicesEnabled {
+                    SettingsListItem(
+                        Localizations.manageDevices,
+                        accessibilityIdentifier: "ManageDevicesLabel"
+                    ) {
+                        store.send(.manageDevicesTapped)
+                    } trailingContent: {
+                        Image(asset: SharedAsset.Icons.chevronRight16)
+                            .imageStyle(.accessoryIcon16)
                     }
                 }
 
                 SettingsListItem(
                     Localizations.twoStepLogin,
-                    accessibilityIdentifier: "TwoStepLoginLinkItemView",
+                    accessibilityIdentifier: "TwoStepLoginLinkItemView"
                 ) {
                     store.send(.twoStepLoginPressed)
                 } trailingContent: {
                     Image(asset: SharedAsset.Icons.externalLink24)
                         .imageStyle(.rowIcon)
+                }
+
+                SettingsListItem(
+                    Localizations.accountFingerprintPhrase,
+                    accessibilityIdentifier: "AccountFingerprintPhraseLabel"
+                ) {
+                    Task {
+                        await store.perform(.accountFingerprintPhrasePressed)
+                    }
                 }
 
                 if store.state.isLockNowVisible {

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -65,6 +65,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
 
     typealias Services = HasASSettingsMediator
         & HasAccountAPIService
+        & HasAppIDService
         & HasAppInfoService
         & HasAuthRepository
         & HasAuthService
@@ -72,6 +73,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasBillingService
         & HasBiometricsRepository
         & HasConfigService
+        & HasDeviceAPIService
         & HasEnvironmentService
         & HasErrorAlertServices.ErrorAlertServices
         & HasErrorReporter
@@ -170,6 +172,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             showAutoFill()
         case .deleteAccount:
             showDeleteAccount()
+        case .deviceManagement:
+            showDeviceManagement()
         case .dismiss:
             stackNavigator?.dismiss()
         case .exportVault:
@@ -347,6 +351,17 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             state: DeleteAccountState(),
         )
         stackNavigator?.present(DeleteAccountView(store: Store(processor: processor)))
+    }
+
+    /// Shows the device management screen.
+    ///
+    private func showDeviceManagement() {
+        let processor = DeviceManagementProcessor(
+            coordinator: asAnyCoordinator(),
+            services: services,
+            state: DeviceManagementState(),
+        )
+        stackNavigator?.present(DeviceManagementView(store: Store(processor: processor)))
     }
 
     /// Shows the export vault screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
@@ -32,6 +32,9 @@ public enum SettingsRoute: Equatable, Hashable {
     /// A route to the delete account screen.
     case deleteAccount
 
+    /// A route to the device management screen.
+    case deviceManagement
+
     /// A route that dismisses the current view.
     case dismiss
 


### PR DESCRIPTION
Depends on: https://github.com/bitwarden/ios/pull/2490

## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33981

## 📔 Objective

Integrate the device management feature into Account Security settings:
- Add `deviceManagement` route to `SettingsRoute`
- Add navigation handling in `SettingsCoordinator`
- Add `isManageDevicesEnabled` state and `manageDevicesTapped` action
- Add "Manage devices" menu item in Account Security Other section
- Hide legacy "Approve login requests" when device management is enabled
- Reorder Other section: Manage devices → Two-step login → Fingerprint phrase



## 📸Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/1c93ebe4-e053-473d-b67c-966b7f15147c" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a9ea55ea-9f68-4a69-8e6e-e14665e4f7fa" />

