### PR TITLE
[PM-35329] fix: Show certificate validation alerts via coordinator to prevent dialog race condition

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Utilities/InputValidator/InputValidator.swift
+++ b/BitwardenKit/UI/Platform/Application/Utilities/InputValidator/InputValidator.swift
@@ -7,5 +7,5 @@ public protocol InputValidator {
     ///
     /// - Parameter input: The input to validate.
     ///
-    func validate(input: String?) throws
+    func validate(input: String?) throws(InputValidationError)
 }

--- a/BitwardenKit/UI/Platform/Application/Utilities/InputValidator/Validators/EmptyInputValidator.swift
+++ b/BitwardenKit/UI/Platform/Application/Utilities/InputValidator/Validators/EmptyInputValidator.swift
@@ -22,7 +22,7 @@ public struct EmptyInputValidator: InputValidator {
 
     // MARK: InputValidator
 
-    public func validate(input: String?) throws {
+    public func validate(input: String?) throws(InputValidationError) {
         guard input?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false else {
             throw InputValidationError(message: Localizations.validationFieldRequired(fieldName))
         }

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessor.swift
@@ -155,13 +155,11 @@ final class SelfHostedProcessor: StateProcessor<SelfHostedState, SelfHostedActio
     ///   - password: The password entered by the user.
     ///
     private func handleCertificateInfoSubmitted(alias: String, password: String) {
-        guard !password.trimmingCharacters(in: .whitespaces).isEmpty else {
-            state.dialog = .error(message: Localizations.validationFieldRequired(Localizations.password))
-            return
-        }
-
-        guard !alias.trimmingCharacters(in: .whitespaces).isEmpty else {
-            state.dialog = .error(message: Localizations.validationFieldRequired(Localizations.alias))
+        do {
+            try EmptyInputValidator(fieldName: Localizations.password).validate(input: password)
+            try EmptyInputValidator(fieldName: Localizations.alias).validate(input: alias)
+        } catch {
+            coordinator.showAlert(.inputValidationAlert(error: error))
             return
         }
 

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
@@ -322,29 +322,37 @@ class SelfHostedProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         }
     }
 
-    /// Receiving `.certificateInfoSubmitted` with empty alias shows error dialog.
+    /// Receiving `.certificateInfoSubmitted` with empty alias shows an alert via coordinator.
     @MainActor
-    func test_receive_certificateInfoSubmitted_emptyAlias() {
+    func test_receive_certificateInfoSubmitted_emptyAlias() throws {
         subject.state.pendingCertificateData = Data([0x01])
 
         subject.receive(.certificateInfoSubmitted(alias: "", password: "pass123"))
 
+        XCTAssertNil(subject.state.dialog)
+        let alert = try XCTUnwrap(coordinator.alertShown.first)
         XCTAssertEqual(
-            subject.state.dialog,
-            .error(message: Localizations.validationFieldRequired(Localizations.alias)),
+            alert,
+            .inputValidationAlert(error: InputValidationError(
+                message: Localizations.validationFieldRequired(Localizations.alias)
+            )),
         )
     }
 
-    /// Receiving `.certificateInfoSubmitted` with empty password shows error dialog.
+    /// Receiving `.certificateInfoSubmitted` with empty password shows an alert via coordinator.
     @MainActor
-    func test_receive_certificateInfoSubmitted_emptyPassword() {
+    func test_receive_certificateInfoSubmitted_emptyPassword() throws {
         subject.state.pendingCertificateData = Data([0x01])
 
         subject.receive(.certificateInfoSubmitted(alias: "test", password: ""))
 
+        XCTAssertNil(subject.state.dialog)
+        let alert = try XCTUnwrap(coordinator.alertShown.first)
         XCTAssertEqual(
-            subject.state.dialog,
-            .error(message: Localizations.validationFieldRequired(Localizations.password)),
+            alert,
+            .inputValidationAlert(error: InputValidationError(
+                message: Localizations.validationFieldRequired(Localizations.password)
+            )),
         )
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35329](https://bitwarden.atlassian.net/browse/PM-35329)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a race condition in SelfHostedProcessor where validation errors (empty alias or password) during certificate import were silently dismissed. The SwiftUI alert binding sends dialogDismiss whenever its isPresented binding transitions to false, including when state.dialog changes type, causing a newly set .error dialog to be immediately cleared. This updates the processor to display alerts via the coordinator, which matches the pattern for alerts elsewhere.


[PM-35329]: https://bitwarden.atlassian.net/browse/PM-35329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ