### PR TITLE
[PM-35271] chore: Provide environment URLs to SDK client via ClientSettings

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ClientBuilder.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientBuilder.swift
@@ -1,0 +1,72 @@
+import BitwardenKit
+import BitwardenSdk
+import Foundation
+
+// MARK: - ClientBuilder
+
+/// A protocol for creating a new `BitwardenSdkClient`.
+///
+protocol ClientBuilder {
+    /// Creates a `BitwardenSdkClient`.
+    ///
+    /// - Returns: A new `BitwardenSdkClient`.
+    ///
+    func buildClient() async -> BitwardenSdkClient
+}
+
+// MARK: - DefaultClientBuilder
+
+/// A default `ClientBuilder` implementation.
+///
+class DefaultClientBuilder: ClientBuilder {
+    // MARK: Properties
+
+    /// The service used by the application to manage the app's ID.
+    private let appIDService: AppIDService
+
+    /// The service used by the application to manage the environment settings.
+    private let environmentService: EnvironmentService
+
+    /// The token provider to pass to the SDK.
+    private let tokenProvider: ClientManagedTokens
+
+    /// The user agent builder to pass to the SDK.
+    private let userAgentBuilder: UserAgentBuilder
+
+    // MARK: Initialization
+
+    /// Initializes a new client.
+    ///
+    /// - Parameters:
+    ///   - appIDService: The service used by the application to manage the app's ID.
+    ///   - environmentService: The service used by the application to manage the environment settings.
+    ///   - tokenProvider: The token provider to pass to the SDK.
+    ///   - userAgentBuilder: The user agent builder used to construct the user agent string.
+    init(
+        appIDService: AppIDService,
+        environmentService: EnvironmentService,
+        tokenProvider: ClientManagedTokens,
+        userAgentBuilder: UserAgentBuilder,
+    ) {
+        self.appIDService = appIDService
+        self.environmentService = environmentService
+        self.tokenProvider = tokenProvider
+        self.userAgentBuilder = userAgentBuilder
+    }
+
+    // MARK: Methods
+
+    func buildClient() async -> BitwardenSdkClient {
+        let deviceIdentifier = await appIDService.getOrCreateAppID()
+        let settings = ClientSettings(
+            identityUrl: environmentService.identityURL.absoluteString,
+            apiUrl: environmentService.apiURL.absoluteString,
+            userAgent: userAgentBuilder.value,
+            deviceType: .iOs,
+            deviceIdentifier: deviceIdentifier,
+            bitwardenClientVersion: Bundle.main.appVersion,
+            bitwardenPackageType: nil,
+        )
+        return Client(tokenProvider: tokenProvider, settings: settings)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/ClientBuilderTests.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientBuilderTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenKitMocks
 import XCTest
 
@@ -6,8 +7,9 @@ import XCTest
 class ClientBuilderTests: BitwardenTestCase {
     // MARK: Properties
 
+    var appIDService: AppIDService!
     var clientManagedTokens: MockClientManagedTokens!
-    var errorReporter: MockErrorReporter!
+    var environmentService: MockEnvironmentService!
     var mockPlatform: MockPlatformClientService!
     var subject: DefaultClientBuilder!
 
@@ -16,29 +18,37 @@ class ClientBuilderTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        appIDService = AppIDService(appIDSettingsStore: MockAppIDSettingsStore())
         clientManagedTokens = MockClientManagedTokens()
-        errorReporter = MockErrorReporter()
+        environmentService = MockEnvironmentService()
         mockPlatform = MockPlatformClientService()
         subject = DefaultClientBuilder(
-            errorReporter: errorReporter,
+            appIDService: appIDService,
+            environmentService: environmentService,
             tokenProvider: clientManagedTokens,
+            userAgentBuilder: UserAgentBuilder(
+                appName: "TestApp",
+                appVersion: "1.0",
+                systemDevice: MockSystemDevice(),
+            ),
         )
     }
 
     override func tearDown() {
         super.tearDown()
 
+        appIDService = nil
         clientManagedTokens = nil
-        errorReporter = nil
+        environmentService = nil
         mockPlatform = nil
         subject = nil
     }
 
     // MARK: Tests
 
-    /// `buildClient(for:)` creates a client and loads feature flags.
-    func test_buildClient() {
-        let builtClient = subject.buildClient()
+    /// `buildClient(for:)` creates a client.
+    func test_buildClient() async {
+        let builtClient = await subject.buildClient()
 
         XCTAssertNotNil(builtClient)
         XCTAssertNotNil(mockPlatform.featureFlags)

--- a/BitwardenShared/Core/Platform/Services/ClientService.swift
+++ b/BitwardenShared/Core/Platform/Services/ClientService.swift
@@ -152,9 +152,6 @@ actor DefaultClientService: ClientService {
     /// The factory to create SDK repositories.
     private let sdkRepositoryFactory: SdkRepositoryFactory
 
-    /// Basic client behavior settings.
-    private let settings: ClientSettings?
-
     /// The service used by the application to manage account state.
     private let stateService: StateService
 
@@ -170,7 +167,6 @@ actor DefaultClientService: ClientService {
     ///   - configService: The service to get server-specified configuration.
     ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - sdkRepositoryFactory: The factory to create SDK repositories.
-    ///   - settings: The settings to apply to the client. Defaults to `nil`.
     ///   - stateService: The service used by the application to manage account state.
     ///
     init(
@@ -178,14 +174,12 @@ actor DefaultClientService: ClientService {
         configService: ConfigService,
         errorReporter: ErrorReporter,
         sdkRepositoryFactory: SdkRepositoryFactory,
-        settings: ClientSettings? = nil,
         stateService: StateService,
     ) {
         self.clientBuilder = clientBuilder
         self.configService = configService
         self.errorReporter = errorReporter
         self.sdkRepositoryFactory = sdkRepositoryFactory
-        self.settings = settings
         self.stateService = stateService
 
         Task {
@@ -254,7 +248,7 @@ actor DefaultClientService: ClientService {
         guard !isPreAuth else {
             // If this client is being used for a new user prior to authentication, a user ID doesn't
             // exist for the user to map the client to, so return a new client.
-            return clientBuilder.buildClient()
+            return await clientBuilder.buildClient()
         }
 
         do {
@@ -281,7 +275,7 @@ actor DefaultClientService: ClientService {
                         "set in this scenario.",
                 ),
             )
-            return clientBuilder.buildClient()
+            return await clientBuilder.buildClient()
         }
     }
 
@@ -304,8 +298,7 @@ actor DefaultClientService: ClientService {
     /// - Parameter userId: A user ID that the new client is being mapped to.
     ///
     private func createAndMapClient(for userId: String) async -> BitwardenSdkClient {
-        let client = clientBuilder.buildClient()
-
+        let client = await clientBuilder.buildClient()
         userClientArray.updateValue(client, forKey: userId)
         return client
     }
@@ -329,58 +322,6 @@ actor DefaultClientService: ClientService {
         } catch {
             errorReporter.log(error: error)
         }
-    }
-}
-
-// MARK: - ClientBuilder
-
-/// A protocol for creating a new `BitwardenSdkClient`.
-///
-protocol ClientBuilder {
-    /// Creates a `BitwardenSdkClient`.
-    /// - Returns: A new `BitwardenSdkClient`.
-    ///
-    func buildClient() -> BitwardenSdkClient
-}
-
-// MARK: DefaultClientBuilder
-
-/// A default `ClientBuilder` implementation.
-///
-class DefaultClientBuilder: ClientBuilder {
-    // MARK: Properties
-
-    /// The service used by the application to report non-fatal errors.
-    private let errorReporter: ErrorReporter
-
-    /// The settings applied to the client.
-    private let settings: ClientSettings?
-
-    /// The token provider to pass to the SDK.
-    private let tokenProvider: ClientManagedTokens
-
-    // MARK: Initialization
-
-    /// Initializes a new client.
-    ///
-    /// - Parameters:
-    ///   - errorReporter: The service used by the application to report non-fatal errors.
-    ///   - settings: The settings applied to the client.
-    ///   - tokenProvider: The token provider to pass to the SDK.
-    init(
-        errorReporter: ErrorReporter,
-        settings: ClientSettings? = nil,
-        tokenProvider: ClientManagedTokens,
-    ) {
-        self.errorReporter = errorReporter
-        self.settings = settings
-        self.tokenProvider = tokenProvider
-    }
-
-    // MARK: Methods
-
-    func buildClient() -> BitwardenSdkClient {
-        Client(tokenProvider: tokenProvider, settings: settings)
     }
 }
 
@@ -441,4 +382,4 @@ extension Client: BitwardenSdkClient {
     func vault() -> VaultClientService {
         vault() as VaultClient
     }
-} // swiftlint:disable:this file_length
+}

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -595,8 +595,10 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         )
 
         let clientBuilder = DefaultClientBuilder(
-            errorReporter: errorReporter,
+            appIDService: appIDService,
+            environmentService: environmentService,
             tokenProvider: tokenService,
+            userAgentBuilder: userAgentBuilder,
         )
         let sdkRepositoryFactory = DefaultSdkRepositoryFactory(
             cipherDataStore: dataStore,

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockClientBuilder.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockClientBuilder.swift
@@ -6,7 +6,7 @@ final class MockClientBuilder: ClientBuilder {
     var clients = [MockClient]()
     var setupClientOnCreation: ((MockClient) -> Void)?
 
-    func buildClient() -> BitwardenSdkClient {
+    func buildClient() async -> BitwardenSdkClient {
         let client = MockClient()
         if let setupClientOnCreation {
             setupClientOnCreation(client)

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
@@ -334,7 +334,7 @@ class SelfHostedProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(
             alert,
             .inputValidationAlert(error: InputValidationError(
-                message: Localizations.validationFieldRequired(Localizations.alias)
+                message: Localizations.validationFieldRequired(Localizations.alias),
             )),
         )
     }
@@ -351,7 +351,7 @@ class SelfHostedProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(
             alert,
             .inputValidationAlert(error: InputValidationError(
-                message: Localizations.validationFieldRequired(Localizations.password)
+                message: Localizations.validationFieldRequired(Localizations.password),
             )),
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35271](https://bitwarden.atlassian.net/browse/PM-35271)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

As part of the V2 encryption changes, the SDK is going to start making networking requests previously made by the app. In order to support this, the app needs to expose the environment URLs to the SDK.

When constructing the SDK, the URLs are provided in `ClientSettings`. This updates `DefaultClientBuilder` to gather the necessary values and provide a populated `ClientSettings` to the SDK.

[PM-35271]: https://bitwarden.atlassian.net/browse/PM-35271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ