### PR TITLE
[PM-33847] feat: Handle premiumStatusChanged push notification

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/NotificationType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/NotificationType.swift
@@ -26,4 +26,6 @@ enum NotificationType: Int, Codable {
     case authRequestResponse = 16
 
     case policyChanged = 25
+
+    case premiumStatusChanged = 27
 }

--- a/BitwardenShared/Core/Platform/Services/NotificationService.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationService.swift
@@ -269,7 +269,8 @@ class DefaultNotificationService: NotificationService { // swiftlint:disable:thi
                 // No action necessary, since the LoginWithDeviceProcessor already checks for updates
                 // every few seconds.
                 break
-            case .policyChanged:
+            case .policyChanged,
+                 .premiumStatusChanged:
                 try await syncService.fetchSync(forceSync: false)
             }
         } catch {

--- a/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/NotificationServiceTests.swift
@@ -427,6 +427,23 @@ class NotificationServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertTrue(syncService.didFetchSync)
     }
 
+    /// `messageReceived(_:notificationDismissed:notificationTapped:)` performs a sync when
+    /// receiving a premium status changed notification.
+    func test_messageReceived_premiumStatusChanged() async throws {
+        stateService.setIsAuthenticated()
+        appIDSettingsStore.appID = "10"
+        let message: [AnyHashable: Any] = [
+            "data": [
+                "type": NotificationType.premiumStatusChanged.rawValue,
+                "payload": "anything",
+            ],
+        ]
+
+        await subject.messageReceived(message, notificationDismissed: nil, notificationTapped: nil)
+
+        XCTAssertTrue(syncService.didFetchSync)
+    }
+
     /// `messageReceived(_:notificationDismissed:notificationTapped:)` logs to the flight recorder
     /// when a login request push notification is received for an account that doesn't exist.
     @MainActor


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-33847

## 📔 Objective

Add support for the `premiumStatusChanged` push notification type. When received, the app triggers a sync to refresh the user's premium status.