### PR TITLE
[PM-35220] fix: Prevent data race on DefaultEnvironmentService.environmentURLs

### DIFF
--- a/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
@@ -19,11 +19,26 @@ class DefaultEnvironmentService: EnvironmentService {
 
     // MARK: Private Properties
 
+    /// Backing store for `currentClientCertificateFingerprint`. Access via the computed property.
+    private nonisolated(unsafe) var _currentClientCertificateFingerprint: String?
+
+    /// Backing store for `environmentURLs`. Access via the computed property.
+    private nonisolated(unsafe) var _environmentURLs: EnvironmentURLs
+
     /// The SHA-256 fingerprint of the client certificate for the current environment.
-    private var currentClientCertificateFingerprint: String?
+    private var currentClientCertificateFingerprint: String? {
+        get { lock.withLock { _currentClientCertificateFingerprint } }
+        set { lock.withLock { _currentClientCertificateFingerprint = newValue } }
+    }
 
     /// The app's current environment URLs.
-    private var environmentURLs: EnvironmentURLs
+    private var environmentURLs: EnvironmentURLs {
+        get { lock.withLock { _environmentURLs } }
+        set { lock.withLock { _environmentURLs = newValue } }
+    }
+
+    /// Lock protecting mutable environment state accessed from concurrent async tasks.
+    private let lock = NSLock()
 
     /// The shared UserDefaults instance (NOTE: this should be the standard one just for the app,
     /// not one in the app group).
@@ -43,7 +58,7 @@ class DefaultEnvironmentService: EnvironmentService {
         self.stateService = stateService
         self.standardUserDefaults = standardUserDefaults
 
-        environmentURLs = EnvironmentURLs(environmentURLData: .defaultUS)
+        _environmentURLs = EnvironmentURLs(environmentURLData: .defaultUS)
     }
 
     // MARK: EnvironmentService

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -41,6 +41,19 @@ class EnvironmentServiceTests: XCTestCase {
 
     // MARK: Tests
 
+    /// Concurrent reads and writes to environment properties should not produce a data race.
+    func test_concurrentReadWrite_noDataRace() async {
+        let urls = EnvironmentURLData(base: .example)
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0 ..< 50 {
+                group.addTask { await self.subject.setPreAuthURLs(urls: urls) }
+                group.addTask { _ = self.subject.apiURL }
+                group.addTask { _ = self.subject.clientCertificateFingerprint }
+            }
+        }
+    }
+
     /// The default US URLs are returned if the URLs haven't been loaded.
     func test_defaultUrls() {
         XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35220](https://bitwarden.atlassian.net/browse/PM-35220)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a crash (EXC_BAD_ACCESS KERN_INVALID_ADDRESS) which can occur in `DefaultEnvironmentService.setPreAuthURLs(urls:)` due to a data race on the `environmentURLs` stored property.

Since the EnvironmentURLs could be accessed concurrency with no existing actor isolation, the reference counts of the URL values (which, despite being a struct, wrap reference-counted _SwiftURL/URLParseInfo objects internally) in EnvironmentURLs could be come corrupted, leading to a crash in _swift_release_dealloc when the old value is freed.

This introduces an NSLock to serialize reads and writes of the two mutable properties (environmentURLs and currentClientCertificateFingerprint). The backing stores are marked `nonisolated(unsafe)` rather than using `@unchecked Sendable` on the whole class so the compiler continues to enforce Sendable checking on all other stored properties. I opted for this route vs making the class an actor since many of the URL computed properties are accessed from non-async contexts.

Crashlytics crash:
https://console.firebase.google.com/u/1/project/bitwarden-c2b35/crashlytics/app/ios:com.8bit.bitwarden/issues/4e5a4cf42e0f5f0218d6e488369a5b45?time=90d&types=crash&sessionEventKey=5dd009a162e14d1581dd9c2fe7b6c339_2207230093368192844

[PM-35220]: https://bitwarden.atlassian.net/browse/PM-35220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ