### PR TITLE
[PM-25831] chore: Remove cxp-import-mobile feature flag

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -11,9 +11,6 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// Flag to enable/disable Credential Exchange export flow.
     static let cxpExportMobile = FeatureFlag(rawValue: "cxp-export-mobile")
 
-    /// Flag to enable/disable Credential Exchange import flow.
-    static let cxpImportMobile = FeatureFlag(rawValue: "cxp-import-mobile")
-
     /// Flag to enable/disable individual cipher encryption configured remotely.
     static let cipherKeyEncryption = FeatureFlag(rawValue: "cipher-key-encryption")
 
@@ -42,7 +39,6 @@ extension FeatureFlag: @retroactive CaseIterable {
         [
             .archiveVaultItems,
             .cxpExportMobile,
-            .cxpImportMobile,
             .cipherKeyEncryption,
             .deviceAuthKey,
             .enableCipherKeyEncryption,

--- a/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ExportCXFCiphersRepositoryTests.swift
@@ -1,4 +1,3 @@
-#if SUPPORTS_CXP
 import AuthenticationServices
 import BitwardenKitMocks
 import InlineSnapshotTesting
@@ -6,6 +5,7 @@ import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
 // MARK: - ExportCXFCiphersRepositoryTests
 
@@ -117,7 +117,7 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
         XCTAssertEqual(result.count, 2)
         XCTAssertEqual(result[0].id, "1")
         XCTAssertEqual(result[1].id, "2")
-        XCTAssertEqual(exportVaultService.fetchAllCiphersIncludeArchived, false)
+        XCTAssertEqual(exportVaultService.fetchAllCiphersToExportIncludeArchived, false)
     }
 
     /// `getAllCiphersToExportCXF()` throws when fetching ciphers throws.
@@ -235,5 +235,3 @@ class ExportCXFCiphersRepositoryTests: BitwardenTestCase {
         }
     }
 }
-
-#endif

--- a/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/ImportCiphersRepositoryTests.swift
@@ -1,4 +1,3 @@
-#if SUPPORTS_CXP
 import AuthenticationServices
 import BitwardenKit
 import TestHelpers
@@ -252,4 +251,3 @@ class ImportCiphersRepositoryTests: BitwardenTestCase {
         return credentialDataJsonString
     }
 }
-#endif

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessor.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessor.swift
@@ -10,8 +10,7 @@ import BitwardenSdk
 class ImportCXFProcessor: StateProcessor<ImportCXFState, Void, ImportCXFEffect> {
     // MARK: Types
 
-    typealias Services = HasConfigService
-        & HasErrorReporter
+    typealias Services = HasErrorReporter
         & HasImportCiphersRepository
         & HasPolicyService
         & HasStateService
@@ -67,7 +66,7 @@ class ImportCXFProcessor: StateProcessor<ImportCXFState, Void, ImportCXFEffect> 
 
     /// Checks whether the CXF import feature is enabled.
     private func checkEnabled() async {
-        guard #available(iOS 26.0, *), await services.configService.getFeatureFlag(.cxpImportMobile) else {
+        guard #available(iOS 26.0, *) else {
             state.status = .failure(message: Localizations.importingFromAnotherProviderIsNotAvailableForThisDevice)
             return
         }

--- a/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/ImportCXF/ImportCXF/ImportCXFProcessorTests.swift
@@ -10,7 +10,6 @@ import XCTest
 class ImportCXFProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
-    var configService: MockConfigService!
     var coordinator: MockCoordinator<ImportCXFRoute, Void>!
     var errorReporter: MockErrorReporter!
     var importCiphersRepository: MockImportCiphersRepository!
@@ -24,7 +23,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
-        configService = MockConfigService()
         coordinator = MockCoordinator<ImportCXFRoute, Void>()
         errorReporter = MockErrorReporter()
         importCiphersRepository = MockImportCiphersRepository()
@@ -34,7 +32,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
         subject = ImportCXFProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
-                configService: configService,
                 errorReporter: errorReporter,
                 importCiphersRepository: importCiphersRepository,
                 policyService: policyService,
@@ -47,7 +44,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
-        configService = nil
         coordinator = nil
         errorReporter = nil
         importCiphersRepository = nil
@@ -59,10 +55,28 @@ class ImportCXFProcessorTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// `perform(_:)` with `.appeared` sets the status as `.failure` with a message
-    /// when the feature flag `.cxpImportMobile` is not enabled.
+    /// `perform(_:)` with `.appeared` doesn't set the status as `.failure`
+    /// when the device supports CXP import and `.personalOwnership`
+    /// policy doesn't apply to user.
     @MainActor
-    func test_perform_appearedNoFeatureFlag() async {
+    func test_perform_appeared() async throws {
+        guard #available(iOS 26.0, *) else {
+            throw XCTSkip("CXP Import feature is not available on this device")
+        }
+
+        await subject.perform(.appeared)
+        if case .failure = subject.state.status {
+            XCTFail("Status shouldn't be failure when CXP import is enabled")
+        }
+    }
+
+    /// `perform(_:)` with `.appeared` sets the status as `.failure` with a message
+    /// when the device is running iOS < 26.0 (CXP Import not available).
+    @MainActor
+    func test_perform_appearedNotAvailableOnDevice() async throws {
+        if #available(iOS 26.0, *) {
+            throw XCTSkip("CXP Import is available on this device")
+        }
         await subject.perform(.appeared)
         guard case let .failure(message) = subject.state.status else {
             XCTFail("Status should be failure")
@@ -72,15 +86,13 @@ class ImportCXFProcessorTests: BitwardenTestCase {
     }
 
     /// `perform(_:)` with `.appeared` sets the status as `.failure` with a message
-    /// when the feature flag `.cxpImportMobile` is enabled. but `.personalOwnership`
-    /// policy applies to user.
+    /// when `.personalOwnership` policy applies to user.
     @MainActor
     func test_perform_appearedPersonalOwnership() async throws {
         guard #available(iOS 26.0, *) else {
             throw XCTSkip("CXP Import feature is not available on this device")
         }
 
-        configService.featureFlagsBool[.cxpImportMobile] = true
         policyService.policyAppliesToUserResult[.personalOwnership] = true
 
         await subject.perform(.appeared)
@@ -91,22 +103,6 @@ class ImportCXFProcessorTests: BitwardenTestCase {
         }
         XCTAssertEqual(message, Localizations.personalOwnershipPolicyInEffect)
         XCTAssertTrue(subject.state.isFeatureUnavailable)
-    }
-
-    /// `perform(_:)` with `.appeared` doesn't set the status as `.failure`
-    /// when the feature flag `.cxpImportMobile` is enabled and `.personalOwnership`
-    /// policy doesn't apply to user.
-    @MainActor
-    func test_perform_appearedFeatureFlagEnabled() async throws {
-        guard #available(iOS 26.0, *) else {
-            throw XCTSkip("CXP Import feature is not available on this device")
-        }
-
-        configService.featureFlagsBool[.cxpImportMobile] = true
-        await subject.perform(.appeared)
-        if case .failure = subject.state.status {
-            XCTFail("Status shouldn't be failure when CXP import is enabled")
-        }
     }
 
     /// `perform(_:)` with `.cancel` with feature available shows confirmation and navigates to dismiss.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-25831](https://bitwarden.atlassian.net/browse/PM-25831)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the `cxp-import-mobile` feature flag.

I also removed the remaining `#if SUPPORTS_CXP` macros which were previously removed in https://github.com/bitwarden/ios/pull/1964. 

[PM-25831]: https://bitwarden.atlassian.net/browse/PM-25831?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ