### PR TITLE
[PM-33569] fix: Remove pending login request if it no longer exists

### DIFF
--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/PendingLoginRequest.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/PendingLoginRequest.swift
@@ -1,6 +1,14 @@
 import Foundation
 import Networking
 
+// MARK: - PendingLoginRequestError
+
+/// Errors thrown from validating a `PendingLoginRequest` response.
+enum PendingLoginRequestError: Error {
+    /// The login request was not found (e.g., it expired before it could be answered).
+    case notFound
+}
+
 // MARK: - PendingLoginRequest
 
 /// A request for getting a specific pending login request.
@@ -18,4 +26,12 @@ struct PendingLoginRequest: Request {
 
     /// The URL path for this request.
     var path: String { "/auth-requests/\(id)" }
+
+    // MARK: Request
+
+    func validate(_ response: HTTPResponse) throws {
+        if response.statusCode == 404 {
+            throw PendingLoginRequestError.notFound
+        }
+    }
 }

--- a/BitwardenShared/Core/Platform/Services/NotificationService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationService.swift
@@ -78,7 +78,7 @@ protocol NotificationServiceDelegate: AnyObject {
 
 /// The default implementation of `NotificationService`.
 ///
-class DefaultNotificationService: NotificationService {
+class DefaultNotificationService: NotificationService { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     /// The delegate to handle login request actions originating from notifications.
@@ -264,7 +264,7 @@ class DefaultNotificationService: NotificationService {
                 // TODO: PM-33817 Remove isAlertNotification once all auth request pushes are
                 // alert-style and the silent push path is no longer needed.
                 let isAlertNotification = (message["aps"] as? [AnyHashable: Any])?["alert"] != nil
-                try await handleLoginRequest(notificationData, isAlertNotification: isAlertNotification, userId: userId)
+                try await handleLoginRequest(notificationData, isAlertNotification: isAlertNotification)
             case .authRequestResponse:
                 // No action necessary, since the LoginWithDeviceProcessor already checks for updates
                 // every few seconds.
@@ -337,12 +337,10 @@ class DefaultNotificationService: NotificationService {
     ///     When `true`, the OS has already displayed the notification banner (enriched by the
     ///     notification service extension), so creating a local notification is skipped to avoid
     ///     showing the banner twice.
-    ///   - userId: The user's id.
     ///
     private func handleLoginRequest(
         _ notificationData: PushNotificationData,
         isAlertNotification: Bool,
-        userId: String,
     ) async throws {
         let data: LoginRequestNotification = try notificationData.data()
 
@@ -376,7 +374,7 @@ class DefaultNotificationService: NotificationService {
             // Create an in-app banner notification to tell the user about the login request.
             let content = UNMutableNotificationContent()
             content.title = Localizations.logInRequested
-            content.body = Localizations.confimLogInAttempForX(loginSourceEmail)
+            content.body = Localizations.confirmLogInAttemptForX(loginSourceEmail)
             content.categoryIdentifier = "dismissableCategory"
             if let loginRequestData,
                let loginRequestEncoded = String(data: loginRequestData, encoding: .utf8) {
@@ -393,15 +391,7 @@ class DefaultNotificationService: NotificationService {
             try await UNUserNotificationCenter.current().add(request)
         }
 
-        if data.userId == userId {
-            // If the request is for the existing account, show the login request view automatically.
-            guard let loginRequest = try await authService.getPendingLoginRequest(withId: data.id).first
-            else { return }
-            await delegate?.showLoginRequest(loginRequest)
-        } else {
-            // Otherwise, show an alert asking the user if they want to switch accounts.
-            await delegate?.switchAccountsForLoginRequest(to: loginSourceAccount, showAlert: true)
-        }
+        try await showOrSwitchForLoginRequest(id: data.id, loginSourceAccount: loginSourceAccount, showAlert: true)
     }
 
     /// Attempt to decode the notification data as a response to a login notification banner.
@@ -468,23 +458,13 @@ class DefaultNotificationService: NotificationService {
     /// Handle a banner notification with login request data being tapped.
     private func handleNotificationTapped(_ loginRequestData: LoginRequestPushNotification) async {
         do {
-            // Get the user id of the source of the login request.
             let loginSourceAccount = try await stateService.getAccount(userId: loginRequestData.userId)
 
-            // Get the active account ID for comparison.
-            let activeAccountId = try await stateService.getActiveAccountId()
-
-            // If the notification banner was tapped but it's for a different account, switch
-            // to that account automatically.
-            if activeAccountId != loginSourceAccount.profile.userId {
-                await delegate?.switchAccountsForLoginRequest(to: loginSourceAccount, showAlert: false)
-            } else {
-                // If the request is for the existing account, show the login request view automatically.
-                guard let id = loginRequestData.id,
-                      let loginRequest = try await authService.getPendingLoginRequest(withId: id).first
-                else { return }
-                await delegate?.showLoginRequest(loginRequest)
-            }
+            try await showOrSwitchForLoginRequest(
+                id: loginRequestData.id,
+                loginSourceAccount: loginSourceAccount,
+                showAlert: false,
+            )
         } catch StateServiceError.noAccounts {
             let userId = loginRequestData.userId
             await flightRecorder.log(
@@ -492,6 +472,36 @@ class DefaultNotificationService: NotificationService {
             )
         } catch {
             errorReporter.log(error: error)
+        }
+    }
+
+    /// Shows the login request if it belongs to the active account, or switches to the account
+    /// that owns it.
+    ///
+    /// - Parameters:
+    ///   - id: The ID of the login request.
+    ///   - loginSourceAccount: The account the login request belongs to.
+    ///   - showAlert: Whether to prompt the user before switching accounts (`true` when receiving
+    ///     a new push, `false` when the user has already tapped a notification banner).
+    ///
+    private func showOrSwitchForLoginRequest(
+        id: String?,
+        loginSourceAccount: Account,
+        showAlert: Bool,
+    ) async throws {
+        let activeAccountId = try await stateService.getActiveAccountId()
+        if activeAccountId == loginSourceAccount.profile.userId {
+            do {
+                guard let id,
+                      let loginRequest = try await authService.getPendingLoginRequest(withId: id).first
+                else { return }
+                await delegate?.showLoginRequest(loginRequest)
+            } catch is PendingLoginRequestError {
+                // Login request no longer exists on the server (e.g., expired); clear it from state.
+                await stateService.setLoginRequest(nil)
+            }
+        } else {
+            await delegate?.switchAccountsForLoginRequest(to: loginSourceAccount, showAlert: showAlert)
         }
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
@@ -558,6 +558,29 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(delegate.showLoginRequestRequest, .fixture())
     }
 
+    /// `messageReceived(_:notificationDismissed:notificationTapped:)` clears the login request from state
+    /// when the server returns 404 (request expired) for a same-account login request notification.
+    @MainActor
+    func test_messageReceived_loginRequest_sameAccount_notFound() async throws {
+        stateService.setIsAuthenticated()
+        stateService.accounts = [.fixture()]
+        appIDSettingsStore.appID = "10"
+        authService.getPendingLoginRequestResult = .failure(PendingLoginRequestError.notFound)
+        let loginRequestNotification = LoginRequestNotification(id: "requestId", userId: "1")
+        let notificationData = try JSONEncoder().encode(loginRequestNotification)
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
+            "data": [
+                "type": NotificationType.authRequest.rawValue,
+                "payload": String(data: notificationData, encoding: .utf8) ?? "",
+            ],
+        ]
+
+        await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: nil)
+
+        XCTAssertNil(stateService.loginRequest)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` handles logout requests and will not route
     /// to the landing screen if the logged-out account was not the currently active account.
     @MainActor
@@ -886,6 +909,30 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: true)
 
         XCTAssertEqual(delegate.showLoginRequestRequest, .fixture(id: "requestId"))
+    }
+
+    /// `messageReceived(_:notificationDismissed:notificationTapped:)` clears the login request from state
+    /// when the server returns 404 (request expired) for a same-account notification tap.
+    @MainActor
+    func test_messageReceived_notificationTapped_sameAccount_notFound() async throws {
+        stateService.accounts = [.fixture()]
+        stateService.activeAccount = .fixture()
+        stateService.loginRequest = LoginRequestNotification(id: "requestId", userId: "1")
+        authService.getPendingLoginRequestResult = .failure(PendingLoginRequestError.notFound)
+        let loginRequest = LoginRequestPushNotification(
+            id: "requestId",
+            timeoutInMinutes: 15,
+            userId: Account.fixture().profile.userId,
+        )
+        let testData = try JSONEncoder().encode(loginRequest)
+        nonisolated(unsafe) let message: [AnyHashable: Any] = [
+            "notificationData": String(data: testData, encoding: .utf8) ?? "",
+        ]
+
+        await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: true)
+
+        XCTAssertNil(stateService.loginRequest)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -275,6 +275,9 @@ extension VaultListProcessor {
                 // Since the request has been handled, remove it from local storage.
                 await services.stateService.setLoginRequest(nil)
             }
+        } catch is PendingLoginRequestError {
+            // Login request no longer exists on the server (e.g., expired); clear it from state.
+            await services.stateService.setLoginRequest(nil)
         } catch {
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -269,6 +269,20 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertNil(stateService.loginRequest)
     }
 
+    /// `perform(_:)` with `appeared` clears the pending login request from state when the server
+    /// returns 404 (request expired or deleted), without logging an error.
+    @MainActor
+    func test_perform_appeared_checkPendingLoginRequests_notFound() async {
+        stateService.activeAccount = .fixture()
+        stateService.loginRequest = .init(id: "2", userId: Account.fixture().profile.userId)
+        authService.getPendingLoginRequestResult = .failure(PendingLoginRequestError.notFound)
+
+        await subject.perform(.appeared)
+
+        XCTAssertNil(stateService.loginRequest)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `perform(_:)` with `appeared` checks if the user's KDF settings need to be updated and logs
     /// an error and shows an alert if updating the settings fails.
     @MainActor


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-33569](https://bitwarden.atlassian.net/browse/PM-33569)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When a login with device push notification is received by the app, the app will attempt to prompt the user immediately.

It's possible that it can't be shown immediately (app is backgrounded and killed before the user returns or the user's vault is locked when the push notification is received). For this case, the login with device request is persisted until the next vault unlock, when we attempt to show it to the user. In the meantime, it's possible that the request has expired and been removed from the server, resulting in a 404.

When this occurred, an error was logged to the console/flight recorder, but the persisted request was never deleted. So the app would continue to try and fetch the request on each vault unlock.

This catches the error and deletes the request so the app doesn't continue to try fetching it.

[PM-33569]: https://bitwarden.atlassian.net/browse/PM-33569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ