### PR TITLE
[PM-34062] [Backport] fix: Increase wait time for dismiss on sync with browser

### DIFF
--- a/BitwardenShared/UI/Platform/GlobalModal/GlobalModalCoordinator.swift
+++ b/BitwardenShared/UI/Platform/GlobalModal/GlobalModalCoordinator.swift
@@ -54,7 +54,7 @@ public final class GlobalModalCoordinator: NSObject, Coordinator, HasStackNaviga
             // PM-34062 Sometimes it doesn't get dismissed because it tries to do it before coming back
             // from the browser to the view. So we wait a bit here and execute this on
             // main thread to handle the edge case.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) { [weak self] in
                 self?.stackNavigator?.dismiss(animated: true, completion: {
                     onDismiss?.action()
                 })


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34062](https://bitwarden.atlassian.net/browse/PM-34062])

## 📔 Objective

🍒 Cherry pick from RC #2493 for backport to `main`.

Increase wait time for dismiss on sync with browser to handle more edge cases.


[PM-34062]: https://bitwarden.atlassian.net/browse/PM-34062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ