### PR TITLE
[PM-35271] refactor: Extract user agent construction to a shared UserAgentBuilder

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/API/APIService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/APIService.swift
@@ -1,6 +1,6 @@
 import BitwardenKit
+import Foundation
 import Networking
-import UIKit
 
 /// A service used by the application to make API requests.
 ///
@@ -31,19 +31,19 @@ class APIService {
     ///     to `URLSession.shared`.
     ///   - environmentService: The service used by the application to retrieve the environment settings.
     ///   - flightRecorder: The service used by the application for recording temporary debug logs.
+    ///   - userAgentBuilder: Builds the user agent string from app and device information.
     ///
     init(
         client: HTTPClient = URLSession.shared,
         environmentService: EnvironmentService,
         flightRecorder: FlightRecorder,
+        userAgentBuilder: UserAgentBuilder,
     ) {
         self.client = client
 
         defaultHeadersRequestHandler = DefaultHeadersRequestHandler(
-            appName: "Bitwarden_Authenticator_Mobile",
             appVersion: Bundle.main.appVersion,
-            buildNumber: Bundle.main.buildNumber,
-            systemDevice: UIDevice.current,
+            userAgentBuilder: userAgentBuilder,
         )
 
         apiUnauthenticatedService = HTTPService(

--- a/AuthenticatorShared/Core/Platform/Services/API/APIServiceTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/APIServiceTests.swift
@@ -41,6 +41,11 @@ class APIServiceTests: BitwardenTestCase {
             client: MockHTTPClient(),
             environmentService: MockEnvironmentService(),
             flightRecorder: mockFlightRecorder,
+            userAgentBuilder: UserAgentBuilder(
+                appName: "TestApp",
+                appVersion: "1.0",
+                systemDevice: MockSystemDevice(),
+            ),
         )
 
         XCTAssertTrue(

--- a/AuthenticatorShared/Core/Platform/Services/API/TestHelpers/APIService+Mocks.swift
+++ b/AuthenticatorShared/Core/Platform/Services/API/TestHelpers/APIService+Mocks.swift
@@ -8,11 +8,17 @@ extension APIService {
     convenience init(
         client: HTTPClient,
         flightRecorder: FlightRecorder = MockFlightRecorder(),
+        userAgentBuilder: UserAgentBuilder = UserAgentBuilder(
+            appName: "TestApp",
+            appVersion: "1.0",
+            systemDevice: MockSystemDevice(),
+        ),
     ) {
         self.init(
             client: client,
             environmentService: MockEnvironmentService(),
             flightRecorder: flightRecorder,
+            userAgentBuilder: userAgentBuilder,
         )
     }
 }

--- a/AuthenticatorShared/Core/Platform/Services/ServiceContainer.swift
+++ b/AuthenticatorShared/Core/Platform/Services/ServiceContainer.swift
@@ -247,6 +247,11 @@ public class ServiceContainer: Services {
         let apiService = APIService(
             environmentService: environmentService,
             flightRecorder: flightRecorder,
+            userAgentBuilder: UserAgentBuilder(
+                appName: "Bitwarden_Authenticator_Mobile",
+                appVersion: Bundle.main.appVersion,
+                systemDevice: UIDevice.current,
+            ),
         )
 
         let errorReportBuilder = DefaultErrorReportBuilder(

--- a/BitwardenKit/Core/Platform/Services/API/Handlers/DefaultHeadersRequestHandler.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Handlers/DefaultHeadersRequestHandler.swift
@@ -1,56 +1,36 @@
 import Networking
-import UIKit
 
 /// A `RequestHandler` that applies default headers (user agent, client type & name, etc) to requests.
 ///
 public final class DefaultHeadersRequestHandler: RequestHandler {
     // MARK: Properties
 
-    /// The app's name.
-    let appName: String
-
     /// The app's version number.
     let appVersion: String
 
-    /// The app's build number.
-    let buildNumber: String
-
-    /// A `SystemDevice` instance used to get device details.
-    let systemDevice: SystemDevice
+    /// Builds the user agent string from app and device information.
+    let userAgentBuilder: UserAgentBuilder
 
     // MARK: Initialization
 
     /// Initializes a `DefaultHeadersRequestHandler`.
     ///
     /// - Parameters:
-    ///   - appName: The app's name.
     ///   - appVersion: The app's version number.
-    ///   - buildNumber: The app's build number.
-    ///   - systemDevice: A `SystemDevice` instance used to get device details.
+    ///   - userAgentBuilder: Builds the user agent string from app and device information.
     ///
-    public init(
-        appName: String,
-        appVersion: String,
-        buildNumber: String,
-        systemDevice: SystemDevice,
-    ) {
-        self.appName = appName
+    public init(appVersion: String, userAgentBuilder: UserAgentBuilder) {
         self.appVersion = appVersion
-        self.buildNumber = buildNumber
-        self.systemDevice = systemDevice
+        self.userAgentBuilder = userAgentBuilder
     }
 
     // MARK: Request Handler
 
     public func handle(_ request: inout HTTPRequest) async throws -> HTTPRequest {
-        let osVersion = systemDevice.systemVersion
-        let systemName = systemDevice.systemName
-        let model = systemDevice.model
-
         request.headers["Bitwarden-Client-Name"] = Constants.clientType
         request.headers["Bitwarden-Client-Version"] = appVersion
         request.headers["Device-Type"] = String(Constants.deviceType)
-        request.headers["User-Agent"] = "\(appName)/\(appVersion) (\(systemName) \(osVersion); Model \(model))"
+        request.headers["User-Agent"] = userAgentBuilder.value
 
         return request
     }

--- a/BitwardenKit/Core/Platform/Services/API/Handlers/DefaultHeadersRequestHandlerTests.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Handlers/DefaultHeadersRequestHandlerTests.swift
@@ -15,10 +15,12 @@ class DefaultHeadersRequestHandlerTests: BitwardenTestCase {
         super.setUp()
 
         subject = DefaultHeadersRequestHandler(
-            appName: "Bitwarden",
             appVersion: "2023.8.0",
-            buildNumber: "123",
-            systemDevice: MockSystemDevice(),
+            userAgentBuilder: UserAgentBuilder(
+                appName: "Bitwarden",
+                appVersion: "2023.8.0",
+                systemDevice: MockSystemDevice(),
+            ),
         )
     }
 

--- a/BitwardenKit/Core/Platform/Utilities/UserAgentBuilder.swift
+++ b/BitwardenKit/Core/Platform/Utilities/UserAgentBuilder.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Builds the standard Bitwarden user agent string from app and device information.
+///
+public struct UserAgentBuilder: Sendable {
+    // MARK: Properties
+
+    /// The app's name (e.g. `"Bitwarden_Mobile"`).
+    let appName: String
+
+    /// The app's version string.
+    let appVersion: String
+
+    /// The system device used to read OS and model info.
+    let systemDevice: SystemDevice
+
+    // MARK: Computed Properties
+
+    /// The formatted user agent string.
+    public var value: String {
+        "\(appName)/\(appVersion)"
+            + " (\(systemDevice.systemName) \(systemDevice.systemVersion);"
+            + " Model \(systemDevice.model))"
+    }
+
+    // MARK: Initialization
+
+    /// Initializes a `UserAgentBuilder`.
+    ///
+    /// - Parameters:
+    ///   - appName: The app's name (e.g. `"Bitwarden_Mobile"`).
+    ///   - appVersion: The app's version string.
+    ///   - systemDevice: The system device used to read OS and model info.
+    ///
+    public init(appName: String, appVersion: String, systemDevice: SystemDevice) {
+        self.appName = appName
+        self.appVersion = appVersion
+        self.systemDevice = systemDevice
+    }
+}

--- a/BitwardenKit/Core/Platform/Utilities/UserAgentBuilderTests.swift
+++ b/BitwardenKit/Core/Platform/Utilities/UserAgentBuilderTests.swift
@@ -1,0 +1,24 @@
+import BitwardenKit
+import BitwardenKitMocks
+import Testing
+
+/// Tests for `UserAgentBuilder`.
+struct UserAgentBuilderTests {
+    // MARK: Tests
+
+    /// `value` returns the correctly formatted user agent string.
+    @Test
+    func value() {
+        let subject = UserAgentBuilder(
+            appName: "Bitwarden_Mobile",
+            appVersion: "2024.1.0",
+            systemDevice: MockSystemDevice(
+                model: "iPhone",
+                systemName: "iOS",
+                systemVersion: "17.0",
+            ),
+        )
+
+        #expect(subject.value == "Bitwarden_Mobile/2024.1.0 (iOS 17.0; Model iPhone)")
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/API/APIService.swift
+++ b/BitwardenShared/Core/Platform/Services/API/APIService.swift
@@ -52,6 +52,7 @@ class APIService {
     ///   - stateService: The service used by the application to manage account state.
     ///   - tokenService: The `TokenService` which manages accessing and updating the active
     ///     account's tokens.
+    ///   - userAgentBuilder: Builds the user agent string from app and device information.
     ///
     init(
         accountTokenProvider: AccountTokenProvider? = nil,
@@ -63,16 +64,15 @@ class APIService {
         serverCommunicationConfigClientSingleton: @escaping () -> ServerCommunicationConfigClientSingleton?,
         stateService: StateService,
         tokenService: TokenService,
+        userAgentBuilder: UserAgentBuilder,
     ) {
         self.stateService = stateService
 
         httpServiceBuilder = HTTPServiceBuilder(
             client: client,
             defaultHeadersRequestHandler: DefaultHeadersRequestHandler(
-                appName: "Bitwarden_Mobile",
                 appVersion: Bundle.main.appVersion,
-                buildNumber: Bundle.main.buildNumber,
-                systemDevice: UIDevice.current,
+                userAgentBuilder: userAgentBuilder,
             ),
             loggers: [
                 FlightRecorderHTTPLogger(flightRecorder: flightRecorder),

--- a/BitwardenShared/Core/Platform/Services/API/RefreshableAPIServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/RefreshableAPIServiceTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import TestHelpers
 import XCTest
@@ -27,6 +28,11 @@ class RefreshableAPIServiceTests: BitwardenTestCase {
             serverCommunicationConfigClientSingleton: { MockServerCommunicationConfigClientSingleton() },
             stateService: MockStateService(),
             tokenService: MockTokenService(),
+            userAgentBuilder: UserAgentBuilder(
+                appName: "TestApp",
+                appVersion: "1.0",
+                systemDevice: MockSystemDevice(),
+            ),
         )
     }
 

--- a/BitwardenShared/Core/Platform/Services/API/TestHelpers/APIService+Mocks.swift
+++ b/BitwardenShared/Core/Platform/Services/API/TestHelpers/APIService+Mocks.swift
@@ -15,6 +15,11 @@ extension APIService {
         // swiftlint:disable:next line_length
         serverCommunicationConfigClientSingleton: ServerCommunicationConfigClientSingleton = MockServerCommunicationConfigClientSingleton(),
         stateService: StateService = MockStateService(),
+        userAgentBuilder: UserAgentBuilder = UserAgentBuilder(
+            appName: "TestApp",
+            appVersion: "1.0",
+            systemDevice: MockSystemDevice(),
+        ),
     ) {
         self.init(
             accountTokenProvider: accountTokenProvider,
@@ -26,6 +31,7 @@ extension APIService {
             serverCommunicationConfigClientSingleton: { serverCommunicationConfigClientSingleton },
             stateService: stateService,
             tokenService: MockTokenService(),
+            userAgentBuilder: userAgentBuilder,
         )
     }
 }

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -555,6 +555,11 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             )
         }
 
+        let userAgentBuilder = UserAgentBuilder(
+            appName: "Bitwarden_Mobile",
+            appVersion: Bundle.main.appVersion,
+            systemDevice: UIDevice.current,
+        )
         let apiService = APIService(
             activeAccountStateProvider: stateService,
             client: certificateHttpClient,
@@ -564,6 +569,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             serverCommunicationConfigClientSingleton: { serverCommConfigClientSingletonHolder },
             stateService: stateService,
             tokenService: tokenService,
+            userAgentBuilder: userAgentBuilder,
         )
 
         let errorReportBuilder = DefaultErrorReportBuilder(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35271](https://bitwarden.atlassian.net/browse/PM-35271)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

As part of the V2 encryption changes, the SDK is going to start making networking requests previously made by the app. In order to support this, the app will need to provide environment URLs and the user agent to the SDK.

This extracts the construction of the user agent to a `UserAgentBuilder`. A future PR will use this when constructing the SDK client so that the same `UserAgentBuilder` is shared between the app and SDK.


[PM-35271]: https://bitwarden.atlassian.net/browse/PM-35271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ