### PR TITLE
[PM-27240] chore: Update development app version to avoid triggering V2 encryption server check

### DIFF
--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -11,7 +11,7 @@ options:
     "icon":
       file: true 
 settings:
-  MARKETING_VERSION: 2024.6.1
+  MARKETING_VERSION: 2026.4.0
   CURRENT_PROJECT_VERSION: 1
 packages:
   SwiftProtobuf:

--- a/project-bwk.yml
+++ b/project-bwk.yml
@@ -7,7 +7,7 @@ configs:
 include:
   - path: project-common.yml
 settings:
-  MARKETING_VERSION: 2024.6.0    # Bump this for a new version update.
+  MARKETING_VERSION: 2026.4.0    # Bump this for a new version update.
   CURRENT_PROJECT_VERSION: 1
 packages:
   SwiftUIIntrospect:

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -12,7 +12,7 @@ options:
     "icon":
       file: true 
 settings:
-  MARKETING_VERSION: 2024.6.0    # Bump this for a new version update.
+  MARKETING_VERSION: 2026.4.0    # Bump this for a new version update.
   CURRENT_PROJECT_VERSION: 1
 projectReferences:
   BitwardenKit:


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27240](https://bitwarden.atlassian.net/browse/PM-27240)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The server has an app version check which returns an error for accounts with V2 encryption if the app version is less than 2025.11.0. This ends up triggering for local dev builds since this version isn't bumped in the repo itself.

This updates the local dev version to 2026.4.0.


[PM-27240]: https://bitwarden.atlassian.net/browse/PM-27240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ