### PR TITLE
[PM-35040] fix: Prevent Authenticator lock overlay from being dismissed

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
@@ -109,7 +109,12 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             coordinator.navigate(to: authRoute)
         } else {
             guard let rootNavigator else { return }
+
             let navigationController = module.makeNavigationController()
+            navigationController.isModalInPresentation = true
+            navigationController.isNavigationBarHidden = true
+            navigationController.modalPresentationStyle = .fullScreen
+
             let coordinator = module.makeAuthCoordinator(
                 delegate: self,
                 rootNavigator: rootNavigator,
@@ -117,8 +122,6 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             )
 
             coordinator.start()
-            navigationController.modalPresentationStyle = .overFullScreen
-            navigationController.isNavigationBarHidden = true
             rootNavigator.rootViewController?.present(navigationController, animated: false)
         }
     }

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -26,22 +26,6 @@ struct AppCoordinatorTests {
 
     // MARK: Tests
 
-    /// `switchToSettingsTab(route:)` navigates to the settings tab with the specified route.
-    @Test
-    func switchToSettingsTab_navigatesToSettingsTab() {
-        subject.switchToSettingsTab(route: .settings)
-
-        #expect(module.tabCoordinator.routes.last == .settings(.settings))
-    }
-
-    /// `switchToSettingsTab(route:)` navigates to the settings tab with the export items route.
-    @Test
-    func switchToSettingsTab_navigatesToExportItems() {
-        subject.switchToSettingsTab(route: .exportItems)
-
-        #expect(module.tabCoordinator.routes.last == .settings(.exportItems))
-    }
-
     /// `handleEvent(.didStart)` with biometrics enabled and a non-never vault timeout presents
     /// the auth overlay with `isModalInPresentation` set to prevent swipe-to-dismiss bypasses.
     @Test
@@ -87,5 +71,21 @@ struct AppCoordinatorTests {
         let presentedVC = (mockRootNavigator.rootViewController as? MockUIViewController)?.presentedView
         #expect(presentedVC?.isModalInPresentation == true)
         #expect(presentedVC?.modalPresentationStyle == .fullScreen)
+    }
+
+    /// `switchToSettingsTab(route:)` navigates to the settings tab with the specified route.
+    @Test
+    func switchToSettingsTab_navigatesToSettingsTab() {
+        subject.switchToSettingsTab(route: .settings)
+
+        #expect(module.tabCoordinator.routes.last == .settings(.settings))
+    }
+
+    /// `switchToSettingsTab(route:)` navigates to the settings tab with the export items route.
+    @Test
+    func switchToSettingsTab_navigatesToExportItems() {
+        subject.switchToSettingsTab(route: .exportItems)
+
+        #expect(module.tabCoordinator.routes.last == .settings(.exportItems))
     }
 }

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -41,4 +41,51 @@ struct AppCoordinatorTests {
 
         #expect(module.tabCoordinator.routes.last == .settings(.exportItems))
     }
+
+    /// `handleEvent(.didStart)` with biometrics enabled and a non-never vault timeout presents
+    /// the auth overlay with `isModalInPresentation` set to prevent swipe-to-dismiss bypasses.
+    @Test
+    func handleEvent_didStart_biometricsEnabledAndTimeout_setsModalInPresentation() async {
+        let biometricsRepository = MockBiometricsRepository()
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        let stateService = MockStateService()
+        stateService.vaultTimeout = .immediately
+        let mockRootNavigator = MockRootNavigator()
+        mockRootNavigator.rootViewController = MockUIViewController()
+        let localSubject = AppCoordinator(
+            appContext: .mainApp,
+            module: MockAppModule(),
+            rootNavigator: mockRootNavigator,
+            services: ServiceContainer.withMocks(
+                biometricsRepository: biometricsRepository,
+                stateService: stateService,
+            ),
+        )
+
+        await localSubject.handleEvent(.didStart)
+
+        let presentedVC = (mockRootNavigator.rootViewController as? MockUIViewController)?.presentedView
+        #expect(presentedVC?.isModalInPresentation == true)
+        #expect(presentedVC?.modalPresentationStyle == .fullScreen)
+    }
+
+    /// `handleEvent(.vaultTimeout)` presents the auth overlay with `isModalInPresentation` set
+    /// and `modalPresentationStyle` set to `.fullScreen` to prevent swipe-to-dismiss bypasses.
+    @Test
+    func handleEvent_vaultTimeout_setsModalInPresentation() async {
+        let mockRootNavigator = MockRootNavigator()
+        mockRootNavigator.rootViewController = MockUIViewController()
+        let localSubject = AppCoordinator(
+            appContext: .mainApp,
+            module: MockAppModule(),
+            rootNavigator: mockRootNavigator,
+            services: ServiceContainer.withMocks(),
+        )
+
+        await localSubject.handleEvent(.vaultTimeout)
+
+        let presentedVC = (mockRootNavigator.rootViewController as? MockUIViewController)?.presentedView
+        #expect(presentedVC?.isModalInPresentation == true)
+        #expect(presentedVC?.modalPresentationStyle == .fullScreen)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35040](https://bitwarden.atlassian.net/browse/PM-35040)

## 📔 Objective

Fixes [VULN-512](https://bitwarden.atlassian.net/browse/VULN-512) (CVSS 6.8): the Authenticator app's lock overlay could be interactively swipe-dismissed after a failed or cancelled Face ID prompt, bypassing authentication entirely.

**Root cause**: `AppCoordinator.showAuth()` presented the lock navigation controller without `isModalInPresentation = true`, allowing iOS to interactively dismiss it. The Password Manager app already had this protection. Fix sets `isModalInPresentation = true` and `modalPresentationStyle = .fullScreen` on the auth navigation controller.

[PM-35040]: https://bitwarden.atlassian.net/browse/PM-35040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VULN-512]: https://bitwarden.atlassian.net/browse/VULN-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ