### PR TITLE
[BWA-99] feat: add show next TOTP code setting and preview in item list

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -19,6 +19,9 @@ protocol AppSettingsStore: AnyObject {
     /// Whether to disable the website icons.
     var disableWebIcons: Bool { get set }
 
+    /// Whether to show the next TOTP code in the item list.
+    var showNextCode: Bool { get set }
+
     /// The default save location for new keys.
     var defaultSaveOption: DefaultSaveOption { get set }
 
@@ -294,6 +297,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case defaultSaveOption
         case disableWebIcons
         case flightRecorderData
+        case showNextCode
         case hasSeenWelcomeTutorial
         case hasSyncedAccount(name: String)
         case lastActiveTime(userId: String)
@@ -324,6 +328,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "defaultSaveOption"
             case .disableWebIcons:
                 "disableFavicon"
+            case .showNextCode:
+                "showNextCode"
             case .flightRecorderData:
                 "flightRecorderData"
             case .hasSeenWelcomeTutorial:
@@ -360,6 +366,11 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
     var disableWebIcons: Bool {
         get { fetch(for: .disableWebIcons) }
         set { store(newValue, for: .disableWebIcons) }
+    }
+
+    var showNextCode: Bool {
+        get { fetch(for: .showNextCode) }
+        set { store(newValue, for: .showNextCode) }
     }
 
     var defaultSaveOption: DefaultSaveOption {

--- a/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -11,6 +11,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var appLocale: String?
     var appTheme: String?
     var disableWebIcons = false
+    var showNextCode = false
     var defaultSaveOption: DefaultSaveOption = .none
     var flightRecorderData: FlightRecorderData?
     var hasSeenDefaultSaveOptionPrompt = false

--- a/AuthenticatorShared/Core/Vault/Models/Domain/Fixtures/ItemListItem+Fixtures.swift
+++ b/AuthenticatorShared/Core/Vault/Models/Domain/Fixtures/ItemListItem+Fixtures.swift
@@ -55,10 +55,12 @@ public extension ItemListTotpItem {
             codeGenerationDate: Date(),
             period: 30,
         ),
+        nextTotpCode: TOTPCodeModel? = nil,
     ) -> ItemListTotpItem {
         ItemListTotpItem(
             itemView: itemView,
             totpCode: totpCode,
+            nextTotpCode: nextTotpCode,
         )
     }
 }
@@ -71,10 +73,12 @@ public extension ItemListSharedTotpItem {
             codeGenerationDate: Date(),
             period: 30,
         ),
+        nextTotpCode: TOTPCodeModel? = nil,
     ) -> ItemListSharedTotpItem {
         ItemListSharedTotpItem(
             itemView: itemView,
             totpCode: totpCode,
+            nextTotpCode: nextTotpCode,
         )
     }
 }

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
@@ -357,7 +357,13 @@ extension DefaultAuthenticatorItemRepository: AuthenticatorItemRepository {
                     using: Double(keyModel.period),
                 ),
             )
-            let nextCode = try? await totpService.getTotpCode(for: keyModel, date: nextPeriodDate)
+            let nextCode: TOTPCodeModel?
+            do {
+                nextCode = try await totpService.getTotpCode(for: keyModel, date: nextPeriodDate)
+            } catch {
+                errorReporter.log(error: error)
+                nextCode = nil
+            }
             return item.with(newTotpModel: code, nextTotpModel: nextCode)
         }
     }

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
@@ -351,7 +351,14 @@ extension DefaultAuthenticatorItemRepository: AuthenticatorItemRepository {
                 return item
             }
             let code = try await totpService.getTotpCode(for: keyModel)
-            return item.with(newTotpModel: code)
+            let nextPeriodDate = timeProvider.presentTime.addingTimeInterval(
+                TOTPExpirationCalculator.timeRemaining(
+                    for: timeProvider.presentTime,
+                    using: Double(keyModel.period),
+                ),
+            )
+            let nextCode = try? await totpService.getTotpCode(for: keyModel, date: nextPeriodDate)
+            return item.with(newTotpModel: code, nextTotpModel: nextCode)
         }
     }
 

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -179,6 +179,42 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertEqual(actual.accountName, item.accountName)
     }
 
+    /// `refreshTOTPCodes(for:)` returns items with both the current and next TOTP codes populated.
+    func test_refreshTOTPCodes_success_includesNextCode() async throws {
+        let currentCode = "123456"
+        let nextCode = "654321"
+        totpService.getTotpCodeResult = .success(
+            TOTPCodeModel(code: currentCode, codeGenerationDate: timeProvider.presentTime, period: 30)
+        )
+        totpService.getTotpCodeAtDateResult = .success(
+            TOTPCodeModel(code: nextCode, codeGenerationDate: timeProvider.presentTime, period: 30)
+        )
+
+        let item = ItemListItem.fixture()
+        let result = try await subject.refreshTOTPCodes(for: [item])
+        let actual = try XCTUnwrap(result[0])
+
+        XCTAssertEqual(actual.totpCodeModel?.code, currentCode)
+        XCTAssertEqual(actual.nextTotpCodeModel?.code, nextCode)
+        XCTAssertNotNil(totpService.capturedDate)
+    }
+
+    /// `refreshTOTPCodes(for:)` returns items with only the current code when next-code generation fails.
+    func test_refreshTOTPCodes_nextCodeFails_returnsCurrentCodeOnly() async throws {
+        totpService.getTotpCodeResult = .success(
+            TOTPCodeModel(code: "123456", codeGenerationDate: timeProvider.presentTime, period: 30)
+        )
+        totpService.getTotpCodeAtDateResult = .failure(TOTPServiceError.unableToGenerateCode("next code error"))
+
+        let item = ItemListItem.fixture()
+        let result = try await subject.refreshTOTPCodes(for: [item])
+        let actual = try XCTUnwrap(result[0])
+
+        XCTAssertNotNil(actual.totpCodeModel)
+        XCTAssertNil(actual.nextTotpCodeModel)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `refreshTOTPCodes(on:)` updates the TOTP codes on items.
     func test_refreshTOTPCodes_success() async throws {
         let newCode = "987654"

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -184,10 +184,10 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
         let currentCode = "123456"
         let nextCode = "654321"
         totpService.getTotpCodeResult = .success(
-            TOTPCodeModel(code: currentCode, codeGenerationDate: timeProvider.presentTime, period: 30)
+            TOTPCodeModel(code: currentCode, codeGenerationDate: timeProvider.presentTime, period: 30),
         )
         totpService.getTotpCodeAtDateResult = .success(
-            TOTPCodeModel(code: nextCode, codeGenerationDate: timeProvider.presentTime, period: 30)
+            TOTPCodeModel(code: nextCode, codeGenerationDate: timeProvider.presentTime, period: 30),
         )
 
         let item = ItemListItem.fixture()
@@ -202,7 +202,7 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
     /// `refreshTOTPCodes(for:)` returns items with only the current code when next-code generation fails.
     func test_refreshTOTPCodes_nextCodeFails_returnsCurrentCodeOnly() async throws {
         totpService.getTotpCodeResult = .success(
-            TOTPCodeModel(code: "123456", codeGenerationDate: timeProvider.presentTime, period: 30)
+            TOTPCodeModel(code: "123456", codeGenerationDate: timeProvider.presentTime, period: 30),
         )
         totpService.getTotpCodeAtDateResult = .failure(TOTPServiceError.unableToGenerateCode("next code error"))
 
@@ -212,7 +212,7 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
 
         XCTAssertNotNil(actual.totpCodeModel)
         XCTAssertNil(actual.nextTotpCodeModel)
-        XCTAssertTrue(errorReporter.errors.isEmpty)
+        XCTAssertFalse(errorReporter.errors.isEmpty)
     }
 
     /// `refreshTOTPCodes(on:)` updates the TOTP codes on items.

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
@@ -11,6 +11,14 @@ protocol TOTPService {
     ///
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel
 
+    /// Calculates the TOTP code for a given key at a specific date.
+    ///
+    /// - Parameters:
+    ///   - key: The `TOTPKeyModel` to generate a code for
+    ///   - date: The date for which to generate the code
+    ///
+    func getTotpCode(for key: TOTPKeyModel, date: Date) async throws -> TOTPCodeModel
+
     /// Retrieves the TOTP configuration for a given key.
     ///
     /// - Parameter key: A string representing the TOTP key.
@@ -57,6 +65,13 @@ extension DefaultTOTPService: TOTPService {
         try await clientService.vault().generateTOTPCode(
             for: key.rawAuthenticatorKey,
             date: timeProvider.presentTime,
+        )
+    }
+
+    func getTotpCode(for key: TOTPKeyModel, date: Date) async throws -> TOTPCodeModel {
+        try await clientService.vault().generateTOTPCode(
+            for: key.rawAuthenticatorKey,
+            date: date,
         )
     }
 

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
@@ -69,4 +69,16 @@ final class TOTPServiceTests: BitwardenTestCase {
             )
         }
     }
+
+    /// `getTotpCode(for:date:)` generates a code using the provided date, not the current time.
+    func test_getTotpCode_withExplicitDate() async throws {
+        let specificDate = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        clientService.mockVault.generateTOTPCodeResult = .success("654321")
+        let key = try subject.getTOTPConfiguration(key: .base32Key)
+
+        let result = try await subject.getTotpCode(for: key, date: specificDate)
+
+        XCTAssertEqual(result.code, "654321")
+        XCTAssertEqual(result.codeGenerationDate, specificDate)
+    }
 }

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
@@ -9,12 +9,24 @@ class MockTOTPService: TOTPService {
     )
     var getTotpCodeConfig: TOTPKeyModel?
 
+    var getTotpCodeAtDateResult: Result<TOTPCodeModel, Error> = .success(
+        TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30),
+    )
+    var getTotpCodeAtDateConfig: TOTPKeyModel?
+    var capturedDate: Date?
+
     var capturedKey: String?
     var getTOTPConfigResult: Result<TOTPKeyModel, Error> = .failure(TOTPKeyError.invalidKeyFormat)
 
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel {
         getTotpCodeConfig = key
         return try getTotpCodeResult.get()
+    }
+
+    func getTotpCode(for key: TOTPKeyModel, date: Date) async throws -> TOTPCodeModel {
+        getTotpCodeAtDateConfig = key
+        capturedDate = date
+        return try getTotpCodeAtDateResult.get()
     }
 
     func getTOTPConfiguration(key: String?) throws -> TOTPKeyModel {

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -33,6 +33,9 @@ enum SettingsAction: Equatable {
     /// The privacy policy button was tapped.
     case privacyPolicyTapped
 
+    /// The show next code toggle was changed.
+    case showNextCodeToggled(Bool)
+
     /// The sync with bitwarden app button was tapped.
     case syncWithBitwardenAppTapped
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -117,6 +117,9 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             coordinator.showAlert(.privacyPolicyAlert {
                 self.state.url = ExternalLinksConstants.privacyPolicy
             })
+        case let .showNextCodeToggled(isOn):
+            state.showNextCode = isOn
+            services.appSettingsStore.showNextCode = isOn
         case .syncWithBitwardenAppTapped:
             if services.application?.canOpenURL(ExternalLinksConstants.passwordManagerScheme) ?? false {
                 state.url = ExternalLinksConstants.passwordManagerSettings
@@ -161,6 +164,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         state.sessionTimeoutValue = loadTimeoutValue(biometricsEnabled: state.biometricUnlockStatus.isEnabled)
         state.shouldShowDefaultSaveOption = await services.authenticatorItemRepository.isPasswordManagerSyncActive()
         state.defaultSaveOption = services.appSettingsStore.defaultSaveOption
+        state.showNextCode = services.appSettingsStore.showNextCode
     }
 
     /// Load the Session Timeout Value.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -311,4 +311,36 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.passwordManagerLink)
     }
+
+    /// Performing `.loadData` loads the current `showNextCode` value from `AppSettingsStore`.
+    @MainActor
+    func test_perform_loadData_loadsShowNextCode() async {
+        appSettingsStore.showNextCode = true
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(true)` updates both state and the settings store.
+    @MainActor
+    func test_receive_showNextCodeToggled_updatesStateAndStore() {
+        XCTAssertFalse(subject.state.showNextCode)
+
+        subject.receive(.showNextCodeToggled(true))
+
+        XCTAssertTrue(subject.state.showNextCode)
+        XCTAssertTrue(appSettingsStore.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(false)` turns the setting off.
+    @MainActor
+    func test_receive_showNextCodeToggled_off() {
+        appSettingsStore.showNextCode = true
+        subject.state.showNextCode = true
+
+        subject.receive(.showNextCodeToggled(false))
+
+        XCTAssertFalse(subject.state.showNextCode)
+        XCTAssertFalse(appSettingsStore.showNextCode)
+    }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -28,6 +28,9 @@ struct SettingsState: Equatable {
     /// The current default save option.
     var sessionTimeoutValue: SessionTimeoutValue = .never
 
+    /// Whether to show the next TOTP code in the item list.
+    var showNextCode = false
+
     /// A flag to indicate if we should show the default save option menu.
     var shouldShowDefaultSaveOption = false
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -120,6 +120,22 @@ struct SettingsView: View {
                 if store.state.shouldShowDefaultSaveOption {
                     defaultSaveOption
                 }
+
+                BitwardenToggle(
+                    isOn: store.binding(
+                        get: \.showNextCode,
+                        send: SettingsAction.showNextCodeToggled,
+                    ),
+                    accessibilityIdentifier: "ShowNextCodeSwitch",
+                    accessibilityLabel: Localizations.showNextCode,
+                ) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(Localizations.showNextCode)
+                        Text(Localizations.showNextCodeDescription)
+                            .styleGuide(.subheadline)
+                            .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                    }
+                }
             }
         }
     }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
@@ -59,6 +59,18 @@ extension ItemListItem {
         }
     }
 
+    /// The associated next-period `TOTPCodeModel`, or `nil` if not yet computed or unavailable.
+    var nextTotpCodeModel: TOTPCodeModel? {
+        switch itemType {
+        case let .sharedTotp(model):
+            model.nextTotpCode
+        case .syncError:
+            nil
+        case let .totp(model):
+            model.nextTotpCode
+        }
+    }
+
     /// Initialize an `ItemListItem` from an `AuthenticatorItemView`
     ///
     /// - Parameters:
@@ -132,15 +144,18 @@ extension ItemListItem {
 
     /// Make a new `ItemListItem` that is a copy of the existing one, but with an updated `TOTPCodeModel`.
     ///
-    /// - Parameter newTotpModel: the new `TOTPCodeModel` to insert in this ItemListItem
+    /// - Parameters:
+    ///   - newTotpModel: The new current `TOTPCodeModel` to insert in this `ItemListItem`.
+    ///   - nextTotpModel: The optional next-period `TOTPCodeModel` to insert. Defaults to `nil`.
     /// - Returns: An exact copy of the data in the existing `ItemListItem`, but with the new
     ///     `TOTPCodeModel` inserted into the itemType's model.
     ///
-    public func with(newTotpModel: TOTPCodeModel) -> ItemListItem {
+    public func with(newTotpModel: TOTPCodeModel, nextTotpModel: TOTPCodeModel? = nil) -> ItemListItem {
         switch itemType {
         case let .sharedTotp(oldModel):
             var updatedModel = oldModel
             updatedModel.totpCode = newTotpModel
+            updatedModel.nextTotpCode = nextTotpModel
             return ItemListItem(
                 id: id,
                 name: name,
@@ -152,6 +167,7 @@ extension ItemListItem {
         case let .totp(oldModel):
             var updatedModel = oldModel
             updatedModel.totpCode = newTotpModel
+            updatedModel.nextTotpCode = nextTotpModel
             return ItemListItem(
                 id: id,
                 name: name,
@@ -194,6 +210,9 @@ public struct ItemListTotpItem: Equatable {
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
+
+    /// The next-period TOTP code, pre-computed at refresh time.
+    var nextTotpCode: TOTPCodeModel?
 }
 
 // MARK: - ItemListSharedTotpItem
@@ -204,4 +223,7 @@ public struct ItemListSharedTotpItem: Equatable {
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
+
+    /// The next-period TOTP code, pre-computed at refresh time.
+    var nextTotpCode: TOTPCodeModel?
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItemTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItemTests.swift
@@ -81,4 +81,51 @@ class ItemListItemTests: BitwardenTestCase {
         let newItem = subject.with(newTotpModel: newModel)
         XCTAssertEqual(newItem.totpCodeModel, newModel)
     }
+
+    /// `nextTotpCodeModel` returns the next code for a `.sharedTotp` item.
+    func test_nextTotpCodeModel_sharedTotp() {
+        let nextCode = TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30)
+        subject = .fixtureShared(totp: .fixture(nextTotpCode: nextCode))
+
+        XCTAssertEqual(subject.nextTotpCodeModel, nextCode)
+    }
+
+    /// `nextTotpCodeModel` returns the next code for a `.totp` item.
+    func test_nextTotpCodeModel_totp() {
+        let nextCode = TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30)
+        subject = .fixture(totp: .fixture(nextTotpCode: nextCode))
+
+        XCTAssertEqual(subject.nextTotpCodeModel, nextCode)
+    }
+
+    /// `nextTotpCodeModel` returns `nil` when no next code is set.
+    func test_nextTotpCodeModel_nil() {
+        subject = .fixture()
+
+        XCTAssertNil(subject.nextTotpCodeModel)
+    }
+
+    /// `with(newTotpModel:nextTotpModel:)` updates both the current and next TOTP codes.
+    func test_with_updatesNextTotpModel() {
+        subject = .fixture()
+        let newModel = TOTPCodeModel(code: "111111", codeGenerationDate: Date(), period: 30)
+        let nextModel = TOTPCodeModel(code: "222222", codeGenerationDate: Date(), period: 30)
+
+        let newItem = subject.with(newTotpModel: newModel, nextTotpModel: nextModel)
+
+        XCTAssertEqual(newItem.totpCodeModel, newModel)
+        XCTAssertEqual(newItem.nextTotpCodeModel, nextModel)
+    }
+
+    /// `with(newTotpModel:)` leaves `nextTotpCodeModel` nil when `nextTotpModel` is omitted.
+    func test_with_nextTotpModelDefaultsToNil() {
+        let nextCode = TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30)
+        subject = .fixture(totp: .fixture(nextTotpCode: nextCode))
+        let newModel = TOTPCodeModel(code: "111111", codeGenerationDate: Date(), period: 30)
+
+        let newItem = subject.with(newTotpModel: newModel)
+
+        XCTAssertEqual(newItem.totpCodeModel, newModel)
+        XCTAssertNil(newItem.nextTotpCodeModel)
+    }
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -107,6 +107,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
             guard case let .totp(model) = item.itemType else { return }
             await moveItemToBitwarden(item: model.itemView)
         case .refresh:
+            state.showNextCode = services.appSettingsStore.showNextCode
             await determineItemListCardState()
             await streamItemList()
         case let .search(text):

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -80,6 +80,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
         case .addItemPressed:
             await setupTotp()
         case .appeared:
+            state.showNextCode = services.appSettingsStore.showNextCode
             await determineItemListCardState()
             await streamItemList()
         case let .closeCard(card):

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -144,6 +144,22 @@ class ItemListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(coordinator.routes, [.setupTotpManual])
     }
 
+    /// `perform(_:)` with `.appeared` loads the `showNextCode` setting from `AppSettingsStore`.
+    @MainActor
+    func test_perform_appeared_loadsShowNextCodeSetting() {
+        appSettingsStore.showNextCode = true
+        authItemRepository.itemListSubject.send([])
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
     /// `perform(_:)` with `.appeared` starts streaming vault items.
     @MainActor
     func test_perform_appeared() {

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
@@ -45,6 +45,9 @@ struct ItemListState: Equatable {
     /// Whether to show the Move to Bitwarden button on local items.
     var showMoveToBitwarden = false
 
+    /// Whether to show the next TOTP code in each row (when ≤ 10s remaining).
+    var showNextCode = false
+
     /// Whether to show the special web icons.
     var showWebIcons = true
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -325,6 +325,7 @@ private struct SearchableItemListView: View { // swiftlint:disable:this type_bod
                         iconBaseURL: state.iconBaseURL,
                         item: item,
                         hasDivider: !isLastInSection,
+                        showNextCode: state.showNextCode,
                         showWebIcons: state.showWebIcons,
                     )
                 },

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
@@ -15,6 +15,9 @@ struct ItemListItemRowState {
     /// A flag indicating if this row should display a divider on the bottom edge.
     var hasDivider: Bool
 
+    /// Whether to show the next TOTP code (feature flag).
+    var showNextCode = false
+
     /// Whether to show the special web icons.
     var showWebIcons: Bool
 }

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
@@ -19,6 +19,14 @@ struct ItemListItemRowView: View {
     /// The `TimeProvider` used to calculate TOTP expiration.
     var timeProvider: any TimeProvider
 
+    // MARK: Private Properties
+
+    /// The remaining-seconds threshold at which the next code becomes visible.
+    private let nextCodeThreshold = 10
+
+    /// Whether the next TOTP code should currently be shown based on remaining time.
+    @State private var showNextCode = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 16) {
@@ -51,6 +59,17 @@ struct ItemListItemRowView: View {
                 Divider()
                     .padding(.leading, 22 + 16 + 16)
             }
+        }
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
+            guard store.state.showNextCode,
+                  let model = store.state.item.totpCodeModel else { return }
+            showNextCode = TOTPExpirationCalculator.remainingSeconds(
+                for: timeProvider.presentTime,
+                using: Int(model.period),
+            ) <= nextCodeThreshold
+        }
+        .onChange(of: store.state.item.totpCodeModel) { _ in
+            showNextCode = false
         }
     }
 
@@ -105,9 +124,17 @@ struct ItemListItemRowView: View {
             totpCode: model,
             onExpiration: nil,
         )
-        Text(model.displayCode)
-            .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
-            .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+        VStack(alignment: .trailing, spacing: 0) {
+            Text(model.displayCode)
+                .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
+                .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+            if showNextCode, let nextCode = store.state.item.nextTotpCodeModel {
+                Text(nextCode.displayCode)
+                    .styleGuide(.subheadline, weight: .regular, monoSpacedDigit: true)
+                    .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                    .accessibilityLabel(Localizations.nextVerificationCode + ": " + nextCode.displayCode)
+            }
+        }
     }
 }
 

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
@@ -22,10 +22,10 @@ struct ItemListItemRowView: View {
     // MARK: Private Properties
 
     /// The remaining-seconds threshold at which the next code becomes visible.
-    private let nextCodeThreshold = 10
+    private static let nextCodeThreshold = 10
 
     /// Whether the next TOTP code should currently be shown based on remaining time.
-    @State private var showNextCode = false
+    @State private var nextCodeVisible = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -63,13 +63,13 @@ struct ItemListItemRowView: View {
         .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { _ in
             guard store.state.showNextCode,
                   let model = store.state.item.totpCodeModel else { return }
-            showNextCode = TOTPExpirationCalculator.remainingSeconds(
+            nextCodeVisible = TOTPExpirationCalculator.remainingSeconds(
                 for: timeProvider.presentTime,
                 using: Int(model.period),
-            ) <= nextCodeThreshold
+            ) <= Self.nextCodeThreshold
         }
         .onChange(of: store.state.item.totpCodeModel) { _ in
-            showNextCode = false
+            nextCodeVisible = false
         }
     }
 
@@ -128,7 +128,7 @@ struct ItemListItemRowView: View {
             Text(model.displayCode)
                 .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
                 .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
-            if showNextCode, let nextCode = store.state.item.nextTotpCodeModel {
+            if nextCodeVisible, let nextCode = store.state.item.nextTotpCodeModel {
                 Text(nextCode.displayCode)
                     .styleGuide(.subheadline, weight: .regular, monoSpacedDigit: true)
                     .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -241,6 +241,9 @@
 "ZipPostalCode" = "Zip / Postal code";
 "Address" = "Address";
 "Expiration" = "Expiration";
+"NextVerificationCode" = "Next verification code";
+"ShowNextCode" = "Show next code";
+"ShowNextCodeDescription" = "See incoming codes in the list";
 "ShowWebsiteIcons" = "Show website icons";
 "ShowWebsiteIconsDescription" = "Show a recognizable image next to each login.";
 "IconsUrl" = "Icons server URL";


### PR DESCRIPTION
## 🎟️ Tracking
[BWA-99](https://bitwarden.atlassian.net/browse/BWA-99)

## 📔 Objective
Adds an opt-in "Show next code" toggle in Settings (Vault section) that, when enabled, displays the upcoming TOTP code below the current one in the verification codes list once ≤ 10 seconds remain on the current code. The next code is pre-computed at each refresh and shown in a smaller secondary style with no label, matching the Figma design. The feature is off by default.

## 📸 Screenshots
| Setting off (> 10s) | Setting on (≤ 10s) | Settings toggle |
|---|---|---|
| Current behavior unchanged | Next code appears below current code in secondary style | Toggle in Vault section with subtitle |

[BWA-99]: https://bitwarden.atlassian.net/browse/BWA-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ