### PR TITLE
[PM-34898] feat: Self-hosted support for PremiumUpgradeView

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Views/ActionCard+ViewInspectorTests.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/ActionCard+ViewInspectorTests.swift
@@ -40,6 +40,19 @@ final class ActionCardTests: BitwardenTestCase {
         XCTAssertTrue(dismissButtonTapped)
     }
 
+    /// The title is hidden when it is nil.
+    @MainActor
+    func test_nilTitle_hidesTitle() throws {
+        let subject = ActionCard(
+            message: "Message only",
+        )
+
+        // Only the message text should be found, no title.
+        let texts = subject.inspect().findAll(ViewType.Text.self)
+        let textStrings = texts.compactMap { try? $0.string() }
+        XCTAssertEqual(textStrings, ["Message only"])
+    }
+
     /// Tapping the secondary button should call the secondary button state's action closure.
     @MainActor
     func test_secondaryButton_tap() async throws {

--- a/BitwardenKit/UI/Platform/Application/Views/ActionCard+ViewInspectorTests.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/ActionCard+ViewInspectorTests.swift
@@ -47,10 +47,9 @@ final class ActionCardTests: BitwardenTestCase {
             message: "Message only",
         )
 
-        // Only the message text should be found, no title.
-        let texts = subject.inspect().findAll(ViewType.Text.self)
-        let textStrings = texts.compactMap { try? $0.string() }
-        XCTAssertEqual(textStrings, ["Message only"])
+        // The message text should be found.
+        let message = try subject.inspect().find(text: "Message only")
+        XCTAssertNotNil(message)
     }
 
     /// Tapping the secondary button should call the secondary button state's action closure.

--- a/BitwardenKit/UI/Platform/Application/Views/ActionCard.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/ActionCard.swift
@@ -51,7 +51,7 @@ public struct ActionCard<LeadingContent: View>: View {
     let secondaryButtonState: ButtonState?
 
     /// The title of the card.
-    let title: String
+    let title: String?
 
     // MARK: View
 
@@ -63,8 +63,10 @@ public struct ActionCard<LeadingContent: View>: View {
                 }
 
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(title)
-                        .styleGuide(.title2, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
+                    if let title {
+                        Text(title)
+                            .styleGuide(.title2, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
+                    }
 
                     if let message {
                         Text(message)
@@ -115,7 +117,7 @@ public struct ActionCard<LeadingContent: View>: View {
     /// Initialize an `ActionCard` with leading content.
     ///
     /// - Parameters:
-    ///   - title: The title of the card.
+    ///   - title: The title of the card. If `nil`, the title is hidden.
     ///   - message: The message to display in the card.
     ///   - actionButtonState: State that describes the action button.
     ///   - dismissButtonState: State that describes the dismiss button.
@@ -123,7 +125,7 @@ public struct ActionCard<LeadingContent: View>: View {
     ///   - leadingContent: Content that is displayed at the leading edge of the title and message.
     ///
     public init(
-        title: String,
+        title: String? = nil,
         message: String? = nil,
         actionButtonState: ButtonState? = nil,
         dismissButtonState: ButtonState? = nil,
@@ -141,14 +143,14 @@ public struct ActionCard<LeadingContent: View>: View {
     /// Initialize an `ActionCard` with no leading content.
     ///
     /// - Parameters:
-    ///   - title: The title of the card.
+    ///   - title: The title of the card. If `nil`, the title is hidden.
     ///   - message: The message to display in the card.
     ///   - actionButtonState: State that describes the action button.
     ///   - dismissButtonState: State that describes the dismiss button.
     ///   - secondaryButtonState: State that describes the secondary button.
     ///
     public init(
-        title: String,
+        title: String? = nil,
         message: String? = nil,
         actionButtonState: ButtonState? = nil,
         dismissButtonState: ButtonState? = nil,

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1061,4 +1061,4 @@
 "UserID" = "User ID";
 "CopyUserID" = "Copy user ID";
 "UserIDUnavailable" = "User ID unavailable";
-"ToManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer" = "To manage your Premium subscription, please log in to your web vault on a computer.";
+"ToManageYourPremiumSubscriptionDescriptionLong" = "To manage your Premium subscription, please log in to your web vault on a computer.";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1061,3 +1061,4 @@
 "UserID" = "User ID";
 "CopyUserID" = "Copy user ID";
 "UserIDUnavailable" = "User ID unavailable";
+"ToManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer" = "To manage your Premium subscription, please log in to your web vault on a computer.";

--- a/BitwardenShared/UI/Billing/BillingCoordinator.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinator.swift
@@ -10,6 +10,7 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasBillingService
+        & HasEnvironmentService
         & HasErrorReportBuilder
         & HasErrorReporter
 

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeAction.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeAction.swift
@@ -9,6 +9,9 @@ enum PremiumUpgradeAction: Equatable {
     /// Clear the checkout URL after it has been opened.
     case clearURL
 
+    /// The self-hosted info banner dismiss button was tapped.
+    case dismissBannerTapped
+
     /// The checkout URL failed to open in the browser.
     case urlOpenFailed
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeEffect.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeEffect.swift
@@ -3,6 +3,9 @@
 /// Effects that can be processed by a `PremiumUpgradeProcessor`.
 ///
 enum PremiumUpgradeEffect {
+    /// The view appeared.
+    case appeared
+
     /// The upgrade now button was tapped.
     case upgradeNowTapped
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
@@ -12,6 +12,7 @@ final class PremiumUpgradeProcessor: StateProcessor<
     // MARK: Types
 
     typealias Services = HasBillingService
+        & HasEnvironmentService
         & HasErrorReporter
 
     // MARK: Properties
@@ -45,6 +46,8 @@ final class PremiumUpgradeProcessor: StateProcessor<
 
     override func perform(_ effect: PremiumUpgradeEffect) async {
         switch effect {
+        case .appeared:
+            state.isSelfHosted = services.environmentService.region == .selfHosted
         case .upgradeNowTapped:
             await createCheckoutSession()
         }
@@ -56,6 +59,8 @@ final class PremiumUpgradeProcessor: StateProcessor<
             coordinator.navigate(to: .dismiss)
         case .clearURL:
             state.checkoutURL = nil
+        case .dismissBannerTapped:
+            state.isBannerDismissed = true
         case .urlOpenFailed:
             Task {
                 await coordinator.showErrorAlert(error: BillingError.unableToOpenCheckout)

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
@@ -15,6 +15,7 @@ struct PremiumUpgradeProcessorTests {
 
     let billingService: MockBillingService
     let coordinator: MockCoordinator<BillingRoute, Void>
+    let environmentService: MockEnvironmentService
     let errorReporter: MockErrorReporter
     let subject: PremiumUpgradeProcessor
 
@@ -23,9 +24,11 @@ struct PremiumUpgradeProcessorTests {
     init() {
         billingService = MockBillingService()
         coordinator = MockCoordinator<BillingRoute, Void>()
+        environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         let services = ServiceContainer.withMocks(
             billingService: billingService,
+            environmentService: environmentService,
             errorReporter: errorReporter,
         )
         subject = PremiumUpgradeProcessor(
@@ -36,6 +39,26 @@ struct PremiumUpgradeProcessorTests {
     }
 
     // MARK: Tests
+
+    /// `perform(_:)` with `.appeared` sets `isSelfHosted` to `true` when the environment is self-hosted.
+    @Test
+    func perform_appeared_selfHosted() async {
+        environmentService.region = .selfHosted
+
+        await subject.perform(.appeared)
+
+        #expect(subject.state.isSelfHosted == true)
+    }
+
+    /// `perform(_:)` with `.appeared` sets `isSelfHosted` to `false` when the environment is not self-hosted.
+    @Test
+    func perform_appeared_notSelfHosted() async {
+        environmentService.region = .unitedStates
+
+        await subject.perform(.appeared)
+
+        #expect(subject.state.isSelfHosted == false)
+    }
 
     /// `perform(_:)` with `.upgradeNowTapped` logs the error and shows an error alert on failure.
     @Test
@@ -83,6 +106,18 @@ struct PremiumUpgradeProcessorTests {
         subject.receive(.cancelTapped)
 
         #expect(coordinator.routes.last == .dismiss)
+    }
+
+    /// `receive(_:)` with `.dismissBannerTapped` sets `isBannerDismissed` to `true`.
+    @Test
+    func receive_dismissBannerTapped() {
+        subject.state.isSelfHosted = true
+        #expect(subject.state.showSelfHostedBanner == true)
+
+        subject.receive(.dismissBannerTapped)
+
+        #expect(subject.state.isBannerDismissed == true)
+        #expect(subject.state.showSelfHostedBanner == false)
     }
 
     /// `receive(_:)` with `.clearURL` clears the checkout URL.

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeState.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeState.swift
@@ -10,10 +10,23 @@ struct PremiumUpgradeState: Equatable {
     /// The checkout URL to open when the user taps the upgrade button.
     var checkoutURL: URL?
 
+    /// Whether the self-hosted info banner has been dismissed.
+    var isBannerDismissed = false
+
     /// Whether the view is loading the checkout session.
     var isLoading = false
+
+    /// Whether the user is on a self-hosted server.
+    var isSelfHosted = false
 
     // TODO: PM-33852 - Remove this temporary variable and fetch the price from the API.
     /// The premium price to display.
     var premiumPrice = "$1.65"
+
+    // MARK: Computed Properties
+
+    /// Whether the self-hosted info banner should be shown.
+    var showSelfHostedBanner: Bool {
+        isSelfHosted && !isBannerDismissed
+    }
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView+SnapshotTests.swift
@@ -45,4 +45,19 @@ class PremiumUpgradeViewSnapshotTests: BitwardenTestCase {
         processor.state.isLoading = true
         assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
+
+    /// Check the snapshot for the self-hosted state with banner visible.
+    @MainActor
+    func disabletest_snapshot_selfHosted() {
+        processor.state.isSelfHosted = true
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+    }
+
+    /// Check the snapshot for the self-hosted state with banner dismissed.
+    @MainActor
+    func disabletest_snapshot_selfHosted_bannerDismissed() {
+        processor.state.isSelfHosted = true
+        processor.state.isBannerDismissed = true
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+    }
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView+ViewInspectorTests.swift
@@ -78,7 +78,7 @@ class PremiumUpgradeViewTests: BitwardenTestCase {
     func test_selfHostedBanner_visible() throws {
         processor.state.isSelfHosted = true
         let text = try subject.inspect().find(
-            text: Localizations.toManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer,
+            text: Localizations.toManageYourPremiumSubscriptionDescriptionLong,
         )
         XCTAssertNotNil(text)
     }
@@ -90,7 +90,7 @@ class PremiumUpgradeViewTests: BitwardenTestCase {
         processor.state.isBannerDismissed = true
         XCTAssertThrowsError(
             try subject.inspect().find(
-                text: Localizations.toManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer,
+                text: Localizations.toManageYourPremiumSubscriptionDescriptionLong,
             ),
         )
     }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView+ViewInspectorTests.swift
@@ -72,4 +72,35 @@ class PremiumUpgradeViewTests: BitwardenTestCase {
         let text = try subject.inspect().find(text: "$9.99")
         XCTAssertNotNil(text)
     }
+
+    /// The self-hosted banner is visible when the user is on a self-hosted server.
+    @MainActor
+    func test_selfHostedBanner_visible() throws {
+        processor.state.isSelfHosted = true
+        let text = try subject.inspect().find(
+            text: Localizations.toManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer,
+        )
+        XCTAssertNotNil(text)
+    }
+
+    /// The self-hosted banner is hidden when dismissed.
+    @MainActor
+    func test_selfHostedBanner_hidden_whenDismissed() throws {
+        processor.state.isSelfHosted = true
+        processor.state.isBannerDismissed = true
+        XCTAssertThrowsError(
+            try subject.inspect().find(
+                text: Localizations.toManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer,
+            ),
+        )
+    }
+
+    /// The upgrade button and Stripe footer are hidden when self-hosted.
+    @MainActor
+    func test_upgradeButton_hidden_whenSelfHosted() throws {
+        processor.state.isSelfHosted = true
+        XCTAssertThrowsError(
+            try subject.inspect().find(asyncButton: Localizations.upgradeNow),
+        )
+    }
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView.swift
@@ -88,19 +88,6 @@ struct PremiumUpgradeView: View {
         .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 
-    /// The self-hosted info banner displayed above the premium card.
-    private var selfHostedBanner: some View {
-        ActionCard(
-            message: Localizations.toManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer,
-            dismissButtonState: ActionCard.ButtonState(title: Localizations.close) {
-                store.send(.dismissBannerTapped)
-            }
-        ) {
-            SharedAsset.Icons.informationCircle24.swiftUIImage
-                .foregroundStyle(SharedAsset.Colors.iconSecondary.swiftUIColor)
-        }
-    }
-
     /// The price display section.
     private var priceSection: some View {
         HStack(alignment: .firstTextBaseline, spacing: 0) {
@@ -111,6 +98,19 @@ struct PremiumUpgradeView: View {
             Text(Localizations.perMonth)
                 .styleGuide(.body)
                 .foregroundColor(Color(asset: SharedAsset.Colors.textSecondary))
+        }
+    }
+
+    /// The self-hosted info banner displayed above the premium card.
+    private var selfHostedBanner: some View {
+        ActionCard(
+            message: Localizations.toManageYourPremiumSubscriptionDescriptionLong,
+            dismissButtonState: ActionCard.ButtonState(title: Localizations.close) {
+                store.send(.dismissBannerTapped)
+            },
+        ) {
+            SharedAsset.Icons.informationCircle24.swiftUIImage
+                .foregroundStyle(SharedAsset.Colors.iconSecondary.swiftUIColor)
         }
     }
 

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView.swift
@@ -41,27 +41,44 @@ struct PremiumUpgradeView: View {
     /// The main content of the view.
     private var content: some View {
         VStack(spacing: 0) {
+            if store.state.showSelfHostedBanner {
+                selfHostedBanner
+                    .padding(.bottom, 16)
+            }
+
             premiumCard
                 .padding(.bottom, 24)
 
-            upgradeButton
-                .padding(.bottom, 12)
+            if !store.state.isSelfHosted {
+                upgradeButton
+                    .padding(.bottom, 12)
 
-            stripeFooter
+                stripeFooter
+            }
         }
         .scrollView()
+        .task {
+            await store.perform(.appeared)
+        }
     }
 
     /// The premium upgrade card containing price, description, and features.
     private var premiumCard: some View {
         VStack(alignment: .leading, spacing: 0) {
-            priceSection
-                .padding(.bottom, 4)
+            if store.state.isSelfHosted {
+                Text(Localizations.unlockMoreAdvancedFeaturesWithPremiumPlan)
+                    .styleGuide(.headline, weight: .semibold)
+                    .foregroundColor(Color(asset: SharedAsset.Colors.textPrimary))
+                    .padding(.bottom, 16)
+            } else {
+                priceSection
+                    .padding(.bottom, 4)
 
-            Text(Localizations.unlockMoreAdvancedFeaturesWithPremiumPlan)
-                .styleGuide(.body)
-                .foregroundColor(Color(asset: SharedAsset.Colors.textSecondary))
-                .padding(.bottom, 16)
+                Text(Localizations.unlockMoreAdvancedFeaturesWithPremiumPlan)
+                    .styleGuide(.body)
+                    .foregroundColor(Color(asset: SharedAsset.Colors.textSecondary))
+                    .padding(.bottom, 16)
+            }
 
             PremiumFeaturesList()
         }
@@ -69,6 +86,19 @@ struct PremiumUpgradeView: View {
         .padding(.horizontal, 16)
         .background(Color(asset: SharedAsset.Colors.backgroundSecondary))
         .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    /// The self-hosted info banner displayed above the premium card.
+    private var selfHostedBanner: some View {
+        ActionCard(
+            message: Localizations.toManageYourPremiumSubscriptionPleaseLogInToYourWebVaultOnAComputer,
+            dismissButtonState: ActionCard.ButtonState(title: Localizations.close) {
+                store.send(.dismissBannerTapped)
+            }
+        ) {
+            SharedAsset.Icons.informationCircle24.swiftUIImage
+                .foregroundStyle(SharedAsset.Colors.iconSecondary.swiftUIColor)
+        }
     }
 
     /// The price display section.
@@ -113,12 +143,26 @@ struct PremiumUpgradeView: View {
 // MARK: - Previews
 
 #if DEBUG
-#Preview {
+#Preview("Cloud") {
     NavigationView {
         PremiumUpgradeView(
             store: Store(
                 processor: StateProcessor(
                     state: PremiumUpgradeState(),
+                ),
+            ),
+        )
+    }
+}
+
+#Preview("Self-Hosted") {
+    NavigationView {
+        PremiumUpgradeView(
+            store: Store(
+                processor: StateProcessor(
+                    state: PremiumUpgradeState(
+                        isSelfHosted: true,
+                    ),
                 ),
             ),
         )


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-34898

## 📔 Objective

When the user is on a self-hosted server, the Premium Upgrade screen now shows a different layout:

- **Info banner**: A dismissable `ActionCard` banner above the content card informing the user to manage their Premium subscription via the web vault on a computer.
- **Header**: Replaces the price section with a single headline-style title ("Unlock more advanced features with a Premium plan.").
- **Hidden controls**: The "Upgrade now" button and Stripe footer are hidden since self-hosted users cannot purchase through the app.

Additionally, `ActionCard` was updated to support an optional `title` (`String?`), allowing cards with only a message and no title.

## 📸 Screenshots

https://github.com/user-attachments/assets/19dce7f2-3abc-455f-826f-eb2ae64c6625

