### PR TITLE
[BWA-99] feat: Add next TOTP code preview to item list with opt-in se…

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -19,6 +19,9 @@ protocol AppSettingsStore: AnyObject {
     /// Whether to disable the website icons.
     var disableWebIcons: Bool { get set }
 
+    /// Whether to show the next TOTP code in the item list when the current code has ≤ 10 seconds remaining.
+    var showNextCode: Bool { get set }
+
     /// The default save location for new keys.
     var defaultSaveOption: DefaultSaveOption { get set }
 
@@ -294,6 +297,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case defaultSaveOption
         case disableWebIcons
         case flightRecorderData
+        case showNextCode
         case hasSeenWelcomeTutorial
         case hasSyncedAccount(name: String)
         case lastActiveTime(userId: String)
@@ -326,6 +330,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "disableFavicon"
             case .flightRecorderData:
                 "flightRecorderData"
+            case .showNextCode:
+                "showNextCode"
             case .hasSeenWelcomeTutorial:
                 "hasSeenWelcomeTutorial"
             case let .hasSyncedAccount(name: name):
@@ -360,6 +366,11 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
     var disableWebIcons: Bool {
         get { fetch(for: .disableWebIcons) }
         set { store(newValue, for: .disableWebIcons) }
+    }
+
+    var showNextCode: Bool {
+        get { fetch(for: .showNextCode) }
+        set { store(newValue, for: .showNextCode) }
     }
 
     var defaultSaveOption: DefaultSaveOption {

--- a/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -12,6 +12,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var appTheme: String?
     var disableWebIcons = false
     var defaultSaveOption: DefaultSaveOption = .none
+    var showNextCode = false
     var flightRecorderData: FlightRecorderData?
     var hasSeenDefaultSaveOptionPrompt = false
     var hasSeenWelcomeTutorial = false

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
@@ -351,7 +351,8 @@ extension DefaultAuthenticatorItemRepository: AuthenticatorItemRepository {
                 return item
             }
             let code = try await totpService.getTotpCode(for: keyModel)
-            return item.with(newTotpModel: code)
+            let nextCode = try? await totpService.getNextTotpCode(for: keyModel, currentCode: code)
+            return item.with(newTotpModel: code, nextTotpModel: nextCode)
         }
     }
 

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -213,6 +213,49 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertTrue(errorReporter.errors.isEmpty)
     }
 
+    /// `refreshTOTPCodes(on:)` populates the next TOTP code on successfully refreshed items.
+    func test_refreshTOTPCodes_populatesNextTotpCode() async throws {
+        let currentCodeModel = TOTPCodeModel(
+            code: "111111",
+            codeGenerationDate: timeProvider.presentTime,
+            period: 30,
+        )
+        let nextCodeModel = TOTPCodeModel(
+            code: "222222",
+            codeGenerationDate: timeProvider.presentTime.addingTimeInterval(30),
+            period: 30,
+        )
+        totpService.getTotpCodeResult = .success(currentCodeModel)
+        totpService.getNextTotpCodeResult = .success(nextCodeModel)
+
+        let item = ItemListItem.fixture()
+        let result = try await subject.refreshTOTPCodes(for: [item])
+        let actual = try XCTUnwrap(result.first)
+
+        XCTAssertEqual(actual.totpCodeModel, currentCodeModel)
+        XCTAssertEqual(actual.nextTotpCodeModel, nextCodeModel)
+    }
+
+    /// `refreshTOTPCodes(on:)` still returns the current code when next code generation fails,
+    /// and `nextTotpCodeModel` is `nil`.
+    func test_refreshTOTPCodes_nextCodeFailure_doesNotBlockCurrentCode() async throws {
+        let currentCodeModel = TOTPCodeModel(
+            code: "333333",
+            codeGenerationDate: timeProvider.presentTime,
+            period: 30,
+        )
+        totpService.getTotpCodeResult = .success(currentCodeModel)
+        totpService.getNextTotpCodeResult = .failure(BitwardenTestError.example)
+
+        let item = ItemListItem.fixture()
+        let result = try await subject.refreshTOTPCodes(for: [item])
+        let actual = try XCTUnwrap(result.first)
+
+        XCTAssertEqual(actual.totpCodeModel, currentCodeModel)
+        XCTAssertNil(actual.nextTotpCodeModel)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `saveTemporarySharedItem(_)` saves a temporary item into the Authenticator Bridge shared store.
     func test_saveTemporarySharedItem_success() async throws {
         let totpKey = "TOTP Key"

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
@@ -11,6 +11,14 @@ protocol TOTPService {
     ///
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel
 
+    /// Calculates the TOTP code for the period immediately following `currentCode`.
+    ///
+    /// - Parameters:
+    ///   - key: The `TOTPKeyModel` to generate a code for.
+    ///   - currentCode: The currently active code, used to determine the next period's start date.
+    ///
+    func getNextTotpCode(for key: TOTPKeyModel, currentCode: TOTPCodeModel) async throws -> TOTPCodeModel
+
     /// Retrieves the TOTP configuration for a given key.
     ///
     /// - Parameter key: A string representing the TOTP key.
@@ -57,6 +65,14 @@ extension DefaultTOTPService: TOTPService {
         try await clientService.vault().generateTOTPCode(
             for: key.rawAuthenticatorKey,
             date: timeProvider.presentTime,
+        )
+    }
+
+    func getNextTotpCode(for key: TOTPKeyModel, currentCode: TOTPCodeModel) async throws -> TOTPCodeModel {
+        let nextPeriodDate = timeProvider.presentTime.addingTimeInterval(Double(currentCode.period))
+        return try await clientService.vault().generateTOTPCode(
+            for: key.rawAuthenticatorKey,
+            date: nextPeriodDate,
         )
     }
 

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
@@ -69,4 +69,31 @@ final class TOTPServiceTests: BitwardenTestCase {
             )
         }
     }
+
+    /// `getNextTotpCode(for:currentCode:)` passes a date equal to `presentTime + period` to the SDK.
+    func test_getNextTotpCode_usesNextPeriodDate() async throws {
+        let fixedTime = Date(timeIntervalSince1970: 1000)
+        timeProvider.timeConfig = .mockTime(fixedTime)
+
+        let keyModel = try subject.getTOTPConfiguration(key: .base32Key)
+        let currentCode = TOTPCodeModel(code: "123456", codeGenerationDate: fixedTime, period: 30)
+
+        let result = try await subject.getNextTotpCode(for: keyModel, currentCode: currentCode)
+
+        XCTAssertEqual(result.codeGenerationDate, fixedTime.addingTimeInterval(30))
+    }
+
+    /// `getNextTotpCode(for:currentCode:)` respects non-standard periods.
+    func test_getNextTotpCode_usesNextPeriodDate_nonStandardPeriod() async throws {
+        let fixedTime = Date(timeIntervalSince1970: 2000)
+        timeProvider.timeConfig = .mockTime(fixedTime)
+        clientService.mockVault.totpPeriod = 60
+
+        let keyModel = try subject.getTOTPConfiguration(key: .base32Key)
+        let currentCode = TOTPCodeModel(code: "123456", codeGenerationDate: fixedTime, period: 60)
+
+        let result = try await subject.getNextTotpCode(for: keyModel, currentCode: currentCode)
+
+        XCTAssertEqual(result.codeGenerationDate, fixedTime.addingTimeInterval(60))
+    }
 }

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
@@ -9,12 +9,22 @@ class MockTOTPService: TOTPService {
     )
     var getTotpCodeConfig: TOTPKeyModel?
 
+    var getNextTotpCodeResult: Result<TOTPCodeModel, Error> = .success(
+        TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30),
+    )
+    var getNextTotpCodeConfig: TOTPKeyModel?
+
     var capturedKey: String?
     var getTOTPConfigResult: Result<TOTPKeyModel, Error> = .failure(TOTPKeyError.invalidKeyFormat)
 
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel {
         getTotpCodeConfig = key
         return try getTotpCodeResult.get()
+    }
+
+    func getNextTotpCode(for key: TOTPKeyModel, currentCode: TOTPCodeModel) async throws -> TOTPCodeModel {
+        getNextTotpCodeConfig = key
+        return try getNextTotpCodeResult.get()
     }
 
     func getTOTPConfiguration(key: String?) throws -> TOTPKeyModel {

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -33,6 +33,9 @@ enum SettingsAction: Equatable {
     /// The privacy policy button was tapped.
     case privacyPolicyTapped
 
+    /// The show next code toggle was changed.
+    case showNextCodeToggled(Bool)
+
     /// The sync with bitwarden app button was tapped.
     case syncWithBitwardenAppTapped
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -117,6 +117,9 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             coordinator.showAlert(.privacyPolicyAlert {
                 self.state.url = ExternalLinksConstants.privacyPolicy
             })
+        case let .showNextCodeToggled(isOn):
+            state.showNextCode = isOn
+            services.appSettingsStore.showNextCode = isOn
         case .syncWithBitwardenAppTapped:
             if services.application?.canOpenURL(ExternalLinksConstants.passwordManagerScheme) ?? false {
                 state.url = ExternalLinksConstants.passwordManagerSettings
@@ -161,6 +164,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         state.sessionTimeoutValue = loadTimeoutValue(biometricsEnabled: state.biometricUnlockStatus.isEnabled)
         state.shouldShowDefaultSaveOption = await services.authenticatorItemRepository.isPasswordManagerSyncActive()
         state.defaultSaveOption = services.appSettingsStore.defaultSaveOption
+        state.showNextCode = services.appSettingsStore.showNextCode
     }
 
     /// Load the Session Timeout Value.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -311,4 +311,41 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.passwordManagerLink)
     }
+
+    /// Performing `.loadData` sets `showNextCode` to `true` when the app settings store has it enabled.
+    @MainActor
+    func test_perform_loadData_showNextCode_true() async {
+        appSettingsStore.showNextCode = true
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
+    /// Performing `.loadData` sets `showNextCode` to `false` when the app settings store has it disabled.
+    @MainActor
+    func test_perform_loadData_showNextCode_false() async {
+        appSettingsStore.showNextCode = false
+        await subject.perform(.loadData)
+
+        XCTAssertFalse(subject.state.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(true)` sets state and persists the value.
+    @MainActor
+    func test_receive_showNextCodeToggled_true() {
+        subject.receive(.showNextCodeToggled(true))
+
+        XCTAssertTrue(subject.state.showNextCode)
+        XCTAssertTrue(appSettingsStore.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(false)` clears state and persists the value.
+    @MainActor
+    func test_receive_showNextCodeToggled_false() {
+        appSettingsStore.showNextCode = true
+        subject.receive(.showNextCodeToggled(false))
+
+        XCTAssertFalse(subject.state.showNextCode)
+        XCTAssertFalse(appSettingsStore.showNextCode)
+    }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -28,6 +28,9 @@ struct SettingsState: Equatable {
     /// The current default save option.
     var sessionTimeoutValue: SessionTimeoutValue = .never
 
+    /// Whether to show the next TOTP code in the item list.
+    var showNextCode: Bool = false
+
     /// A flag to indicate if we should show the default save option menu.
     var shouldShowDefaultSaveOption = false
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -117,6 +117,8 @@ struct SettingsView: View {
 
                 syncWithPasswordManagerRow
 
+                showNextCodeRow
+
                 if store.state.shouldShowDefaultSaveOption {
                     defaultSaveOption
                 }
@@ -192,6 +194,19 @@ struct SettingsView: View {
         default:
             EmptyView()
         }
+    }
+
+    /// The toggle row for showing the next TOTP code in the item list.
+    private var showNextCodeRow: some View {
+        BitwardenToggle(
+            Localizations.showNextCode,
+            footer: Localizations.seeIncomingCodesInTheList,
+            isOn: store.binding(
+                get: \.showNextCode,
+                send: SettingsAction.showNextCodeToggled,
+            ),
+            accessibilityIdentifier: "ShowNextCodeToggle",
+        )
     }
 
     /// The settings row for syncing with the Password Manager app.

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
@@ -46,6 +46,18 @@ extension ItemListItem {
     /// so that `code` is non-optional and always has a value.
     private static let defaultTotpCode = "123456"
 
+    /// The next `TOTPCodeModel` for the next period, if available.
+    var nextTotpCodeModel: TOTPCodeModel? {
+        switch itemType {
+        case let .sharedTotp(model):
+            model.nextTotpCode
+        case .syncError:
+            nil
+        case let .totp(model):
+            model.nextTotpCode
+        }
+    }
+
     /// The associated `TOTPCodeModel` if this item is an `itemType` with an associated code (i.e. `.totp`
     /// and `.sharedTotp`) or `nil` if there is no associated code (i.e. `.syncError`)
     var totpCodeModel: TOTPCodeModel? {
@@ -130,17 +142,20 @@ extension ItemListItem {
         )
     }
 
-    /// Make a new `ItemListItem` that is a copy of the existing one, but with an updated `TOTPCodeModel`.
+    /// Make a new `ItemListItem` that is a copy of the existing one, but with updated TOTP code models.
     ///
-    /// - Parameter newTotpModel: the new `TOTPCodeModel` to insert in this ItemListItem
+    /// - Parameters:
+    ///   - newTotpModel: The new current `TOTPCodeModel` to insert in this ItemListItem.
+    ///   - nextTotpModel: The next `TOTPCodeModel` for the upcoming period. Defaults to `nil`.
     /// - Returns: An exact copy of the data in the existing `ItemListItem`, but with the new
-    ///     `TOTPCodeModel` inserted into the itemType's model.
+    ///     TOTP code models inserted into the itemType's model.
     ///
-    public func with(newTotpModel: TOTPCodeModel) -> ItemListItem {
+    public func with(newTotpModel: TOTPCodeModel, nextTotpModel: TOTPCodeModel? = nil) -> ItemListItem {
         switch itemType {
         case let .sharedTotp(oldModel):
             var updatedModel = oldModel
             updatedModel.totpCode = newTotpModel
+            updatedModel.nextTotpCode = nextTotpModel
             return ItemListItem(
                 id: id,
                 name: name,
@@ -152,6 +167,7 @@ extension ItemListItem {
         case let .totp(oldModel):
             var updatedModel = oldModel
             updatedModel.totpCode = newTotpModel
+            updatedModel.nextTotpCode = nextTotpModel
             return ItemListItem(
                 id: id,
                 name: name,
@@ -192,6 +208,9 @@ public struct ItemListTotpItem: Equatable {
     /// The `AuthenticatorItemView` used to populate the view
     let itemView: AuthenticatorItemView
 
+    /// The next TOTP code for the item, valid for the period immediately after `totpCode` expires.
+    var nextTotpCode: TOTPCodeModel?
+
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
 }
@@ -201,6 +220,9 @@ public struct ItemListTotpItem: Equatable {
 public struct ItemListSharedTotpItem: Equatable {
     /// The `AuthenticatorBridgeItemDataView` used to populate the view
     let itemView: AuthenticatorBridgeItemDataView
+
+    /// The next TOTP code for the item, valid for the period immediately after `totpCode` expires.
+    var nextTotpCode: TOTPCodeModel?
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -80,6 +80,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
         case .addItemPressed:
             await setupTotp()
         case .appeared:
+            state.showNextCode = services.appSettingsStore.showNextCode
             await determineItemListCardState()
             await streamItemList()
         case let .closeCard(card):

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -1293,4 +1293,30 @@ class ItemListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         XCTAssertEqual(subject.state.itemListCardState, .none)
     }
+
+    /// `perform(_:)` with `.appeared` sets `showNextCode` to `true` when enabled in app settings.
+    @MainActor
+    func test_perform_appeared_showNextCode_true() {
+        appSettingsStore.showNextCode = true
+        let task = Task {
+            await self.subject.perform(.appeared)
+        }
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
+    /// `perform(_:)` with `.appeared` sets `showNextCode` to `false` when disabled in app settings.
+    @MainActor
+    func test_perform_appeared_showNextCode_false() {
+        appSettingsStore.showNextCode = false
+        let task = Task {
+            await self.subject.perform(.appeared)
+        }
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertFalse(subject.state.showNextCode)
+    }
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
@@ -45,6 +45,9 @@ struct ItemListState: Equatable {
     /// Whether to show the Move to Bitwarden button on local items.
     var showMoveToBitwarden = false
 
+    /// Whether to show the next TOTP code in item rows when the current code has ≤ 10 seconds remaining.
+    var showNextCode = false
+
     /// Whether to show the special web icons.
     var showWebIcons = true
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -325,6 +325,7 @@ private struct SearchableItemListView: View { // swiftlint:disable:this type_bod
                         iconBaseURL: state.iconBaseURL,
                         item: item,
                         hasDivider: !isLastInSection,
+                        showNextCode: state.showNextCode,
                         showWebIcons: state.showWebIcons,
                     )
                 },

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
@@ -15,6 +15,9 @@ struct ItemListItemRowState {
     /// A flag indicating if this row should display a divider on the bottom edge.
     var hasDivider: Bool
 
+    /// Whether to show the next TOTP code when the current code has ≤ 10 seconds remaining.
+    var showNextCode: Bool
+
     /// Whether to show the special web icons.
     var showWebIcons: Bool
 }

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
@@ -9,6 +9,9 @@ import SwiftUI
 struct ItemListItemRowView: View {
     // MARK: Properties
 
+    /// Whether the next code preview should currently be visible based on the countdown timer.
+    @State private var shouldShowNextCode = false
+
     /// The `Store` for this view.
     var store: Store<
         ItemListItemRowState,
@@ -105,9 +108,38 @@ struct ItemListItemRowView: View {
             totpCode: model,
             onExpiration: nil,
         )
-        Text(model.displayCode)
-            .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
-            .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+        codeColumn(model: model)
+    }
+
+    /// A vertical stack showing the current code and, when conditions are met, the next code preview.
+    @ViewBuilder
+    private func codeColumn(model: TOTPCodeModel) -> some View {
+        VStack(alignment: .trailing, spacing: 2) {
+            Text(model.displayCode)
+                .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
+                .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+            if store.state.showNextCode,
+               shouldShowNextCode,
+               let nextCode = store.state.item.nextTotpCodeModel {
+                Text(nextCode.displayCode)
+                    .styleGuide(.subheadline, monoSpacedDigit: true)
+                    .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                    .accessibilityLabel(
+                        Localizations.showNextCode + ": "
+                            + nextCode.code.map(String.init).joined(separator: " "),
+                    )
+            }
+        }
+        .task(id: model.codeGenerationDate) {
+            while !Task.isCancelled {
+                let seconds = TOTPExpirationCalculator.remainingSeconds(
+                    for: timeProvider.presentTime,
+                    using: Int(model.period),
+                )
+                shouldShowNextCode = seconds <= TOTPCountdownTimer.nextCodeRevealThreshold
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
     }
 }
 
@@ -133,6 +165,7 @@ struct ItemListItemRowView: View {
                         ),
                     ),
                     hasDivider: true,
+                    showNextCode: false,
                     showWebIcons: true,
                 ),
             ),
@@ -162,6 +195,7 @@ struct ItemListItemRowView: View {
                         ),
                     ),
                     hasDivider: true,
+                    showNextCode: false,
                     showWebIcons: true,
                 ),
             ),
@@ -191,6 +225,7 @@ struct ItemListItemRowView: View {
                         ),
                     ),
                     hasDivider: true,
+                    showNextCode: false,
                     showWebIcons: true,
                 ),
             ),
@@ -210,6 +245,7 @@ struct ItemListItemRow_Previews: PreviewProvider {
                                 state: ItemListItemRowState(
                                     item: item,
                                     hasDivider: true,
+                                    showNextCode: false,
                                     showWebIcons: true,
                                 ),
                             ),
@@ -230,6 +266,7 @@ struct ItemListItemRow_Previews: PreviewProvider {
                                 state: ItemListItemRowState(
                                     item: item,
                                     hasDivider: true,
+                                    showNextCode: false,
                                     showWebIcons: true,
                                 ),
                             ),

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
@@ -7,6 +7,11 @@ import SwiftUI
 ///     Used to manage the state for a `TOTPCountdownTimerView`.
 ///
 class TOTPCountdownTimer: ObservableObject {
+    // MARK: Static Properties
+
+    /// The number of seconds remaining on the current code at which the next code preview is revealed.
+    static let nextCodeRevealThreshold = 10
+
     // MARK: Public Properties
 
     /// A `@Published` string representing the number of seconds remaining for a TOTP code.

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -241,7 +241,9 @@
 "ZipPostalCode" = "Zip / Postal code";
 "Address" = "Address";
 "Expiration" = "Expiration";
+"ShowNextCode" = "Show next code";
 "ShowWebsiteIcons" = "Show website icons";
+"SeeIncomingCodesInTheList" = "See incoming codes in the list";
 "ShowWebsiteIconsDescription" = "Show a recognizable image next to each login.";
 "IconsUrl" = "Icons server URL";
 "AutofillWithBitwarden" = "Autofill with Bitwarden";


### PR DESCRIPTION
…tting

  When "Show next code" is enabled in Settings, each item list row reveals
  the upcoming TOTP code (in a smaller, secondary style) during the final
  10 seconds of the current code's period. The setting defaults to off and
  is persisted to UserDefaults. Next code generation is best-effort and
  does not block display of the current code on failure.

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
