### PR TITLE
[PM-34205] fix: Hide unmasked password text field from VO when password is masked

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -157,6 +157,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
             ZStack {
                 let isPassword = isPasswordVisible != nil || canViewPassword == false
                 let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
+                let isPasswordMasked = !isPasswordVisible && isPassword
                 TextField("", text: $text)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
@@ -164,20 +165,21 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
                     // calls should be placed before setting an id
                     // or hiding the field to avoid breaking accessibilityIds used on our mobile automation test suite
                     .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
-                    .hidden(!isPasswordVisible && isPassword)
+                    .hidden(isPasswordMasked)
                     .id(title)
                     .introspect(.textField, on: .iOS(.v15, .v16, .v17, .v18)) { textField in
                         textField.smartDashesType = isPassword ? .no : .default
                         textField.smartQuotesType = isPassword ? .no : .default
                     }
                     .accessibilityLabel(title ?? "")
+                    .accessibilityHidden(isPasswordMasked)
                     .foregroundStyle(
                         isEnabled && !isTextFieldDisabled
                             ? SharedAsset.Colors.textPrimary.swiftUIColor
                             : SharedAsset.Colors.textDisabled.swiftUIColor,
                     )
                     .disabled(isTextFieldDisabled)
-                if isPassword, !isPasswordVisible {
+                if isPasswordMasked {
                     SecureField("", text: $text)
                         .focused($isSecureFieldFocused)
                         .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-34205](https://bitwarden.atlassian.net/browse/PM-34205)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When navigating through a password field with VoiceOver, VoiceOver is reading the text field twice when the password is masked, but it should only be reading it once.

When the password is masked, there's two text fields stacked on top of each other: a regular one and a secure one. The regular one is hidden, but present to maintain spacing. However, since it wasn't hidden from accessibility, VoiceOver was still reading it when the password was masked. This hides the field from VoiceOver.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/c8c142b4-854a-4b38-8ccf-9c49b18dcbda" /> | <video src="https://github.com/user-attachments/assets/7648eb07-2078-4453-8054-fcd4e66831c7" /> | 




[PM-34205]: https://bitwarden.atlassian.net/browse/PM-34205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ