### PR TITLE
[PM-34443] chore: Fix Testing.md Sourcery usage/path

### DIFF
--- a/Docs/Testing.md
+++ b/Docs/Testing.md
@@ -540,8 +540,7 @@ The codebase uses [Sourcery](https://github.com/krzysztofzablocki/Sourcery) to a
 #### Mark a Protocol for Mocking
 
 ```swift
-// sourcery: AutoMockable
-protocol ExampleService {
+protocol ExampleService { // sourcery: AutoMockable
     func fetchData() async throws -> [String]
     var dataPublisher: AnyPublisher<[String], Never> { get }
 }
@@ -550,7 +549,7 @@ protocol ExampleService {
 #### Generated Mock Location
 
 Mocks are generated in:
-- `BitwardenShared/Core/Platform/Models/Sourcery/AutoMockable.generated.swift`
+- `BitwardenShared/Sourcery/Generated/AutoMockable.generated.swift`
 
 #### Using Generated Mocks
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34443](https://bitwarden.atlassian.net/browse/PM-34443)

## 📔 Objective

Updated Sourcery usage and also where are sourcery mocks generated in `Testing.md` file.


[PM-34443]: https://bitwarden.atlassian.net/browse/PM-34443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ