### PR TITLE
QA-1654: Adding accessibilityIDs to FlightRecorderLogsView elements

### DIFF
--- a/BitwardenKit/UI/Platform/Settings/FlightRecorder/FlightRecorderLogs/FlightRecorderLogsView.swift
+++ b/BitwardenKit/UI/Platform/Settings/FlightRecorder/FlightRecorderLogs/FlightRecorderLogsView.swift
@@ -80,15 +80,18 @@ struct FlightRecorderLogsView: View {
                 Text(log.formattedLoggingDateRange)
                     .styleGuide(.body)
                     .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .accessibilityIdentifier("FlightRecorderLogDateRangeLabel")
                     .accessibilityLabel(log.loggingDateRangeAccessibilityLabel)
 
                 HStack(spacing: 16) {
                     Text(log.fileSize)
+                        .accessibilityIdentifier("FlightRecorderLogFileSizeLabel")
 
                     if let formattedExpiration = log.formattedExpiration(currentDate: timeProvider.presentTime) {
                         Text(formattedExpiration)
                             .frame(maxWidth: .infinity, alignment: .trailing)
                             .multilineTextAlignment(.trailing)
+                            .accessibilityIdentifier("FlightRecorderLogExpirationLabel")
                     }
                 }
                 .styleGuide(.subheadline)
@@ -109,10 +112,11 @@ struct FlightRecorderLogsView: View {
                 SharedAsset.Icons.ellipsisHorizontal24.swiftUIImage
                     .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
             }
-            .accessibilityLabel(Localizations.moreOptions)
             .accessibilityIdentifier("FlightRecorderLogOptionsButton")
+            .accessibilityLabel(Localizations.moreOptions)
         }
         .accessibilityElement(children: .combine)
+        .accessibilityIdentifier("FlightRecorderLogRow")
         .padding(.horizontal, 16)
         .padding(.vertical, 12)
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

As part of our automation testing work for Flight Recorder, we are adding the required `accessibilityIds` to the FlightRecorderLogs view.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
