### PR TITLE
[PM-35126] feat: Add billing subscription endpoint

### DIFF
--- a/BitwardenShared/Core/Billing/Models/Enum/BitwardenDiscountType.swift
+++ b/BitwardenShared/Core/Billing/Models/Enum/BitwardenDiscountType.swift
@@ -1,0 +1,11 @@
+// MARK: - BitwardenDiscountType
+
+/// The type of discounts Bitwarden supports.
+///
+enum BitwardenDiscountType: String, Codable, Equatable, Sendable {
+    /// A fixed amount discount.
+    case amountOff = "amount-off"
+
+    /// A percentage discount.
+    case percentOff = "percent-off"
+}

--- a/BitwardenShared/Core/Billing/Models/Enum/BitwardenDiscountType.swift
+++ b/BitwardenShared/Core/Billing/Models/Enum/BitwardenDiscountType.swift
@@ -3,7 +3,7 @@
 /// The type of discounts Bitwarden supports.
 ///
 enum BitwardenDiscountType: String, Codable, Equatable, Sendable {
-    /// A fixed amount discount.
+    /// A fixed-amount discount.
     case amountOff = "amount-off"
 
     /// A percentage discount.

--- a/BitwardenShared/Core/Billing/Models/Enum/PlanCadenceType.swift
+++ b/BitwardenShared/Core/Billing/Models/Enum/PlanCadenceType.swift
@@ -1,0 +1,11 @@
+// MARK: - PlanCadenceType
+
+/// The billing cadence for a subscription plan.
+///
+enum PlanCadenceType: String, Codable, Equatable, Sendable {
+    /// An annual billing cadence.
+    case annually
+
+    /// A monthly billing cadence.
+    case monthly
+}

--- a/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
+++ b/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
@@ -18,7 +18,7 @@ struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
     /// The subscription's cart, including line items, any discounts, and estimated tax.
     let cart: SubscriptionCartResponseModel
 
-    /// The number of days after the subscription goes 'past_due' the subscriber has to resolve their
+    /// The number of days after the subscription goes past due the subscriber has to resolve their
     /// open invoices before the subscription is suspended.
     let gracePeriod: Int?
 
@@ -83,7 +83,7 @@ struct CartItemResponseModel: JSONResponse, Equatable, Sendable {
     let discount: BitwardenDiscountResponseModel?
 
     /// The quantity of this cart item.
-    let quantity: Int64
+    let quantity: Int
 
     /// The translation key for the cart item's display name.
     let translationKey: String
@@ -111,7 +111,7 @@ struct SubscriptionStorageResponseModel: JSONResponse, Equatable, Sendable {
     // MARK: Properties
 
     /// The available storage in GB.
-    let available: Int
+    let available: Double
 
     /// A human-readable representation of the used storage.
     let readableUsed: String

--- a/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
+++ b/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
@@ -42,8 +42,8 @@ struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
 struct SubscriptionCartResponseModel: JSONResponse, Equatable, Sendable {
     // MARK: Properties
 
-    /// The billing cadence (e.g. "annually", "monthly").
-    let cadence: String
+    /// The billing cadence (e.g. annually, monthly).
+    let cadence: PlanCadenceType
 
     /// Any discount applied to the cart.
     let discount: BitwardenDiscountResponseModel?

--- a/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
+++ b/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
@@ -8,15 +8,6 @@ import Networking
 struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
     // MARK: Properties
 
-    /// The status of the subscription.
-    let status: String
-
-    /// The subscription's cart, including line items, any discounts, and estimated tax.
-    let cart: SubscriptionCartResponseModel
-
-    /// The amount of storage available and used for the subscription.
-    let storage: SubscriptionStorageResponseModel?
-
     /// If the subscription is pending cancellation, the date at which the
     /// subscription will be canceled.
     let cancelAt: Date?
@@ -24,15 +15,24 @@ struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
     /// The date the subscription was canceled.
     let canceled: Date?
 
-    /// The date of the next charge for the subscription.
-    let nextCharge: Date?
-
-    /// The date the subscription will be or was suspended due to lack of payment.
-    let suspension: Date?
+    /// The subscription's cart, including line items, any discounts, and estimated tax.
+    let cart: SubscriptionCartResponseModel
 
     /// The number of days after the subscription goes 'past_due' the subscriber has to resolve their
     /// open invoices before the subscription is suspended.
     let gracePeriod: Int?
+
+    /// The date of the next charge for the subscription.
+    let nextCharge: Date?
+
+    /// The status of the subscription.
+    let status: String
+
+    /// The amount of storage available and used for the subscription.
+    let storage: SubscriptionStorageResponseModel?
+
+    /// The date the subscription will be or was suspended due to lack of payment.
+    let suspension: Date?
 }
 
 // MARK: - SubscriptionCartResponseModel
@@ -42,9 +42,6 @@ struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
 struct SubscriptionCartResponseModel: JSONResponse, Equatable, Sendable {
     // MARK: Properties
 
-    /// The Password Manager product line items.
-    let passwordManager: PasswordManagerCartItemsResponseModel?
-
     /// The billing cadence (e.g. "annually", "monthly").
     let cadence: String
 
@@ -53,6 +50,9 @@ struct SubscriptionCartResponseModel: JSONResponse, Equatable, Sendable {
 
     /// The estimated tax amount.
     let estimatedTax: Decimal
+
+    /// The Password Manager product line items.
+    let passwordManager: PasswordManagerCartItemsResponseModel?
 }
 
 // MARK: - PasswordManagerCartItemsResponseModel
@@ -62,11 +62,11 @@ struct SubscriptionCartResponseModel: JSONResponse, Equatable, Sendable {
 struct PasswordManagerCartItemsResponseModel: JSONResponse, Equatable, Sendable {
     // MARK: Properties
 
-    /// The seat line item details.
-    let seats: CartItemResponseModel
-
     /// The additional storage line item details.
     let additionalStorage: CartItemResponseModel?
+
+    /// The seat line item details.
+    let seats: CartItemResponseModel
 }
 
 // MARK: - CartItemResponseModel
@@ -76,17 +76,17 @@ struct PasswordManagerCartItemsResponseModel: JSONResponse, Equatable, Sendable 
 struct CartItemResponseModel: JSONResponse, Equatable, Sendable {
     // MARK: Properties
 
-    /// The translation key for the cart item's display name.
-    let translationKey: String
-
-    /// The quantity of this cart item.
-    let quantity: Int64
-
     /// The cost for this cart item.
     let cost: Decimal
 
     /// Any discount applied to this cart item.
     let discount: BitwardenDiscountResponseModel?
+
+    /// The quantity of this cart item.
+    let quantity: Int64
+
+    /// The translation key for the cart item's display name.
+    let translationKey: String
 }
 
 // MARK: - BitwardenDiscountResponseModel
@@ -113,9 +113,9 @@ struct SubscriptionStorageResponseModel: JSONResponse, Equatable, Sendable {
     /// The available storage in GB.
     let available: Int
 
-    /// The used storage in bytes.
-    let used: Double
-
     /// A human-readable representation of the used storage.
     let readableUsed: String
+
+    /// The used storage in bytes.
+    let used: Double
 }

--- a/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
+++ b/BitwardenShared/Core/Billing/Models/Response/BitwardenSubscriptionResponseModel.swift
@@ -1,0 +1,121 @@
+import Foundation
+import Networking
+
+// MARK: - BitwardenSubscriptionResponseModel
+
+/// API response model for the user's subscription details.
+///
+struct BitwardenSubscriptionResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The status of the subscription.
+    let status: String
+
+    /// The subscription's cart, including line items, any discounts, and estimated tax.
+    let cart: SubscriptionCartResponseModel
+
+    /// The amount of storage available and used for the subscription.
+    let storage: SubscriptionStorageResponseModel?
+
+    /// If the subscription is pending cancellation, the date at which the
+    /// subscription will be canceled.
+    let cancelAt: Date?
+
+    /// The date the subscription was canceled.
+    let canceled: Date?
+
+    /// The date of the next charge for the subscription.
+    let nextCharge: Date?
+
+    /// The date the subscription will be or was suspended due to lack of payment.
+    let suspension: Date?
+
+    /// The number of days after the subscription goes 'past_due' the subscriber has to resolve their
+    /// open invoices before the subscription is suspended.
+    let gracePeriod: Int?
+}
+
+// MARK: - SubscriptionCartResponseModel
+
+/// API response model for a subscription's cart.
+///
+struct SubscriptionCartResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The Password Manager product line items.
+    let passwordManager: PasswordManagerCartItemsResponseModel?
+
+    /// The billing cadence (e.g. "annually", "monthly").
+    let cadence: String
+
+    /// Any discount applied to the cart.
+    let discount: BitwardenDiscountResponseModel?
+
+    /// The estimated tax amount.
+    let estimatedTax: Decimal
+}
+
+// MARK: - PasswordManagerCartItemsResponseModel
+
+/// API response model for Password Manager line items within the cart.
+///
+struct PasswordManagerCartItemsResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The seat line item details.
+    let seats: CartItemResponseModel
+
+    /// The additional storage line item details.
+    let additionalStorage: CartItemResponseModel?
+}
+
+// MARK: - CartItemResponseModel
+
+/// API response model for an individual cart item.
+///
+struct CartItemResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The translation key for the cart item's display name.
+    let translationKey: String
+
+    /// The quantity of this cart item.
+    let quantity: Int64
+
+    /// The cost for this cart item.
+    let cost: Decimal
+
+    /// Any discount applied to this cart item.
+    let discount: BitwardenDiscountResponseModel?
+}
+
+// MARK: - BitwardenDiscountResponseModel
+
+/// API response model for a discount applied to a cart or cart item.
+///
+struct BitwardenDiscountResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The type of discount.
+    let type: BitwardenDiscountType
+
+    /// The discount value.
+    let value: Decimal
+}
+
+// MARK: - SubscriptionStorageResponseModel
+
+/// API response model for a subscription's storage usage.
+///
+struct SubscriptionStorageResponseModel: JSONResponse, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The available storage in GB.
+    let available: Int
+
+    /// The used storage in bytes.
+    let used: Double
+
+    /// A human-readable representation of the used storage.
+    let readableUsed: String
+}

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIService.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIService.swift
@@ -20,6 +20,12 @@ protocol BillingAPIService { // sourcery: AutoMockable
     /// - Returns: A `PortalUrlResponseModel` containing the portal URL.
     ///
     func getPortalUrl() async throws -> PortalUrlResponseModel
+
+    /// Gets the user's subscription details.
+    ///
+    /// - Returns: A `BitwardenSubscriptionResponseModel` containing the subscription details.
+    ///
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel
 }
 
 // MARK: - APIService Extension
@@ -42,5 +48,9 @@ extension APIService: BillingAPIService {
 
     func getPortalUrl() async throws -> PortalUrlResponseModel {
         try await apiService.send(GetPortalUrlRequest())
+    }
+
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel {
+        try await apiService.send(GetSubscriptionRequest())
     }
 }

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIService.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIService.swift
@@ -9,17 +9,17 @@ protocol BillingAPIService { // sourcery: AutoMockable
     ///
     func createCheckoutSession() async throws -> CheckoutSessionResponseModel
 
-    /// Gets the premium subscription plan.
-    ///
-    /// - Returns: A `PremiumPlanResponseModel` containing the premium plan details.
-    ///
-    func getPremiumPlan() async throws -> PremiumPlanResponseModel
-
     /// Creates a customer portal session for managing the premium subscription.
     ///
     /// - Returns: A `PortalUrlResponseModel` containing the portal URL.
     ///
     func getPortalUrl() async throws -> PortalUrlResponseModel
+
+    /// Gets the premium subscription plan.
+    ///
+    /// - Returns: A `PremiumPlanResponseModel` containing the premium plan details.
+    ///
+    func getPremiumPlan() async throws -> PremiumPlanResponseModel
 
     /// Gets the user's subscription details.
     ///
@@ -42,12 +42,12 @@ extension APIService: BillingAPIService {
         )
     }
 
-    func getPremiumPlan() async throws -> PremiumPlanResponseModel {
-        try await apiService.send(GetPremiumPlanRequest())
-    }
-
     func getPortalUrl() async throws -> PortalUrlResponseModel {
         try await apiService.send(GetPortalUrlRequest())
+    }
+
+    func getPremiumPlan() async throws -> PremiumPlanResponseModel {
+        try await apiService.send(GetPremiumPlanRequest())
     }
 
     func getSubscription() async throws -> BitwardenSubscriptionResponseModel {

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
@@ -62,23 +62,12 @@ struct BillingAPIServiceTests {
     func getPremiumPlan() async throws {
         client.result = .httpSuccess(testData: .premiumPlanResponse)
 
-        let response = try await subject.getPremiumPlan()
+        _ = try await subject.getPremiumPlan()
 
         let request = try #require(client.requests.last)
         #expect(request.method == .get)
         #expect(request.url.absoluteString == "https://example.com/api/plans/premium")
         #expect(request.body == nil)
-
-        // Verify response parsing
-        #expect(response.name == "Premium")
-        #expect(response.available)
-        #expect(response.legacyYear == nil)
-        #expect(response.seat.stripePriceId == "premium-annually-2026")
-        #expect(response.seat.price == 19.80)
-        #expect(response.seat.provided == 0)
-        #expect(response.storage.stripePriceId == "personal-storage-gb-annually")
-        #expect(response.storage.price == 4)
-        #expect(response.storage.provided == 5)
     }
 
     /// `getSubscription()` performs the request with the correct method and path.
@@ -86,35 +75,11 @@ struct BillingAPIServiceTests {
     func getSubscription() async throws {
         client.result = .httpSuccess(testData: .subscriptionResponse)
 
-        let response = try await subject.getSubscription()
+        _ = try await subject.getSubscription()
 
         let request = try #require(client.requests.last)
         #expect(request.method == .get)
         #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/subscription")
         #expect(request.body == nil)
-
-        // Verify response parsing
-        #expect(response.status == "active")
-        #expect(response.cart.cadence == "annually")
-        #expect(response.cart.estimatedTax == 4.55)
-        #expect(response.cart.discount == nil)
-
-        let seats = try #require(response.cart.passwordManager?.seats)
-        #expect(seats.translationKey == "premiumMembership")
-        #expect(seats.quantity == 1)
-        #expect(seats.cost == 19.8)
-        #expect(seats.discount == nil)
-        #expect(response.cart.passwordManager?.additionalStorage == nil)
-
-        let storage = try #require(response.storage)
-        #expect(storage.available == 5)
-        #expect(storage.used == 0)
-        #expect(storage.readableUsed == "0 Bytes")
-
-        #expect(response.cancelAt == nil)
-        #expect(response.canceled == nil)
-        #expect(response.nextCharge != nil)
-        #expect(response.suspension == nil)
-        #expect(response.gracePeriod == nil)
     }
 }

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
@@ -44,6 +44,19 @@ struct BillingAPIServiceTests {
         #expect(json?["platform"] as? String == "ios")
     }
 
+    /// `getPortalUrl()` performs the request with the correct method and path.
+    @Test
+    func getPortalUrl() async throws {
+        client.result = .httpSuccess(testData: .portalUrl)
+
+        _ = try await subject.getPortalUrl()
+
+        let request = try #require(client.requests.last)
+        #expect(request.method == .post)
+        #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/portal-session")
+        #expect(request.body == nil)
+    }
+
     /// `getPremiumPlan()` performs the request with the correct method and path.
     @Test
     func getPremiumPlan() async throws {
@@ -66,19 +79,6 @@ struct BillingAPIServiceTests {
         #expect(response.storage.stripePriceId == "personal-storage-gb-annually")
         #expect(response.storage.price == 4)
         #expect(response.storage.provided == 5)
-    }
-
-    /// `getPortalUrl()` performs the request with the correct method and path.
-    @Test
-    func getPortalUrl() async throws {
-        client.result = .httpSuccess(testData: .portalUrl)
-
-        _ = try await subject.getPortalUrl()
-
-        let request = try #require(client.requests.last)
-        #expect(request.method == .post)
-        #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/portal-session")
-        #expect(request.body == nil)
     }
 
     /// `getSubscription()` performs the request with the correct method and path.

--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
@@ -80,4 +80,41 @@ struct BillingAPIServiceTests {
         #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/portal-session")
         #expect(request.body == nil)
     }
+
+    /// `getSubscription()` performs the request with the correct method and path.
+    @Test
+    func getSubscription() async throws {
+        client.result = .httpSuccess(testData: .subscriptionResponse)
+
+        let response = try await subject.getSubscription()
+
+        let request = try #require(client.requests.last)
+        #expect(request.method == .get)
+        #expect(request.url.absoluteString == "https://example.com/api/account/billing/vnext/subscription")
+        #expect(request.body == nil)
+
+        // Verify response parsing
+        #expect(response.status == "active")
+        #expect(response.cart.cadence == "annually")
+        #expect(response.cart.estimatedTax == 4.55)
+        #expect(response.cart.discount == nil)
+
+        let seats = try #require(response.cart.passwordManager?.seats)
+        #expect(seats.translationKey == "premiumMembership")
+        #expect(seats.quantity == 1)
+        #expect(seats.cost == 19.8)
+        #expect(seats.discount == nil)
+        #expect(response.cart.passwordManager?.additionalStorage == nil)
+
+        let storage = try #require(response.storage)
+        #expect(storage.available == 5)
+        #expect(storage.used == 0)
+        #expect(storage.readableUsed == "0 Bytes")
+
+        #expect(response.cancelAt == nil)
+        #expect(response.canceled == nil)
+        #expect(response.nextCharge != nil)
+        #expect(response.suspension == nil)
+        #expect(response.gracePeriod == nil)
+    }
 }

--- a/BitwardenShared/Core/Billing/Services/API/Fixtures/APITestData+Billing.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Fixtures/APITestData+Billing.swift
@@ -32,6 +32,39 @@ public extension APITestData {
     }
     """.utf8))
 
+    // MARK: Subscription
+
+    static let subscriptionResponse = APITestData(data: Data("""
+    {
+        "status": "active",
+        "cart": {
+            "passwordManager": {
+                "seats": {
+                    "translationKey": "premiumMembership",
+                    "quantity": 1,
+                    "cost": 19.8,
+                    "discount": null
+                },
+                "additionalStorage": null
+            },
+            "secretsManager": null,
+            "cadence": "annually",
+            "discount": null,
+            "estimatedTax": 4.55
+        },
+        "storage": {
+            "available": 5,
+            "used": 0,
+            "readableUsed": "0 Bytes"
+        },
+        "cancelAt": null,
+        "canceled": null,
+        "nextCharge": "2027-02-20T15:48:11Z",
+        "suspension": null,
+        "gracePeriod": null
+    }
+    """.utf8))
+
     // MARK: Portal URL
 
     static let portalUrl = APITestData(data: Data("""

--- a/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequest.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequest.swift
@@ -1,0 +1,17 @@
+import Networking
+
+// MARK: - GetSubscriptionRequest
+
+/// A networking request to get the user's subscription details.
+///
+struct GetSubscriptionRequest: Request {
+    typealias Response = BitwardenSubscriptionResponseModel
+
+    // MARK: Properties
+
+    /// The HTTP method for this request.
+    var method: HTTPMethod { .get }
+
+    /// The URL path for this request.
+    var path: String { "/account/billing/vnext/subscription" }
+}

--- a/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequestTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequestTests.swift
@@ -1,0 +1,32 @@
+import Networking
+import Testing
+
+@testable import BitwardenShared
+
+// MARK: - GetSubscriptionRequestTests
+
+struct GetSubscriptionRequestTests {
+    // MARK: Properties
+
+    var subject: GetSubscriptionRequest!
+
+    // MARK: Initialization
+
+    init() {
+        subject = GetSubscriptionRequest()
+    }
+
+    // MARK: Tests
+
+    /// `method` returns the method of the request.
+    @Test
+    func method() {
+        #expect(subject.method == .get)
+    }
+
+    /// `path` returns the path of the request.
+    @Test
+    func path() {
+        #expect(subject.path == "/account/billing/vnext/subscription")
+    }
+}

--- a/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequestTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequestTests.swift
@@ -18,6 +18,12 @@ struct GetSubscriptionRequestTests {
 
     // MARK: Tests
 
+    /// `body` returns nil for requests without a payload.
+    @Test
+    func body() {
+        #expect(subject.body == nil)
+    }
+
     /// `method` returns the method of the request.
     @Test
     func method() {

--- a/BitwardenShared/Core/Billing/Services/BillingService.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingService.swift
@@ -17,6 +17,12 @@ protocol BillingService: AnyObject { // sourcery: AutoMockable
     /// - Returns: A `PremiumPlanResponseModel` containing the premium plan details.
     ///
     func getPremiumPlan() async throws -> PremiumPlanResponseModel
+
+    /// Gets the user's subscription details.
+    ///
+    /// - Returns: A `BitwardenSubscriptionResponseModel` containing the subscription details.
+    ///
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel
 }
 
 // MARK: - DefaultBillingService
@@ -54,5 +60,9 @@ class DefaultBillingService: BillingService {
 
     func getPremiumPlan() async throws -> PremiumPlanResponseModel {
         try await billingAPIService.getPremiumPlan()
+    }
+
+    func getSubscription() async throws -> BitwardenSubscriptionResponseModel {
+        try await billingAPIService.getSubscription()
     }
 }

--- a/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
@@ -124,7 +124,7 @@ struct BillingServiceTests {
             cancelAt: nil,
             canceled: nil,
             cart: SubscriptionCartResponseModel(
-                cadence: "annually",
+                cadence: .annually,
                 discount: nil,
                 estimatedTax: 4.55,
                 passwordManager: PasswordManagerCartItemsResponseModel(

--- a/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
@@ -121,31 +121,31 @@ struct BillingServiceTests {
     @Test
     func getSubscription_success() async throws {
         let expectedSubscription = BitwardenSubscriptionResponseModel(
-            status: "active",
+            cancelAt: nil,
+            canceled: nil,
             cart: SubscriptionCartResponseModel(
-                passwordManager: PasswordManagerCartItemsResponseModel(
-                    seats: CartItemResponseModel(
-                        translationKey: "premiumMembership",
-                        quantity: 1,
-                        cost: 19.8,
-                        discount: nil,
-                    ),
-                    additionalStorage: nil,
-                ),
                 cadence: "annually",
                 discount: nil,
                 estimatedTax: 4.55,
+                passwordManager: PasswordManagerCartItemsResponseModel(
+                    additionalStorage: nil,
+                    seats: CartItemResponseModel(
+                        cost: 19.8,
+                        discount: nil,
+                        quantity: 1,
+                        translationKey: "premiumMembership",
+                    ),
+                ),
             ),
+            gracePeriod: nil,
+            nextCharge: nil,
+            status: "active",
             storage: SubscriptionStorageResponseModel(
                 available: 5,
-                used: 0,
                 readableUsed: "0 Bytes",
+                used: 0,
             ),
-            cancelAt: nil,
-            canceled: nil,
-            nextCharge: nil,
             suspension: nil,
-            gracePeriod: nil,
         )
         billingAPIService.getSubscriptionReturnValue = expectedSubscription
 

--- a/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
@@ -116,4 +116,54 @@ struct BillingServiceTests {
 
         #expect(billingAPIService.getPremiumPlanCallsCount == 1)
     }
+
+    /// `getSubscription()` returns the subscription from the API service.
+    @Test
+    func getSubscription_success() async throws {
+        let expectedSubscription = BitwardenSubscriptionResponseModel(
+            status: "active",
+            cart: SubscriptionCartResponseModel(
+                passwordManager: PasswordManagerCartItemsResponseModel(
+                    seats: CartItemResponseModel(
+                        translationKey: "premiumMembership",
+                        quantity: 1,
+                        cost: 19.8,
+                        discount: nil,
+                    ),
+                    additionalStorage: nil,
+                ),
+                cadence: "annually",
+                discount: nil,
+                estimatedTax: 4.55,
+            ),
+            storage: SubscriptionStorageResponseModel(
+                available: 5,
+                used: 0,
+                readableUsed: "0 Bytes",
+            ),
+            cancelAt: nil,
+            canceled: nil,
+            nextCharge: nil,
+            suspension: nil,
+            gracePeriod: nil,
+        )
+        billingAPIService.getSubscriptionReturnValue = expectedSubscription
+
+        let result = try await subject.getSubscription()
+
+        #expect(billingAPIService.getSubscriptionCallsCount == 1)
+        #expect(result == expectedSubscription)
+    }
+
+    /// `getSubscription()` propagates errors from the API service.
+    @Test
+    func getSubscription_apiError() async throws {
+        billingAPIService.getSubscriptionThrowableError = URLError(.notConnectedToInternet)
+
+        await #expect(throws: URLError.self) {
+            try await subject.getSubscription()
+        }
+
+        #expect(billingAPIService.getSubscriptionCallsCount == 1)
+    }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-35126

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Add the billing subscription API endpoint to fetch the user's subscription details. This includes:

- New response models (`BitwardenSubscriptionResponseModel`, `BitwardenDiscountType`, and related cart/storage models)
- New `GetSubscriptionRequest` for the `/account/billing/vnext/subscription` endpoint
- `getSubscription()` method added to `BillingAPIService` and `BillingService`
- Full test coverage for the request, API service, and billing service layers