### PR TITLE
[BWA-99] feat: add next TOTP code preview to item list when countdown is near expiry

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -19,6 +19,9 @@ protocol AppSettingsStore: AnyObject {
     /// Whether to disable the website icons.
     var disableWebIcons: Bool { get set }
 
+    /// Whether to show the next TOTP code in the item list when the current code is about to expire.
+    var showNextCode: Bool { get set }
+
     /// The default save location for new keys.
     var defaultSaveOption: DefaultSaveOption { get set }
 
@@ -293,6 +296,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case debugFeatureFlag(name: String)
         case defaultSaveOption
         case disableWebIcons
+        case showNextCode
         case flightRecorderData
         case hasSeenWelcomeTutorial
         case hasSyncedAccount(name: String)
@@ -324,6 +328,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "defaultSaveOption"
             case .disableWebIcons:
                 "disableFavicon"
+            case .showNextCode:
+                "showNextCode"
             case .flightRecorderData:
                 "flightRecorderData"
             case .hasSeenWelcomeTutorial:
@@ -360,6 +366,11 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
     var disableWebIcons: Bool {
         get { fetch(for: .disableWebIcons) }
         set { store(newValue, for: .disableWebIcons) }
+    }
+
+    var showNextCode: Bool {
+        get { fetch(for: .showNextCode) }
+        set { store(newValue, for: .showNextCode) }
     }
 
     var defaultSaveOption: DefaultSaveOption {

--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -195,6 +195,22 @@ class AppSettingsStoreTests: BitwardenTestCase {
         XCTAssertFalse(userDefaults.bool(forKey: "bwaPreferencesStorage:disableFavicon"))
     }
 
+    /// `showNextCode` returns `false` if there isn't a previously stored value.
+    func test_showNextCode_isInitiallyFalse() {
+        XCTAssertFalse(subject.showNextCode)
+    }
+
+    /// `showNextCode` can be used to get and set the persisted value in user defaults.
+    func test_showNextCode_withValue() {
+        subject.showNextCode = true
+        XCTAssertTrue(subject.showNextCode)
+        XCTAssertTrue(userDefaults.bool(forKey: "bwaPreferencesStorage:showNextCode"))
+
+        subject.showNextCode = false
+        XCTAssertFalse(subject.showNextCode)
+        XCTAssertFalse(userDefaults.bool(forKey: "bwaPreferencesStorage:showNextCode"))
+    }
+
     /// `hasSyncedAccount(name:)` can be used to get and set if the user has synced previously with a given account.
     /// Account names should be hashed so as to not appear in plaintext.
     func test_hasSyncedAccount_withValue() {

--- a/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -11,6 +11,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var appLocale: String?
     var appTheme: String?
     var disableWebIcons = false
+    var showNextCode = false
     var defaultSaveOption: DefaultSaveOption = .none
     var flightRecorderData: FlightRecorderData?
     var hasSeenDefaultSaveOptionPrompt = false

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
@@ -350,8 +350,14 @@ extension DefaultAuthenticatorItemRepository: AuthenticatorItemRepository {
                 }
                 return item
             }
-            let code = try await totpService.getTotpCode(for: keyModel)
-            return item.with(newTotpModel: code)
+            let currentCode = try await totpService.getTotpCode(for: keyModel)
+            let timeRemaining = TOTPExpirationCalculator.timeRemaining(
+                for: timeProvider.presentTime,
+                using: TimeInterval(currentCode.period),
+            )
+            let nextPeriodDate = timeProvider.presentTime.addingTimeInterval(timeRemaining)
+            let nextCode = try? await totpService.getTotpCode(for: keyModel, date: nextPeriodDate)
+            return item.with(newTotpModel: currentCode).with(newNextTotpModel: nextCode)
         }
     }
 

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -213,6 +213,50 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertTrue(errorReporter.errors.isEmpty)
     }
 
+    /// `refreshTOTPCodes(on:)` fetches the next-period code for each item alongside the current code.
+    func test_refreshTOTPCodes_fetchesNextCode() async throws {
+        let currentCode = TOTPCodeModel(
+            code: "123456",
+            codeGenerationDate: timeProvider.presentTime,
+            period: 30,
+        )
+        let nextCode = TOTPCodeModel(
+            code: "654321",
+            codeGenerationDate: timeProvider.presentTime,
+            period: 30,
+        )
+        totpService.getTotpCodeResult = .success(currentCode)
+        totpService.getTotpCodeForDateResult = .success(nextCode)
+
+        let item = ItemListItem.fixture()
+        let result = try await subject.refreshTOTPCodes(for: [item])
+        let actual = try XCTUnwrap(result[0])
+
+        XCTAssertEqual(actual.totpCodeModel, currentCode)
+        XCTAssertEqual(actual.nextTotpCodeModel, nextCode)
+        XCTAssertNotNil(totpService.getTotpCodeForDateConfig)
+    }
+
+    /// `refreshTOTPCodes(on:)` silently suppresses next-code fetch errors, returning the item with
+    /// only the current code and a nil next code.
+    func test_refreshTOTPCodes_nextCodeError_suppressedSilently() async throws {
+        let currentCode = TOTPCodeModel(
+            code: "123456",
+            codeGenerationDate: timeProvider.presentTime,
+            period: 30,
+        )
+        totpService.getTotpCodeResult = .success(currentCode)
+        totpService.getTotpCodeForDateResult = .failure(BitwardenTestError.example)
+
+        let item = ItemListItem.fixture()
+        let result = try await subject.refreshTOTPCodes(for: [item])
+        let actual = try XCTUnwrap(result[0])
+
+        XCTAssertEqual(actual.totpCodeModel, currentCode)
+        XCTAssertNil(actual.nextTotpCodeModel)
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
     /// `saveTemporarySharedItem(_)` saves a temporary item into the Authenticator Bridge shared store.
     func test_saveTemporarySharedItem_success() async throws {
         let totpKey = "TOTP Key"

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
@@ -4,12 +4,20 @@ import Foundation
 
 /// Protocol defining the functionality of a TOTP (Time-based One-Time Password) service.
 protocol TOTPService {
-    /// Calculates the TOTP code for a given key
+    /// Calculates the TOTP code for a given key using the current time.
     ///
     /// - Parameters:
     ///   - key: The `TOTPKeyModel` to generate a code for
     ///
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel
+
+    /// Calculates the TOTP code for a given key at a specific date.
+    ///
+    /// - Parameters:
+    ///   - key: The `TOTPKeyModel` to generate a code for
+    ///   - date: The date for which to generate the code
+    ///
+    func getTotpCode(for key: TOTPKeyModel, date: Date) async throws -> TOTPCodeModel
 
     /// Retrieves the TOTP configuration for a given key.
     ///
@@ -57,6 +65,13 @@ extension DefaultTOTPService: TOTPService {
         try await clientService.vault().generateTOTPCode(
             for: key.rawAuthenticatorKey,
             date: timeProvider.presentTime,
+        )
+    }
+
+    func getTotpCode(for key: TOTPKeyModel, date: Date) async throws -> TOTPCodeModel {
+        try await clientService.vault().generateTOTPCode(
+            for: key.rawAuthenticatorKey,
+            date: date,
         )
     }
 

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
@@ -69,4 +69,12 @@ final class TOTPServiceTests: BitwardenTestCase {
             )
         }
     }
+
+    /// `getTotpCode(for:date:)` generates a code using the provided date.
+    func test_getTotpCode_withDate() async throws {
+        let specificDate = Date(timeIntervalSince1970: 1000)
+        let keyModel = try subject.getTOTPConfiguration(key: .base32Key)
+        let result = try await subject.getTotpCode(for: keyModel, date: specificDate)
+        XCTAssertEqual(result.codeGenerationDate, specificDate)
+    }
 }

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
@@ -9,12 +9,22 @@ class MockTOTPService: TOTPService {
     )
     var getTotpCodeConfig: TOTPKeyModel?
 
+    var getTotpCodeForDateResult: Result<TOTPCodeModel, Error> = .success(
+        TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30),
+    )
+    var getTotpCodeForDateConfig: (TOTPKeyModel, Date)?
+
     var capturedKey: String?
     var getTOTPConfigResult: Result<TOTPKeyModel, Error> = .failure(TOTPKeyError.invalidKeyFormat)
 
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel {
         getTotpCodeConfig = key
         return try getTotpCodeResult.get()
+    }
+
+    func getTotpCode(for key: TOTPKeyModel, date: Date) async throws -> TOTPCodeModel {
+        getTotpCodeForDateConfig = (key, date)
+        return try getTotpCodeForDateResult.get()
     }
 
     func getTOTPConfiguration(key: String?) throws -> TOTPKeyModel {

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -33,6 +33,9 @@ enum SettingsAction: Equatable {
     /// The privacy policy button was tapped.
     case privacyPolicyTapped
 
+    /// The show next code toggle was changed.
+    case showNextCodeToggled(Bool)
+
     /// The sync with bitwarden app button was tapped.
     case syncWithBitwardenAppTapped
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -117,6 +117,9 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             coordinator.showAlert(.privacyPolicyAlert {
                 self.state.url = ExternalLinksConstants.privacyPolicy
             })
+        case let .showNextCodeToggled(isOn):
+            state.showNextCode = isOn
+            services.appSettingsStore.showNextCode = isOn
         case .syncWithBitwardenAppTapped:
             if services.application?.canOpenURL(ExternalLinksConstants.passwordManagerScheme) ?? false {
                 state.url = ExternalLinksConstants.passwordManagerSettings
@@ -161,6 +164,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         state.sessionTimeoutValue = loadTimeoutValue(biometricsEnabled: state.biometricUnlockStatus.isEnabled)
         state.shouldShowDefaultSaveOption = await services.authenticatorItemRepository.isPasswordManagerSyncActive()
         state.defaultSaveOption = services.appSettingsStore.defaultSaveOption
+        state.showNextCode = services.appSettingsStore.showNextCode
     }
 
     /// Load the Session Timeout Value.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -311,4 +311,34 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.passwordManagerLink)
     }
+
+    /// Receiving `.showNextCodeToggled(true)` updates state and persists the value in app settings.
+    @MainActor
+    func test_receive_showNextCodeToggled_on() {
+        subject.receive(.showNextCodeToggled(true))
+
+        XCTAssertTrue(subject.state.showNextCode)
+        XCTAssertTrue(appSettingsStore.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(false)` updates state and persists the value in app settings.
+    @MainActor
+    func test_receive_showNextCodeToggled_off() {
+        appSettingsStore.showNextCode = true
+        subject.state.showNextCode = true
+
+        subject.receive(.showNextCodeToggled(false))
+
+        XCTAssertFalse(subject.state.showNextCode)
+        XCTAssertFalse(appSettingsStore.showNextCode)
+    }
+
+    /// Performing `.loadData` loads `showNextCode` from app settings into state.
+    @MainActor
+    func test_perform_loadData_showNextCode() async {
+        appSettingsStore.showNextCode = true
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -28,6 +28,9 @@ struct SettingsState: Equatable {
     /// The current default save option.
     var sessionTimeoutValue: SessionTimeoutValue = .never
 
+    /// Whether to show the next TOTP code in the item list when the current code is about to expire.
+    var showNextCode = false
+
     /// A flag to indicate if we should show the default save option menu.
     var shouldShowDefaultSaveOption = false
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -99,9 +99,9 @@ struct SettingsView: View {
             .frame(maxWidth: .infinity)
     }
 
-    /// The data section containing import, export, backup, and sync options.
+    /// The vault section containing import, export, backup, sync, and code display options.
     @ViewBuilder private var dataSection: some View {
-        SectionView(Localizations.data) {
+        SectionView(Localizations.vault) {
             ContentBlock(dividerLeadingPadding: 16) {
                 SettingsListItem(Localizations.import) {
                     store.send(.importItemsTapped)
@@ -120,6 +120,16 @@ struct SettingsView: View {
                 if store.state.shouldShowDefaultSaveOption {
                     defaultSaveOption
                 }
+
+                BitwardenToggle(
+                    Localizations.showNextCode,
+                    footer: Localizations.seeIncomingCodesInTheList,
+                    isOn: store.binding(
+                        get: \.showNextCode,
+                        send: SettingsAction.showNextCodeToggled,
+                    ),
+                )
+                .accessibilityIdentifier("ShowNextCodeToggle")
             }
         }
     }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
@@ -59,6 +59,18 @@ extension ItemListItem {
         }
     }
 
+    /// The next-period `TOTPCodeModel` for preview, if available.
+    var nextTotpCodeModel: TOTPCodeModel? {
+        switch itemType {
+        case let .sharedTotp(model):
+            model.nextTotpCode
+        case .syncError:
+            nil
+        case let .totp(model):
+            model.nextTotpCode
+        }
+    }
+
     /// Initialize an `ItemListItem` from an `AuthenticatorItemView`
     ///
     /// - Parameters:
@@ -160,6 +172,37 @@ extension ItemListItem {
             )
         }
     }
+
+    /// Make a new `ItemListItem` that is a copy of the existing one, but with an updated next-period `TOTPCodeModel`.
+    ///
+    /// - Parameter newNextTotpModel: the new next-period `TOTPCodeModel` to insert in this `ItemListItem`
+    /// - Returns: An exact copy of the data in the existing `ItemListItem`, but with the new
+    ///     next-period `TOTPCodeModel` inserted into the itemType's model.
+    ///
+    public func with(newNextTotpModel: TOTPCodeModel?) -> ItemListItem {
+        switch itemType {
+        case let .sharedTotp(oldModel):
+            var updatedModel = oldModel
+            updatedModel.nextTotpCode = newNextTotpModel
+            return ItemListItem(
+                id: id,
+                name: name,
+                accountName: accountName,
+                itemType: .sharedTotp(model: updatedModel),
+            )
+        case .syncError:
+            return self
+        case let .totp(oldModel):
+            var updatedModel = oldModel
+            updatedModel.nextTotpCode = newNextTotpModel
+            return ItemListItem(
+                id: id,
+                name: name,
+                accountName: accountName,
+                itemType: .totp(model: updatedModel),
+            )
+        }
+    }
 }
 
 extension ItemListItem {
@@ -194,6 +237,9 @@ public struct ItemListTotpItem: Equatable {
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
+
+    /// The next-period TOTP code, used to preview the upcoming code.
+    var nextTotpCode: TOTPCodeModel?
 }
 
 // MARK: - ItemListSharedTotpItem
@@ -204,4 +250,7 @@ public struct ItemListSharedTotpItem: Equatable {
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
+
+    /// The next-period TOTP code, used to preview the upcoming code.
+    var nextTotpCode: TOTPCodeModel?
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -383,6 +383,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
                 }
                 groupTotpExpirationManager?.configureTOTPRefreshScheduling(for: sectionList.flatMap(\.items))
                 state.showMoveToBitwarden = await services.authenticatorItemRepository.isPasswordManagerSyncActive()
+                state.showNextCode = services.appSettingsStore.showNextCode
                 state.loadingState = .data(sectionList)
                 if showToast {
                     state.toast = Toast(title: Localizations.accountsSyncedFromBitwardenApp)

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -662,6 +662,29 @@ class ItemListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(subject.state.showMoveToBitwarden)
     }
 
+    /// `perform(_:)` with `.streamItemList` reads `showNextCode` from `appSettingsStore` and sets it in state.
+    @MainActor
+    func test_perform_streamItemList_showNextCode() {
+        appSettingsStore.showNextCode = true
+        let totpCode = TOTPCodeModel(code: "654321",
+                                     codeGenerationDate: Date(year: 2023, month: 12, day: 31),
+                                     period: 30)
+        let results = [ItemListItem.fixture(totp: .fixture(totpCode: totpCode))]
+        let resultSection = ItemListSection(id: "", items: results, name: "")
+
+        authItemRepository.itemListSubject.send([resultSection])
+        authItemRepository.refreshTotpCodesResult = .success(results)
+
+        let task = Task {
+            await subject.perform(.streamItemList)
+        }
+        defer { task.cancel() }
+
+        waitFor(subject.state.loadingState != .loading(nil))
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
     /// `.receive` with `.clearURL` sets the `state.url` to `nil`.
     @MainActor
     func test_receive_clearURL() throws {

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
@@ -45,6 +45,9 @@ struct ItemListState: Equatable {
     /// Whether to show the Move to Bitwarden button on local items.
     var showMoveToBitwarden = false
 
+    /// Whether to show the next TOTP code when the current code is about to expire.
+    var showNextCode = false
+
     /// Whether to show the special web icons.
     var showWebIcons = true
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -325,6 +325,7 @@ private struct SearchableItemListView: View { // swiftlint:disable:this type_bod
                         iconBaseURL: state.iconBaseURL,
                         item: item,
                         hasDivider: !isLastInSection,
+                        showNextCode: state.showNextCode,
                         showWebIcons: state.showWebIcons,
                     )
                 },

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
@@ -15,6 +15,9 @@ struct ItemListItemRowState {
     /// A flag indicating if this row should display a divider on the bottom edge.
     var hasDivider: Bool
 
+    /// Whether to show the next TOTP code when the current code is about to expire.
+    var showNextCode: Bool = false
+
     /// Whether to show the special web icons.
     var showWebIcons: Bool
 }

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
@@ -103,12 +103,6 @@ struct ItemListItemRowView: View {
             }
         }
         Spacer()
-        TOTPCountdownTimerView(
-            timeProvider: timeProvider,
-            totpCode: model,
-            isNearExpiration: $isNearExpiration,
-            onExpiration: nil,
-        )
         VStack(alignment: .trailing, spacing: 0) {
             Text(model.displayCode)
                 .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
@@ -118,11 +112,17 @@ struct ItemListItemRowView: View {
                isNearExpiration,
                let nextCode = store.state.item.nextTotpCodeModel {
                 Text(nextCode.displayCode)
-                    .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
+                    .styleGuide(.caption2Monospaced, weight: .regular, monoSpacedDigit: true)
                     .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
                     .accessibilityLabel("\(Localizations.nextCode): \(nextCode.displayCode)")
             }
         }
+        TOTPCountdownTimerView(
+            timeProvider: timeProvider,
+            totpCode: model,
+            isNearExpiration: $isNearExpiration,
+            onExpiration: nil,
+        )
     }
 }
 

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
@@ -19,6 +19,9 @@ struct ItemListItemRowView: View {
     /// The `TimeProvider` used to calculate TOTP expiration.
     var timeProvider: any TimeProvider
 
+    /// Whether the countdown is in the final 10 seconds, used to show the next code preview.
+    @State private var isNearExpiration = false
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 16) {
@@ -103,11 +106,23 @@ struct ItemListItemRowView: View {
         TOTPCountdownTimerView(
             timeProvider: timeProvider,
             totpCode: model,
+            isNearExpiration: $isNearExpiration,
             onExpiration: nil,
         )
-        Text(model.displayCode)
-            .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
-            .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+        VStack(alignment: .trailing, spacing: 0) {
+            Text(model.displayCode)
+                .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
+                .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+                .accessibilityLabel("\(Localizations.verificationCode): \(model.displayCode)")
+            if store.state.showNextCode,
+               isNearExpiration,
+               let nextCode = store.state.item.nextTotpCodeModel {
+                Text(nextCode.displayCode)
+                    .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
+                    .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                    .accessibilityLabel("\(Localizations.nextCode): \(nextCode.displayCode)")
+            }
+        }
     }
 }
 

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
@@ -13,6 +13,10 @@ class TOTPCountdownTimer: ObservableObject {
     ///
     @Published var displayTime: String?
 
+    /// A `@Published` integer representing the whole seconds remaining for a TOTP code.
+    ///
+    @Published private(set) var secondsRemaining: Int
+
     /// A closure to call on expiration
     ///
     var onExpiration: (() -> Void)?
@@ -54,12 +58,6 @@ class TOTPCountdownTimer: ObservableObject {
         Int(totpCodeMode.period)
     }
 
-    /// The countdown remainder calculated relative to the current time.
-    ///
-    private var secondsRemaining: Int {
-        TOTPExpirationCalculator.remainingSeconds(for: timeProvider.presentTime, using: period)
-    }
-
     /// Initializes a new countdown timer
     ///
     /// - Parameters
@@ -78,6 +76,10 @@ class TOTPCountdownTimer: ObservableObject {
         totpCodeMode = totpCode
         self.timeProvider = timeProvider
         self.onExpiration = onExpiration
+        secondsRemaining = TOTPExpirationCalculator.remainingSeconds(
+            for: timeProvider.presentTime,
+            using: Int(totpCode.period),
+        )
         displayTime = "\(secondsRemaining)"
         timer = Timer.scheduledTimer(
             withTimeInterval: timerInterval,
@@ -114,6 +116,7 @@ class TOTPCountdownTimer: ObservableObject {
     /// Updates the countdown timer value.
     ///
     private func updateCountdown() {
+        secondsRemaining = TOTPExpirationCalculator.remainingSeconds(for: timeProvider.presentTime, using: period)
         displayTime = "\(secondsRemaining)"
         withAnimation {
             remainingFraction = CGFloat(durationFractionRemaining)

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
@@ -18,6 +18,10 @@ struct TOTPCountdownTimerView: View {
     ///
     let totpCode: TOTPCodeModel
 
+    /// A binding updated to reflect whether the countdown is in the final 10 seconds.
+    ///
+    var isNearExpiration: Binding<Bool>?
+
     /// The `TOTPCountdownTimer`responsible for updating the view state.
     ///
     @ObservedObject private(set) var timer: TOTPCountdownTimer
@@ -43,6 +47,9 @@ struct TOTPCountdownTimerView: View {
                     value: timer.remainingFraction,
                 )
         }
+        .onChange(of: timer.secondsRemaining) { newValue in
+            isNearExpiration?.wrappedValue = newValue < 10
+        }
     }
 
     /// Initializes the view for a TOTPCodeModel and a timer expiration handler.
@@ -51,14 +58,18 @@ struct TOTPCountdownTimerView: View {
     ///   - timeProvider: A protocol providing the present time as a `Date`.
     ///         Used to calculate time remaining for a present TOTP code.
     ///   - totpCode: The code that the timer represents.
+    ///   - isNearExpiration: An optional binding updated when the countdown enters or exits
+    ///     the final 10 seconds.
     ///   - onExpiration: A closure called when the code expires.
     ///
     init(
         timeProvider: any TimeProvider,
         totpCode: TOTPCodeModel,
+        isNearExpiration: Binding<Bool>? = nil,
         onExpiration: (() -> Void)?,
     ) {
         self.totpCode = totpCode
+        self.isNearExpiration = isNearExpiration
         timer = .init(
             timeProvider: timeProvider,
             timerInterval: TOTPCountdownTimerView.timerInterval,

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
@@ -47,6 +47,9 @@ struct TOTPCountdownTimerView: View {
                     value: timer.remainingFraction,
                 )
         }
+        .onAppear {
+            isNearExpiration?.wrappedValue = timer.secondsRemaining < 10
+        }
         .onChange(of: timer.secondsRemaining) { newValue in
             isNearExpiration?.wrappedValue = newValue < 10
         }

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -767,6 +767,7 @@
 "UnableToMoveTheSelectedItemPleaseTryAgain" = "Unable to move the selected item. Please try again.";
 "Done" = "Done";
 "Next" = "Next";
+"NextCode" = "Next code";
 "CopyPublicKey" = "Copy public key";
 "CopyPrivateKey" = "Copy private key";
 "CopyFingerprint" = "Copy fingerprint";
@@ -831,6 +832,8 @@
 "LoggingDuration" = "Logging duration";
 "LogsWillBeAutomaticallyDeletedAfter30DaysDescriptionLong" = "Logs will be automatically deleted after 30 days. Bitwarden is only able to access your log data when you share it.";
 "ForDetailsOnWhatIsAndIsntLoggedVisitTheBitwardenHelpCenter" = "For details on what is and isn’t logged, visit the **[Bitwarden help center](%1$@)**.";
+"SeeIncomingCodesInTheList" = "See incoming codes in the list";
+"ShowNextCode" = "Show next code";
 "ShowMore" = "Show more";
 "ShowLess" = "Show less";
 "ItemNameX" = "Item name, %1$@";

--- a/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/SelfHosted/SelfHostedProcessorTests.swift
@@ -334,7 +334,7 @@ class SelfHostedProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(
             alert,
             .inputValidationAlert(error: InputValidationError(
-                message: Localizations.validationFieldRequired(Localizations.alias)
+                message: Localizations.validationFieldRequired(Localizations.alias),
             )),
         )
     }
@@ -351,7 +351,7 @@ class SelfHostedProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(
             alert,
             .inputValidationAlert(error: InputValidationError(
-                message: Localizations.validationFieldRequired(Localizations.password)
+                message: Localizations.validationFieldRequired(Localizations.password),
             )),
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking
[BWA-99](https://bitwarden.atlassian.net/browse/BWA-99)

## 📔 Objective
Adds a "Show next code" toggle to the Vault section of Authenticator Settings. When enabled and the TOTP countdown drops below 10 seconds, each item row displays the upcoming next-period code (smaller, below the current code), giving users a heads-up before the active code expires.

**Implementation highlights:**
- New `showNextCode: Bool` persisted in `AppSettingsStore` (UserDefaults)
- New `TOTPService.getTotpCode(for:date:)` overload generates the next-period code via the existing SDK `generateTOTPCode(for:date:)` path — no new SDK surface
- `refreshTotpCodes` in `AuthenticatorItemRepository` fetches both current and next code; next-code failures are silently suppressed (`try?`) so the current code always renders
- `TOTPCountdownTimer` exposes `@Published secondsRemaining`; `TOTPCountdownTimerView` propagates an `isNearExpiration` binding (seeded on `.onAppear` to avoid first-render delay) to `ItemListItemRowView`
- Applies to both `.totp` and `.sharedTotp` item types

## 📸 Screenshots
<!-- UI changes — screenshots to be added -->

[BWA-99]: https://bitwarden.atlassian.net/browse/BWA-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ