### PR TITLE
[PM-36040] Send folder

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -254,6 +254,7 @@
 "AttachementAdded" = "Attachment added";
 "AttachmentDeleted" = "Attachment deleted";
 "ChooseFile" = "Choose file";
+"ChooseFolder" = "Choose folder";
 "File" = "File";
 "NoFileChosen" = "No file chosen";
 "NoAttachments" = "There are no attachments.";
@@ -1176,6 +1177,7 @@
 "EnableToAllowTheAppToRespondToSiriAndShortcutsUsingAppIntents" = "Enable to allow the app to respond to Siri and Shortcuts using App Intents.";
 "ThereIsNoActiveAccount" = "There is no active account.";
 "NewFileSend" = "New file Send";
+"NewFolderSend" = "New folder Send";
 "NewTextSend" = "New text Send";
 "EditFileSend" = "Edit file Send";
 "EditTextSend" = "Edit text Send";
@@ -1183,6 +1185,9 @@
 "AllLogsDeleted" = "All logs deleted";
 "LoggingEndsOnDateAtTime" = "Logging ends on %1$@ at %2$@";
 "YouMustAttachAFileToSaveThisSend" = "You must attach a file to save this send";
+"YouMustSelectAFolderToSaveThisSend" = "You must select a folder to save this Send.";
+"FolderSendDescription" = "The selected folder will be compressed and uploaded as a zip file.";
+"TheSelectedFolderIsEmpty" = "The selected folder is empty.";
 "SendUpdated" = "Send updated";
 "WeDontRecognizeThisDeviceEnterTheCodeSentToYourEmailDescriptionLong" = "We don’t recognize this device. Enter the code sent to your email to verify your identity.";
 "Created" = "Created: %1$@";

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -38,6 +38,9 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// Flag to enable/disable sends email verification feature.
     static let sendEmailVerification = FeatureFlag(rawValue: "pm-19051-send-email-verification")
 
+    /// Flag to enable/disable folder Send feature.
+    static let sendFolder = FeatureFlag(rawValue: "innovation-sprint-2026-send-folder")
+
     public static var allCases: [FeatureFlag] {
         [
             .archiveVaultItems,
@@ -51,6 +54,7 @@ extension FeatureFlag: @retroactive CaseIterable {
             .noLogoutOnKdfChange,
             .premiumUpgradePath,
             .sendEmailVerification,
+            .sendFolder,
         ]
     }
 }

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -300,4 +300,12 @@ class MockSendClient: SendClientProtocol {
     func encryptFile(send _: Send, decryptedFilePath _: String, encryptedFilePath _: String) throws {
         fatalError("Not implemented yet")
     }
+
+    func makeSendFolderFile(
+        folderName _: String,
+        files _: [MakeSendFolderFileUniFfiEntry],
+        destination _: String
+    ) throws -> MakeSendFolderFileUniFfiResult {
+        fatalError("Not implemented yet")
+    }
 }

--- a/BitwardenShared/UI/Platform/Application/Extensions/View.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View.swift
@@ -60,14 +60,24 @@ extension View {
     ///
     /// - Parameters:
     ///   - hidden: Whether the menu button should be hidden.
+    ///   - isFolderEnabled: Whether the folder option should be shown.
     ///   - action: The action to perform when a send type is tapped in the menu.
+    ///   - folderAction: The action to perform when the folder option is tapped in the menu.
     /// - Returns: A `FloatingActionMenu` configured for adding a send item.
     ///
     func addSendItemFloatingActionMenu(
         hidden: Bool = false,
+        isFolderEnabled: Bool = false,
         action: @escaping (SendType) async -> Void,
+        folderAction: @escaping () async -> Void,
     ) -> some View {
         FloatingActionMenu(image: SharedAsset.Icons.plus32.swiftUIImage) {
+            if isFolderEnabled {
+                AsyncButton(Localizations.folder) {
+                    await folderAction()
+                }
+            }
+
             ForEach(SendType.allCases) { type in
                 AsyncButton(type.localizedName) {
                     await action(type)

--- a/BitwardenShared/UI/Platform/FolderSelection/FolderSelectionCoordinator.swift
+++ b/BitwardenShared/UI/Platform/FolderSelection/FolderSelectionCoordinator.swift
@@ -1,0 +1,87 @@
+import BitwardenKit
+import UIKit
+import UniformTypeIdentifiers
+
+// MARK: - FolderSelectionCoordinator
+
+/// A coordinator that manages navigation for folder selection.
+///
+@MainActor
+class FolderSelectionCoordinator: NSObject, Coordinator, HasStackNavigator {
+    // MARK: Types
+
+    typealias Services = HasErrorAlertServices.ErrorAlertServices
+        & HasErrorReporter
+
+    // MARK: Properties
+
+    /// The delegate for this coordinator.
+    weak var delegate: FolderSelectionDelegate?
+
+    /// The services used by this coordinator.
+    let services: Services
+
+    /// The navigator that is used to present each of the flows within this coordinator.
+    private(set) weak var stackNavigator: StackNavigator?
+
+    // MARK: Initialization
+
+    /// Creates a new `FolderSelectionCoordinator`.
+    ///
+    /// - Parameters:
+    ///   - delegate: The delegate for this coordinator.
+    ///   - services: The services for this coordinator.
+    ///   - stackNavigator: The navigator that is used to present each of the flows within this
+    ///     coordinator. This navigator should be one already used in the coordinator that is
+    ///     presenting this coordinator, since this navigator is purely used to present other flows
+    ///     modally.
+    ///
+    init(
+        delegate: FolderSelectionDelegate,
+        services: Services,
+        stackNavigator: StackNavigator,
+    ) {
+        self.delegate = delegate
+        self.services = services
+        self.stackNavigator = stackNavigator
+    }
+
+    // MARK: Methods
+
+    func navigate(to route: Never, context: AnyObject?) {}
+
+    func start() {
+        showFolderBrowser()
+    }
+
+    // MARK: Private Methods
+
+    /// Shows the folder browser screen.
+    ///
+    private func showFolderBrowser() {
+        let viewController = UIDocumentPickerViewController(forOpeningContentTypes: [.folder])
+        viewController.allowsMultipleSelection = false
+        viewController.delegate = self
+        stackNavigator?.present(viewController)
+    }
+}
+
+// MARK: - HasErrorAlertServices
+
+extension FolderSelectionCoordinator: HasErrorAlertServices {
+    var errorAlertServices: ErrorAlertServices { services }
+}
+
+// MARK: - FolderSelectionCoordinator:UIDocumentPickerDelegate
+
+extension FolderSelectionCoordinator: UIDocumentPickerDelegate {
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
+        controller.dismiss(animated: UI.animated)
+        guard let url = urls.first else { return }
+        delegate?.folderSelectionCompleted(folderURL: url)
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        controller.dismiss(animated: UI.animated)
+    }
+}

--- a/BitwardenShared/UI/Platform/FolderSelection/FolderSelectionDelegate.swift
+++ b/BitwardenShared/UI/Platform/FolderSelection/FolderSelectionDelegate.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+// MARK: - FolderSelectionDelegate
+
+/// A delegate object that responds to folder selection events.
+///
+@MainActor
+protocol FolderSelectionDelegate: AnyObject {
+    /// A folder was chosen by the user.
+    ///
+    /// - Parameter folderURL: The URL of the selected folder.
+    ///
+    func folderSelectionCompleted(folderURL: URL)
+}

--- a/BitwardenShared/UI/Platform/FolderSelection/FolderSelectionModule.swift
+++ b/BitwardenShared/UI/Platform/FolderSelection/FolderSelectionModule.swift
@@ -1,0 +1,33 @@
+import BitwardenKit
+
+// MARK: - FolderSelectionModule
+
+/// An object that builds coordinators for the folder selection flow.
+///
+@MainActor
+protocol FolderSelectionModule {
+    /// Initializes a coordinator for folder selection.
+    ///
+    /// - Parameters:
+    ///   - delegate: The delegate for this coordinator.
+    ///   - stackNavigator: The stack navigator that will be used to navigate between routes.
+    /// - Returns: A `FolderSelectionCoordinator` that manages folder selection.
+    ///
+    func makeFolderSelectionCoordinator(
+        delegate: FolderSelectionDelegate,
+        stackNavigator: StackNavigator,
+    ) -> FolderSelectionCoordinator
+}
+
+extension DefaultAppModule: FolderSelectionModule {
+    func makeFolderSelectionCoordinator(
+        delegate: FolderSelectionDelegate,
+        stackNavigator: StackNavigator,
+    ) -> FolderSelectionCoordinator {
+        FolderSelectionCoordinator(
+            delegate: delegate,
+            services: services,
+            stackNavigator: stackNavigator,
+        )
+    }
+}

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -65,6 +65,9 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
 
     func navigate(to route: SendRoute, context: AnyObject?) {
         switch route {
+        case .addFolderItem:
+            guard let delegate = context as? SendItemDelegate else { return }
+            showItem(route: .add(content: .folder), delegate: delegate)
         case let .addItem(type):
             guard let delegate = context as? SendItemDelegate else { return }
             let route: SendItemRoute = if let type {

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListEffect.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListEffect.swift
@@ -2,6 +2,9 @@
 
 /// Effects that can be processed by a `SendListProcessor`.
 enum SendListEffect: Equatable {
+    /// The add folder item button was pressed.
+    case addFolderItemPressed
+
     /// The add item button was pressed.
     case addItemPressed(SendType)
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -48,6 +48,8 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
 
     override func perform(_ effect: SendListEffect) async {
         switch effect {
+        case .addFolderItemPressed:
+            await addFolderSend()
         case let .addItemPressed(sendType):
             await addNewSend(sendType: sendType)
         case .loadData:
@@ -119,6 +121,17 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
 
     // MARK: Private Methods
 
+    /// Navigates to the add folder send view. Requires premium since folder sends are file sends.
+    ///
+    private func addFolderSend() async {
+        let hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
+        guard hasPremium else {
+            coordinator.showAlert(.defaultAlert(title: Localizations.sendFilePremiumRequired))
+            return
+        }
+        coordinator.navigate(to: .addFolderItem, context: self)
+    }
+
     /// Navigates to the add new send view. If the user is trying to add a new send type which
     /// requires premium and they don't have premium this will instead show an error alert to the
     /// user.
@@ -171,6 +184,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     ///
     private func loadData() async {
         state.isSendDisabled = await services.policyService.policyAppliesToUser(.disableSend)
+        state.isSendFolderEnabled = await services.configService.getFeatureFlag(.sendFolder)
     }
 
     /// Removes the password from the provided send.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
@@ -16,6 +16,9 @@ struct SendListState: Sendable {
     /// Whether sends are disabled via a policy.
     var isSendDisabled = false
 
+    /// Whether the send folder feature is enabled.
+    var isSendFolderEnabled = false
+
     /// A flag indicating if the info button should be hidden.
     var isInfoButtonHidden: Bool { type != nil }
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -43,9 +43,15 @@ private struct MainSendListView: View {
                             await store.perform(.addItemPressed(sendType))
                         }
                     } else {
-                        addSendItemFloatingActionMenu { sendType in
-                            await store.perform(.addItemPressed(sendType))
-                        }
+                        addSendItemFloatingActionMenu(
+                            isFolderEnabled: store.state.isSendFolderEnabled,
+                            action: { sendType in
+                                await store.perform(.addItemPressed(sendType))
+                            },
+                            folderAction: {
+                                await store.perform(.addFolderItemPressed)
+                            },
+                        )
                     }
                 }
 
@@ -100,6 +106,12 @@ private struct MainSendListView: View {
                             ForEach(SendType.allCases.reversed()) { sendType in
                                 AsyncButton(sendType.localizedName) {
                                     await store.perform(.addItemPressed(sendType))
+                                }
+                            }
+
+                            if store.state.isSendFolderEnabled {
+                                AsyncButton(Localizations.folder) {
+                                    await store.perform(.addFolderItemPressed)
                                 }
                             }
                         } label: {

--- a/BitwardenShared/UI/Tools/Send/Send/SendRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendRoute.swift
@@ -6,6 +6,9 @@ import Foundation
 /// The route to a specific screen in the send tab.
 ///
 public enum SendRoute: Equatable {
+    /// A route to the add folder item screen.
+    case addFolderItem
+
     /// A route to the add item screen.
     case addItem(type: SendType? = nil)
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemAction.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemAction.swift
@@ -15,6 +15,9 @@ enum AddEditSendItemAction: Equatable {
     /// The choose file button was pressed.
     case chooseFilePressed
 
+    /// The choose folder button was pressed.
+    case chooseFolderPressed
+
     /// Clear the URL that was opened.
     case clearURL
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -7,11 +7,12 @@ import Foundation
 
 /// The processor used to manage state and handle actions for the add/edit send item screen.
 ///
-class AddEditSendItemProcessor:
+class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     StateProcessor<AddEditSendItemState, AddEditSendItemAction, AddEditSendItemEffect> {
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasClientService
         & HasConfigService
         & HasEnvironmentService
         & HasErrorReporter
@@ -107,6 +108,8 @@ class AddEditSendItemProcessor:
             state.focusedRecipientEmailIndex = state.recipientEmails.count - 1
         case .chooseFilePressed:
             presentFileSelectionAlert()
+        case .chooseFolderPressed:
+            coordinator.navigate(to: .folderSelection, context: self)
         case .clearURL:
             state.url = nil
         case let .deletionDateChanged(newValue):
@@ -305,12 +308,25 @@ class AddEditSendItemProcessor:
             let newSendView: SendView
             switch state.mode {
             case .add, .shareExtension:
-                switch state.type {
-                case .file:
-                    guard let fileData = state.fileData else { return }
-                    newSendView = try await services.sendRepository.addFileSend(sendView, data: fileData)
-                case .text:
-                    newSendView = try await services.sendRepository.addTextSend(sendView)
+                if state.isFolderSend {
+                    guard let folderURL = state.folderURL else { return }
+                    let zipData = try await compressFolderToZip(folderURL: folderURL)
+                    guard zipData.count <= Constants.maxFileSizeBytes else {
+                        coordinator.showAlert(.defaultAlert(
+                            title: Localizations.anErrorHasOccurred,
+                            message: Localizations.maxFileSize,
+                        ))
+                        return
+                    }
+                    newSendView = try await services.sendRepository.addFileSend(sendView, data: zipData)
+                } else {
+                    switch state.type {
+                    case .file:
+                        guard let fileData = state.fileData else { return }
+                        newSendView = try await services.sendRepository.addFileSend(sendView, data: fileData)
+                    case .text:
+                        newSendView = try await services.sendRepository.addTextSend(sendView)
+                    }
                 }
                 await services.reviewPromptService.trackUserAction(.createdNewSend)
             case .edit:
@@ -401,25 +417,90 @@ class AddEditSendItemProcessor:
         // Only perform further checks when adding a new file send.
         guard state.mode == .add else { return true }
 
-        guard let fileData = state.fileData, state.fileName != nil else {
-            let alert = Alert.defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: Localizations.youMustAttachAFileToSaveThisSend,
-            )
-            coordinator.showAlert(alert)
-            return false
-        }
+        if state.isFolderSend {
+            guard state.folderURL != nil else {
+                let alert = Alert.defaultAlert(
+                    title: Localizations.anErrorHasOccurred,
+                    message: Localizations.youMustSelectAFolderToSaveThisSend,
+                )
+                coordinator.showAlert(alert)
+                return false
+            }
+        } else {
+            guard let fileData = state.fileData, state.fileName != nil else {
+                let alert = Alert.defaultAlert(
+                    title: Localizations.anErrorHasOccurred,
+                    message: Localizations.youMustAttachAFileToSaveThisSend,
+                )
+                coordinator.showAlert(alert)
+                return false
+            }
 
-        guard fileData.count <= Constants.maxFileSizeBytes else {
-            let alert = Alert.defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: Localizations.maxFileSize,
-            )
-            coordinator.showAlert(alert)
-            return false
+            guard fileData.count <= Constants.maxFileSizeBytes else {
+                let alert = Alert.defaultAlert(
+                    title: Localizations.anErrorHasOccurred,
+                    message: Localizations.maxFileSize,
+                )
+                coordinator.showAlert(alert)
+                return false
+            }
         }
 
         return true
+    }
+
+    /// Compresses the contents of a folder into a zip file using the Bitwarden SDK.
+    ///
+    /// - Parameter folderURL: The URL of the folder to compress.
+    /// - Returns: The zip file data.
+    ///
+    private func compressFolderToZip(folderURL: URL) async throws -> Data {
+        let didStartAccessing = folderURL.startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccessing {
+                folderURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let fileManager = FileManager.default
+        guard let enumerator = fileManager.enumerator(
+            at: folderURL,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles],
+        ) else {
+            throw BitwardenError.dataError("Failed to enumerate folder contents")
+        }
+
+        var entries: [MakeSendFolderFileUniFfiEntry] = []
+        for case let fileURL as URL in enumerator {
+            let resourceValues = try fileURL.resourceValues(forKeys: [.isRegularFileKey])
+            guard resourceValues.isRegularFile == true else { continue }
+
+            let relativePath = fileURL.path.replacingOccurrences(
+                of: folderURL.path + "/",
+                with: "",
+            )
+            entries.append(MakeSendFolderFileUniFfiEntry(
+                path: relativePath,
+                source: fileURL.path,
+            ))
+        }
+
+        let zipURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("zip")
+        defer {
+            try? fileManager.removeItem(at: zipURL)
+        }
+
+        _ = try await services.clientService.sends()
+            .makeSendFolderFile(
+                folderName: folderURL.lastPathComponent,
+                files: entries,
+                destination: zipURL.path,
+            )
+
+        return try Data(contentsOf: zipURL)
     }
 
     /// Shows an alert indicating that the "Specific People" feature requires a premium subscription.
@@ -439,6 +520,49 @@ extension AddEditSendItemProcessor: FileSelectionDelegate {
     func fileSelectionCompleted(fileName: String, data: Data) {
         state.fileName = fileName
         state.fileData = data
+    }
+}
+
+// MARK: - AddEditSendItemProcessor:FolderSelectionDelegate
+
+extension AddEditSendItemProcessor: FolderSelectionDelegate {
+    func folderSelectionCompleted(folderURL: URL) {
+        let didStartAccessing = folderURL.startAccessingSecurityScopedResource()
+        defer {
+            if didStartAccessing {
+                folderURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        var fileCount = 0
+        var totalSize: Int64 = 0
+        if let enumerator = FileManager.default.enumerator(
+            at: folderURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles],
+        ) {
+            for case let fileURL as URL in enumerator {
+                if let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
+                   values.isRegularFile == true {
+                    fileCount += 1
+                    totalSize += Int64(values.fileSize ?? 0)
+                }
+            }
+        }
+
+        guard fileCount > 0 else {
+            coordinator.showAlert(.defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.theSelectedFolderIsEmpty,
+            ))
+            return
+        }
+
+        state.folderURL = folderURL
+        state.folderName = folderURL.lastPathComponent
+        state.fileName = folderURL.lastPathComponent + ".zip"
+        state.folderFileCount = fileCount
+        state.folderTotalSize = totalSize
     }
 }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -50,11 +50,36 @@ struct AddEditSendItemState: Equatable, Sendable {
     /// A description of the size of the file attached to this send.
     var fileSize: String?
 
+    /// The number of files in the selected folder.
+    var folderFileCount: Int = 0
+
+    /// The name of the selected folder.
+    var folderName: String?
+
+    /// The total size of all files in the selected folder.
+    var folderTotalSize: Int64 = 0
+
+    /// A formatted description of the folder contents (file count and total size).
+    var folderSizeDescription: String? {
+        guard folderFileCount > 0 else { return nil }
+        let sizeString = ByteCountFormatter.string(
+            fromByteCount: folderTotalSize,
+            countStyle: .binary,
+        )
+        return "\(Localizations.xItems(folderFileCount)), \(sizeString)"
+    }
+
+    /// The URL of the selected folder for a folder send.
+    var folderURL: URL?
+
     /// The index of the currently focused recipient email field, or `nil` if none is focused.
     var focusedRecipientEmailIndex: Int?
 
     /// The id for this send.
     var id: String?
+
+    /// A flag indicating if this is a folder send (folder compressed to zip and uploaded as file send).
+    var isFolderSend: Bool = false
 
     /// A flag indicating if this item should be deactivated.
     var isDeactivateThisSendOn = false
@@ -157,11 +182,15 @@ struct AddEditSendItemState: Equatable, Sendable {
         switch mode {
         case .add,
              .shareExtension:
-            switch type {
-            case .file:
-                Localizations.newFileSend
-            case .text:
-                Localizations.newTextSend
+            if isFolderSend {
+                Localizations.newFolderSend
+            } else {
+                switch type {
+                case .file:
+                    Localizations.newFileSend
+                case .text:
+                    Localizations.newTextSend
+                }
             }
         case .edit:
             switch type {

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -290,16 +290,65 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
         }
     }
 
+    /// The attributes for a folder type send.
+    @ViewBuilder private var folderSendAttributes: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if let folderName = store.state.folderName {
+                BitwardenField {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(folderName)
+                            .styleGuide(.body)
+                            .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+
+                        if let sizeDescription = store.state.folderSizeDescription {
+                            Text(sizeDescription)
+                                .styleGuide(.footnote)
+                                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                        }
+                    }
+                    .accessibilityIdentifier("SendCurrentFolderNameLabel")
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Button(Localizations.chooseFolder) {
+                    store.send(.chooseFolderPressed)
+                }
+                .buttonStyle(.secondary())
+                .accessibilityIdentifier("SendChooseFolderButton")
+
+                Text(Localizations.folderSendDescription)
+                    .styleGuide(.subheadline)
+                    .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                    .padding(.leading, 12)
+
+                Text(Localizations.requiredMaximumFileSizeIsX(
+                    ByteCountFormatter.string(
+                        fromByteCount: Int64(Constants.maxFileSizeBytes),
+                        countStyle: .binary,
+                    ),
+                ))
+                .styleGuide(.subheadline)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .padding(.leading, 12)
+            }
+        }
+    }
+
     /// Additional details for the send.
     @ViewBuilder private var sendDetails: some View {
         SectionView(Localizations.sendDetails, contentSpacing: 8) {
             nameField
 
-            switch store.state.type {
-            case .text:
-                textSendAttributes
-            case .file:
-                fileSendAttributes
+            if store.state.isFolderSend {
+                folderSendAttributes
+            } else {
+                switch store.state.type {
+                case .text:
+                    textSendAttributes
+                case .file:
+                    fileSendAttributes
+                }
             }
 
             if store.state.type == .text {

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
@@ -13,6 +13,7 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
     // MARK: Types
 
     typealias Module = FileSelectionModule
+        & FolderSelectionModule
         & GeneratorModule
         & NavigatorBuilderModule
         & ProfileSwitcherModule
@@ -20,6 +21,7 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
 
     typealias Services = GeneratorCoordinator.Services
         & HasAuthRepository
+        & HasClientService
         & HasConfigService
         & HasEnvironmentService
         & HasErrorAlertServices.ErrorAlertServices
@@ -34,6 +36,10 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
     /// The most recent coordinator used to navigate to a `FileSelectionRoute`. Used to keep the
     /// coordinator in memory.
     private var fileSelectionCoordinator: AnyCoordinator<FileSelectionRoute, Void>?
+
+    /// The most recent coordinator used to navigate to the folder selection flow. Used to keep the
+    /// coordinator in memory.
+    private var folderSelectionCoordinator: FolderSelectionCoordinator?
 
     /// The most recent coordinator used to navigate to a `GeneratorRoute`. Used to keep the
     /// coordinator in memory.
@@ -98,6 +104,9 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
         case let .fileSelection(route):
             guard let delegate = context as? FileSelectionDelegate else { return }
             showFileSelection(route: route, delegate: delegate)
+        case .folderSelection:
+            guard let delegate = context as? FolderSelectionDelegate else { return }
+            showFolderSelection(delegate: delegate)
         case .generator:
             guard let delegate = context as? GeneratorCoordinatorDelegate else { return }
             showGenerator(delegate: delegate)
@@ -146,6 +155,10 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
             state.fileData = fileData
             state.type = .file
             state.mode = .shareExtension(.empty())
+        case .folder:
+            state.type = .file
+            state.isFolderSend = true
+            state.mode = .add
         case let .text(text):
             state.text = text
             state.type = .text
@@ -203,6 +216,20 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
         coordinator.start()
         coordinator.navigate(to: route)
         fileSelectionCoordinator = coordinator
+    }
+
+    /// Shows the folder selection screen.
+    ///
+    /// - Parameter delegate: The `FolderSelectionDelegate` for this navigation.
+    ///
+    private func showFolderSelection(delegate: FolderSelectionDelegate) {
+        guard let stackNavigator else { return }
+        let coordinator = module.makeFolderSelectionCoordinator(
+            delegate: delegate,
+            stackNavigator: stackNavigator,
+        )
+        coordinator.start()
+        folderSelectionCoordinator = coordinator
     }
 
     /// Shows the password generator screen.

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
@@ -9,6 +9,9 @@ public enum AddSendContentType: Equatable, Hashable {
     /// A file type, with the provided name and data.
     case file(fileName: String, fileData: Data)
 
+    /// A folder type, for compressing and sending a folder as a zip file.
+    case folder
+
     /// A text type, with the provided string value.
     case text(String)
 
@@ -58,6 +61,9 @@ public enum SendItemRoute: Equatable, Hashable {
     /// - Parameter route: The file selection route to follow.
     ///
     case fileSelection(_ route: FileSelectionRoute)
+
+    /// A route to the folder selection screen.
+    case folderSelection
 
     /// A route to the password generator screen.
     case generator

--- a/GlobalTestHelpers/MockAppModule.swift
+++ b/GlobalTestHelpers/MockAppModule.swift
@@ -14,6 +14,7 @@ class MockAppModule:
     ExportCXFModule,
     ExtensionSetupModule,
     FileSelectionModule,
+    FolderSelectionModule,
     FlightRecorderModule,
     GeneratorModule,
     GlobalModalModule,
@@ -41,6 +42,8 @@ class MockAppModule:
     var extensionSetupCoordinator = MockCoordinator<ExtensionSetupRoute, Void>()
     var fileSelectionDelegate: FileSelectionDelegate?
     var fileSelectionCoordinator = MockCoordinator<FileSelectionRoute, Void>()
+    var folderSelectionDelegate: FolderSelectionDelegate?
+    var folderSelectionCoordinator: FolderSelectionCoordinator?
     var flightRecorderCoordinator = MockCoordinator<FlightRecorderRoute, Void>()
     var generatorCoordinator = MockCoordinator<GeneratorRoute, Void>()
     var globalModalCoordinator = MockCoordinator<GlobalModalRoute, Void>()
@@ -115,6 +118,15 @@ class MockAppModule:
     ) -> AnyCoordinator<FileSelectionRoute, Void> {
         fileSelectionDelegate = delegate
         return fileSelectionCoordinator.asAnyCoordinator()
+    }
+
+    func makeFolderSelectionCoordinator(
+        delegate: FolderSelectionDelegate,
+        stackNavigator _: StackNavigator,
+    ) -> FolderSelectionCoordinator {
+        folderSelectionDelegate = delegate
+        // swiftlint:disable:next force_unwrapping
+        return folderSelectionCoordinator!
     }
 
     func makeFlightRecorderCoordinator(


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36040

## 📔 Objective

Add folder support to Bitwarden Send, allowing users to select an entire folder from their computer with a single click.
The folder (including all its files and subfolders) will be automatically compressed into a single encrypted package (zip) and uploaded just like a regular file Send.
Uses SDK WASM implementation for the compression.
Uses storage compression (basically zero, no compression algorithm at all)

Behind `innovation-sprint-2026-send-folder` feature flag.

## 📸 Screenshots

https://github.com/user-attachments/assets/ed3f8f8b-d995-4594-b165-99c6c81e6e49

Create new send type:
<img width="301" height="234" alt="image" src="https://github.com/user-attachments/assets/ac9e32d3-039c-4d18-81b9-052a03f76d65" />

Folder send:
<img width="394" height="602" alt="image" src="https://github.com/user-attachments/assets/2d907066-a2a5-4a4d-af83-dcdf9e1f985b" />

Folder selected:
<img width="396" height="308" alt="image" src="https://github.com/user-attachments/assets/15c0f718-5f70-4524-b38c-e892e0dfea65" />

Folder not selected:
<img width="335" height="192" alt="image" src="https://github.com/user-attachments/assets/7c522626-ba08-417c-a49a-7ad92ffd090b" />

Empty folder:
<img width="330" height="164" alt="image" src="https://github.com/user-attachments/assets/4dc5a621-aba3-4bce-b1cd-b8914b03be99" />