### PR TITLE
[PM-31836] fix: Prevent double-resume crash on Fido2 credential continuations

### DIFF
--- a/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
+++ b/BitwardenShared/UI/Autofill/Utilities/Fido2UserInterfaceHelper.swift
@@ -203,10 +203,12 @@ class DefaultFido2UserInterfaceHelper: Fido2UserInterfaceHelper {
 
     func pickedCredentialForAuthentication(result: Result<CipherView, Error>) {
         credentialForAuthenticationContinuation?.resume(with: result)
+        credentialForAuthenticationContinuation = nil
     }
 
     func pickedCredentialForCreation(result: Result<CheckUserAndPickCredentialForCreationResult, Error>) {
         credentialForCreationContinuation?.resume(with: result)
+        credentialForCreationContinuation = nil
     }
 
     func setupDelegate(fido2UserInterfaceHelperDelegate: Fido2UserInterfaceHelperDelegate) {

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -891,15 +891,9 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         }
 
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertFalse(appExtensionDelegate.completeAssertionRequestMocker.called)
-        fido2UserInterfaceHelper.pickedCredentialForAuthenticationMocker.assertUnwrapping { result in
-            guard case let .failure(err) = result,
-                  err as? BitwardenTestError == BitwardenTestError.example else {
-                return false
-            }
-            return true
-        }
-
+        XCTAssertFalse(fido2UserInterfaceHelper.pickedCredentialForAuthenticationMocker.called)
         XCTAssertTrue(subject.state.isAutofillingFido2List)
         XCTAssertEqual(subject.state.emptyViewMessage, Localizations.noItemsTap)
     }
@@ -984,14 +978,9 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         }
 
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
         XCTAssertFalse(appExtensionDelegate.completeRegistrationRequestMocker.called)
-        fido2UserInterfaceHelper.pickedCredentialForCreationMocker.assertUnwrapping { result in
-            guard case let .failure(err) = result,
-                  err as? BitwardenTestError == BitwardenTestError.example else {
-                return false
-            }
-            return true
-        }
+        XCTAssertFalse(fido2UserInterfaceHelper.pickedCredentialForCreationMocker.called)
     }
 
     /// `perform(_:)` with `.initFido2` doesn't call `makeCredential` from the Fido2 authenticator when

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -637,8 +637,8 @@ extension VaultAutofillListProcessor {
 
             autofillAppExtensionDelegate.completeAssertionRequest(assertionCredential: assertionCredential)
         } catch {
-            services.fido2UserInterfaceHelper.pickedCredentialForAuthentication(result: .failure(error))
             services.errorReporter.log(error: error)
+            await coordinator.showErrorAlert(error: error)
         }
     }
 
@@ -696,8 +696,8 @@ extension VaultAutofillListProcessor {
                 return
             }
 
-            services.fido2UserInterfaceHelper.pickedCredentialForCreation(result: .failure(error))
             services.errorReporter.log(error: error)
+            await coordinator.showErrorAlert(error: error)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31836](https://bitwarden.atlassian.net/browse/PM-31836)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a continuation double-resume crash if an error occurs while adding a passkey.

> Crash: Fatal error: SWIFT TASK CONTINUATION MISUSE: checkUserAndPickCredentialForCreation(options:newCredential:) tried to resume its continuation more than once, throwing MakeCredential(BitwardenSdk.MakeCredentialError.Other(message: "make_credential error: Ctap2(Vendor(VendorError(241)))"))!

When saving a new passkey, the SDK calls `checkUserAndPickCredentialForCreation`/`pickCredentialForAuthentication`, which suspends on a continuation waiting for the user to pick a cipher. Once the user picks, the continuation is resumed with `.success`. The SDK then proceeds and, in some cases (e.g. API error due to enterprise personal ownership policy violation), fails. The catch block in `handleFido2CredentialCreation`/`handleFido2CredentialAutofill` then attempted to resume the already-completed continuation with `.failure`, triggering Swift's fatal continuation misuse error.

This fixes the issue by removing the potential second resume call, adding an error alert, and clearing the continuations after they have been resumed.



[PM-31836]: https://bitwarden.atlassian.net/browse/PM-31836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ