### PR TITLE
[PM-31836] fix: Handle no default collection case when saving Fido2 credential as new login

### DIFF
--- a/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelper.swift
@@ -5,11 +5,11 @@ import BitwardenSdk
 
 /// Errors thrown by `CipherOwnershipHelper`.
 enum CipherOwnershipHelperError: Error, Equatable {
-    /// No eligible organization is available for cipher ownership when personal ownership is disabled.
-    case noEligibleOrganization
-
     /// No default collection is available for the organization when personal ownership is disabled.
     case noDefaultCollection
+
+    /// No eligible organization is available for cipher ownership when personal ownership is disabled.
+    case noEligibleOrganization
 }
 
 // MARK: - CipherOwnershipHelper

--- a/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelper.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelper.swift
@@ -7,6 +7,9 @@ import BitwardenSdk
 enum CipherOwnershipHelperError: Error, Equatable {
     /// No eligible organization is available for cipher ownership when personal ownership is disabled.
     case noEligibleOrganization
+
+    /// No default collection is available for the organization when personal ownership is disabled.
+    case noDefaultCollection
 }
 
 // MARK: - CipherOwnershipHelper
@@ -95,6 +98,11 @@ class DefaultCipherOwnershipHelper: CipherOwnershipHelper {
             }),
                 let defaultCollectionId = defaultCollection.id {
                 collectionIds = [defaultCollectionId]
+            }
+
+            guard !collectionIds.isEmpty else {
+                // No default collection available - abort with error
+                throw CipherOwnershipHelperError.noDefaultCollection
             }
         }
 

--- a/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelperTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherOwnershipHelperTests.swift
@@ -42,8 +42,7 @@ class CipherOwnershipHelperTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// `createCipherView(from:)` creates a cipher with the organization but empty collectionIds
-    /// when the default collection has a nil id.
+    /// `createCipherView(from:)` throws `noDefaultCollection` when the default collection has a nil id.
     func test_createCipherView_defaultCollectionNilId() async throws {
         let fido2CredentialNewView = Fido2CredentialNewView.fixture(
             rpId: "example.com",
@@ -66,10 +65,9 @@ class CipherOwnershipHelperTests: BitwardenTestCase {
             ),
         ])
 
-        let cipher = try await subject.createCipherView(from: fido2CredentialNewView)
-
-        XCTAssertEqual(cipher.organizationId, organizationId)
-        XCTAssertEqual(cipher.collectionIds, [])
+        await assertAsyncThrows(error: CipherOwnershipHelperError.noDefaultCollection) {
+            _ = try await subject.createCipherView(from: fido2CredentialNewView)
+        }
     }
 
     /// `createCipherView(from:)` selects the first eligible organization when multiple
@@ -111,8 +109,8 @@ class CipherOwnershipHelperTests: BitwardenTestCase {
         XCTAssertEqual(cipher.collectionIds, [collectionId1])
     }
 
-    /// `createCipherView(from:)` creates a cipher with the organization but empty collectionIds
-    /// when personal ownership is disabled but no default collection exists.
+    /// `createCipherView(from:)` throws `noDefaultCollection` when personal ownership is disabled
+    /// and an eligible organization is available but has no default collection.
     func test_createCipherView_noDefaultCollection() async throws {
         let fido2CredentialNewView = Fido2CredentialNewView.fixture(
             rpId: "example.com",
@@ -135,11 +133,9 @@ class CipherOwnershipHelperTests: BitwardenTestCase {
             ),
         ])
 
-        let cipher = try await subject.createCipherView(from: fido2CredentialNewView)
-
-        XCTAssertEqual(cipher.organizationId, organizationId)
-        XCTAssertEqual(cipher.collectionIds, [])
-        XCTAssertEqual(cipher.name, "Example App")
+        await assertAsyncThrows(error: CipherOwnershipHelperError.noDefaultCollection) {
+            _ = try await subject.createCipherView(from: fido2CredentialNewView)
+        }
     }
 
     /// `createCipherView(from:)` throws `noEligibleOrganization` when personal ownership is disabled

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor+Fido2Tests.swift
@@ -295,6 +295,36 @@ class VaultAutofillListProcessorFido2Tests: BitwardenTestCase { // swiftlint:dis
         XCTAssertFalse(fido2UserInterfaceHelper.pickedCredentialForCreationMocker.called)
     }
 
+    /// `receive(_:)` with `.addTapped` navigates to the add item screen when personal ownership
+    /// is disabled but no default collection is available (via cipherOwnershipHelper throwing error).
+    @MainActor
+    func test_receive_addTapped_fido2CreationEmptyViewNoDefaultCollection() throws {
+        appExtensionDelegate.extensionMode = .registerFido2Credential(ASPasskeyCredentialRequest.fixture())
+        let fido2CredentialNewView = Fido2CredentialNewView.fixture(userName: "username", rpName: "rpName")
+        fido2UserInterfaceHelper.fido2CredentialNewView = fido2CredentialNewView
+        fido2UserInterfaceHelper.fido2CreationOptions = CheckUserOptions(
+            requirePresence: true,
+            requireVerification: .required,
+        )
+
+        cipherOwnershipHelper.createCipherViewThrowableError = CipherOwnershipHelperError.noDefaultCollection
+
+        subject.receive(.addTapped(fromFAB: false))
+
+        let expectedNewCipherOptions = NewCipherOptions(
+            name: fido2CredentialNewView.rpName,
+            uri: fido2CredentialNewView.rpId,
+            username: fido2CredentialNewView.userName,
+        )
+        waitFor(!coordinator.routes.isEmpty)
+
+        XCTAssertEqual(
+            coordinator.routes.last,
+            .addItem(group: .login, newCipherOptions: expectedNewCipherOptions, type: .login),
+        )
+        XCTAssertFalse(fido2UserInterfaceHelper.pickedCredentialForCreationMocker.called)
+    }
+
     /// `receive(_:)` with `.addTapped` shows an alert and logs
     /// when executed from the empty view and in the create Fido2 credential context but user verification throws.
     @MainActor

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -190,13 +190,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
                   !fromFAB,
                   let autofillAppExtensionDelegate,
                   autofillAppExtensionDelegate.isCreatingFido2Credential else {
-                coordinator.navigate(
-                    to: .addItem(
-                        group: .login,
-                        newCipherOptions: createNewCipherOptions(),
-                        type: .login,
-                    ),
-                )
+                navigateToAddNewLogin()
                 return
             }
 
@@ -343,6 +337,15 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
                 }
             },
         )
+    }
+
+    /// Navigates to the add item screen to create a new login.
+    private func navigateToAddNewLogin() {
+        coordinator.navigate(to: .addItem(
+            group: .login,
+            newCipherOptions: createNewCipherOptions(),
+            type: .login,
+        ))
     }
 
     /// Refreshes the vault group's TOTP Codes.
@@ -772,6 +775,10 @@ extension VaultAutofillListProcessor {
                 from: fido2CredentialNewView,
             )
             await checkUserAndDoPickedCredentialForCreation(for: newCipher, fido2CreationOptions: fido2CreationOptions)
+        } catch CipherOwnershipHelperError.noDefaultCollection {
+            // If there's no default collection, the Fido2 credential cannot be saved without user
+            // interaction. Redirect the user to the add login screen.
+            navigateToAddNewLogin()
         } catch {
             services.errorReporter.log(error: error)
             await coordinator.showErrorAlert(error: error)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31836](https://bitwarden.atlassian.net/browse/PM-31836)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a case where a passkey would fail to save if the personal ownership disabled policy is enabled and there's no default collection (My Items is disabled). In this case, the passkey is being saved to the organization, but the user must select a collection to save the passkey to, or saving will fail.

This case can be detected, and instead of saving the passkey automatically, the add item screen is shown so that a collection can be selected.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/0e887b1f-937e-4722-bed9-1d213bf966b3" /> | <video src="https://github.com/user-attachments/assets/aa310d6b-71e6-4573-8271-79088e2cd5ca" /> | 








[PM-31836]: https://bitwarden.atlassian.net/browse/PM-31836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ