### PR TITLE
[PM-35285] fix: Prevent StateService.isAuthenticated(userId:) from throwing if token doesn't exist in keychain

### DIFF
--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -446,15 +446,11 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
 
     func getPendingAdminLoginRequest(userId: String?) async throws -> PendingAdminLoginRequest? {
         let activeUserId = try await stateService.getAccountIdOrActiveId(userId: userId)
-        do {
-            if let jsonString = try await keychainRepository.getPendingAdminLoginRequest(userId: activeUserId),
-               let jsonData = jsonString.data(using: .utf8) {
-                return try JSONDecoder().decode(PendingAdminLoginRequest.self, from: jsonData)
-            }
-            return nil
-        } catch KeychainServiceError.osStatusError(errSecItemNotFound) {
-            return nil
+        if let jsonString = try await keychainRepository.getPendingAdminLoginRequest(userId: activeUserId),
+           let jsonData = jsonString.data(using: .utf8) {
+            return try JSONDecoder().decode(PendingAdminLoginRequest.self, from: jsonData)
         }
+        return nil
     }
 
     func getPendingLoginRequest(withId id: String?) async throws -> [LoginRequest] {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1814,7 +1814,7 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
             return false
         } catch StateServiceError.noAccounts {
             return false
-        } catch KeychainServiceError.osStatusError(errSecItemNotFound) {
+        } catch KeychainServiceError.osStatusError(errSecItemNotFound), KeychainServiceError.keyNotFound {
             return false
         }
     }

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -1385,7 +1385,7 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
     func test_isAuthenticated() async throws {
         await subject.addAccount(.fixture())
 
-        keychainRepository.getAccessTokenThrowableError = KeychainServiceError.osStatusError(errSecItemNotFound)
+        keychainRepository.getAccessTokenThrowableError = KeychainServiceError.keyNotFound(BitwardenKeychainItem.accessToken(userId: "1"))
         var authenticationState = try await subject.isAuthenticated()
         XCTAssertFalse(authenticationState)
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35285](https://bitwarden.atlassian.net/browse/PM-35285)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The keychain changes in #2507 changed the behavior of which error is thrown if an item isn't found in the keychain. `StateService.isAuthenticated(userId:)` was catching `KeychainServiceError.osStatusError(errSecItemNotFound)`, but not `KeychainServiceError.keyNotFound`. This resulted in soft-logged out accounts appearing as if they were still logged in. When attempting to log back into a soft-logged out account, the app would ask if you want to switch to the already logged in account which would land you on an empty vault unlock screen.

I also removed the catch block from `AuthService.getPendingAdminLoginRequest(userId:)` since the error is already caught in the `KeychainRepository`.

https://github.com/bitwarden/ios/blob/c8ba32b6280bfb3aae5570b5630206765ee5cbf3/BitwardenShared/Core/Auth/Services/KeychainRepository.swift#L392-L399

## 📸 Screenshots

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/b92c8a88-ad6a-4ea2-8037-ce200ab25773" /> | <video src="https://github.com/user-attachments/assets/4ab84175-7888-4c5d-9fd2-599e632b9444" /> | 




[PM-35285]: https://bitwarden.atlassian.net/browse/PM-35285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ