### PR TITLE
Fix to set latest on PWM release notes only

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -186,7 +186,7 @@ jobs:
           # Extract release tag from URL
           release_id_from_url=$(echo "$release_url" | sed 's/.*\/tag\///')
           echo "release_id_from_url=$release_id_from_url" >> "$GITHUB_OUTPUT"
-
+          echo "is_latest_release=$is_latest_release" >> "$GITHUB_OUTPUT"
           echo "url=$release_url" >> "$GITHUB_OUTPUT"
 
           echo "✅ Release created: $release_url"
@@ -198,6 +198,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           _RELEASE_ID: ${{ steps.create_release.outputs.release_id_from_url }}
           _ARTIFACT_RUN_ID: ${{ inputs.artifact-run-id }}
+          _IS_LATEST: ${{ steps.create_release.outputs.is_latest_release }}
         run: |
           echo "Getting current release body. Release ID: $_RELEASE_ID"
           current_body=$(gh release view "$_RELEASE_ID" --json body --jq .body)
@@ -211,7 +212,7 @@ jobs:
           ${current_body}
           **Builds Source:** https://github.com/${{ github.repository }}/actions/runs/$_ARTIFACT_RUN_ID"
 
-          new_release_url=$(gh release edit "$_RELEASE_ID" --notes "$updated_body")
+          new_release_url=$(gh release edit "$_RELEASE_ID" --notes "$updated_body" --latest="$_IS_LATEST")
 
           # draft release links change after editing
           echo "release_url=$new_release_url" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 📔 Objective

Occasionally Authenticator is marked as 'Latest' when the release notes are taken out of draft, which shouldn't happen (we only set `Latest` on PWM). This fixes that.

Reasoning per claude:

`gh release edit` without `--latest` may send a `make_latest:true` default to the GitHub API, which would override the `--latest=false` set during draft creation. By explicitly forwarding the same `is_latest_release` value, the Authenticator draft release will consistently remain `make_latest=false`.