### PR TITLE
[PM-35251] fix: Adjust presentation style to avoid Tab Bar issues in BWA

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinator.swift
@@ -113,7 +113,7 @@ class AppCoordinator: Coordinator, HasRootNavigator {
             let navigationController = module.makeNavigationController()
             navigationController.isModalInPresentation = true
             navigationController.isNavigationBarHidden = true
-            navigationController.modalPresentationStyle = .fullScreen
+            navigationController.modalPresentationStyle = .overFullScreen
 
             let coordinator = module.makeAuthCoordinator(
                 delegate: self,

--- a/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppCoordinatorTests.swift
@@ -50,7 +50,7 @@ struct AppCoordinatorTests {
 
         let presentedVC = (mockRootNavigator.rootViewController as? MockUIViewController)?.presentedView
         #expect(presentedVC?.isModalInPresentation == true)
-        #expect(presentedVC?.modalPresentationStyle == .fullScreen)
+        #expect(presentedVC?.modalPresentationStyle == .overFullScreen)
     }
 
     /// `handleEvent(.vaultTimeout)` presents the auth overlay with `isModalInPresentation` set
@@ -70,7 +70,7 @@ struct AppCoordinatorTests {
 
         let presentedVC = (mockRootNavigator.rootViewController as? MockUIViewController)?.presentedView
         #expect(presentedVC?.isModalInPresentation == true)
-        #expect(presentedVC?.modalPresentationStyle == .fullScreen)
+        #expect(presentedVC?.modalPresentationStyle == .overFullScreen)
     }
 
     /// `switchToSettingsTab(route:)` navigates to the settings tab with the specified route.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35251

## 📔 Objective

This adjusts how the BWA auth screen presents to be `.overFullScreen` instead of `.fullScreen`, which fixes the color issue with the tab bar. The ultimate reason for this is that `.fullScreen` doesn't properly render things about the tab bar, causing issues with rendering on dismissal; with `.overFullScreen`, the system can render the tab bar appropriately before the dismissal.