### PR TITLE
[PM-34527] chore: Fix non-Sendable related trivial warnings.

### DIFF
--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsView+ViewInspectorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ExportItems/ExportItemsView+ViewInspectorTests.swift
@@ -36,7 +36,7 @@ class ExportItemsViewTests: BitwardenTestCase {
     /// Tapping the cancel button dispatches the `.dismiss` action.
     @MainActor
     func test_cancelButton_tap() throws {
-        var button = try subject.inspect().findCancelToolbarButton()
+        let button = try subject.inspect().findCancelToolbarButton()
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .dismiss)
     }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsView+ViewInspectorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/ImportItems/ImportItemsView+ViewInspectorTests.swift
@@ -35,7 +35,7 @@ class ImportItemsViewTests: BitwardenTestCase {
     /// Tapping the cancel button dispatches the `.dismiss` action.
     @MainActor
     func test_cancelButton_tap() throws {
-        var button = try subject.inspect().findCancelToolbarButton()
+        let button = try subject.inspect().findCancelToolbarButton()
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .dismiss)
     }

--- a/BitwardenKit/Application/TestHelpers/ServiceContainer.swift
+++ b/BitwardenKit/Application/TestHelpers/ServiceContainer.swift
@@ -9,8 +9,8 @@ typealias Services = HasConfigService
     & HasErrorReporter
     & HasFlightRecorder
     & HasLanguageStateService
-    & HasTimeProvider
     & HasServerCommunicationConfigClientSingleton
+    & HasTimeProvider
 
 /// A service container used for testing processors within `BitwardenKitTests`.
 ///

--- a/BitwardenKit/Core/Platform/Extensions/String.swift
+++ b/BitwardenKit/Core/Platform/Extensions/String.swift
@@ -64,22 +64,6 @@ public extension String {
         self == "bitwarden"
     }
 
-    /// Validates whether the string is a valid email address.
-    ///
-    /// - Parameter useStrictValidation: If `true`, validates against a regex pattern requiring
-    ///   a properly formatted email (e.g., `user@domain.com`). If `false`, only checks for
-    ///   the presence of an `@` symbol. Defaults to `true`.
-    /// - Returns: `true` if the string is a valid email according to the validation mode.
-    ///
-    func isValidEmail(useStrictValidation: Bool = true) -> Bool {
-        if useStrictValidation {
-            let emailRegex = "^[A-Za-z0-9._%+-/*]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
-            return range(of: emailRegex, options: .regularExpression) != nil
-        } else {
-            return contains("@")
-        }
-    }
-
     /// Returns `true` if the URL is valid.
     var isValidURL: Bool {
         guard rangeOfCharacter(from: .whitespaces) == nil else { return false }
@@ -129,6 +113,22 @@ public extension String {
         }
 
         return result
+    }
+
+    /// Validates whether the string is a valid email address.
+    ///
+    /// - Parameter useStrictValidation: If `true`, validates against a regex pattern requiring
+    ///   a properly formatted email (e.g., `user@domain.com`). If `false`, only checks for
+    ///   the presence of an `@` symbol. Defaults to `true`.
+    /// - Returns: `true` if the string is a valid email according to the validation mode.
+    ///
+    func isValidEmail(useStrictValidation: Bool = true) -> Bool {
+        if useStrictValidation {
+            let emailRegex = "^[A-Za-z0-9._%+-/*]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+            return range(of: emailRegex, options: .regularExpression) != nil
+        } else {
+            return contains("@")
+        }
     }
 
     /// Returns a copy of the string, padded to the specified length on the left side with the

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -1132,7 +1132,8 @@ extension DefaultAuthRepository: AuthRepository {
     private func profileItem(from account: Account) async -> ProfileSwitcherItem {
         let isLocked = await (try? isLocked(userId: account.profile.userId)) ?? true
         let isAuthenticated = await (try? stateService.isAuthenticated(userId: account.profile.userId)) == true
-        let hasNeverLock = await (try? userSessionStateService.getVaultTimeout(userId: account.profile.userId)) == .never
+        let vaultTimeout = try? await userSessionStateService.getVaultTimeout(userId: account.profile.userId)
+        let hasNeverLock = vaultTimeout == .never
         let isManuallyLocked = await (try? stateService.getManuallyLockedAccount(
             userId: account.profile.userId,
         )) == true

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -993,7 +993,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `getProfilesState()` can return locked accounts correctly on timeout `.never`.
-    func test_getProfilesState_lockedOnNeverLock() async {
+    func test_getProfilesState_lockedOnNeverLock() async { // swiftlint:disable:this function_body_length
         stateService.accounts = [
             anneAccount,
             beeAccount,
@@ -1572,7 +1572,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     /// `setMasterPassword()` sets the user's master password, saves their encryption keys and
     /// unlocks the vault.
-    func test_setMasterPassword_TDE() async throws {
+    func test_setMasterPassword_TDE() async throws { // swiftlint:disable:this function_body_length
         var account = Account.fixtureWithTDE()
         account.profile.userDecryptionOptions?.masterPasswordUnlock = .fixture()
         client.result = .httpSuccess(testData: .emptyResponse)

--- a/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
@@ -473,4 +473,4 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(client.requests[0].method, .post)
         XCTAssertEqual(client.requests[0].url.absoluteString, "https://example.com/api/accounts/verify-otp")
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Auth/Services/KeychainRepository+UserSessionTests.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepository+UserSessionTests.swift
@@ -1,6 +1,5 @@
 // swiftlint:disable:this file_name
 
-import BitwardenKitMocks
 import BitwardenKit
 import BitwardenKitMocks
 import XCTest

--- a/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/CredentialIdentityFactoryTests.swift
@@ -446,4 +446,4 @@ class CredentialIdentityFactoryTests: BitwardenTestCase { // swiftlint:disable:t
         let passwordIdentity = subject.tryCreatePasswordCredentialIdentity(from: cipher)
         XCTAssertNil(passwordIdentity)
     }
-}
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Autofill/Utilities/CredentialProviderContext/CredentialProviderContext.swift
+++ b/BitwardenShared/Core/Autofill/Utilities/CredentialProviderContext/CredentialProviderContext.swift
@@ -110,6 +110,8 @@ public struct DefaultCredentialProviderContext: CredentialProviderContext {
         }
 
         return switch serviceIdentifier.type {
+        case .app:
+            serviceIdentifier.identifier
         case .domain:
             "https://" + serviceIdentifier.identifier
         case .URL:

--- a/BitwardenShared/Core/Billing/Models/Response/PlanResponseModel.swift
+++ b/BitwardenShared/Core/Billing/Models/Response/PlanResponseModel.swift
@@ -81,5 +81,4 @@ struct PlanResponseModel: JSONResponse, Equatable, Sendable {
 
     /// Whether users on the plan get premium features.
     let usersGetPremium: Bool
-
 }

--- a/BitwardenShared/Core/Platform/Services/NotificationService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationService.swift
@@ -78,7 +78,7 @@ protocol NotificationServiceDelegate: AnyObject {
 
 /// The default implementation of `NotificationService`.
 ///
-class DefaultNotificationService: NotificationService {
+class DefaultNotificationService: NotificationService { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     /// The delegate to handle login request actions originating from notifications.

--- a/BitwardenShared/Core/Platform/Services/Services.swift
+++ b/BitwardenShared/Core/Platform/Services/Services.swift
@@ -13,9 +13,9 @@ typealias Services = HasAPIService
     & HasApplication
     & HasAuthAPIService
     & HasAuthRepository
-    & HasBillingAPIService
     & HasAuthService
     & HasAutofillCredentialService
+    & HasBillingAPIService
     & HasBiometricsRepository
     & HasCameraService
     & HasChangeKdfService

--- a/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelper.swift
@@ -90,8 +90,8 @@ class DefaultCipherOwnershipHelper: CipherOwnershipHelper {
             let collections = try await vaultRepository.fetchCollections(includeReadOnly: false)
             let collectionsForOwner = collections.filter { $0.organizationId == ownerOrgId }
 
-            if let defaultCollection = collectionsForOwner.first(where: {
-                $0.type == .defaultUserCollection
+            if let defaultCollection = collectionsForOwner.first(where: { col in
+                col.type == .defaultUserCollection
             }),
                 let defaultCollectionId = defaultCollection.id {
                 collectionIds = [defaultCollectionId]

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
@@ -32,8 +32,8 @@ class MockSyncService: SyncService {
     var needsSyncOnlyCheckLocalData: Bool = false
     var needsSyncResult: Result<Bool, Error> = .success(false)
 
-    var organizationIdRequiringVaultMigrationCalled = false
-    var organizationIdRequiringVaultMigrationResult: Result<String?, Error> = .success(nil)
+    var organizationIdRequiringVaultMigrationCalled = false // swiftlint:disable:this identifier_name
+    var organizationIdRequiringVaultMigrationResult: Result<String?, Error> = .success(nil) // swiftlint:disable:this identifier_name line_length
 
     func deleteCipher(data: SyncCipherNotification) async throws {
         deleteCipherData = data

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationStateTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationStateTests.swift
@@ -15,8 +15,9 @@ class CompleteRegistrationStateTests: BitwardenTestCase {
 
         XCTAssertTrue(subject.doesMasterPasswordMatchHint)
     }
-    
-    /// `doesMasterPasswordMatchHint` returns `true` if the password and hint match after trimming whitespace from the hint.
+
+    /// `doesMasterPasswordMatchHint` returns `true` if the password and hint match after
+    /// trimming whitespace from the hint.
     func test_doesMasterPasswordMatchHint_whenWhitespaceDifference_returnsTrue() {
         var subject = CompleteRegistrationState(
             emailVerificationToken: "",
@@ -54,7 +55,7 @@ class CompleteRegistrationStateTests: BitwardenTestCase {
 
         XCTAssertFalse(subject.continueButtonEnabled)
     }
-    
+
     /// `continueButtonEnabled` returns `false` when password is too short.
     func test_isContinueButtonEnabled_whenPasswordShort_returnsFalse() {
         var subject = CompleteRegistrationState(
@@ -67,7 +68,7 @@ class CompleteRegistrationStateTests: BitwardenTestCase {
 
         XCTAssertFalse(subject.continueButtonEnabled)
     }
-    
+
     /// `continueButtonEnabled` returns `true` when password is valid .
     func test_isContinueButtonEnabled_validPassword_returnsTrue() {
         var subject = CompleteRegistrationState(

--- a/BitwardenShared/UI/Autofill/Utilities/ASSettingsMediator.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/ASSettingsMediator.swift
@@ -54,7 +54,7 @@ class DefaultASSettingsMediator: ASSettingsMediator {
     init(
         asSettingsHelperProxy: ASSettingsHelperProxy,
         stateService: AutofillStateService,
-        timeProvider: TimeProvider
+        timeProvider: TimeProvider,
     ) {
         self.asSettingsHelperProxy = asSettingsHelperProxy
         self.stateService = stateService

--- a/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Application/AppCoordinator.swift
@@ -8,7 +8,7 @@ import UIKit
 
 /// A coordinator that manages the app's top-level navigation.
 ///
-class AppCoordinator: Coordinator, HasRootNavigator {
+class AppCoordinator: Coordinator, HasRootNavigator { // swiftlint:disable:this type_body_length
     // MARK: Types
 
     /// The types of modules used by this coordinator.
@@ -290,9 +290,11 @@ class AppCoordinator: Coordinator, HasRootNavigator {
         // Make sure that the user is authenticated.
         // In the main app, childCoordinator is TabRoute. In extensions, it's VaultRoute or SendItemRoute.
         guard childCoordinator is AnyCoordinator<TabRoute, Void>
-                || childCoordinator is AnyCoordinator<VaultRoute, AuthAction>
-                || childCoordinator is AnyCoordinator<SendItemRoute, AuthAction>
-        else { return }
+            || childCoordinator is AnyCoordinator<VaultRoute, AuthAction>
+            || childCoordinator is AnyCoordinator<SendItemRoute, AuthAction>
+        else {
+            return
+        }
 
         // Make sure that the user is not currently viewing the migrate to my items view.
         let currentView = rootNavigator?.rootViewController?.topmostViewController()

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -92,54 +92,10 @@ public class AppProcessor {
         UI.initialLanguageCode = services.appSettingsStore.appLocale ?? Bundle.main.preferredLocalizations.first
         UI.applyDefaultAppearances()
 
-        Task {
-            for await _ in services.notificationCenterService.willEnterForegroundPublisher() {
-                startEventTimer()
-                await checkIfExtensionSwitchedAccounts()
-                await services.authRepository.checkSessionTimeouts { [weak self] activeUserId in
-                    // Allow the AuthCoordinator to handle the timeout for the active user
-                    // so any necessary routing can occur.
-                    await self?.coordinator?.handleEvent(.didTimeout(userId: activeUserId))
-                }
-                await handleNeverTimeOutAccountBecameActive()
-                await completeAutofillAccountSetupIfEnabled()
-                #if DEBUG
-                debugWillEnterForeground?()
-                #endif
-            }
-        }
-
-        Task {
-            for await _ in services.notificationCenterService.didEnterBackgroundPublisher() {
-                stopEventTimer()
-                do {
-                    let userId = try await self.services.stateService.getActiveAccountId()
-                    try await services.vaultTimeoutService.setLastActiveTime(userId: userId)
-                } catch StateServiceError.noActiveAccount {
-                    // No-op: nothing to do if there's no active account.
-                } catch {
-                    services.errorReporter.log(error: error)
-                }
-                #if DEBUG
-                debugDidEnterBackground?()
-                #endif
-            }
-        }
-
-        // PM-19400: We need to listen to the changes on pending app intent actions
-        // so they get executed and update the navigation/UI accordingly.
-        Task {
-            for await _ in await services.stateService.pendingAppIntentActionsPublisher().values {
-                await services.pendingAppIntentActionMediator.executePendingAppIntentActions()
-            }
-        }
-
-        Task {
-            for await hostname in await services.serverCommunicationConfigAPIService.acquireCookiesPublisher().values {
-                guard hostname != nil else { continue }
-                coordinator?.navigate(to: .syncWithBrowser)
-            }
-        }
+        listenForWillEnterForeground(debugWillEnterForeground: debugWillEnterForeground)
+        listenForDidEnterBackground(debugDidEnterBackground: debugDidEnterBackground)
+        listenForPendingAppIntentActions()
+        listenForAcquireCookies()
     }
 
     // MARK: Methods
@@ -516,6 +472,87 @@ extension AppProcessor {
         }
 
         return AppRoute.tab(.vault(.vaultItemSelection(totpKeyModel)))
+    }
+
+    /// Subscribes to the server communication cookie-acquisition publisher and navigates to the
+    /// sync-with-browser flow whenever a non-nil hostname is received.
+    ///
+    private func listenForAcquireCookies() {
+        Task {
+            for await hostname in await services.serverCommunicationConfigAPIService.acquireCookiesPublisher().values {
+                guard hostname != nil else { continue }
+                coordinator?.navigate(to: .syncWithBrowser)
+            }
+        }
+    }
+
+    /// Subscribes to the did-enter-background notification and performs the necessary work
+    /// each time the app moves to the background, including stopping the event timer and
+    /// recording the last active time for the current user.
+    ///
+    /// - Parameter debugDidEnterBackground: An optional closure invoked in debug builds after
+    ///   background work completes, used for testing.
+    ///
+    private func listenForDidEnterBackground(debugDidEnterBackground: (() -> Void)?) {
+        Task {
+            for await _ in services.notificationCenterService.didEnterBackgroundPublisher() {
+                stopEventTimer()
+                do {
+                    let userId = try await self.services.stateService.getActiveAccountId()
+                    try await services.vaultTimeoutService.setLastActiveTime(userId: userId)
+                } catch StateServiceError.noActiveAccount {
+                    // No-op: nothing to do if there's no active account.
+                } catch {
+                    services.errorReporter.log(error: error)
+                }
+                #if DEBUG
+                debugDidEnterBackground?()
+                #endif
+            }
+        }
+    }
+
+    /// Subscribes to the pending `AppIntent` actions publisher and executes any pending actions
+    /// as they arrive, updating navigation and UI accordingly.
+    ///
+    /// This listener is required so that `AppIntent` actions enqueued while the app was inactive
+    /// are dispatched promptly once the app is ready to handle them.
+    ///
+    private func listenForPendingAppIntentActions() {
+        // PM-19400: We need to listen to the changes on pending app intent actions
+        // so they get executed and update the navigation/UI accordingly.
+        Task {
+            for await _ in await services.stateService.pendingAppIntentActionsPublisher().values {
+                await services.pendingAppIntentActionMediator.executePendingAppIntentActions()
+            }
+        }
+    }
+
+    /// Subscribes to the will-enter-foreground notification and performs the necessary work
+    /// each time the app returns to the foreground, including restarting the event timer,
+    /// checking for extension account switches, session timeouts, never-timeout unlocks,
+    /// and autofill account setup completion.
+    ///
+    /// - Parameter debugWillEnterForeground: An optional closure invoked in debug builds after
+    ///   foreground work completes, used for testing.
+    ///
+    private func listenForWillEnterForeground(debugWillEnterForeground: (() -> Void)?) {
+        Task {
+            for await _ in services.notificationCenterService.willEnterForegroundPublisher() {
+                startEventTimer()
+                await checkIfExtensionSwitchedAccounts()
+                await services.authRepository.checkSessionTimeouts { [weak self] activeUserId in
+                    // Allow the AuthCoordinator to handle the timeout for the active user
+                    // so any necessary routing can occur.
+                    await self?.coordinator?.handleEvent(.didTimeout(userId: activeUserId))
+                }
+                await handleNeverTimeOutAccountBecameActive()
+                await completeAutofillAccountSetupIfEnabled()
+                #if DEBUG
+                debugWillEnterForeground?()
+                #endif
+            }
+        }
     }
 
     /// Logs out the user automatically, if `nil` is passed as `userId` then it will act on the current user.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
@@ -130,6 +130,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
     func test_perform_setUpAutofill_cantRequest() async {
         guard #available(iOS 18, *) else { return }
 
+        // swiftlint:disable:next line_length
         asSettingsMediator.requestToTurnOnCredentialProviderExtensionThrowableError = ASSettingsMediatorError.cantRequest
 
         await subject.perform(.setUpAutofill)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/PasswordAutoFill/PasswordAutoFillProcessorTests.swift
@@ -201,6 +201,7 @@ class PasswordAutoFillProcessorTests: BitwardenTestCase {
     func test_perform_continueTapped_iOS18_cantRequest() async {
         guard #available(iOS 18, *) else { return }
 
+        // swiftlint:disable:next line_length
         asSettingsMediator.requestToTurnOnCredentialProviderExtensionThrowableError = ASSettingsMediatorError.cantRequest
 
         await subject.perform(.continueTapped)

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -7,7 +7,7 @@ import Foundation
 
 /// The processor used to manage state and handle actions for the add/edit send item screen.
 ///
-class AddEditSendItemProcessor:
+class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     StateProcessor<AddEditSendItemState, AddEditSendItemAction, AddEditSendItemEffect> {
     // MARK: Types
 
@@ -89,7 +89,7 @@ class AddEditSendItemProcessor:
         }
     }
 
-    override func receive(_ action: AddEditSendItemAction) {
+    override func receive(_ action: AddEditSendItemAction) { // swiftlint:disable:this function_body_length
         switch action {
         case let .accessTypeChanged(newValue):
             // Check if non-premium user is trying to select "Specific People"
@@ -353,7 +353,7 @@ class AddEditSendItemProcessor:
     ///
     /// - Returns: A flag indicating if the state holds valid information for creating a send.
     ///
-    private func validateSend() async -> Bool {
+    private func validateSend() async -> Bool { // swiftlint:disable:this function_body_length cyclomatic_complexity
         guard !state.name.isEmpty else {
             let alert = Alert.validationFieldRequired(fieldName: Localizations.name)
             coordinator.showAlert(alert)

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import BitwardenShared
 
-class AddEditSendItemStateTests: BitwardenTestCase {
+class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Tests
 
     // MARK: availableAccessTypes


### PR DESCRIPTION
## 🎟️ Tracking

[PM-34527](https://bitwarden.atlassian.net/browse/PM-34527)

## 📔 Objective

Fix non-Sendable related trivial warnings.
Also refactored a bit `AppProcessor` init so the Tasks have been extracted to private listen functions as it was getting big.

[PM-34527]: https://bitwarden.atlassian.net/browse/PM-34527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ