### PR TITLE
[PM-35126] feat: Add billing subscription endpoint

### DIFF
--- a/BitwardenShared/Core/Billing/Models/Enum/BitwardenDiscountType.swift
+++ b/BitwardenShared/Core/Billing/Models/Enum/BitwardenDiscountType.swift
@@ -1,0 +1,11 @@
+// MARK: - BitwardenDiscountType
+
+/// The type of discounts Bitwarden supports.
+///
+enum BitwardenDiscountType: String, Codable, Equatable, Sendable {
+    /// A fixed amount discount.
+    case amountOff = "amount-off"
+
+    /// A percentage discount.
+    case percentOff = "percent-off"
+}

--- a/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
+++ b/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Networking
+
+// MARK: - BitwardenSubscriptionResponseModel
+
+/// API response model for the user's subscription details.
+///
+struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The status of the subscription.
+    let status: String
+
+    /// The subscription's cart, including line items, any discounts, and estimated tax.
+    let cart: SubscriptionCartResponseModel
+
+    /// The amount of storage available and used for the subscription.
+    let storage: SubscriptionStorageResponseModel?
+
+    /// If the subscription is pending cancellation, the date at which the
+    /// subscription will be canceled.
+    let cancelAt: Date?
+
+    /// The date the subscription was canceled.
+    let canceled: Date?
+
+    /// The date of the next charge for the subscription.
+    let nextCharge: Date?
+
+    /// The date the subscription will be or was suspended due to lack of payment.
+    let suspension: Date?
+
+    /// The number of days after the subscription goes 'past_due' the subscriber has to resolve their
+    /// open invoices before the subscription is suspended.
+    let gracePeriod: Int?
+}
+
+// MARK: - SubscriptionCartResponseModel
+
+/// API response model for a subscription's cart.
+///
+struct SubscriptionCartResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The Password Manager product line items.
+    let passwordManager: PasswordManagerCartItemsResponseModel?
+
+    /// The billing cadence (e.g. "annually", "monthly").
+    let cadence: String
+
+    /// Any discount applied to the cart.
+    let discount: BitwardenDiscountResponseModel?
+
+    /// The estimated tax amount.
+    let estimatedTax: Decimal
+}
+
+// MARK: - PasswordManagerCartItemsResponseModel
+
+/// API response model for Password Manager line items within the cart.
+///
+struct PasswordManagerCartItemsResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The seat line item details.
+    let seats: CartItemResponseModel
+
+    /// The additional storage line item details.
+    let additionalStorage: CartItemResponseModel?
+}
+
+// MARK: - CartItemResponseModel
+
+/// API response model for an individual cart item.
+///
+struct CartItemResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The translation key for the cart item's display name.
+    let translationKey: String
+
+    /// The quantity of this cart item.
+    let quantity: Int64
+
+    /// The cost for this cart item.
+    let cost: Decimal
+
+    /// Any discount applied to this cart item.
+    let discount: BitwardenDiscountResponseModel?
+}
+
+// MARK: - BitwardenDiscountResponseModel
+
+/// API response model for a discount applied to a cart or cart item.
+///
+struct BitwardenDiscountResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The type of discount.
+    let type: BitwardenDiscountType
+
+    /// The discount value.
+    let value: Decimal
+}
+
+// MARK: - SubscriptionStorageResponseModel
+
+/// API response model for a subscription's storage usage.
+///
+struct SubscriptionStorageResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The available storage in GB.
+    let available: Int
+
+    /// The used storage in bytes.
+    let used: Double
+
+    /// A human-readable representation of the used storage.
+    let readableUsed: String
+}

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIService.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIService.swift
@@ -20,6 +20,12 @@ protocol BillingAPIService { // sourcery: AutoMockable
     /// - Returns: A `PortalUrlResponseModel` containing the portal URL.
     ///
     func getPortalUrl() async throws -> PortalUrlResponseModel
+
+    /// Gets the user's subscription details.
+    ///
+    /// - Returns: A `BitwardenSubscriptionResponseModel` containing the subscription details.
+    ///
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel
 }
 
 // MARK: - APIService Extension
@@ -42,5 +48,9 @@ extension APIService: BillingAPIService {
 
     func getPortalUrl() async throws -> PortalUrlResponseModel {
         try await apiService.send(GetPortalUrlRequest())
+    }
+
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel {
+        try await apiService.send(GetSubscriptionRequest())
     }
 }

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
@@ -80,4 +80,41 @@ struct BillingAPIServiceTests {
         #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/portal-session")
         #expect(request.body == nil)
     }
+
+    /// `getSubscription()` performs the request with the correct method and path.
+    @Test
+    func getSubscription() async throws {
+        client.result = .httpSuccess(testData: .subscriptionResponse)
+
+        let response = try await subject.getSubscription()
+
+        let request = try #require(client.requests.last)
+        #expect(request.method == .get)
+        #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/subscription")
+        #expect(request.body == nil)
+
+        // Verify response parsing
+        #expect(response.status == "active")
+        #expect(response.cart.cadence == "annually")
+        #expect(response.cart.estimatedTax == 4.55)
+        #expect(response.cart.discount == nil)
+
+        let seats = try #require(response.cart.passwordManager?.seats)
+        #expect(seats.translationKey == "premiumMembership")
+        #expect(seats.quantity == 1)
+        #expect(seats.cost == 19.8)
+        #expect(seats.discount == nil)
+        #expect(response.cart.passwordManager?.additionalStorage == nil)
+
+        let storage = try #require(response.storage)
+        #expect(storage.available == 5)
+        #expect(storage.used == 0)
+        #expect(storage.readableUsed == "0 Bytes")
+
+        #expect(response.cancelAt == nil)
+        #expect(response.canceled == nil)
+        #expect(response.nextCharge != nil)
+        #expect(response.suspension == nil)
+        #expect(response.gracePeriod == nil)
+    }
 }

--- a/BitwardenShared/Core/Billing/Services/API/Fixtures/APITestData+Billing.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Fixtures/APITestData+Billing.swift
@@ -32,6 +32,39 @@ public extension APITestData {
     }
     """.utf8))
 
+    // MARK: Subscription
+
+    static let subscriptionResponse = APITestData(data: Data("""
+    {
+        "status": "active",
+        "cart": {
+            "passwordManager": {
+                "seats": {
+                    "translationKey": "premiumMembership",
+                    "quantity": 1,
+                    "cost": 19.8,
+                    "discount": null
+                },
+                "additionalStorage": null
+            },
+            "secretsManager": null,
+            "cadence": "annually",
+            "discount": null,
+            "estimatedTax": 4.55
+        },
+        "storage": {
+            "available": 5,
+            "used": 0,
+            "readableUsed": "0 Bytes"
+        },
+        "cancelAt": null,
+        "canceled": null,
+        "nextCharge": "2027-02-20T15:48:11Z",
+        "suspension": null,
+        "gracePeriod": null
+    }
+    """.utf8))
+
     // MARK: Portal URL
 
     static let portalUrl = APITestData(data: Data("""

--- a/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequest.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequest.swift
@@ -1,0 +1,17 @@
+import Networking
+
+// MARK: - GetSubscriptionRequest
+
+/// A networking request to get the user's subscription details.
+///
+struct GetSubscriptionRequest: Request {
+    typealias Response = BitwardenSubscriptionResponseModel
+
+    // MARK: Properties
+
+    /// The HTTP method for this request.
+    var method: HTTPMethod { .get }
+
+    /// The URL path for this request.
+    var path: String { "/account/billing/vnext/subscription" }
+}

--- a/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequestTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequestTests.swift
@@ -1,0 +1,32 @@
+import Networking
+import Testing
+
+@testable import BitwardenShared
+
+// MARK: - GetSubscriptionRequestTests
+
+struct GetSubscriptionRequestTests {
+    // MARK: Properties
+
+    var subject: GetSubscriptionRequest!
+
+    // MARK: Initialization
+
+    init() {
+        subject = GetSubscriptionRequest()
+    }
+
+    // MARK: Tests
+
+    /// `method` returns the method of the request.
+    @Test
+    func method() {
+        #expect(subject.method == .get)
+    }
+
+    /// `path` returns the path of the request.
+    @Test
+    func path() {
+        #expect(subject.path == "/account/billing/vnext/subscription")
+    }
+}

--- a/BitwardenShared/Core/Billing/Services/BillingService.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingService.swift
@@ -17,6 +17,12 @@ protocol BillingService: AnyObject { // sourcery: AutoMockable
     /// - Returns: A `PremiumPlanResponseModel` containing the premium plan details.
     ///
     func getPremiumPlan() async throws -> PremiumPlanResponseModel
+
+    /// Gets the user's subscription details.
+    ///
+    /// - Returns: A `BitwardenSubscriptionResponseModel` containing the subscription details.
+    ///
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel
 }
 
 // MARK: - DefaultBillingService
@@ -54,5 +60,9 @@ class DefaultBillingService: BillingService {
 
     func getPremiumPlan() async throws -> PremiumPlanResponseModel {
         try await billingAPIService.getPremiumPlan()
+    }
+
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel {
+        try await billingAPIService.getSubscription()
     }
 }

--- a/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
@@ -116,4 +116,54 @@ struct BillingServiceTests {
 
         #expect(billingAPIService.getPremiumPlanCallsCount == 1)
     }
+
+    /// `getSubscription()` returns the subscription from the API service.
+    @Test
+    func getSubscription_success() async throws {
+        let expectedSubscription = BitwardenSubscriptionResponseModel(
+            status: "active",
+            cart: SubscriptionCartResponseModel(
+                passwordManager: PasswordManagerCartItemsResponseModel(
+                    seats: CartItemResponseModel(
+                        translationKey: "premiumMembership",
+                        quantity: 1,
+                        cost: 19.8,
+                        discount: nil,
+                    ),
+                    additionalStorage: nil,
+                ),
+                cadence: "annually",
+                discount: nil,
+                estimatedTax: 4.55,
+            ),
+            storage: SubscriptionStorageResponseModel(
+                available: 5,
+                used: 0,
+                readableUsed: "0 Bytes",
+            ),
+            cancelAt: nil,
+            canceled: nil,
+            nextCharge: nil,
+            suspension: nil,
+            gracePeriod: nil,
+        )
+        billingAPIService.getSubscriptionReturnValue = expectedSubscription
+
+        let result = try await subject.getSubscription()
+
+        #expect(billingAPIService.getSubscriptionCallsCount == 1)
+        #expect(result == expectedSubscription)
+    }
+
+    /// `getSubscription()` propagates errors from the API service.
+    @Test
+    func getSubscription_apiError() async throws {
+        billingAPIService.getSubscriptionThrowableError = URLError(.notConnectedToInternet)
+
+        await #expect(throws: URLError.self) {
+            try await subject.getSubscription()
+        }
+
+        #expect(billingAPIService.getSubscriptionCallsCount == 1)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35126

## 📔 Objective

Add the `getSubscription` API endpoint to fetch the user's billing subscription details. This includes:

- `BitwardenSubscriptionResponseModel` and related response models (`SubscriptionCartResponseModel`, `PasswordManagerCartItemsResponseModel`, `CartItemResponseModel`, `BitwardenDiscountResponseModel`, `SubscriptionStorageResponseModel`)
- `BitwardenDiscountType` enum for discount types
- `GetSubscriptionRequest` targeting `/account/billing/vnext/subscription`
- Wiring through `BillingAPIService` and `BillingService` protocols and implementations
- Tests for the request, API service, and billing service layers