### PR TITLE
[PM-35271] refactor: Move ClientManagedTokens to AccountTokenProvider so SDK receives refreshed tokens

### DIFF
--- a/BitwardenShared/Core/Platform/Services/API/AccountTokenProvider.swift
+++ b/BitwardenShared/Core/Platform/Services/API/AccountTokenProvider.swift
@@ -1,11 +1,12 @@
 import BitwardenKit
+import BitwardenSdk
 import Foundation
 import Networking
 
 // MARK: - AccountTokenProvider
 
 /// A more specific `TokenProvider` protocol to use and ease testing.
-protocol AccountTokenProvider: TokenProvider {
+protocol AccountTokenProvider: TokenProvider, ClientManagedTokens {
     /// Sets the delegate to use in this token provider.
     /// - Parameter delegate: The delegate to use.
     func setDelegate(delegate: AccountTokenProviderDelegate) async
@@ -153,6 +154,21 @@ actor DefaultAccountTokenProvider: AccountTokenProvider {
         return expirationDate <= refreshThreshold
     }
 }
+
+// MARK: - ClientManagedTokens (SDK)
+
+extension DefaultAccountTokenProvider: ClientManagedTokens {
+    func getAccessToken() async -> String? {
+        do {
+            return try await getToken()
+        } catch {
+            errorReporter.log(error: error)
+            return nil
+        }
+    }
+}
+
+// MARK: - AccountTokenProviderDelegate
 
 /// Delegate to be used by the `AccountTokenProvider`.
 protocol AccountTokenProviderDelegate: AnyObject {

--- a/BitwardenShared/Core/Platform/Services/API/AccountTokenProviderTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/AccountTokenProviderTests.swift
@@ -270,4 +270,25 @@ class AccountTokenProviderTests: BitwardenTestCase {
         // setTokens was never called
         XCTAssertNil(tokenService.setTokensCalledWithUserId)
     }
+
+    // MARK: ClientManagedTokens Tests
+
+    /// `getAccessToken()` (ClientManagedTokens) returns the access token when `getToken()` succeeds.
+    func test_getAccessToken_sdk_success() async {
+        tokenService.accessToken = "ACCESS_TOKEN"
+        tokenService.accessTokenExpirationDateResult = .success(expirationDateUnexpired)
+
+        let token = await subject.getAccessToken()
+        XCTAssertEqual(token, "ACCESS_TOKEN")
+    }
+
+    /// `getAccessToken()` (ClientManagedTokens) returns nil and logs the error when `getToken()` throws.
+    func test_getAccessToken_sdk_error() async {
+        tokenService.accessTokenThrowableError = BitwardenTestError.example
+
+        let token = await subject.getAccessToken()
+        XCTAssertNil(token)
+        XCTAssertEqual(errorReporter.errors.count, 1)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
 }

--- a/BitwardenShared/Core/Platform/Services/API/TestHelpers/MockAccountTokenProvider.swift
+++ b/BitwardenShared/Core/Platform/Services/API/TestHelpers/MockAccountTokenProvider.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenSdk
 
 @testable import BitwardenShared
 
@@ -7,9 +8,14 @@ import BitwardenKit
 @MainActor
 class MockAccountTokenProvider: AccountTokenProvider {
     var delegate: AccountTokenProviderDelegate?
+    var getAccessTokenReturnValue: String? = "ACCESS_TOKEN"
     var getTokenResult: Result<String, Error> = .success("ACCESS_TOKEN")
     var refreshTokenCalled = false
     var refreshTokenResult: Result<String, Error> = .success("ACCESS_TOKEN")
+
+    func getAccessToken() async -> String? {
+        getAccessTokenReturnValue
+    }
 
     func getToken() async throws -> String {
         try getTokenResult.get()

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -597,7 +597,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         let clientBuilder = DefaultClientBuilder(
             appIDService: appIDService,
             environmentService: environmentService,
-            tokenProvider: tokenService,
+            tokenProvider: apiService.accountTokenProvider,
             userAgentBuilder: userAgentBuilder,
         )
         let sdkRepositoryFactory = DefaultSdkRepositoryFactory(

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockTokenService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockTokenService.swift
@@ -6,6 +6,7 @@ import Networking
 class MockTokenService: TokenService {
     var accessToken: String? = "ACCESS_TOKEN"
     var accessTokenExpirationDateResult: Result<Date?, Error> = .success(nil)
+    var accessTokenThrowableError: (any Error)?
     var expirationDate: Date?
     var getIsExternalResult: Result<Bool, Error> = .success(false)
     var refreshToken: String? = "REFRESH_TOKEN"
@@ -17,12 +18,14 @@ class MockTokenService: TokenService {
     var setTokensCalledWithUserId: String?
 
     func getAccessToken() async throws -> String {
+        if let accessTokenThrowableError { throw accessTokenThrowableError }
         guard let accessToken else { throw StateServiceError.noActiveAccount }
         return accessToken
     }
 
     func getAccessToken(userId: String) async throws -> String {
         getAccessTokenCalledWithUserId = userId
+        if let accessTokenThrowableError { throw accessTokenThrowableError }
         return accessTokenByUserId[userId] ?? accessToken ?? "ACCESS_TOKEN"
     }
 

--- a/BitwardenShared/Core/Platform/Services/TokenService.swift
+++ b/BitwardenShared/Core/Platform/Services/TokenService.swift
@@ -141,14 +141,3 @@ actor DefaultTokenService: TokenService {
         await stateService.setAccessTokenExpirationDate(expirationDate, userId: userId)
     }
 }
-
-// MARK: ClientManagedTokens (SDK)
-
-extension DefaultTokenService: ClientManagedTokens {
-    /// Gets the access token for the SDK, nil if any errors are thrown.
-    func getAccessToken() async -> String? {
-        // TODO: PM-21846 Returning `nil` temporarily until we add validation
-        // given that the SDK expects non-expired token.
-        nil
-    }
-}

--- a/BitwardenShared/Core/Platform/Services/TokenServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/TokenServiceTests.swift
@@ -64,14 +64,6 @@ class TokenServiceTests: BitwardenTestCase {
         }
     }
 
-    /// `getAccessToken()` returns the access token stored in the state service for the active account
-    /// for the `ClientManagedTokens` function. Now it temporarily returns `nil` until the expired validation is added
-    /// as the SDK always expect a valid token.
-    func test_getAccessToken_sdk() async throws {
-        let accessToken: String? = await subject.getAccessToken()
-        XCTAssertNil(accessToken)
-    }
-
     /// `getAccessTokenExpirationDate()` returns the access token's expiration date.
     func test_getAccessTokenExpirationDate() async throws {
         stateService.accessTokenExpirationDateByUserId["1"] = Date(year: 2025, month: 10, day: 2)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35271](https://bitwarden.atlassian.net/browse/PM-35271)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

This enables the SDK to access the app's access token for the user. This wasn't previously enabled because the app wasn't preemptively refreshing the token, but that has been added (#2024).

I moved the `ClientManagedTokens` conformance to `AccountTokenProvider` since that contains the logic for preemptively refreshing the token.

[PM-35271]: https://bitwarden.atlassian.net/browse/PM-35271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ