### PR TITLE
[BWA-99] feat: show next TOTP code in item list when < 10 seconds remain

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -22,6 +22,9 @@ protocol AppSettingsStore: AnyObject {
     /// The default save location for new keys.
     var defaultSaveOption: DefaultSaveOption { get set }
 
+    /// Whether to show the next TOTP code in the item list when less than 10 seconds remain.
+    var showNextCode: Bool { get set }
+
     /// The data used by the flight recorder for the active and any inactive logs.
     var flightRecorderData: FlightRecorderData? { get set }
 
@@ -294,6 +297,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case defaultSaveOption
         case disableWebIcons
         case flightRecorderData
+        case showNextCode
         case hasSeenWelcomeTutorial
         case hasSyncedAccount(name: String)
         case lastActiveTime(userId: String)
@@ -324,6 +328,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "defaultSaveOption"
             case .disableWebIcons:
                 "disableFavicon"
+            case .showNextCode:
+                "showNextCode"
             case .flightRecorderData:
                 "flightRecorderData"
             case .hasSeenWelcomeTutorial:
@@ -360,6 +366,11 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
     var disableWebIcons: Bool {
         get { fetch(for: .disableWebIcons) }
         set { store(newValue, for: .disableWebIcons) }
+    }
+
+    var showNextCode: Bool {
+        get { fetch(for: .showNextCode) }
+        set { store(newValue, for: .showNextCode) }
     }
 
     var defaultSaveOption: DefaultSaveOption {

--- a/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -274,4 +274,20 @@ class AppSettingsStoreTests: BitwardenTestCase {
         XCTAssertEqual(subject.vaultTimeout(userId: "1"), 60)
         XCTAssertEqual(userDefaults.double(forKey: "bwaPreferencesStorage:vaultTimeout_1"), 60)
     }
+
+    /// `showNextCode` defaults to `false` when no value has been stored.
+    func test_showNextCode_defaultsFalse() {
+        XCTAssertFalse(subject.showNextCode)
+    }
+
+    /// `showNextCode` persists and retrieves the value correctly.
+    func test_showNextCode_persistsValue() {
+        subject.showNextCode = true
+        XCTAssertTrue(subject.showNextCode)
+        XCTAssertTrue(userDefaults.bool(forKey: "bwaPreferencesStorage:showNextCode"))
+
+        subject.showNextCode = false
+        XCTAssertFalse(subject.showNextCode)
+        XCTAssertFalse(userDefaults.bool(forKey: "bwaPreferencesStorage:showNextCode"))
+    }
 }

--- a/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/AuthenticatorShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -11,6 +11,7 @@ class MockAppSettingsStore: AppSettingsStore {
     var appLocale: String?
     var appTheme: String?
     var disableWebIcons = false
+    var showNextCode = false
     var defaultSaveOption: DefaultSaveOption = .none
     var flightRecorderData: FlightRecorderData?
     var hasSeenDefaultSaveOptionPrompt = false

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepository.swift
@@ -351,7 +351,8 @@ extension DefaultAuthenticatorItemRepository: AuthenticatorItemRepository {
                 return item
             }
             let code = try await totpService.getTotpCode(for: keyModel)
-            return item.with(newTotpModel: code)
+            let nextCode = try? await totpService.getNextTotpCode(for: keyModel)
+            return item.with(newTotpModel: code).with(nextTotpCode: nextCode)
         }
     }
 

--- a/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
+++ b/AuthenticatorShared/Core/Vault/Repositories/AuthenticatorItemRepositoryTests.swift
@@ -701,6 +701,48 @@ class AuthenticatorItemRepositoryTests: BitwardenTestCase { // swiftlint:disable
         )
     }
 
+    /// `refreshTotpCodes(for:)` populates `nextTotpCode` on each refreshed item.
+    @MainActor
+    func test_refreshTotpCodes_setsNextCode() async throws {
+        let currentCode = TOTPCodeModel(code: "111111", codeGenerationDate: timeProvider.presentTime, period: 30)
+        let nextCode = TOTPCodeModel(code: "222222", codeGenerationDate: timeProvider.presentTime, period: 30)
+        totpService.getTotpCodeResult = .success(currentCode)
+        totpService.getNextTotpCodeResult = .success(nextCode)
+
+        let item = ItemListItem.fixture(
+            totp: ItemListTotpItem.fixture(
+                itemView: AuthenticatorItemView.fixture(),
+                totpCode: currentCode,
+            ),
+        )
+
+        let results = try await subject.refreshTotpCodes(for: [item])
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].nextTotpCodeModel?.code, "222222")
+    }
+
+    /// `refreshTotpCodes(for:)` still returns the refreshed current code when `getNextTotpCode` fails.
+    @MainActor
+    func test_refreshTotpCodes_nextCodeFailure_stillReturnsCurrentCode() async throws {
+        let currentCode = TOTPCodeModel(code: "111111", codeGenerationDate: timeProvider.presentTime, period: 30)
+        totpService.getTotpCodeResult = .success(currentCode)
+        totpService.getNextTotpCodeResult = .failure(TOTPKeyError.invalidKeyFormat)
+
+        let item = ItemListItem.fixture(
+            totp: ItemListTotpItem.fixture(
+                itemView: AuthenticatorItemView.fixture(),
+                totpCode: currentCode,
+            ),
+        )
+
+        let results = try await subject.refreshTotpCodes(for: [item])
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].totpCodeModel?.code, "111111")
+        XCTAssertNil(results[0].nextTotpCodeModel)
+    }
+
     /// Convenience method to create an `ItemListItem` from
     /// an `AuthenticatorBridgeItemDataView` using our test fixtures.
     ///

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPService.swift
@@ -11,6 +11,13 @@ protocol TOTPService {
     ///
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel
 
+    /// Calculates the next TOTP code (one period ahead) for a given key.
+    ///
+    /// - Parameters:
+    ///   - key: The `TOTPKeyModel` to generate a code for
+    ///
+    func getNextTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel
+
     /// Retrieves the TOTP configuration for a given key.
     ///
     /// - Parameter key: A string representing the TOTP key.
@@ -57,6 +64,17 @@ extension DefaultTOTPService: TOTPService {
         try await clientService.vault().generateTOTPCode(
             for: key.rawAuthenticatorKey,
             date: timeProvider.presentTime,
+        )
+    }
+
+    func getNextTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel {
+        let nextDate = Date(
+            timeIntervalSinceReferenceDate: timeProvider.presentTime.timeIntervalSinceReferenceDate
+                + Double(key.period),
+        )
+        return try await clientService.vault().generateTOTPCode(
+            for: key.rawAuthenticatorKey,
+            date: nextDate,
         )
     }
 

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TOTPServiceTests.swift
@@ -69,4 +69,34 @@ final class TOTPServiceTests: BitwardenTestCase {
             )
         }
     }
+
+    /// `getNextTotpCode(for:)` returns the code from the SDK for the next period window.
+    func test_getNextTotpCode_returnsCode() async throws {
+        let keyModel = try XCTUnwrap(TOTPKeyModel(authenticatorKey: .base32Key))
+        let result = try await subject.getNextTotpCode(for: keyModel)
+
+        XCTAssertEqual(result.code, "123456")
+        XCTAssertEqual(result.period, 30)
+    }
+
+    /// `getNextTotpCode(for:)` passes a date one period ahead of the current time to the SDK.
+    func test_getNextTotpCode_usesNextPeriodDate() async throws {
+        let fixedDate = Date(timeIntervalSinceReferenceDate: 1_000_000)
+        timeProvider = MockTimeProvider(.mockTime(fixedDate))
+        subject = DefaultTOTPService(
+            clientService: clientService,
+            errorReporter: errorReporter,
+            timeProvider: timeProvider,
+        )
+        let keyModel = try XCTUnwrap(TOTPKeyModel(authenticatorKey: .base32Key))
+
+        let result = try await subject.getNextTotpCode(for: keyModel)
+
+        // The SDK mock stores the passed date as codeGenerationDate
+        let expectedDate = Date(
+            timeIntervalSinceReferenceDate: fixedDate.timeIntervalSinceReferenceDate
+                + Double(keyModel.period),
+        )
+        XCTAssertEqual(result.codeGenerationDate, expectedDate)
+    }
 }

--- a/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TOTP/TestHelpers/MockTOTPService.swift
@@ -9,12 +9,22 @@ class MockTOTPService: TOTPService {
     )
     var getTotpCodeConfig: TOTPKeyModel?
 
+    var getNextTotpCodeResult: Result<TOTPCodeModel, Error> = .success(
+        TOTPCodeModel(code: "654321", codeGenerationDate: .now, period: 30),
+    )
+    var getNextTotpCodeConfig: TOTPKeyModel?
+
     var capturedKey: String?
     var getTOTPConfigResult: Result<TOTPKeyModel, Error> = .failure(TOTPKeyError.invalidKeyFormat)
 
     func getTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel {
         getTotpCodeConfig = key
         return try getTotpCodeResult.get()
+    }
+
+    func getNextTotpCode(for key: TOTPKeyModel) async throws -> TOTPCodeModel {
+        getNextTotpCodeConfig = key
+        return try getNextTotpCodeResult.get()
     }
 
     func getTOTPConfiguration(key: String?) throws -> TOTPKeyModel {

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -36,6 +36,9 @@ enum SettingsAction: Equatable {
     /// The sync with bitwarden app button was tapped.
     case syncWithBitwardenAppTapped
 
+    /// The show next code toggle was changed.
+    case showNextCodeToggled(Bool)
+
     /// The toast was shown or hidden.
     case toastShown(Toast?)
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -117,6 +117,9 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             coordinator.showAlert(.privacyPolicyAlert {
                 self.state.url = ExternalLinksConstants.privacyPolicy
             })
+        case let .showNextCodeToggled(isOn):
+            state.showNextCode = isOn
+            services.appSettingsStore.showNextCode = isOn
         case .syncWithBitwardenAppTapped:
             if services.application?.canOpenURL(ExternalLinksConstants.passwordManagerScheme) ?? false {
                 state.url = ExternalLinksConstants.passwordManagerSettings
@@ -161,6 +164,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         state.sessionTimeoutValue = loadTimeoutValue(biometricsEnabled: state.biometricUnlockStatus.isEnabled)
         state.shouldShowDefaultSaveOption = await services.authenticatorItemRepository.isPasswordManagerSyncActive()
         state.defaultSaveOption = services.appSettingsStore.defaultSaveOption
+        state.showNextCode = services.appSettingsStore.showNextCode
     }
 
     /// Load the Session Timeout Value.

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -311,4 +311,34 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(subject.state.url, ExternalLinksConstants.passwordManagerLink)
     }
+
+    /// Performing `.loadData` reads `showNextCode` from `AppSettingsStore` and sets it on state.
+    @MainActor
+    func test_perform_loadData_setsShowNextCode() async {
+        appSettingsStore.showNextCode = true
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(true)` updates state and persists to the store.
+    @MainActor
+    func test_receive_showNextCodeToggled_true() {
+        subject.receive(.showNextCodeToggled(true))
+
+        XCTAssertTrue(subject.state.showNextCode)
+        XCTAssertTrue(appSettingsStore.showNextCode)
+    }
+
+    /// Receiving `.showNextCodeToggled(false)` updates state and persists to the store.
+    @MainActor
+    func test_receive_showNextCodeToggled_false() {
+        appSettingsStore.showNextCode = true
+        subject.state.showNextCode = true
+
+        subject.receive(.showNextCodeToggled(false))
+
+        XCTAssertFalse(subject.state.showNextCode)
+        XCTAssertFalse(appSettingsStore.showNextCode)
+    }
 }

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsState.swift
@@ -31,6 +31,9 @@ struct SettingsState: Equatable {
     /// A flag to indicate if we should show the default save option menu.
     var shouldShowDefaultSaveOption = false
 
+    /// Whether to show the next TOTP code in the item list when less than 10 seconds remain.
+    var showNextCode = false
+
     /// A toast message to show in the view.
     var toast: Toast?
 

--- a/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/AuthenticatorShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -117,6 +117,16 @@ struct SettingsView: View {
 
                 syncWithPasswordManagerRow
 
+                BitwardenToggle(
+                    Localizations.showNextCode,
+                    footer: Localizations.seeIncomingCodesInTheList,
+                    isOn: store.binding(
+                        get: \.showNextCode,
+                        send: SettingsAction.showNextCodeToggled,
+                    ),
+                )
+                .accessibilityIdentifier("ShowNextCodeToggle")
+
                 if store.state.shouldShowDefaultSaveOption {
                     defaultSaveOption
                 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListItem.swift
@@ -59,6 +59,18 @@ extension ItemListItem {
         }
     }
 
+    /// The associated next `TOTPCodeModel` (one period ahead) if this item has a next code, or `nil`.
+    var nextTotpCodeModel: TOTPCodeModel? {
+        switch itemType {
+        case let .sharedTotp(model):
+            model.nextTotpCode
+        case .syncError:
+            nil
+        case let .totp(model):
+            model.nextTotpCode
+        }
+    }
+
     /// Initialize an `ItemListItem` from an `AuthenticatorItemView`
     ///
     /// - Parameters:
@@ -160,6 +172,37 @@ extension ItemListItem {
             )
         }
     }
+
+    /// Make a new `ItemListItem` that is a copy of the existing one, but with an updated next `TOTPCodeModel`.
+    ///
+    /// - Parameter nextTotpCode: The next `TOTPCodeModel` to insert, or `nil` to clear it.
+    /// - Returns: An exact copy of the data in the existing `ItemListItem`, but with the new
+    ///     next `TOTPCodeModel` inserted into the itemType's model.
+    ///
+    public func with(nextTotpCode: TOTPCodeModel?) -> ItemListItem {
+        switch itemType {
+        case let .sharedTotp(oldModel):
+            var updatedModel = oldModel
+            updatedModel.nextTotpCode = nextTotpCode
+            return ItemListItem(
+                id: id,
+                name: name,
+                accountName: accountName,
+                itemType: .sharedTotp(model: updatedModel),
+            )
+        case .syncError:
+            return self
+        case let .totp(oldModel):
+            var updatedModel = oldModel
+            updatedModel.nextTotpCode = nextTotpCode
+            return ItemListItem(
+                id: id,
+                name: name,
+                accountName: accountName,
+                itemType: .totp(model: updatedModel),
+            )
+        }
+    }
 }
 
 extension ItemListItem {
@@ -194,6 +237,9 @@ public struct ItemListTotpItem: Equatable {
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
+
+    /// The next TOTP code for the item (one period ahead), used for next-code preview.
+    var nextTotpCode: TOTPCodeModel?
 }
 
 // MARK: - ItemListSharedTotpItem
@@ -204,4 +250,7 @@ public struct ItemListSharedTotpItem: Equatable {
 
     /// The current TOTP code for the item
     var totpCode: TOTPCodeModel
+
+    /// The next TOTP code for the item (one period ahead), used for next-code preview.
+    var nextTotpCode: TOTPCodeModel?
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessor.swift
@@ -382,6 +382,7 @@ final class ItemListProcessor: StateProcessor<ItemListState, ItemListAction, Ite
                     return ItemListSection(id: section.id, items: sortedList, name: section.name)
                 }
                 groupTotpExpirationManager?.configureTOTPRefreshScheduling(for: sectionList.flatMap(\.items))
+                state.showNextCode = services.appSettingsStore.showNextCode
                 state.showMoveToBitwarden = await services.authenticatorItemRepository.isPasswordManagerSyncActive()
                 state.loadingState = .data(sectionList)
                 if showToast {

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListProcessorTests.swift
@@ -1293,4 +1293,40 @@ class ItemListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         XCTAssertEqual(subject.state.itemListCardState, .none)
     }
+
+    /// `perform(_:)` with `.appeared` reads `showNextCode` from `AppSettingsStore` and reflects it in state.
+    @MainActor
+    func test_perform_appeared_setsShowNextCode() {
+        appSettingsStore.showNextCode = true
+        let resultSection = ItemListSection(id: "", items: [], name: "Items")
+        authItemRepository.itemListSubject.send([resultSection])
+        authItemRepository.refreshTotpCodesResult = .success([])
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertTrue(subject.state.showNextCode)
+    }
+
+    /// `perform(_:)` with `.appeared` reflects `showNextCode = false` when the setting is off.
+    @MainActor
+    func test_perform_appeared_showNextCode_false() {
+        appSettingsStore.showNextCode = false
+        let resultSection = ItemListSection(id: "", items: [], name: "Items")
+        authItemRepository.itemListSubject.send([resultSection])
+        authItemRepository.refreshTotpCodesResult = .success([])
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertFalse(subject.state.showNextCode)
+    }
 }

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListState.swift
@@ -45,6 +45,9 @@ struct ItemListState: Equatable {
     /// Whether to show the Move to Bitwarden button on local items.
     var showMoveToBitwarden = false
 
+    /// Whether to show the next TOTP code in item rows when less than 10 seconds remain.
+    var showNextCode = false
+
     /// Whether to show the special web icons.
     var showWebIcons = true
 

--- a/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
+++ b/AuthenticatorShared/UI/Vault/ItemList/ItemList/ItemListView.swift
@@ -325,6 +325,7 @@ private struct SearchableItemListView: View { // swiftlint:disable:this type_bod
                         iconBaseURL: state.iconBaseURL,
                         item: item,
                         hasDivider: !isLastInSection,
+                        showNextCode: state.showNextCode,
                         showWebIcons: state.showWebIcons,
                     )
                 },

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowState.swift
@@ -15,6 +15,9 @@ struct ItemListItemRowState {
     /// A flag indicating if this row should display a divider on the bottom edge.
     var hasDivider: Bool
 
+    /// Whether to show the next TOTP code when less than 10 seconds remain on the current code.
+    var showNextCode: Bool
+
     /// Whether to show the special web icons.
     var showWebIcons: Bool
 }

--- a/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/ItemListItemRow/ItemListItemRowView.swift
@@ -38,6 +38,8 @@ struct ItemListItemRowView: View {
                             name: store.state.item.name,
                             accountName: store.state.item.accountName,
                             model: totpCodeModel,
+                            nextCode: store.state.item.nextTotpCodeModel,
+                            showNextCode: store.state.showNextCode,
                         )
                     } else {
                         EmptyView()
@@ -77,7 +79,13 @@ struct ItemListItemRowView: View {
 
     /// The row showing the totp code.
     @ViewBuilder
-    private func totpCodeRow(name: String, accountName: String?, model: TOTPCodeModel) -> some View {
+    private func totpCodeRow(
+        name: String,
+        accountName: String?,
+        model: TOTPCodeModel,
+        nextCode: TOTPCodeModel?,
+        showNextCode: Bool,
+    ) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             if let name = name.nilIfEmpty {
                 Text(name)
@@ -100,14 +108,78 @@ struct ItemListItemRowView: View {
             }
         }
         Spacer()
-        TOTPCountdownTimerView(
+        TotpCodeRowContent(
+            model: model,
+            nextCode: nextCode,
+            showNextCode: showNextCode,
             timeProvider: timeProvider,
+        )
+    }
+}
+
+// MARK: - TotpCodeRowContent
+
+/// A sub-view that owns the TOTP countdown timer and conditionally displays the next code.
+private struct TotpCodeRowContent: View {
+    // MARK: Static Properties
+
+    /// The number of seconds remaining below which the next code is revealed.
+    static let nextCodeVisibilityThreshold = 10
+
+    // MARK: Properties
+
+    /// The current TOTP code model.
+    let model: TOTPCodeModel
+
+    /// The next TOTP code model (one period ahead), or `nil` if unavailable.
+    let nextCode: TOTPCodeModel?
+
+    /// Whether the "show next code" feature is enabled in settings.
+    let showNextCode: Bool
+
+    /// The `TimeProvider` used to drive the countdown timer.
+    let timeProvider: any TimeProvider
+
+    /// The countdown timer that drives the circular progress indicator.
+    @StateObject private var timer: TOTPCountdownTimer
+
+    // MARK: View
+
+    var body: some View {
+        TOTPCountdownTimerView(totpCode: model, timer: timer)
+        VStack(alignment: .trailing, spacing: 0) {
+            Text(model.displayCode)
+                .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
+                .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+            if showNextCode,
+               timer.secondsRemaining < Self.nextCodeVisibilityThreshold,
+               let next = nextCode {
+                Text(next.displayCode)
+                    .styleGuide(.subheadline, monoSpacedDigit: true)
+                    .foregroundColor(Asset.Colors.textSecondary.swiftUIColor)
+                    .accessibilityLabel(Localizations.nextCode(next.displayCode))
+            }
+        }
+    }
+
+    // MARK: Initialization
+
+    init(
+        model: TOTPCodeModel,
+        nextCode: TOTPCodeModel?,
+        showNextCode: Bool,
+        timeProvider: any TimeProvider,
+    ) {
+        self.model = model
+        self.nextCode = nextCode
+        self.showNextCode = showNextCode
+        self.timeProvider = timeProvider
+        _timer = StateObject(wrappedValue: TOTPCountdownTimer(
+            timeProvider: timeProvider,
+            timerInterval: TOTPCountdownTimerView.timerInterval,
             totpCode: model,
             onExpiration: nil,
-        )
-        Text(model.displayCode)
-            .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
-            .foregroundColor(Asset.Colors.textPrimary.swiftUIColor)
+        ))
     }
 }
 
@@ -133,6 +205,7 @@ struct ItemListItemRowView: View {
                         ),
                     ),
                     hasDivider: true,
+                    showNextCode: false,
                     showWebIcons: true,
                 ),
             ),
@@ -162,6 +235,7 @@ struct ItemListItemRowView: View {
                         ),
                     ),
                     hasDivider: true,
+                    showNextCode: false,
                     showWebIcons: true,
                 ),
             ),
@@ -191,6 +265,7 @@ struct ItemListItemRowView: View {
                         ),
                     ),
                     hasDivider: true,
+                    showNextCode: false,
                     showWebIcons: true,
                 ),
             ),
@@ -210,6 +285,7 @@ struct ItemListItemRow_Previews: PreviewProvider {
                                 state: ItemListItemRowState(
                                     item: item,
                                     hasDivider: true,
+                                    showNextCode: false,
                                     showWebIcons: true,
                                 ),
                             ),
@@ -230,6 +306,7 @@ struct ItemListItemRow_Previews: PreviewProvider {
                                 state: ItemListItemRowState(
                                     item: item,
                                     hasDivider: true,
+                                    showNextCode: false,
                                     showWebIcons: true,
                                 ),
                             ),

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimer.swift
@@ -54,11 +54,9 @@ class TOTPCountdownTimer: ObservableObject {
         Int(totpCodeMode.period)
     }
 
-    /// The countdown remainder calculated relative to the current time.
+    /// The number of seconds remaining for the current TOTP code.
     ///
-    private var secondsRemaining: Int {
-        TOTPExpirationCalculator.remainingSeconds(for: timeProvider.presentTime, using: period)
-    }
+    @Published private(set) var secondsRemaining: Int = 0
 
     /// Initializes a new countdown timer
     ///
@@ -78,6 +76,10 @@ class TOTPCountdownTimer: ObservableObject {
         totpCodeMode = totpCode
         self.timeProvider = timeProvider
         self.onExpiration = onExpiration
+        secondsRemaining = TOTPExpirationCalculator.remainingSeconds(
+            for: timeProvider.presentTime,
+            using: Int(totpCode.period),
+        )
         displayTime = "\(secondsRemaining)"
         timer = Timer.scheduledTimer(
             withTimeInterval: timerInterval,
@@ -114,6 +116,7 @@ class TOTPCountdownTimer: ObservableObject {
     /// Updates the countdown timer value.
     ///
     private func updateCountdown() {
+        secondsRemaining = TOTPExpirationCalculator.remainingSeconds(for: timeProvider.presentTime, using: period)
         displayTime = "\(secondsRemaining)"
         withAnimation {
             remainingFraction = CGFloat(durationFractionRemaining)

--- a/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
+++ b/AuthenticatorShared/UI/Vault/Views/TOTPCountdownTimerView.swift
@@ -66,4 +66,15 @@ struct TOTPCountdownTimerView: View {
             onExpiration: onExpiration,
         )
     }
+
+    /// Initializes the view with an externally-created timer.
+    ///
+    /// - Parameters:
+    ///   - totpCode: The code that the timer represents.
+    ///   - timer: A pre-created `TOTPCountdownTimer` to use for the countdown.
+    ///
+    init(totpCode: TOTPCodeModel, timer: TOTPCountdownTimer) {
+        self.totpCode = totpCode
+        self.timer = timer
+    }
 }

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -833,6 +833,7 @@
 "ForDetailsOnWhatIsAndIsntLoggedVisitTheBitwardenHelpCenter" = "For details on what is and isn’t logged, visit the **[Bitwarden help center](%1$@)**.";
 "ShowMore" = "Show more";
 "ShowLess" = "Show less";
+"ShowNextCode" = "Show next code";
 "ItemNameX" = "Item name, %1$@";
 "OwnerX" = "Owner, %1$@";
 "CollectionX" = "Collection, %1$@";
@@ -913,6 +914,7 @@
 "LocalCodes" = "Local codes";
 "NeedHelpVisitOurHelpCenterForGuidance" = "Need help? Visit our Help Center for guidance.";
 "NoAskMe" = "No, ask me";
+"NextCode" = "Next code: %1$@";
 "NoCodes" = "You don’t have any codes to display";
 "None" = "None";
 "NumberOfDigits" = "Number of digits";
@@ -926,6 +928,7 @@
 "ScanComplete" = "Scan complete";
 "ScanTheQRCodeInYourSettings" = "Scan the QR code in your 2-step verification settings for any account.";
 "SecureYourAssetsWithBitwardenAuthenticator" = "Secure your accounts with Bitwarden Authenticator";
+"SeeIncomingCodesInTheList" = "See incoming codes in the list";
 "SetSaveLocallyAsYourDefaultSaveOption" = "Set “Save locally” as your default save option?";
 "SetSaveToBitwardenAsYourDefaultSaveOption" = "Set “Save to Bitwarden” as your default save option?";
 "SignInUsingUniqueCodes" = "Sign in using unique codes";


### PR DESCRIPTION
## 🎟️ Tracking
[BWA-99](https://bitwarden.atlassian.net/browse/BWA-99)

## 📔 Objective
Adds an opt-in "Show next code" toggle in Authenticator Settings (DATA section, below "Sync with Bitwarden app"). When enabled, the upcoming TOTP code (one period ahead) is displayed in smaller text below the current code in item list rows, but only when fewer than 10 seconds remain on the current period — reducing friction when a code is about to expire.

## 📸 Screenshots
_UI changes affect the item list rows and Settings screen. Snapshot tests are currently disabled; manual verification performed in simulator._

[BWA-99]: https://bitwarden.atlassian.net/browse/BWA-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ