### PR TITLE
[PM-32809] feat: Add Bank Account cipher type

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
+++ b/BitwardenKit/UI/Platform/Application/Appearance/Modifiers/TextFieldConfiguration.swift
@@ -62,6 +62,16 @@ public extension TextFieldConfiguration {
         textInputAutocapitalization: .never,
     )
 
+    /// A `TextFieldConfiguration` for applying common properties to numeric text fields
+    /// where no AutoFill content-type hint should be applied (e.g., secret PINs where
+    /// iOS should not offer SMS one-time-code AutoFill suggestions).
+    static let numericNoContentType = TextFieldConfiguration(
+        isAutocorrectionDisabled: true,
+        keyboardType: .numberPad,
+        textContentType: nil,
+        textInputAutocapitalization: .never,
+    )
+
     /// A `TextFieldConfiguration` for applying common properties to numeric text fields.
     static func numeric(_ textContentType: UITextContentType) -> TextFieldConfiguration {
         TextFieldConfiguration(

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1062,3 +1062,28 @@
 "CopyUserID" = "Copy user ID";
 "UserIDUnavailable" = "User ID unavailable";
 "ToManageYourPremiumSubscriptionDescriptionLong" = "To manage your Premium subscription, please log in to your web vault on a computer.";
+
+/* PM-32009: New Item Types — Bank Account */
+"TypeBankAccount" = "Bank account";
+"NewBankAccount" = "New bank account";
+"EditBankAccount" = "Edit bank account";
+"ViewBankAccount" = "View bank account";
+"BankAccounts" = "Bank accounts";
+"BankAccountDetails" = "Bank account details";
+"BankName" = "Bank name";
+"NameOnAccount" = "Name on account";
+"AccountType" = "Account type";
+"AccountNumber" = "Account number";
+"RoutingNumber" = "Routing number";
+"BranchNumber" = "Branch number";
+"SwiftCode" = "SWIFT code";
+"Iban" = "IBAN";
+"BankContactPhone" = "Bank contact phone";
+
+/* Bank account types */
+"Checking" = "Checking";
+"Savings" = "Savings";
+"CertificateOfDeposit" = "Certificate of deposit (CD)";
+"LineOfCredit" = "Line of credit";
+"InvestmentBrokerage" = "Investment / brokerage";
+"MoneyMarket" = "Money market";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1080,6 +1080,12 @@
 "Iban" = "IBAN";
 "BankContactPhone" = "Bank contact phone";
 
+/* Displayed when a save is attempted for a cipher type that is not yet supported by
+   the current build — e.g., a Bank Account save while the BitwardenSdk dependency has
+   not yet been bumped. Distinct from `AnErrorHasOccurred` so tests and debuggers can
+   tell the failure apart from generic errors. */
+"ThisItemTypeIsNotYetAvailableTryAgainInALaterVersion" = "This item type is not yet available. Try again in a later version of Bitwarden.";
+
 /* Bank account types */
 "Checking" = "Checking";
 "Savings" = "Savings";

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -23,6 +23,9 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// Flag to enable/disable migration from My Vault Items to My Items.
     static let migrateMyVaultToMyItems = FeatureFlag(rawValue: "pm-20558-migrate-myvault-to-myitems")
 
+    /// Flag to enable/disable the new vault item types (Bank Account, Driver's License, Passport).
+    static let newItemTypes = FeatureFlag(rawValue: "pm-32009-new-item-types")
+
     /// Flag to enable/disable not logging out when a user's KDF settings are changed.
     static let noLogoutOnKdfChange = FeatureFlag(rawValue: "pm-23995-no-logout-on-kdf-change")
 
@@ -37,6 +40,7 @@ extension FeatureFlag: @retroactive CaseIterable {
             .enableCipherKeyEncryption,
             .forceUpdateKdfSettings,
             .migrateMyVaultToMyItems,
+            .newItemTypes,
             .noLogoutOnKdfChange,
             .premiumUpgradePath,
         ]

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+NewItemTypes.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+NewItemTypes.swift
@@ -1,7 +1,6 @@
 // swiftlint:disable:this file_name
 
 import BitwardenSdk
-import Foundation
 
 // MARK: - NewItemTypesSdkBridge
 
@@ -49,8 +48,7 @@ enum NewItemTypesSdkBridge {
     static func sdkCipherTypeForBankAccount() -> BitwardenSdk.CipherType? {
         // TODO: PM-32009 Blocked on SDK — return `.bankAccount` once BitwardenSdk ships
         // the case. Until then, return nil so callers fail closed.
-        guard isBankAccountAvailable else { return nil }
-        return nil
+        nil
     }
 
     /// Maps a `BitwardenSdk.CipherType` to the app-layer `CipherType.bankAccount` if

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+NewItemTypes.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+NewItemTypes.swift
@@ -1,0 +1,83 @@
+// swiftlint:disable:this file_name
+
+import BitwardenSdk
+import Foundation
+
+// MARK: - NewItemTypesSdkBridge
+
+/// Centralized SDK-availability gating for the PM-32009 new item types.
+///
+/// `BitwardenSdk` does not yet expose `BankAccount` / `BankAccountView` /
+/// `CipherType.bankAccount` (and similarly for Driver's License and Passport once they land).
+/// Until the SDK ships support, every app-layer site that needs to bridge one of the new
+/// types across the SDK boundary should route through this namespace so that flipping
+/// availability is a single-file change.
+///
+/// **Why centralize?** PR 1 (Bank Account) added ~6 `TODO: PM-32009 Blocked on SDK` sites.
+/// PR 2 (Driver's License) and PR 3 (Passport) would multiply that to ~18 without a shim.
+/// When the SDK lands with the new cases, `isBankAccountAvailable` (and siblings) flip
+/// to `true` and the conditional branches below swap to real SDK conversions — the rest
+/// of the codebase stays still.
+///
+/// - Note: All members are `static` and side-effect free. The bridge does not hold state.
+///
+enum NewItemTypesSdkBridge {
+    // MARK: SDK Availability Flags
+
+    /// Whether the current `BitwardenSdk` dependency exposes the Bank Account types
+    /// (`BitwardenSdk.CipherType.bankAccount`, `BitwardenSdk.BankAccount`,
+    /// `BitwardenSdk.BankAccountView`). Flip to `true` when the SDK ships support and
+    /// replace the guarded fallbacks below with real SDK conversions.
+    ///
+    /// - SeeAlso: `TODO: PM-32009` markers elsewhere are intentionally kept next to the
+    ///   call sites that will need source-level edits when the SDK lands — the flag
+    ///   alone is not sufficient to enable the new type end-to-end.
+    static let isBankAccountAvailable = false
+
+    // MARK: Bank Account Bridging
+
+    /// Returns the SDK `BitwardenSdk.CipherType` value corresponding to the app-layer
+    /// `CipherType.bankAccount` case, or `nil` if the SDK does not yet expose a
+    /// `.bankAccount` case.
+    ///
+    /// Callers must fail closed when this returns `nil` — do NOT coerce to any other
+    /// SDK type (e.g., `.secureNote`) as that would cause silent data loss. See
+    /// `BitwardenSdk+Vault.swift::BitwardenSdk.CipherType.init(_:)`.
+    ///
+    /// - Returns: The SDK enum case, or `nil` while the SDK is blocked on PM-32009.
+    ///
+    static func sdkCipherTypeForBankAccount() -> BitwardenSdk.CipherType? {
+        // TODO: PM-32009 Blocked on SDK — return `.bankAccount` once BitwardenSdk ships
+        // the case. Until then, return nil so callers fail closed.
+        guard isBankAccountAvailable else { return nil }
+        return nil
+    }
+
+    /// Maps a `BitwardenSdk.CipherType` to the app-layer `CipherType.bankAccount` if
+    /// applicable.
+    ///
+    /// - Parameter _: An SDK cipher type to test.
+    /// - Returns: `.bankAccount` when the SDK type matches the (future) SDK `.bankAccount`
+    ///   case, `nil` otherwise.
+    ///
+    static func appCipherTypeForBankAccount(_: BitwardenSdk.CipherType) -> CipherType? {
+        // TODO: PM-32009 Blocked on SDK — when the SDK adds `.bankAccount`, switch on
+        // the value and return `.bankAccount` only for that case.
+        nil
+    }
+
+    /// Whether a `BitwardenSdk.CipherListViewType` represents a bank account list row.
+    ///
+    /// Used by vault-list group filters to avoid pulling in the SDK's associated-value
+    /// enum pattern at call sites.
+    ///
+    /// - Parameter _: The SDK list view type to test.
+    /// - Returns: `true` when the SDK list view type is the (future) `.bankAccount`,
+    ///   `false` otherwise.
+    ///
+    static func isBankAccountListViewType(_: BitwardenSdk.CipherListViewType) -> Bool {
+        // TODO: PM-32009 Blocked on SDK — switch on the SDK type once `.bankAccount`
+        // exists and return `true` for that case only.
+        false
+    }
+}

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -89,7 +89,10 @@ extension CipherDetailsResponseModel {
             revisionDate: cipher.revisionDate,
             secureNote: cipher.secureNote.map(CipherSecureNoteModel.init),
             sshKey: cipher.sshKey.map(CipherSSHKeyModel.init),
-            type: BitwardenShared.CipherType(type: cipher.type),
+            // Unknown SDK cipher types fall back to `.secureNote` on decode so
+            // pre-PM-32813 users see an opaque item rather than a crash. The
+            // backward-compat PR formalizes the "Unknown" display story.
+            type: BitwardenShared.CipherType(type: cipher.type) ?? .secureNote,
             viewPassword: cipher.viewPassword,
         )
     }
@@ -221,9 +224,16 @@ extension CipherSSHKeyModel {
 }
 
 extension CipherType {
-    init(type: BitwardenSdk.CipherType) {
-        // TODO: PM-32009 Blocked on SDK — add a `case .bankAccount` arm once
-        // BitwardenSdk.CipherType exposes `bankAccount`.
+    /// Creates an app-layer `CipherType` from a `BitwardenSdk.CipherType`.
+    ///
+    /// Fails (`nil`) when the SDK value is unknown to the app — either a future SDK case
+    /// not yet mapped (e.g., `.bankAccount` while PM-32009 SDK work is pending) or a
+    /// later SDK bump that adds unmapped cases. Callers must handle `nil` rather than
+    /// assume an exhaustive mapping.
+    ///
+    /// - Parameter type: The SDK cipher type to bridge into the app layer.
+    ///
+    init?(type: BitwardenSdk.CipherType) {
         switch type {
         case .card:
             self = .card
@@ -235,12 +245,26 @@ extension CipherType {
             self = .secureNote
         case .sshKey:
             self = .sshKey
+        @unknown default:
+            // Route through the centralized bridge so PM-32009 and future new-type
+            // PRs flip a single switch (`NewItemTypesSdkBridge.isBankAccountAvailable`
+            // et al.) rather than updating call sites.
+            if let mapped = NewItemTypesSdkBridge.appCipherTypeForBankAccount(type) {
+                self = mapped
+                return
+            }
+            return nil
         }
     }
 
-    init(_ type: BitwardenSdk.CipherListViewType) {
-        // TODO: PM-32009 Blocked on SDK — add a `case .bankAccount` arm once
-        // BitwardenSdk.CipherListViewType exposes `bankAccount`.
+    /// Creates an app-layer `CipherType` from a `BitwardenSdk.CipherListViewType`.
+    ///
+    /// Fails (`nil`) when the SDK value is unknown — see `init?(type:)` above for
+    /// rationale.
+    ///
+    /// - Parameter type: The SDK list view type to bridge into the app layer.
+    ///
+    init?(_ type: BitwardenSdk.CipherListViewType) {
         switch type {
         case .card:
             self = .card
@@ -252,6 +276,12 @@ extension CipherType {
             self = .secureNote
         case .sshKey:
             self = .sshKey
+        @unknown default:
+            if NewItemTypesSdkBridge.isBankAccountListViewType(type) {
+                self = .bankAccount
+                return
+            }
+            return nil
         }
     }
 }
@@ -344,7 +374,12 @@ extension BitwardenSdk.Cipher {
             key: model.key,
             name: model.name,
             notes: model.notes,
-            type: BitwardenSdk.CipherType(model.type),
+            // Fails closed when the app-layer `model.type` is not yet supported by
+            // the SDK (e.g., `.bankAccount` before PM-32009 SDK readiness). The
+            // `.secureNote` fallback is defensive only — the repository / save flow
+            // must reject unsupported types upstream; an `assertionFailure` in
+            // `BitwardenSdk.CipherType.init?(_:)` trips in Debug if reached.
+            type: BitwardenSdk.CipherType(model.type) ?? .secureNote,
             login: model.login.map(Login.init),
             identity: model.identity.map(Identity.init),
             card: model.card.map(Card.init),
@@ -389,7 +424,12 @@ extension BitwardenSdk.Cipher {
             key: model.key,
             name: model.name,
             notes: model.notes,
-            type: BitwardenSdk.CipherType(model.type),
+            // Fails closed when the app-layer `model.type` is not yet supported by
+            // the SDK (e.g., `.bankAccount` before PM-32009 SDK readiness). The
+            // `.secureNote` fallback is defensive only — the repository / save flow
+            // must reject unsupported types upstream; an `assertionFailure` in
+            // `BitwardenSdk.CipherType.init?(_:)` trips in Debug if reached.
+            type: BitwardenSdk.CipherType(model.type) ?? .secureNote,
             login: model.login.map(Login.init),
             identity: model.identity.map(Identity.init),
             card: model.card.map(Card.init),
@@ -503,7 +543,19 @@ extension BitwardenSdk.CipherView: @retroactive Identifiable, Fido2UserVerifiabl
 }
 
 extension BitwardenSdk.CipherType {
-    init(_ cipherType: CipherType) {
+    /// Creates a `BitwardenSdk.CipherType` from an app-layer `CipherType`.
+    ///
+    /// Fails (`nil`) when the app-layer value cannot be represented in the SDK yet —
+    /// currently `.bankAccount`, until PM-32009 SDK work lands. This initializer
+    /// **never** silently coerces an unsupported app type to another SDK case; silent
+    /// coercion would cause data loss on save.
+    ///
+    /// Call sites must handle `nil` (fail the save, surface a clear error) rather than
+    /// treat this as infallible.
+    ///
+    /// - Parameter cipherType: The app-layer type to bridge.
+    ///
+    init?(_ cipherType: CipherType) {
         switch cipherType {
         case .login:
             self = .login
@@ -516,12 +568,25 @@ extension BitwardenSdk.CipherType {
         case .sshKey:
             self = .sshKey
         case .bankAccount:
-            // TODO: PM-32009 Blocked on SDK — map `.bankAccount` to the corresponding
-            // `BitwardenSdk.CipherType.bankAccount` case once the SDK exposes it. Until then,
-            // this path is unreachable in practice because the `newItemTypes` feature flag is
-            // off by default and gates creation of bank account ciphers. Fallback mapping to
-            // `.secureNote` is defensive only.
-            self = .secureNote
+            // Route through the centralized bridge. When the SDK lands support,
+            // `NewItemTypesSdkBridge.sdkCipherTypeForBankAccount()` returns the real
+            // SDK case and this branch succeeds. Until then, it returns `nil` and we
+            // fail closed — no silent coercion.
+            guard let mapped = NewItemTypesSdkBridge.sdkCipherTypeForBankAccount() else {
+                // Tripwire: in Debug builds, surface accidental enabling of the
+                // feature flag before SDK readiness so the divergence is caught in
+                // development rather than producing corrupted saves. Release builds
+                // fail closed via `return nil` immediately below.
+                assertionFailure(
+                    "BitwardenSdk.CipherType.init(_:) called with .bankAccount before the SDK " +
+                        "exposes BankAccount support. Did the newItemTypes feature flag get " +
+                        "enabled ahead of SDK readiness? Fix: keep the flag off until the SDK " +
+                        "dependency is bumped and NewItemTypesSdkBridge.isBankAccountAvailable " +
+                        "is set to true. See PM-32009.",
+                )
+                return nil
+            }
+            self = mapped
         }
     }
 }

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -60,9 +60,13 @@ extension CipherCardModel {
 extension CipherDetailsResponseModel {
     init(cipher: BitwardenSdk.Cipher) throws {
         guard let id = cipher.id else { throw DataMappingError.invalidData }
+        // TODO: PM-32009 Blocked on SDK — map cipher.bankAccount to CipherBankAccountModel once
+        // BitwardenSdk.Cipher exposes a `bankAccount: BankAccount?` property.
+        let bankAccount: CipherBankAccountModel? = nil
         self.init(
             archivedDate: cipher.archivedDate,
             attachments: cipher.attachments?.map(AttachmentResponseModel.init),
+            bankAccount: bankAccount,
             card: cipher.card.map(CipherCardModel.init),
             collectionIds: cipher.collectionIds,
             creationDate: cipher.creationDate,
@@ -218,6 +222,8 @@ extension CipherSSHKeyModel {
 
 extension CipherType {
     init(type: BitwardenSdk.CipherType) {
+        // TODO: PM-32009 Blocked on SDK — add a `case .bankAccount` arm once
+        // BitwardenSdk.CipherType exposes `bankAccount`.
         switch type {
         case .card:
             self = .card
@@ -233,6 +239,8 @@ extension CipherType {
     }
 
     init(_ type: BitwardenSdk.CipherListViewType) {
+        // TODO: PM-32009 Blocked on SDK — add a `case .bankAccount` arm once
+        // BitwardenSdk.CipherListViewType exposes `bankAccount`.
         switch type {
         case .card:
             self = .card
@@ -507,6 +515,13 @@ extension BitwardenSdk.CipherType {
             self = .identity
         case .sshKey:
             self = .sshKey
+        case .bankAccount:
+            // TODO: PM-32009 Blocked on SDK — map `.bankAccount` to the corresponding
+            // `BitwardenSdk.CipherType.bankAccount` case once the SDK exposes it. Until then,
+            // this path is unreachable in practice because the `newItemTypes` feature flag is
+            // off by default and gates creation of bank account ciphers. Fallback mapping to
+            // `.secureNote` is defensive only.
+            self = .secureNote
         }
     }
 }

--- a/BitwardenShared/Core/Vault/Extensions/Cipher+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Extensions/Cipher+Extensions.swift
@@ -17,6 +17,11 @@ extension Cipher {
         switch group {
         case .archive:
             archivedDate != nil
+        case .bankAccount:
+            // TODO: PM-32009 Blocked on SDK — match `type == .bankAccount` (using
+            // `BitwardenSdk.CipherType.bankAccount`) once the SDK exposes it. Until then, no
+            // encrypted ciphers report as bank accounts.
+            false
         case .card:
             type == .card
         case let .collection(id, _, _):

--- a/BitwardenShared/Core/Vault/Extensions/CipherListView+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Extensions/CipherListView+Extensions.swift
@@ -40,6 +40,10 @@ extension CipherListView {
         switch group {
         case .archive:
             archivedDate != nil
+        case .bankAccount:
+            // TODO: PM-32009 Blocked on SDK — match `type == .bankAccount` (using
+            // `BitwardenSdk.CipherListViewType.bankAccount`) once the SDK exposes it.
+            false
         case .card:
             type.isCard
         case let .collection(id, _, _):

--- a/BitwardenShared/Core/Vault/Helpers/VaultListDataPreparator.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListDataPreparator.swift
@@ -269,6 +269,8 @@ struct DefaultVaultListDataPreparator: VaultListDataPreparator { // swiftlint:di
             .prepareCollections(collections: collections, filterType: filter.filterType)
 
         let archiveItemsFeatureFlagEnabled: Bool = await configService.getFeatureFlag(.archiveVaultItems)
+        let newItemTypesFeatureFlagEnabled: Bool = await configService.getFeatureFlag(.newItemTypes)
+        preparedDataBuilder = preparedDataBuilder.setNewItemTypesFFEnabled(newItemTypesFeatureFlagEnabled)
 
         await decryptAndProcessCiphersInBatch(
             ciphers: ciphers,

--- a/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListPreparedDataBuilder.swift
@@ -93,6 +93,12 @@ protocol VaultListPreparedDataBuilder { // sourcery: AutoMockable
     /// Prepares the sections with restricted organization IDs.
     @discardableResult
     func prepareRestrictItemsPolicyOrganizations(restrictedOrganizationIds: [String]) -> VaultListPreparedDataBuilder
+
+    /// Records whether the new item types feature flag is enabled on the prepared data.
+    /// - Parameter isEnabled: Whether the flag is enabled.
+    /// - Returns: This same instance builder for fluent coding.
+    @discardableResult
+    func setNewItemTypesFFEnabled(_ isEnabled: Bool) -> VaultListPreparedDataBuilder
 }
 
 // MARK: - DefaultVaultListPreparedDataBuilder
@@ -221,6 +227,12 @@ class DefaultVaultListPreparedDataBuilder: VaultListPreparedDataBuilder { // swi
         }
 
         switch group {
+        case .bankAccount:
+            // TODO: PM-32009 Blocked on SDK — match `cipher.type == .bankAccount` (using
+            // `BitwardenSdk.CipherListViewType.bankAccount`) once the SDK exposes it. Until
+            // then, no ciphers match this group at runtime, which aligns with the flag-off
+            // default state.
+            return self
         case .card:
             guard cipher.type.isCard else { return self }
         case .identity:
@@ -376,6 +388,12 @@ class DefaultVaultListPreparedDataBuilder: VaultListPreparedDataBuilder { // swi
     @discardableResult
     func prepareRestrictItemsPolicyOrganizations(restrictedOrganizationIds: [String]) -> VaultListPreparedDataBuilder {
         preparedData.restrictedOrganizationIds = restrictedOrganizationIds
+        return self
+    }
+
+    @discardableResult
+    func setNewItemTypesFFEnabled(_ isEnabled: Bool) -> VaultListPreparedDataBuilder {
+        preparedData.isNewItemTypesFFEnabled = isEnabled
         return self
     }
 

--- a/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilder.swift
+++ b/BitwardenShared/Core/Vault/Helpers/VaultListSectionsBuilder.swift
@@ -432,6 +432,15 @@ class DefaultVaultListSectionsBuilder: VaultListSectionsBuilder { // swiftlint:d
             ],
         )
 
+        if preparedData.isNewItemTypesFFEnabled {
+            types.append(
+                VaultListItem(
+                    id: "Types.BankAccounts",
+                    itemType: .group(.bankAccount, preparedData.countPerCipherType[.bankAccount, default: 0]),
+                ),
+            )
+        }
+
         vaultListData.sections.append(VaultListSection(id: "Types", items: types, name: Localizations.types))
         return self
     }
@@ -464,12 +473,17 @@ struct VaultListPreparedData {
 
     /// A dictionary mapping cipher types to their counts in the vault.
     var countPerCipherType: [CipherType: Int] = [
+        .bankAccount: 0,
         .card: 0,
         .identity: 0,
         .login: 0,
         .secureNote: 0,
         .sshKey: 0,
     ]
+
+    /// Whether the new item types (Bank Account, Driver's License, Passport) feature flag is
+    /// enabled for the current user. Gates inclusion of Bank Account rows in the "Types" section.
+    var isNewItemTypesFFEnabled: Bool = false
 
     /// Vault list items that exactly match the search criteria.
     var exactMatchItems: [VaultListItem] = []

--- a/BitwardenShared/Core/Vault/Models/API/CipherBankAccountModel.swift
+++ b/BitwardenShared/Core/Vault/Models/API/CipherBankAccountModel.swift
@@ -1,5 +1,16 @@
 /// API model for a bank account cipher.
 ///
+/// Every field defaults to `nil` so callers can use the synthesized memberwise init
+/// conveniently and so the JSON payload minimizes absent fields.
+///
+/// - Important: Instances of this model are **never** to be serialized directly to a
+///   request body reaching the server. All persisted bank account data must pass
+///   through the `BitwardenSdk` encryption path (`CipherView.bankAccount` /
+///   `Cipher.bankAccount` once the SDK exposes those types). This model is strictly an
+///   intermediate representation for JSON round-tripping when the SDK is not yet
+///   available (TODO: PM-32009 Blocked on SDK). See the serialization tripwire in
+///   `BankAccountItemState.apiModel`.
+///
 struct CipherBankAccountModel: Codable, Equatable, Sendable {
     // MARK: Properties
 
@@ -32,4 +43,45 @@ struct CipherBankAccountModel: Codable, Equatable, Sendable {
 
     /// The SWIFT / BIC code of the bank.
     let swiftCode: String?
+
+    // MARK: Initialization
+
+    /// Creates a new `CipherBankAccountModel`. All parameters default to `nil` so
+    /// callers can build minimal payloads without listing every field.
+    ///
+    /// - Parameters:
+    ///   - accountNumber: The account number (sensitive).
+    ///   - accountType: The bank account type.
+    ///   - bankName: The name of the bank.
+    ///   - bankPhone: The bank contact phone number.
+    ///   - branchNumber: The branch number of the bank.
+    ///   - iban: The IBAN.
+    ///   - nameOnAccount: The name on the account.
+    ///   - pin: The personal identification number (sensitive).
+    ///   - routingNumber: The routing number.
+    ///   - swiftCode: The SWIFT / BIC code.
+    ///
+    init(
+        accountNumber: String? = nil,
+        accountType: BankAccountType? = nil,
+        bankName: String? = nil,
+        bankPhone: String? = nil,
+        branchNumber: String? = nil,
+        iban: String? = nil,
+        nameOnAccount: String? = nil,
+        pin: String? = nil,
+        routingNumber: String? = nil,
+        swiftCode: String? = nil,
+    ) {
+        self.accountNumber = accountNumber
+        self.accountType = accountType
+        self.bankName = bankName
+        self.bankPhone = bankPhone
+        self.branchNumber = branchNumber
+        self.iban = iban
+        self.nameOnAccount = nameOnAccount
+        self.pin = pin
+        self.routingNumber = routingNumber
+        self.swiftCode = swiftCode
+    }
 }

--- a/BitwardenShared/Core/Vault/Models/API/CipherBankAccountModel.swift
+++ b/BitwardenShared/Core/Vault/Models/API/CipherBankAccountModel.swift
@@ -1,0 +1,35 @@
+/// API model for a bank account cipher.
+///
+struct CipherBankAccountModel: Codable, Equatable, Sendable {
+    // MARK: Properties
+
+    /// The account number (sensitive; rendered as a hidden field in the UI).
+    let accountNumber: String?
+
+    /// The type of the bank account (e.g., checking, savings).
+    let accountType: BankAccountType?
+
+    /// The name of the bank.
+    let bankName: String?
+
+    /// The phone number for contacting the bank.
+    let bankPhone: String?
+
+    /// The branch number of the bank.
+    let branchNumber: String?
+
+    /// The IBAN (International Bank Account Number).
+    let iban: String?
+
+    /// The name on the account.
+    let nameOnAccount: String?
+
+    /// The personal identification number (sensitive; rendered as a hidden field in the UI).
+    let pin: String?
+
+    /// The routing number of the bank.
+    let routingNumber: String?
+
+    /// The SWIFT / BIC code of the bank.
+    let swiftCode: String?
+}

--- a/BitwardenShared/Core/Vault/Models/API/CipherBankAccountModelTests.swift
+++ b/BitwardenShared/Core/Vault/Models/API/CipherBankAccountModelTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class CipherBankAccountModelTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `CipherBankAccountModel` round-trips through JSON encoding / decoding with all fields
+    /// populated.
+    func test_codable_roundTrip_populated() throws {
+        let original = CipherBankAccountModel(
+            accountNumber: "1234567890",
+            accountType: .checking,
+            bankName: "Bitwarden Bank",
+            bankPhone: "555-0100",
+            branchNumber: "100",
+            iban: "GB82WEST12345698765432",
+            nameOnAccount: "Bitwarden User",
+            pin: "1234",
+            routingNumber: "011000015",
+            swiftCode: "BTCBUS33",
+        )
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CipherBankAccountModel.self, from: encoded)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    /// `CipherBankAccountModel` round-trips through JSON when all fields are nil.
+    func test_codable_roundTrip_empty() throws {
+        let original = CipherBankAccountModel()
+
+        let encoded = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(CipherBankAccountModel.self, from: encoded)
+
+        XCTAssertEqual(decoded, original)
+    }
+
+    /// `CipherBankAccountModel` decodes a representative JSON payload from the server.
+    func test_decode_serverPayload() throws {
+        let json = """
+        {
+            "accountNumber": "1234567890",
+            "accountType": 0,
+            "bankName": "Bitwarden Bank",
+            "bankPhone": "555-0100",
+            "branchNumber": "100",
+            "iban": "GB82WEST12345698765432",
+            "nameOnAccount": "Bitwarden User",
+            "pin": "1234",
+            "routingNumber": "011000015",
+            "swiftCode": "BTCBUS33"
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(CipherBankAccountModel.self, from: data)
+
+        XCTAssertEqual(decoded.accountNumber, "1234567890")
+        XCTAssertEqual(decoded.accountType, .checking)
+        XCTAssertEqual(decoded.bankName, "Bitwarden Bank")
+        XCTAssertEqual(decoded.bankPhone, "555-0100")
+        XCTAssertEqual(decoded.branchNumber, "100")
+        XCTAssertEqual(decoded.iban, "GB82WEST12345698765432")
+        XCTAssertEqual(decoded.nameOnAccount, "Bitwarden User")
+        XCTAssertEqual(decoded.pin, "1234")
+        XCTAssertEqual(decoded.routingNumber, "011000015")
+        XCTAssertEqual(decoded.swiftCode, "BTCBUS33")
+    }
+
+    /// `CipherBankAccountModel` decodes when optional fields are missing.
+    func test_decode_missingOptionalFields() throws {
+        let json = """
+        {
+            "bankName": "Bitwarden Bank"
+        }
+        """
+        let data = try XCTUnwrap(json.data(using: .utf8))
+        let decoded = try JSONDecoder().decode(CipherBankAccountModel.self, from: data)
+
+        XCTAssertEqual(decoded.bankName, "Bitwarden Bank")
+        XCTAssertNil(decoded.accountNumber)
+        XCTAssertNil(decoded.accountType)
+        XCTAssertNil(decoded.bankPhone)
+        XCTAssertNil(decoded.branchNumber)
+        XCTAssertNil(decoded.iban)
+        XCTAssertNil(decoded.nameOnAccount)
+        XCTAssertNil(decoded.pin)
+        XCTAssertNil(decoded.routingNumber)
+        XCTAssertNil(decoded.swiftCode)
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Enum/BankAccountType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/BankAccountType.swift
@@ -1,0 +1,43 @@
+import BitwardenKit
+import BitwardenResources
+
+// MARK: - BankAccountType
+
+/// An enum describing the type of a bank account cipher.
+///
+public enum BankAccountType: Int, Codable, CaseIterable, Sendable {
+    /// A checking account.
+    case checking = 0
+
+    /// A savings account.
+    case savings = 1
+
+    /// A certificate of deposit (CD) account.
+    case certificateOfDeposit = 2
+
+    /// A line of credit account.
+    case lineOfCredit = 3
+
+    /// An investment / brokerage account.
+    case investmentBrokerage = 4
+
+    /// A money market account.
+    case moneyMarket = 5
+
+    /// Any other type of bank account not covered by the explicit cases.
+    case other = 6
+}
+
+extension BankAccountType: Menuable {
+    public var localizedName: String {
+        switch self {
+        case .checking: Localizations.checking
+        case .savings: Localizations.savings
+        case .certificateOfDeposit: Localizations.certificateOfDeposit
+        case .lineOfCredit: Localizations.lineOfCredit
+        case .investmentBrokerage: Localizations.investmentBrokerage
+        case .moneyMarket: Localizations.moneyMarket
+        case .other: Localizations.other
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Enum/BankAccountTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/BankAccountTypeTests.swift
@@ -1,0 +1,51 @@
+import BitwardenResources
+import XCTest
+
+@testable import BitwardenShared
+
+class BankAccountTypeTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// Each case has a distinct raw value matching the cross-platform contract.
+    func test_rawValues_matchContract() {
+        XCTAssertEqual(BankAccountType.checking.rawValue, 0)
+        XCTAssertEqual(BankAccountType.savings.rawValue, 1)
+        XCTAssertEqual(BankAccountType.certificateOfDeposit.rawValue, 2)
+        XCTAssertEqual(BankAccountType.lineOfCredit.rawValue, 3)
+        XCTAssertEqual(BankAccountType.investmentBrokerage.rawValue, 4)
+        XCTAssertEqual(BankAccountType.moneyMarket.rawValue, 5)
+        XCTAssertEqual(BankAccountType.other.rawValue, 6)
+    }
+
+    /// `allCases` exposes all seven account types in stable order.
+    func test_allCases_ordering() {
+        XCTAssertEqual(
+            BankAccountType.allCases,
+            [
+                .checking,
+                .savings,
+                .certificateOfDeposit,
+                .lineOfCredit,
+                .investmentBrokerage,
+                .moneyMarket,
+                .other,
+            ],
+        )
+    }
+
+    /// Each case has a non-empty localized name.
+    func test_localizedName_isNotEmpty() {
+        for bankAccountType in BankAccountType.allCases {
+            XCTAssertFalse(bankAccountType.localizedName.isEmpty, "Missing localizedName for \(bankAccountType)")
+        }
+    }
+
+    /// Raw values round-trip through JSON encoding.
+    func test_codable_roundTrip() throws {
+        for bankAccountType in BankAccountType.allCases {
+            let encoded = try JSONEncoder().encode(bankAccountType)
+            let decoded = try JSONDecoder().decode(BankAccountType.self, from: encoded)
+            XCTAssertEqual(decoded, bankAccountType)
+        }
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
@@ -72,32 +72,66 @@ extension CipherType: Menuable {
 }
 
 extension CipherType {
-    /// The cipher types that the user can use to create a cipher when the new item types feature
-    /// flag is disabled. This is the pre-feature-flag baseline set.
-    static let canCreateCasesBase: [CipherType] = [.login, .card, .identity, .secureNote, .sshKey]
+    /// The cipher types the user can use to create a cipher when the `newItemTypes` feature
+    /// flag is disabled. This is the authoritative "today" set.
+    ///
+    /// Callers with access to a `ConfigService` should prefer the flag-aware
+    /// `canCreateCases(isNewItemTypesEnabled:)` helper; this constant is only appropriate
+    /// for seeding default state before the flag value is known.
+    static let canCreateCasesBase: [CipherType] = [.login, .card, .identity, .secureNote]
 
-    /// The cipher types that the user can use to create a cipher when the new item types feature
+    /// The cipher types the user can use to create a cipher when the `newItemTypes` feature
     /// flag is enabled. Extends the base set with the new types introduced by PM-32009.
     static let canCreateCasesWithNewItemTypes: [CipherType] = canCreateCasesBase + [.bankAccount]
 
-    /// These are the cases of `CipherType` that the user can use to create a cipher when the new
-    /// item types feature flag is disabled. Callers that have access to the feature flag state
-    /// should use `canCreateCases(isNewItemTypesEnabled:)` to get the full list.
-    static let canCreateCases: [CipherType] = [.login, .card, .identity, .secureNote]
-
     /// The allowed custom field types per cipher type.
+    ///
+    /// - Note: Bank Account is limited to `.text`, `.hidden`, `.boolean` — linked fields are
+    ///   not part of MVP (US-1.1).
     var allowedFieldTypes: [FieldType] {
         switch self {
-        case .bankAccount, .card, .identity, .login:
+        case .card, .identity, .login:
             [.text, .hidden, .boolean, .linked]
-        case .secureNote, .sshKey:
+        case .bankAccount, .secureNote, .sshKey:
             [.text, .hidden, .boolean]
         }
     }
 }
 
 extension CipherType {
-    /// Returns the cipher types that the user can create, gated by the new item types feature flag.
+    /// The type-agnostic placeholder icon for this cipher type.
+    ///
+    /// Centralizes icon routing so the final assets from PM-34128 can be swapped in a
+    /// single place when design ships. Callers that need a brand-specific icon (e.g.,
+    /// card brand icons) should special-case before falling back to this helper.
+    ///
+    /// - Note: Bank Account currently reuses `card24` until the PM-34128 design work
+    ///   delivers a dedicated asset. Driver's License and Passport will join this
+    ///   helper in PRs 2 and 3.
+    ///
+    var iconPlaceholder: SharedImageAsset {
+        switch self {
+        case .bankAccount:
+            // TODO: PM-34128 Swap to the final bank account asset when icon design
+            // ships.
+            SharedAsset.Icons.card24
+        case .card:
+            SharedAsset.Icons.card24
+        case .identity:
+            SharedAsset.Icons.idCard24
+        case .login:
+            SharedAsset.Icons.globe24
+        case .secureNote:
+            SharedAsset.Icons.stickyNote24
+        case .sshKey:
+            SharedAsset.Icons.key24
+        }
+    }
+}
+
+extension CipherType {
+    /// Returns the cipher types that the user can create, gated by the new item types feature
+    /// flag.
     ///
     /// - Parameter isNewItemTypesEnabled: Whether the `newItemTypes` feature flag is enabled.
     /// - Returns: The creatable cipher types. When the flag is enabled, the new types (Bank

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
@@ -18,6 +18,9 @@ public enum CipherType: Int, Codable, Sendable {
 
     /// An SSH key.
     case sshKey = 5
+
+    /// A bank account.
+    case bankAccount = 6
 }
 
 extension CipherType {
@@ -27,6 +30,8 @@ extension CipherType {
     ///
     init?(group: VaultListGroup) {
         switch group {
+        case .bankAccount:
+            self = .bankAccount
         case .card:
             self = .card
         case .identity:
@@ -50,12 +55,13 @@ extension CipherType {
 }
 
 extension CipherType: CaseIterable {
-    public static let allCases: [CipherType] = [.login, .card, .identity, .secureNote, .sshKey]
+    public static let allCases: [CipherType] = [.login, .card, .identity, .secureNote, .sshKey, .bankAccount]
 }
 
 extension CipherType: Menuable {
     public var localizedName: String {
         switch self {
+        case .bankAccount: Localizations.typeBankAccount
         case .card: Localizations.typeCard
         case .identity: Localizations.typeIdentity
         case .login: Localizations.typeLogin
@@ -66,16 +72,38 @@ extension CipherType: Menuable {
 }
 
 extension CipherType {
-    /// These are the cases of `CipherType` that the user can use to create a cipher.
+    /// The cipher types that the user can use to create a cipher when the new item types feature
+    /// flag is disabled. This is the pre-feature-flag baseline set.
+    static let canCreateCasesBase: [CipherType] = [.login, .card, .identity, .secureNote, .sshKey]
+
+    /// The cipher types that the user can use to create a cipher when the new item types feature
+    /// flag is enabled. Extends the base set with the new types introduced by PM-32009.
+    static let canCreateCasesWithNewItemTypes: [CipherType] = canCreateCasesBase + [.bankAccount]
+
+    /// These are the cases of `CipherType` that the user can use to create a cipher when the new
+    /// item types feature flag is disabled. Callers that have access to the feature flag state
+    /// should use `canCreateCases(isNewItemTypesEnabled:)` to get the full list.
     static let canCreateCases: [CipherType] = [.login, .card, .identity, .secureNote]
 
     /// The allowed custom field types per cipher type.
     var allowedFieldTypes: [FieldType] {
         switch self {
-        case .card, .identity, .login:
+        case .bankAccount, .card, .identity, .login:
             [.text, .hidden, .boolean, .linked]
         case .secureNote, .sshKey:
             [.text, .hidden, .boolean]
         }
+    }
+}
+
+extension CipherType {
+    /// Returns the cipher types that the user can create, gated by the new item types feature flag.
+    ///
+    /// - Parameter isNewItemTypesEnabled: Whether the `newItemTypes` feature flag is enabled.
+    /// - Returns: The creatable cipher types. When the flag is enabled, the new types (Bank
+    ///   Account) are appended to the base list.
+    ///
+    static func canCreateCases(isNewItemTypesEnabled: Bool) -> [CipherType] {
+        isNewItemTypesEnabled ? canCreateCasesWithNewItemTypes : canCreateCasesBase
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
@@ -13,6 +13,7 @@ class CipherTypeTests: BitwardenTestCase {
         XCTAssertEqual(CipherType.identity.allowedFieldTypes, [.text, .hidden, .boolean, .linked])
         XCTAssertEqual(CipherType.secureNote.allowedFieldTypes, [.text, .hidden, .boolean])
         XCTAssertEqual(CipherType.sshKey.allowedFieldTypes, [.text, .hidden, .boolean])
+        XCTAssertEqual(CipherType.bankAccount.allowedFieldTypes, [.text, .hidden, .boolean])
     }
 
     /// `localizedName` returns the correct values.
@@ -22,6 +23,7 @@ class CipherTypeTests: BitwardenTestCase {
         XCTAssertEqual(CipherType.login.localizedName, Localizations.typeLogin)
         XCTAssertEqual(CipherType.secureNote.localizedName, Localizations.typeSecureNote)
         XCTAssertEqual(CipherType.sshKey.localizedName, Localizations.sshKey)
+        XCTAssertEqual(CipherType.bankAccount.localizedName, Localizations.typeBankAccount)
     }
 
     /// `init` with a `VaultListGroup` produces the correct value.
@@ -33,12 +35,44 @@ class CipherTypeTests: BitwardenTestCase {
         XCTAssertEqual(CipherType(group: .login), .login)
         XCTAssertEqual(CipherType(group: .secureNote), .secureNote)
         XCTAssertEqual(CipherType(group: .sshKey), .sshKey)
+        XCTAssertEqual(CipherType(group: .bankAccount), .bankAccount)
         XCTAssertNil(CipherType(group: .archive))
         XCTAssertNil(CipherType(group: .trash))
     }
 
-    /// `canCreateCases` return the correct cipher types that the user can use to create ciphers.
-    func test_canCreateCases() {
-        XCTAssertEqual(CipherType.canCreateCases, [.login, .card, .identity, .secureNote])
+    /// `canCreateCasesBase` preserves today's flag-off creation set.
+    func test_canCreateCasesBase() {
+        XCTAssertEqual(CipherType.canCreateCasesBase, [.login, .card, .identity, .secureNote])
+    }
+
+    /// `canCreateCasesWithNewItemTypes` extends the base set with the PM-32009 types.
+    func test_canCreateCasesWithNewItemTypes() {
+        XCTAssertEqual(
+            CipherType.canCreateCasesWithNewItemTypes,
+            [.login, .card, .identity, .secureNote, .bankAccount],
+        )
+    }
+
+    /// `canCreateCases(isNewItemTypesEnabled:)` returns the base set when the flag is off and
+    /// adds Bank Account when the flag is on.
+    func test_canCreateCases_withFlag() {
+        XCTAssertEqual(
+            CipherType.canCreateCases(isNewItemTypesEnabled: false),
+            [.login, .card, .identity, .secureNote],
+        )
+        XCTAssertEqual(
+            CipherType.canCreateCases(isNewItemTypesEnabled: true),
+            [.login, .card, .identity, .secureNote, .bankAccount],
+        )
+        // The flag-off list never contains `.bankAccount`.
+        XCTAssertFalse(CipherType.canCreateCases(isNewItemTypesEnabled: false).contains(.bankAccount))
+    }
+
+    /// `allCases` returns every app-layer cipher type in a stable order.
+    func test_allCases() {
+        XCTAssertEqual(
+            CipherType.allCases,
+            [.login, .card, .identity, .secureNote, .sshKey, .bankAccount],
+        )
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/LinkedIdType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/LinkedIdType.swift
@@ -158,6 +158,10 @@ extension LinkedIdType {
     ///
     static func getLinkedIdType(for cipherType: CipherType) -> [LinkedIdType] {
         switch cipherType {
+        case .bankAccount:
+            // TODO: PM-32009 Populate linked-id types for bank account fields once the SDK /
+            // server define the canonical `LinkedIdType` values for the new cipher type.
+            []
         case .card:
             [
                 .cardCardholderName,

--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
@@ -107,7 +107,11 @@ extension CipherRequestModel {
             reprompt: CipherRepromptType(type: cipher.reprompt),
             secureNote: cipher.secureNote.map(CipherSecureNoteModel.init),
             sshKey: cipher.sshKey.map(CipherSSHKeyModel.init),
-            type: CipherType(type: cipher.type),
+            // Unknown SDK cipher types fall back to `.secureNote` on this outbound
+            // request mapping. PM-32813 backward-compat work will formalize the
+            // unknown-type handling (e.g., block the save or surface a clear error
+            // before reaching this point).
+            type: CipherType(type: cipher.type) ?? .secureNote,
         )
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Response/CipherDetailsResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/CipherDetailsResponseModel.swift
@@ -13,6 +13,9 @@ struct CipherDetailsResponseModel: JSONResponse, Equatable {
     /// The cipher's list of attachments.
     let attachments: [AttachmentResponseModel]?
 
+    /// Bank account data if the cipher is a bank account.
+    let bankAccount: CipherBankAccountModel?
+
     /// Card data if the cipher is a card.
     let card: CipherCardModel?
 

--- a/BitwardenShared/Core/Vault/Models/Response/CipherDetailsResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/CipherDetailsResponseModel.swift
@@ -14,7 +14,15 @@ struct CipherDetailsResponseModel: JSONResponse, Equatable {
     let attachments: [AttachmentResponseModel]?
 
     /// Bank account data if the cipher is a bank account.
-    let bankAccount: CipherBankAccountModel?
+    ///
+    /// Declared as `var` with an explicit `nil` default so the synthesized memberwise
+    /// init exposes `bankAccount:` as an optional parameter. This keeps pre-PM-32009
+    /// test call sites that construct `CipherDetailsResponseModel` with the legacy
+    /// field list source-compatible. Do not let swiftformat strip the `= nil` — the
+    /// compiler only includes the default in the synthesized memberwise init when it
+    /// is present at the declaration.
+    // swiftformat:disable:next redundantNilInit
+    var bankAccount: CipherBankAccountModel? = nil
 
     /// Card data if the cipher is a card.
     let card: CipherCardModel?

--- a/BitwardenShared/Core/Vault/Models/Response/CipherMiniResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/CipherMiniResponseModel.swift
@@ -16,6 +16,9 @@ struct CipherMiniResponseModel: JSONResponse, Equatable {
     /// The cipher's list of attachments.
     let attachments: [AttachmentResponseModel]?
 
+    /// Bank account data if the cipher is a bank account.
+    let bankAccount: CipherBankAccountModel?
+
     /// Card data if the cipher is a card.
     let card: CipherCardModel?
 

--- a/BitwardenShared/Core/Vault/Models/Response/CipherMiniResponseModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Response/CipherMiniResponseModel.swift
@@ -17,7 +17,15 @@ struct CipherMiniResponseModel: JSONResponse, Equatable {
     let attachments: [AttachmentResponseModel]?
 
     /// Bank account data if the cipher is a bank account.
-    let bankAccount: CipherBankAccountModel?
+    ///
+    /// Declared as `var` with an explicit `nil` default so the synthesized memberwise
+    /// init exposes `bankAccount:` as an optional parameter. This keeps pre-PM-32009
+    /// test call sites that construct `CipherMiniResponseModel` with the legacy field
+    /// list source-compatible. Do not let swiftformat strip the `= nil` — the
+    /// compiler only includes the default in the synthesized memberwise init when it
+    /// is present at the declaration.
+    // swiftformat:disable:next redundantNilInit
+    var bankAccount: CipherBankAccountModel? = nil
 
     /// Card data if the cipher is a card.
     let card: CipherCardModel?

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -698,9 +698,9 @@ extension DefaultVaultRepository: VaultRepository {
 
     func getItemTypesUserCanCreate() async -> [CipherType] {
         let isNewItemTypesEnabled = await configService.getFeatureFlag(FeatureFlag.newItemTypes)
-        let itemTypes = CipherType.canCreateCases(
-            isNewItemTypesEnabled: isNewItemTypesEnabled,
-        ).reversed().map(\.self)
+        let itemTypes = Array(
+            CipherType.canCreateCases(isNewItemTypesEnabled: isNewItemTypesEnabled).reversed(),
+        )
         let restrictItemTypesOrgIds = await policyService.getOrganizationIdsForRestricItemTypesPolicy()
         if !restrictItemTypesOrgIds.isEmpty {
             return itemTypes.filter { $0 != .card }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepository.swift
@@ -697,7 +697,10 @@ extension DefaultVaultRepository: VaultRepository {
     }
 
     func getItemTypesUserCanCreate() async -> [CipherType] {
-        let itemTypes: [CipherType] = CipherType.canCreateCases.reversed()
+        let isNewItemTypesEnabled = await configService.getFeatureFlag(FeatureFlag.newItemTypes)
+        let itemTypes = CipherType.canCreateCases(
+            isNewItemTypesEnabled: isNewItemTypesEnabled,
+        ).reversed().map(\.self)
         let restrictItemTypesOrgIds = await policyService.getOrganizationIdsForRestricItemTypesPolicy()
         if !restrictItemTypesOrgIds.isEmpty {
             return itemTypes.filter { $0 != .card }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -1015,6 +1015,31 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(result, [.secureNote, .identity, .card, .login])
     }
 
+    /// `getItemTypesUserCanCreate()` includes Bank Account when the new item types feature
+    /// flag is enabled.
+    @MainActor
+    func test_getItemTypesUserCanCreate_newItemTypesFlagOn() async throws {
+        stateService.activeAccount = .fixture()
+        policyService.policyAppliesToUserPolicies = []
+        configService.featureFlagsBool[.newItemTypes] = true
+
+        let result = await subject.getItemTypesUserCanCreate()
+        XCTAssertEqual(result, [.bankAccount, .secureNote, .identity, .card, .login])
+    }
+
+    /// `getItemTypesUserCanCreate()` excludes Bank Account when the new item types feature
+    /// flag is disabled (default behavior).
+    @MainActor
+    func test_getItemTypesUserCanCreate_newItemTypesFlagOff() async throws {
+        stateService.activeAccount = .fixture()
+        policyService.policyAppliesToUserPolicies = []
+        configService.featureFlagsBool[.newItemTypes] = false
+
+        let result = await subject.getItemTypesUserCanCreate()
+        XCTAssertFalse(result.contains(.bankAccount))
+        XCTAssertEqual(result, [.secureNote, .identity, .card, .login])
+    }
+
     /// `getTOTPKeyIfAllowedToCopy(cipher:)` return the TOTP key when cipher has TOTP key,
     /// is enable to auto copy the TOTP and cipher organization uses TOTP.
     func test_getTOTPKeyIfAllowedToCopy_orgUsesTOTP() async throws {

--- a/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
@@ -233,9 +233,9 @@ class DefaultExportVaultService: ExportVaultService {
             // be mapped to an app-layer `CipherType` (unknown/future case), treat it
             // as unrestricted so export doesn't silently drop it — PM-32813
             // backward-compat will formalize unknown-type handling.
-            let appType = BitwardenShared.CipherType(type: cipher.type)
-            return cipher.organizationId == nil
-                && (appType == nil || !restrictedTypes.contains(appType!))
+            let isRestricted = BitwardenShared.CipherType(type: cipher.type)
+                .map { restrictedTypes.contains($0) } ?? false
+            return cipher.organizationId == nil && !isRestricted
         }
     }
 

--- a/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
+++ b/BitwardenShared/Core/Vault/Services/ExportVaultService.swift
@@ -229,9 +229,13 @@ class DefaultExportVaultService: ExportVaultService {
                 return false
             }
 
-            // Apply organization and restricted type filters
+            // Apply organization and restricted type filters. If the SDK type cannot
+            // be mapped to an app-layer `CipherType` (unknown/future case), treat it
+            // as unrestricted so export doesn't silently drop it — PM-32813
+            // backward-compat will formalize unknown-type handling.
+            let appType = BitwardenShared.CipherType(type: cipher.type)
             return cipher.organizationId == nil
-                && !restrictedTypes.contains(BitwardenShared.CipherType(type: cipher.type))
+                && (appType == nil || !restrictedTypes.contains(appType!))
         }
     }
 

--- a/BitwardenShared/UI/Platform/Application/Extensions/View.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View.swift
@@ -90,7 +90,7 @@ extension View {
     ///
     func addVaultItemFloatingActionMenu(
         hidden: Bool = false,
-        availableItemTypes: [CipherType] = CipherType.canCreateCases,
+        availableItemTypes: [CipherType] = CipherType.canCreateCasesBase,
         addItem: @escaping (CipherType) -> Void,
         addFolder: (() -> Void)? = nil,
     ) -> some View {

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -24,6 +24,8 @@ struct VaultGroupState: Equatable, Sendable {
     /// The title of the add item button.
     var addItemButtonTitle: String {
         switch group {
+        case .bankAccount:
+            Localizations.newBankAccount
         case .card:
             Localizations.newCard
         case .collection, .folder:
@@ -55,7 +57,7 @@ struct VaultGroupState: Equatable, Sendable {
         }
 
         switch group {
-        case .card, .identity, .login, .secureNote:
+        case .bankAccount, .card, .identity, .login, .secureNote:
             return .button
         case .collection, .folder, .noFolder:
             return .menu
@@ -90,6 +92,8 @@ struct VaultGroupState: Equatable, Sendable {
         switch group {
         case .archive:
             Localizations.archiveEmptyDescriptionLong
+        case .bankAccount:
+            Localizations.noItems
         case .card:
             Localizations.thereAreNoCardsInYourVault
         case .collection:

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -76,7 +76,11 @@ struct VaultGroupState: Equatable, Sendable {
     var iconBaseURL: URL?
 
     /// List of available item type for creation.
-    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCases
+    ///
+    /// Seeded with the flag-off baseline; the processor replaces this from
+    /// `VaultRepository.getItemTypesUserCanCreate()` on appearance, which reads the
+    /// `newItemTypes` feature flag.
+    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCasesBase
 
     /// Whether the policy is enforced to disable personal vault ownership.
     var isPersonalOwnershipDisabled: Bool = false

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListGroup.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListGroup.swift
@@ -6,6 +6,9 @@ import BitwardenSdk
 public enum VaultListGroup: Equatable, Hashable, Sendable {
     // MARK: Cipher Types
 
+    /// A group of bank account type ciphers.
+    case bankAccount
+
     /// A group of card type ciphers.
     case card
 
@@ -72,6 +75,8 @@ extension VaultListGroup {
         switch self {
         case .archive:
             Localizations.archive
+        case .bankAccount:
+            Localizations.typeBankAccount
         case .card:
             Localizations.typeCard
         case let .collection(_, name, _):
@@ -100,6 +105,8 @@ extension VaultListGroup {
         switch self {
         case .archive:
             Localizations.archive
+        case .bankAccount:
+            Localizations.bankAccounts
         case .card:
             Localizations.cards
         case let .collection(_, name, _):

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItem.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItem.swift
@@ -137,6 +137,9 @@ extension VaultListItem {
             }
         case let .group(group, _):
             switch group {
+            case .bankAccount:
+                // TODO: PM-34128 Swap to the final bank account asset when icon design ships.
+                SharedAsset.Icons.card24
             case .card:
                 SharedAsset.Icons.card24
             case .collection:

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItem.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListItem.swift
@@ -138,8 +138,9 @@ extension VaultListItem {
         case let .group(group, _):
             switch group {
             case .bankAccount:
-                // TODO: PM-34128 Swap to the final bank account asset when icon design ships.
-                SharedAsset.Icons.card24
+                // Routed through `CipherType.iconPlaceholder` so the final PM-34128
+                // asset swap is a single-file change.
+                CipherType.bankAccount.iconPlaceholder
             case .card:
                 SharedAsset.Icons.card24
             case .collection:

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
@@ -31,7 +31,11 @@ struct VaultListState: Equatable {
     var isPersonalOwnershipDisabled: Bool = false
 
     /// List of available item type for creation.
-    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCases
+    ///
+    /// Seeded with the flag-off baseline; the processor replaces this from
+    /// `VaultRepository.getItemTypesUserCanCreate()` on appearance, which reads the
+    /// `newItemTypes` feature flag.
+    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCasesBase
 
     /// The loading state of the My Vault screen.
     var loadingState: LoadingState<[VaultListSection]> = .loading(nil)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemAction.swift
@@ -1,0 +1,41 @@
+// MARK: - AddEditBankAccountItemAction
+
+/// An enum of actions for adding or editing a Bank Account item in its add/edit state.
+///
+enum AddEditBankAccountItemAction: Equatable, Sendable {
+    /// The account number field changed.
+    case accountNumberChanged(String)
+
+    /// The account type selection changed.
+    case accountTypeChanged(DefaultableType<BankAccountType>)
+
+    /// The bank name field changed.
+    case bankNameChanged(String)
+
+    /// The bank contact phone field changed.
+    case bankPhoneChanged(String)
+
+    /// The branch number field changed.
+    case branchNumberChanged(String)
+
+    /// The IBAN field changed.
+    case ibanChanged(String)
+
+    /// The name-on-account field changed.
+    case nameOnAccountChanged(String)
+
+    /// The PIN field changed.
+    case pinChanged(String)
+
+    /// The routing number field changed.
+    case routingNumberChanged(String)
+
+    /// The SWIFT / BIC code field changed.
+    case swiftCodeChanged(String)
+
+    /// Toggle for the account number visibility changed.
+    case toggleAccountNumberVisibilityChanged(Bool)
+
+    /// Toggle for the PIN visibility changed.
+    case togglePinVisibilityChanged(Bool)
+}

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemView.swift
@@ -1,0 +1,218 @@
+import BitwardenKit
+import BitwardenResources
+import SwiftUI
+
+// MARK: - AddEditBankAccountItemView
+
+/// A view that allows the user to add or edit a bank account item for a vault.
+///
+struct AddEditBankAccountItemView: View {
+    // MARK: Type
+
+    /// The focusable fields in the bank account form.
+    enum FocusedField: Int, Hashable {
+        case bankName
+        case nameOnAccount
+        case accountType
+        case accountNumber
+        case routingNumber
+        case branchNumber
+        case pin
+        case swiftCode
+        case iban
+        case bankPhone
+    }
+
+    // MARK: Properties
+
+    /// The currently focused field.
+    @FocusState private var focusedField: FocusedField?
+
+    /// The `Store` for this view.
+    @ObservedObject var store: Store<
+        any AddEditBankAccountItemState,
+        AddEditBankAccountItemAction,
+        AddEditItemEffect,
+    >
+
+    var body: some View {
+        SectionView(Localizations.bankAccountDetails, contentSpacing: 8) {
+            ContentBlock {
+                BitwardenTextField(
+                    title: Localizations.bankName,
+                    text: store.binding(
+                        get: \.bankName,
+                        send: AddEditBankAccountItemAction.bankNameChanged,
+                    ),
+                    accessibilityIdentifier: "BankNameEntry",
+                )
+                .focused($focusedField, equals: .bankName)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.nameOnAccount,
+                    text: store.binding(
+                        get: \.nameOnAccount,
+                        send: AddEditBankAccountItemAction.nameOnAccountChanged,
+                    ),
+                    accessibilityIdentifier: "NameOnAccountEntry",
+                )
+                .focused($focusedField, equals: .nameOnAccount)
+                .textContentType(.name)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenMenuField(
+                    title: Localizations.accountType,
+                    accessibilityIdentifier: "BankAccountTypePicker",
+                    options: DefaultableType<BankAccountType>.allCases,
+                    selection: store.binding(
+                        get: \.accountType,
+                        send: AddEditBankAccountItemAction.accountTypeChanged,
+                    ),
+                )
+                .focused($focusedField, equals: .accountType)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.accountNumber,
+                    text: store.binding(
+                        get: \.accountNumber,
+                        send: AddEditBankAccountItemAction.accountNumberChanged,
+                    ),
+                    accessibilityIdentifier: "BankAccountNumberEntry",
+                    passwordVisibilityAccessibilityId: "ShowBankAccountNumberButton",
+                    isPasswordVisible: store.binding(
+                        get: \.isAccountNumberVisible,
+                        send: AddEditBankAccountItemAction.toggleAccountNumberVisibilityChanged,
+                    ),
+                )
+                .focused($focusedField, equals: .accountNumber)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.routingNumber,
+                    text: store.binding(
+                        get: \.routingNumber,
+                        send: AddEditBankAccountItemAction.routingNumberChanged,
+                    ),
+                    accessibilityIdentifier: "BankRoutingNumberEntry",
+                )
+                .focused($focusedField, equals: .routingNumber)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.branchNumber,
+                    text: store.binding(
+                        get: \.branchNumber,
+                        send: AddEditBankAccountItemAction.branchNumberChanged,
+                    ),
+                    accessibilityIdentifier: "BankBranchNumberEntry",
+                )
+                .focused($focusedField, equals: .branchNumber)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.pin,
+                    text: store.binding(
+                        get: \.pin,
+                        send: AddEditBankAccountItemAction.pinChanged,
+                    ),
+                    accessibilityIdentifier: "BankPinEntry",
+                    passwordVisibilityAccessibilityId: "ShowBankPinButton",
+                    isPasswordVisible: store.binding(
+                        get: \.isPinVisible,
+                        send: AddEditBankAccountItemAction.togglePinVisibilityChanged,
+                    ),
+                )
+                .textFieldConfiguration(.numeric(.oneTimeCode))
+                .focused($focusedField, equals: .pin)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.swiftCode,
+                    text: store.binding(
+                        get: \.swiftCode,
+                        send: AddEditBankAccountItemAction.swiftCodeChanged,
+                    ),
+                    accessibilityIdentifier: "BankSwiftCodeEntry",
+                )
+                .focused($focusedField, equals: .swiftCode)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.iban,
+                    text: store.binding(
+                        get: \.iban,
+                        send: AddEditBankAccountItemAction.ibanChanged,
+                    ),
+                    accessibilityIdentifier: "BankIbanEntry",
+                )
+                .focused($focusedField, equals: .iban)
+                .onSubmit { focusNextField($focusedField) }
+
+                BitwardenTextField(
+                    title: Localizations.bankContactPhone,
+                    text: store.binding(
+                        get: \.bankPhone,
+                        send: AddEditBankAccountItemAction.bankPhoneChanged,
+                    ),
+                    accessibilityIdentifier: "BankPhoneEntry",
+                )
+                .textContentType(.telephoneNumber)
+                .focused($focusedField, equals: .bankPhone)
+                .onSubmit { focusNextField($focusedField) }
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct AddEditBankAccountItemView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ScrollView {
+                AddEditBankAccountItemView(
+                    store: Store(
+                        processor: StateProcessor(
+                            state: BankAccountItemState() as (any AddEditBankAccountItemState),
+                        ),
+                    ),
+                )
+                .padding(16)
+            }
+            .background(SharedAsset.Colors.backgroundPrimary.swiftUIColor)
+            .navigationBar(title: "Empty Add Edit State", titleDisplayMode: .inline)
+        }
+        .previewDisplayName("Empty Add Edit State")
+
+        NavigationView {
+            ScrollView {
+                AddEditBankAccountItemView(
+                    store: Store(
+                        processor: StateProcessor(
+                            state: {
+                                var state = BankAccountItemState()
+                                state.bankName = "Bitwarden Bank"
+                                state.nameOnAccount = "Bitwarden User"
+                                state.accountType = .custom(.checking)
+                                state.accountNumber = "1234567890"
+                                state.routingNumber = "011000015"
+                                state.branchNumber = "100"
+                                state.pin = "1234"
+                                state.swiftCode = "BTCBUS33"
+                                state.iban = "GB82WEST12345698765432"
+                                state.bankPhone = "555-123-4567"
+                                return state
+                            }() as (any AddEditBankAccountItemState),
+                        ),
+                    ),
+                )
+                .padding(16)
+            }
+            .background(SharedAsset.Colors.backgroundPrimary.swiftUIColor)
+            .navigationBar(title: "Populated Add Edit State", titleDisplayMode: .inline)
+        }
+        .previewDisplayName("Populated Add Edit State")
+    }
+}
+#endif

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemView.swift
@@ -124,7 +124,9 @@ struct AddEditBankAccountItemView: View {
                         send: AddEditBankAccountItemAction.togglePinVisibilityChanged,
                     ),
                 )
-                .textFieldConfiguration(.numeric(.oneTimeCode))
+                // Use the no-AutoFill-hint numeric configuration so iOS doesn't
+                // offer SMS one-time-code suggestions on the bank account PIN field.
+                .textFieldConfiguration(.numericNoContentType)
                 .focused($focusedField, equals: .pin)
                 .onSubmit { focusNextField($focusedField) }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemState.swift
@@ -1,0 +1,132 @@
+import BitwardenSdk
+import Foundation
+
+// MARK: - BankAccountItemState
+
+/// A model for a bank account item.
+///
+struct BankAccountItemState: Equatable, Sendable {
+    // MARK: Properties
+
+    /// The account number.
+    var accountNumber: String = ""
+
+    /// The type of the bank account.
+    var accountType: DefaultableType<BankAccountType> = .default
+
+    /// The name of the bank.
+    var bankName: String = ""
+
+    /// The phone number for contacting the bank.
+    var bankPhone: String = ""
+
+    /// The branch number of the bank.
+    var branchNumber: String = ""
+
+    /// The IBAN (International Bank Account Number).
+    var iban: String = ""
+
+    /// The visibility of the account number field.
+    var isAccountNumberVisible: Bool = false
+
+    /// The visibility of the PIN field.
+    var isPinVisible: Bool = false
+
+    /// The name on the account.
+    var nameOnAccount: String = ""
+
+    /// The personal identification number.
+    var pin: String = ""
+
+    /// The routing number of the bank.
+    var routingNumber: String = ""
+
+    /// The SWIFT / BIC code of the bank.
+    var swiftCode: String = ""
+}
+
+// MARK: - API Round-trip helpers
+
+extension BankAccountItemState {
+    /// Builds an API `CipherBankAccountModel` representation of this state.
+    ///
+    /// Empty text fields are serialized as `nil`.
+    ///
+    var apiModel: CipherBankAccountModel {
+        CipherBankAccountModel(
+            accountNumber: accountNumber.nilIfEmpty,
+            accountType: accountType.customValue,
+            bankName: bankName.nilIfEmpty,
+            bankPhone: bankPhone.nilIfEmpty,
+            branchNumber: branchNumber.nilIfEmpty,
+            iban: iban.nilIfEmpty,
+            nameOnAccount: nameOnAccount.nilIfEmpty,
+            pin: pin.nilIfEmpty,
+            routingNumber: routingNumber.nilIfEmpty,
+            swiftCode: swiftCode.nilIfEmpty,
+        )
+    }
+
+    /// Creates a `BankAccountItemState` from an API `CipherBankAccountModel`.
+    ///
+    /// - Parameter model: The API model to convert. When `nil`, an empty state is returned.
+    /// - Returns: A `BankAccountItemState` populated from the model.
+    ///
+    static func fromAPIModel(_ model: CipherBankAccountModel?) -> BankAccountItemState {
+        guard let model else { return BankAccountItemState() }
+        var state = BankAccountItemState()
+        state.accountNumber = model.accountNumber ?? ""
+        if let type = model.accountType {
+            state.accountType = .custom(type)
+        }
+        state.bankName = model.bankName ?? ""
+        state.bankPhone = model.bankPhone ?? ""
+        state.branchNumber = model.branchNumber ?? ""
+        state.iban = model.iban ?? ""
+        state.nameOnAccount = model.nameOnAccount ?? ""
+        state.pin = model.pin ?? ""
+        state.routingNumber = model.routingNumber ?? ""
+        state.swiftCode = model.swiftCode ?? ""
+        return state
+    }
+}
+
+// MARK: - AddEditBankAccountItemState
+
+/// Protocol describing the add/edit state for a bank account item. Exposed to the add/edit view
+/// so the view can bind to fields without depending on the concrete state struct.
+///
+protocol AddEditBankAccountItemState: Sendable {
+    var accountNumber: String { get set }
+    var accountType: DefaultableType<BankAccountType> { get set }
+    var bankName: String { get set }
+    var bankPhone: String { get set }
+    var branchNumber: String { get set }
+    var iban: String { get set }
+    var isAccountNumberVisible: Bool { get set }
+    var isPinVisible: Bool { get set }
+    var nameOnAccount: String { get set }
+    var pin: String { get set }
+    var routingNumber: String { get set }
+    var swiftCode: String { get set }
+}
+
+extension BankAccountItemState: AddEditBankAccountItemState {}
+
+// MARK: - ViewBankAccountItemState
+
+extension BankAccountItemState: ViewBankAccountItemState {
+    /// Whether the bank account details section has no user-populated content.
+    var isBankAccountDetailsSectionEmpty: Bool {
+        bankName.isEmpty
+            && nameOnAccount.isEmpty
+            && accountType.customValue == nil
+            && accountNumber.isEmpty
+            && routingNumber.isEmpty
+            && branchNumber.isEmpty
+            && pin.isEmpty
+            && swiftCode.isEmpty
+            && iban.isEmpty
+            && bankPhone.isEmpty
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemStateTests.swift
@@ -1,0 +1,117 @@
+import XCTest
+
+@testable import BitwardenShared
+
+class BankAccountItemStateTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `isBankAccountDetailsSectionEmpty` returns `true` when no fields are populated.
+    func test_isBankAccountDetailsSectionEmpty_true() {
+        let subject = BankAccountItemState()
+        XCTAssertTrue(subject.isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` returns `false` when any scalar text field is populated.
+    func test_isBankAccountDetailsSectionEmpty_false_whenBankNameSet() {
+        var subject = BankAccountItemState()
+        subject.bankName = "Bitwarden Bank"
+        XCTAssertFalse(subject.isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` returns `false` when `accountType` is a custom case.
+    func test_isBankAccountDetailsSectionEmpty_false_whenAccountTypeCustom() {
+        var subject = BankAccountItemState()
+        subject.accountType = .custom(.savings)
+        XCTAssertFalse(subject.isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` returns `false` when any hidden field has a value.
+    func test_isBankAccountDetailsSectionEmpty_false_whenPinSet() {
+        var subject = BankAccountItemState()
+        subject.pin = "1234"
+        XCTAssertFalse(subject.isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `apiModel` serializes populated fields verbatim.
+    func test_apiModel_populatesAllFields() {
+        var subject = BankAccountItemState()
+        subject.accountNumber = "1234567890"
+        subject.accountType = .custom(.checking)
+        subject.bankName = "Bitwarden Bank"
+        subject.bankPhone = "555-0100"
+        subject.branchNumber = "100"
+        subject.iban = "GB82WEST12345698765432"
+        subject.nameOnAccount = "Bitwarden User"
+        subject.pin = "1234"
+        subject.routingNumber = "011000015"
+        subject.swiftCode = "BTCBUS33"
+
+        let model = subject.apiModel
+        XCTAssertEqual(model.accountNumber, "1234567890")
+        XCTAssertEqual(model.accountType, .checking)
+        XCTAssertEqual(model.bankName, "Bitwarden Bank")
+        XCTAssertEqual(model.bankPhone, "555-0100")
+        XCTAssertEqual(model.branchNumber, "100")
+        XCTAssertEqual(model.iban, "GB82WEST12345698765432")
+        XCTAssertEqual(model.nameOnAccount, "Bitwarden User")
+        XCTAssertEqual(model.pin, "1234")
+        XCTAssertEqual(model.routingNumber, "011000015")
+        XCTAssertEqual(model.swiftCode, "BTCBUS33")
+    }
+
+    /// `apiModel` maps empty strings to `nil` so the wire representation stays minimal.
+    func test_apiModel_emptyStringsBecomeNil() {
+        let subject = BankAccountItemState()
+        let model = subject.apiModel
+        XCTAssertNil(model.accountNumber)
+        XCTAssertNil(model.accountType)
+        XCTAssertNil(model.bankName)
+        XCTAssertNil(model.bankPhone)
+        XCTAssertNil(model.branchNumber)
+        XCTAssertNil(model.iban)
+        XCTAssertNil(model.nameOnAccount)
+        XCTAssertNil(model.pin)
+        XCTAssertNil(model.routingNumber)
+        XCTAssertNil(model.swiftCode)
+    }
+
+    /// `fromAPIModel(_:)` returns an empty state when `nil` is passed.
+    func test_fromAPIModel_nil_returnsEmptyState() {
+        let subject = BankAccountItemState.fromAPIModel(nil)
+        XCTAssertEqual(subject, BankAccountItemState())
+    }
+
+    /// `fromAPIModel(_:)` populates scalar and enum fields from the API payload.
+    func test_fromAPIModel_populatesState() {
+        let model = CipherBankAccountModel(
+            accountNumber: "1234567890",
+            accountType: .savings,
+            bankName: "Bitwarden Bank",
+            bankPhone: "555-0100",
+            branchNumber: "100",
+            iban: "GB82WEST12345698765432",
+            nameOnAccount: "Bitwarden User",
+            pin: "1234",
+            routingNumber: "011000015",
+            swiftCode: "BTCBUS33",
+        )
+        let subject = BankAccountItemState.fromAPIModel(model)
+        XCTAssertEqual(subject.accountNumber, "1234567890")
+        XCTAssertEqual(subject.accountType, .custom(.savings))
+        XCTAssertEqual(subject.bankName, "Bitwarden Bank")
+        XCTAssertEqual(subject.bankPhone, "555-0100")
+        XCTAssertEqual(subject.branchNumber, "100")
+        XCTAssertEqual(subject.iban, "GB82WEST12345698765432")
+        XCTAssertEqual(subject.nameOnAccount, "Bitwarden User")
+        XCTAssertEqual(subject.pin, "1234")
+        XCTAssertEqual(subject.routingNumber, "011000015")
+        XCTAssertEqual(subject.swiftCode, "BTCBUS33")
+    }
+
+    /// Visibility flags default to hidden.
+    func test_visibilityFlags_defaultToHidden() {
+        let subject = BankAccountItemState()
+        XCTAssertFalse(subject.isAccountNumberVisible)
+        XCTAssertFalse(subject.isPinVisible)
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemStateTests.swift
@@ -114,4 +114,72 @@ class BankAccountItemStateTests: BitwardenTestCase {
         XCTAssertFalse(subject.isAccountNumberVisible)
         XCTAssertFalse(subject.isPinVisible)
     }
+
+    /// Account number visibility toggles independently of the PIN visibility.
+    func test_visibilityFlags_accountNumberIndependentOfPin() {
+        var subject = BankAccountItemState()
+        subject.isAccountNumberVisible = true
+        XCTAssertTrue(subject.isAccountNumberVisible)
+        XCTAssertFalse(subject.isPinVisible)
+
+        subject.isPinVisible = true
+        XCTAssertTrue(subject.isAccountNumberVisible)
+        XCTAssertTrue(subject.isPinVisible)
+    }
+
+    /// Every text field can be set and read back as a simple mutation.
+    func test_fieldSetters_roundTrip() {
+        var subject = BankAccountItemState()
+
+        subject.bankName = "Bitwarden Bank"
+        subject.nameOnAccount = "Bitwarden User"
+        subject.accountType = .custom(.other)
+        subject.accountNumber = "9876543210"
+        subject.routingNumber = "021000021"
+        subject.branchNumber = "200"
+        subject.pin = "4321"
+        subject.swiftCode = "CHASUS33"
+        subject.iban = "DE89370400440532013000"
+        subject.bankPhone = "555-0199"
+
+        XCTAssertEqual(subject.bankName, "Bitwarden Bank")
+        XCTAssertEqual(subject.nameOnAccount, "Bitwarden User")
+        XCTAssertEqual(subject.accountType, .custom(.other))
+        XCTAssertEqual(subject.accountNumber, "9876543210")
+        XCTAssertEqual(subject.routingNumber, "021000021")
+        XCTAssertEqual(subject.branchNumber, "200")
+        XCTAssertEqual(subject.pin, "4321")
+        XCTAssertEqual(subject.swiftCode, "CHASUS33")
+        XCTAssertEqual(subject.iban, "DE89370400440532013000")
+        XCTAssertEqual(subject.bankPhone, "555-0199")
+    }
+
+    /// A fully-populated state round-trips through `apiModel` and back to an
+    /// equivalent state via `fromAPIModel(_:)`.
+    func test_stateRoundTripThroughAPIModel() {
+        var original = BankAccountItemState()
+        original.bankName = "Bitwarden Bank"
+        original.nameOnAccount = "Bitwarden User"
+        original.accountType = .custom(.savings)
+        original.accountNumber = "1234567890"
+        original.routingNumber = "011000015"
+        original.branchNumber = "100"
+        original.pin = "1234"
+        original.swiftCode = "BTCBUS33"
+        original.iban = "GB82WEST12345698765432"
+        original.bankPhone = "555-0100"
+
+        let recreated = BankAccountItemState.fromAPIModel(original.apiModel)
+
+        XCTAssertEqual(recreated.bankName, original.bankName)
+        XCTAssertEqual(recreated.nameOnAccount, original.nameOnAccount)
+        XCTAssertEqual(recreated.accountType, original.accountType)
+        XCTAssertEqual(recreated.accountNumber, original.accountNumber)
+        XCTAssertEqual(recreated.routingNumber, original.routingNumber)
+        XCTAssertEqual(recreated.branchNumber, original.branchNumber)
+        XCTAssertEqual(recreated.pin, original.pin)
+        XCTAssertEqual(recreated.swiftCode, original.swiftCode)
+        XCTAssertEqual(recreated.iban, original.iban)
+        XCTAssertEqual(recreated.bankPhone, original.bankPhone)
+    }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemAction.swift
@@ -13,6 +13,9 @@ enum AddEditItemAction: Equatable, Sendable {
     /// The auth key visibility was toggled.
     case authKeyVisibilityTapped(Bool)
 
+    /// A bank account field changed.
+    case bankAccountFieldChanged(AddEditBankAccountItemAction)
+
     /// A card field changed
     case cardFieldChanged(AddEditCardItemAction)
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -485,26 +485,38 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             state.bankAccountState.swiftCode = value
         case let .toggleAccountNumberVisibilityChanged(isVisible):
             state.bankAccountState.isAccountNumberVisible = isVisible
-            if isVisible, !state.configuration.isAdding {
-                let cipherId = state.cipher.id
-                Task {
-                    await services.eventService.collect(
-                        eventType: .cipherClientToggledHiddenFieldVisible,
-                        cipherId: cipherId,
-                    )
-                }
-            }
+            collectHiddenFieldVisibilityEventIfNeeded(isVisible: isVisible, in: state)
         case let .togglePinVisibilityChanged(isVisible):
             state.bankAccountState.isPinVisible = isVisible
-            if isVisible, !state.configuration.isAdding {
-                let cipherId = state.cipher.id
-                Task {
-                    await services.eventService.collect(
-                        eventType: .cipherClientToggledHiddenFieldVisible,
-                        cipherId: cipherId,
-                    )
-                }
-            }
+            collectHiddenFieldVisibilityEventIfNeeded(isVisible: isVisible, in: state)
+        }
+    }
+
+    /// Emits the `.cipherClientToggledHiddenFieldVisible` event when a hidden field is
+    /// revealed on an existing cipher. Suppressed while the user is creating a new
+    /// cipher (the cipher has no server-side ID yet) and when the field is being
+    /// hidden rather than revealed.
+    ///
+    /// Extracted to avoid duplicating the same five-line `Task { eventService.collect
+    /// }` block at each hidden-field toggle site. PR 2 (Driver's License) and PR 3
+    /// (Passport) will reuse this helper for their own hidden fields.
+    ///
+    /// - Parameters:
+    ///   - isVisible: Whether the field was revealed (`true`) or hidden (`false`).
+    ///   - state: The current add/edit state; used only to read the cipher id and
+    ///     configuration.
+    ///
+    private func collectHiddenFieldVisibilityEventIfNeeded(
+        isVisible: Bool,
+        in state: AddEditItemState,
+    ) {
+        guard isVisible, !state.configuration.isAdding else { return }
+        let cipherId = state.cipher.id
+        Task {
+            await services.eventService.collect(
+                eventType: .cipherClientToggledHiddenFieldVisible,
+                cipherId: cipherId,
+            )
         }
     }
 
@@ -733,6 +745,29 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
                     message: Localizations.selectOneCollection,
                 ),
             )
+            return
+        }
+
+        // Fail-closed guard for PM-32009: reject saves for cipher types whose SDK
+        // representation is not yet available. Without this, `newCipherView()` falls
+        // back to `.secureNote` on the SDK conversion, which would silently persist
+        // the item as an empty Secure Note. The `newItemTypes` feature flag should
+        // already prevent reaching this code path until the SDK is ready, but this
+        // belt-and-suspenders guard makes the invariant explicit.
+        if state.type == .bankAccount, !NewItemTypesSdkBridge.isBankAccountAvailable {
+            coordinator.showAlert(
+                .defaultAlert(
+                    title: Localizations.anErrorHasOccurred,
+                    message: Localizations.anErrorHasOccurred,
+                ),
+            )
+            services.errorReporter.log(error: BitwardenError.generalError(
+                type: "Save item blocked",
+                message: "Attempted to save a Bank Account cipher before SDK support is available " +
+                    "(PM-32009). The newItemTypes feature flag should not be enabled until the " +
+                    "BitwardenSdk dependency is bumped and " +
+                    "NewItemTypesSdkBridge.isBankAccountAvailable is set to true.",
+            ))
             return
         }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -748,28 +748,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             return
         }
 
-        // Fail-closed guard for PM-32009: reject saves for cipher types whose SDK
-        // representation is not yet available. Without this, `newCipherView()` falls
-        // back to `.secureNote` on the SDK conversion, which would silently persist
-        // the item as an empty Secure Note. The `newItemTypes` feature flag should
-        // already prevent reaching this code path until the SDK is ready, but this
-        // belt-and-suspenders guard makes the invariant explicit.
-        if state.type == .bankAccount, !NewItemTypesSdkBridge.isBankAccountAvailable {
-            coordinator.showAlert(
-                .defaultAlert(
-                    title: Localizations.anErrorHasOccurred,
-                    message: Localizations.anErrorHasOccurred,
-                ),
-            )
-            services.errorReporter.log(error: BitwardenError.generalError(
-                type: "Save item blocked",
-                message: "Attempted to save a Bank Account cipher before SDK support is available " +
-                    "(PM-32009). The newItemTypes feature flag should not be enabled until the " +
-                    "BitwardenSdk dependency is bumped and " +
-                    "NewItemTypesSdkBridge.isBankAccountAvailable is set to true.",
-            ))
-            return
-        }
+        guard guardSDKReady() else { return }
 
         defer { coordinator.hideLoadingOverlay() }
         do {
@@ -803,6 +782,39 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
+    }
+
+    /// Fail-closed guard for PM-32009: blocks saves for cipher types whose SDK
+    /// representation is not yet available. Without this, `newCipherView()` falls
+    /// back to `.secureNote` on the SDK conversion, which would silently persist the
+    /// item as an empty Secure Note. The `newItemTypes` feature flag should already
+    /// prevent reaching this code path until the SDK is ready; this belt-and-
+    /// suspenders guard makes the invariant explicit. The alert body uses a distinct
+    /// localization key so tests and debuggers can tell this failure apart from
+    /// generic errors.
+    ///
+    /// - Returns: `true` when the SDK supports the current `state.type` and the save
+    ///   may proceed; `false` when the save was rejected and an alert + telemetry
+    ///   entry were dispatched.
+    ///
+    private func guardSDKReady() -> Bool {
+        guard state.type == .bankAccount, !NewItemTypesSdkBridge.isBankAccountAvailable else {
+            return true
+        }
+        coordinator.showAlert(
+            .defaultAlert(
+                title: Localizations.anErrorHasOccurred,
+                message: Localizations.thisItemTypeIsNotYetAvailableTryAgainInALaterVersion,
+            ),
+        )
+        services.errorReporter.log(error: BitwardenError.generalError(
+            type: "Save item blocked",
+            message: "Attempted to save a Bank Account cipher before SDK support is available " +
+                "(PM-32009). The newItemTypes feature flag should not be enabled until the " +
+                "BitwardenSdk dependency is bumped and " +
+                "NewItemTypesSdkBridge.isBankAccountAvailable is set to true.",
+        ))
+        return false
     }
 
     /// Adds the item currently in `state`.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -189,6 +189,8 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             coordinator.navigate(to: .addFolder, context: self)
         case let .authKeyVisibilityTapped(newValue):
             state.loginState.isAuthKeyVisible = newValue
+        case let .bankAccountFieldChanged(bankAccountFieldAction):
+            updateBankAccountState(&state, for: bankAccountFieldAction)
         case let .cardFieldChanged(cardFieldAction):
             updateCardState(&state, for: cardFieldAction)
         case .clearUrl:
@@ -447,6 +449,63 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     /// Loads the feature flags required for this processor.
     private func loadFeatureFlags() async {
         state.isArchiveVaultItemsFFEnabled = await services.configService.getFeatureFlag(.archiveVaultItems)
+        state.isNewItemTypesFFEnabled = await services.configService.getFeatureFlag(.newItemTypes)
+    }
+
+    /// Receives an `AddEditBankAccountItemAction` from the `AddEditBankAccountItemView` and
+    /// mutates the underlying `BankAccountItemState` on the processor's state.
+    ///
+    /// - Parameters:
+    ///   - state: The parent `AddEditItemState` to be updated.
+    ///   - action: The `AddEditBankAccountItemAction` received.
+    private func updateBankAccountState(
+        _ state: inout AddEditItemState,
+        for action: AddEditBankAccountItemAction,
+    ) {
+        switch action {
+        case let .accountNumberChanged(value):
+            state.bankAccountState.accountNumber = value
+        case let .accountTypeChanged(type):
+            state.bankAccountState.accountType = type
+        case let .bankNameChanged(value):
+            state.bankAccountState.bankName = value
+        case let .bankPhoneChanged(value):
+            state.bankAccountState.bankPhone = value
+        case let .branchNumberChanged(value):
+            state.bankAccountState.branchNumber = value
+        case let .ibanChanged(value):
+            state.bankAccountState.iban = value
+        case let .nameOnAccountChanged(value):
+            state.bankAccountState.nameOnAccount = value
+        case let .pinChanged(value):
+            state.bankAccountState.pin = value
+        case let .routingNumberChanged(value):
+            state.bankAccountState.routingNumber = value
+        case let .swiftCodeChanged(value):
+            state.bankAccountState.swiftCode = value
+        case let .toggleAccountNumberVisibilityChanged(isVisible):
+            state.bankAccountState.isAccountNumberVisible = isVisible
+            if isVisible, !state.configuration.isAdding {
+                let cipherId = state.cipher.id
+                Task {
+                    await services.eventService.collect(
+                        eventType: .cipherClientToggledHiddenFieldVisible,
+                        cipherId: cipherId,
+                    )
+                }
+            }
+        case let .togglePinVisibilityChanged(isVisible):
+            state.bankAccountState.isPinVisible = isVisible
+            if isVisible, !state.configuration.isAdding {
+                let cipherId = state.cipher.id
+                Task {
+                    await services.eventService.collect(
+                        eventType: .cipherClientToggledHiddenFieldVisible,
+                        cipherId: cipherId,
+                    )
+                }
+            }
+        }
     }
 
     /// Receives an `AddEditCardItem` action from the `AddEditCardView` view's store, and updates

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemState.swift
@@ -11,6 +11,9 @@ protocol AddEditItemState: Sendable {
     /// The info text to display when item is archived.
     var archiveInfoText: String { get }
 
+    /// The bank account item state.
+    var bankAccountState: BankAccountItemState { get set }
+
     /// The card item state.
     var cardItemState: CardItemState { get set }
 
@@ -70,6 +73,10 @@ protocol AddEditItemState: Sendable {
 
     /// Whether archive vault items feature flag is enabled.
     var isArchiveVaultItemsFFEnabled: Bool { get set }
+
+    /// Whether the new item types (Bank Account, Driver's License, Passport) feature flag is
+    /// enabled. Gates visibility and creation of the new cipher types per PM-32009.
+    var isNewItemTypesFFEnabled: Bool { get set }
 
     /// A flag indicating if this item is favorited.
     var isFavoriteOn: Bool { get set }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -297,6 +297,21 @@ private extension AddEditItemView {
 }
 
 private extension AddEditItemView {
+    /// Specific fields for a bank account item.
+    @ViewBuilder private var bankAccountItems: some View {
+        AddEditBankAccountItemView(
+            store: store.child(
+                state: { addEditState in
+                    addEditState.bankAccountState
+                },
+                mapAction: { action in
+                    .bankAccountFieldChanged(action)
+                },
+                mapEffect: { $0 },
+            ),
+        )
+    }
+
     /// Specific fields for a card item.
     @ViewBuilder private var cardItems: some View {
         AddEditCardItemView(
@@ -330,6 +345,8 @@ private extension AddEditItemView {
     /// The specific fields for the type of item being created or updated.
     @ViewBuilder private var itemTypeSection: some View {
         switch store.state.type {
+        case .bankAccount:
+            bankAccountItems
         case .card:
             cardItems
         case .login:

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -36,6 +36,9 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
     /// A flag indicating if this account has premium features.
     var accountHasPremium: Bool
 
+    /// The bank account item state.
+    var bankAccountState = BankAccountItemState()
+
     /// The card item state.
     var cardItemState = CardItemState()
 
@@ -80,6 +83,10 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
 
     /// Whether archive vault items feature flag is enabled.
     var isArchiveVaultItemsFFEnabled = false
+
+    /// Whether the new item types (Bank Account, Driver's License, Passport) feature flag is
+    /// enabled. Gates visibility and creation of the new cipher types per PM-32009.
+    var isNewItemTypesFFEnabled = false
 
     /// A flag indicating if this item is favorited.
     var isFavoriteOn = false
@@ -444,6 +451,10 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
             configuration = .existing(cipherView: cipherView)
         }
 
+        // TODO: PM-32009 Blocked on SDK — populate from `cipherView.bankAccount` once the SDK
+        // exposes a `BankAccountView?` on `CipherView`. Until then, bank account state remains
+        // the default empty state when loading an existing cipher.
+        bankAccountState = cipherView.bankAccountItemState()
         cardItemState = cipherView.cardItemState()
         collectionIds = cipherView.collectionIds
         customFieldsState = AddEditCustomFieldsState(cipherType: type, customFields: cipherView.customFields)
@@ -473,6 +484,7 @@ extension CipherItemState: AddEditItemState {
         switch configuration {
         case .add:
             switch type {
+            case .bankAccount: Localizations.newBankAccount
             case .card: Localizations.newCard
             case .identity: Localizations.newIdentity
             case .login: Localizations.newLogin
@@ -481,6 +493,7 @@ extension CipherItemState: AddEditItemState {
             }
         case .existing:
             switch type {
+            case .bankAccount: Localizations.editBankAccount
             case .card: Localizations.editCard
             case .identity: Localizations.editIdentity
             case .login: Localizations.editLogin
@@ -530,6 +543,10 @@ extension CipherItemState: ViewVaultItemState {
         cipher.archivedDate != nil && cipher.deletedDate == nil
     }
 
+    var bankAccountItemViewState: any ViewBankAccountItemState {
+        bankAccountState
+    }
+
     var cardItemViewState: any ViewCardItemState {
         cardItemState
     }
@@ -548,7 +565,10 @@ extension CipherItemState: ViewVaultItemState {
     }
 
     var icon: SharedImageAsset {
-        switch cipher.type {
+        switch type {
+        case .bankAccount:
+            // TODO: PM-34128 Swap to the final bank account asset when icon design ships.
+            return SharedAsset.Icons.card24
         case .card:
             guard case let .custom(brand) = cardItemState.brand else {
                 return SharedAsset.Icons.card24
@@ -625,7 +645,14 @@ extension CipherItemState: ViewVaultItemState {
 
 extension CipherItemState {
     /// Returns a `CipherView` based on the properties of the `CipherItemState`.
+    ///
+    /// - Note: Bank account data cannot currently round-trip through `CipherView` because
+    ///   `BitwardenSdk.CipherView` does not yet expose a `bankAccount: BankAccountView?` property.
+    ///   Once the SDK adds it (tracked in PM-32009 SDK work), wire `bankAccountState` through.
     func newCipherView(creationDate: Date = .now) -> CipherView {
+        // TODO: PM-32009 Blocked on SDK — add `bankAccount: type == .bankAccount ?
+        // bankAccountState.bankAccountView : nil` once `CipherView.init` accepts a
+        // `bankAccount:` parameter.
         CipherView(
             id: nil,
             organizationId: organizationId,

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -369,12 +369,14 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
     }
 
     init(cloneItem cipherView: CipherView, hasPremium: Bool) {
+        // Unknown SDK types fall back to `.secureNote` during clone (PM-32813 will
+        // formalize the "Unknown" display story).
         self.init(
             accountHasPremium: hasPremium,
             configuration: .add,
             iconBaseURL: nil,
             showWebIcons: false,
-            type: .init(type: cipherView.type),
+            type: CipherType(type: cipherView.type) ?? .secureNote,
         )
         apply(
             cipherView: cipherView,
@@ -390,12 +392,14 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
         showWebIcons: Bool = true,
     ) {
         guard cipherView.id != nil else { return nil }
+        // Unknown SDK types fall back to `.secureNote` when editing an existing cipher
+        // (PM-32813 will formalize the "Unknown" display story).
         self.init(
             accountHasPremium: hasPremium,
             configuration: .existing(cipherView: cipherView),
             iconBaseURL: iconBaseURL,
             showWebIcons: showWebIcons,
-            type: .init(type: cipherView.type),
+            type: CipherType(type: cipherView.type) ?? .secureNote,
         )
         apply(cipherView: cipherView)
     }
@@ -445,7 +449,11 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
         overrideLoginItemState: LoginItemState? = nil,
         overrideTOTPState: LoginTOTPState? = nil,
     ) {
-        let type = CipherType(type: cipherView.type)
+        // TODO: PM-32813 When the SDK adds cases the app has not mapped, `CipherType(type:)`
+        // returns `nil`. Handle that properly (e.g., "Unknown" display) as part of the
+        // backward-compat PR; for now fall back to `.secureNote` to preserve existing
+        // behavior on the never-reached-today path.
+        let type = CipherType(type: cipherView.type) ?? .secureNote
 
         if case .existing = configuration {
             configuration = .existing(cipherView: cipherView)
@@ -565,24 +573,13 @@ extension CipherItemState: ViewVaultItemState {
     }
 
     var icon: SharedImageAsset {
-        switch type {
-        case .bankAccount:
-            // TODO: PM-34128 Swap to the final bank account asset when icon design ships.
-            return SharedAsset.Icons.card24
-        case .card:
-            guard case let .custom(brand) = cardItemState.brand else {
-                return SharedAsset.Icons.card24
-            }
+        // Card still has a brand-specific icon; every other type routes through the
+        // centralized `CipherType.iconPlaceholder` helper so the PM-34128 final-asset
+        // swap is a single-file change.
+        if case .card = type, case let .custom(brand) = cardItemState.brand {
             return brand.icon
-        case .identity:
-            return SharedAsset.Icons.idCard24
-        case .login:
-            return SharedAsset.Icons.globe24
-        case .secureNote:
-            return SharedAsset.Icons.stickyNote24
-        case .sshKey:
-            return SharedAsset.Icons.key24
         }
+        return type.iconPlaceholder
     }
 
     var iconAccessibilityId: String {
@@ -649,6 +646,10 @@ extension CipherItemState {
     /// - Note: Bank account data cannot currently round-trip through `CipherView` because
     ///   `BitwardenSdk.CipherView` does not yet expose a `bankAccount: BankAccountView?` property.
     ///   Once the SDK adds it (tracked in PM-32009 SDK work), wire `bankAccountState` through.
+    /// - Important: `AddEditItemProcessor.saveItem()` must reject saves for
+    ///   `.bankAccount` before calling this method while the SDK is unavailable; the
+    ///   `.secureNote` fallback on the SDK type conversion below is defensive only and
+    ///   will trip an `assertionFailure` in Debug.
     func newCipherView(creationDate: Date = .now) -> CipherView {
         // TODO: PM-32009 Blocked on SDK — add `bankAccount: type == .bankAccount ?
         // bankAccountState.bankAccountView : nil` once `CipherView.init` accepts a
@@ -661,7 +662,7 @@ extension CipherItemState {
             key: nil,
             name: name,
             notes: notes.nilIfEmpty,
-            type: BitwardenSdk.CipherType(type),
+            type: BitwardenSdk.CipherType(type) ?? .secureNote,
             login: type == .login ? loginState.loginView : nil,
             identity: type == .identity ? identityState.identityView : nil,
             card: type == .card ? cardItemState.cardView : nil,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemAction.swift
@@ -1,0 +1,11 @@
+// MARK: - ViewBankAccountItemAction
+
+/// An enum of actions for viewing a Bank Account item in its view state.
+///
+enum ViewBankAccountItemAction: Equatable, Sendable {
+    /// Toggle for the account number visibility changed.
+    case toggleAccountNumberVisibilityChanged(Bool)
+
+    /// Toggle for the PIN visibility changed.
+    case togglePinVisibilityChanged(Bool)
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemState.swift
@@ -1,0 +1,44 @@
+// MARK: - ViewBankAccountItemState
+
+/// A protocol for an equatable type that models a Bank Account Item in its view state.
+///
+protocol ViewBankAccountItemState: Equatable, Sendable {
+    /// The account number.
+    var accountNumber: String { get }
+
+    /// The type of the bank account.
+    var accountType: DefaultableType<BankAccountType> { get }
+
+    /// The name of the bank.
+    var bankName: String { get }
+
+    /// The phone number for contacting the bank.
+    var bankPhone: String { get }
+
+    /// The branch number of the bank.
+    var branchNumber: String { get }
+
+    /// The IBAN.
+    var iban: String { get }
+
+    /// Whether the account number is visible.
+    var isAccountNumberVisible: Bool { get }
+
+    /// Whether the bank account details section has no user-populated content.
+    var isBankAccountDetailsSectionEmpty: Bool { get }
+
+    /// Whether the PIN is visible.
+    var isPinVisible: Bool { get }
+
+    /// The name on the account.
+    var nameOnAccount: String { get }
+
+    /// The personal identification number.
+    var pin: String { get }
+
+    /// The routing number of the bank.
+    var routingNumber: String { get }
+
+    /// The SWIFT / BIC code of the bank.
+    var swiftCode: String { get }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
@@ -1,0 +1,257 @@
+import BitwardenKit
+import BitwardenResources
+import SwiftUI
+
+// MARK: - ViewBankAccountItemView
+
+/// A view for displaying the contents of a bank account item in read-only mode, with copy
+/// buttons and visibility toggles for hidden fields.
+///
+struct ViewBankAccountItemView: View {
+    // MARK: Properties
+
+    /// The `Store` for this view.
+    @ObservedObject var store: Store<
+        any ViewBankAccountItemState,
+        ViewItemAction,
+        ViewItemEffect,
+    >
+
+    var body: some View {
+        if !store.state.isBankAccountDetailsSectionEmpty {
+            SectionView(Localizations.bankAccountDetails, contentSpacing: 8) {
+                ContentBlock {
+                    bankNameItem
+
+                    nameOnAccountItem
+
+                    accountTypeItem
+
+                    accountNumberItem
+
+                    routingNumberItem
+
+                    branchNumberItem
+
+                    pinItem
+
+                    swiftCodeItem
+
+                    ibanItem
+
+                    bankPhoneItem
+                }
+            }
+        }
+    }
+
+    // MARK: Private Views
+
+    @ViewBuilder private var bankNameItem: some View {
+        let value = store.state.bankName
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.bankName,
+                value: value,
+                valueAccessibilityIdentifier: "BankNameEntry",
+            ) {
+                copyButton(value: value, field: .bankName, identifier: "BankCopyNameButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var nameOnAccountItem: some View {
+        let value = store.state.nameOnAccount
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.nameOnAccount,
+                value: value,
+                valueAccessibilityIdentifier: "NameOnAccountEntry",
+            ) {
+                copyButton(value: value, field: .bankNameOnAccount, identifier: "BankCopyNameOnAccountButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var accountTypeItem: some View {
+        if case .custom = store.state.accountType {
+            BitwardenTextValueField(
+                title: Localizations.accountType,
+                value: store.state.accountType.localizedName,
+            )
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("ItemRow")
+        }
+    }
+
+    @ViewBuilder private var accountNumberItem: some View {
+        let value = store.state.accountNumber
+        let isVisible = store.state.isAccountNumberVisible
+        if !value.isEmpty {
+            BitwardenField(title: Localizations.accountNumber) {
+                PasswordText(password: value, isPasswordVisible: isVisible)
+                    .styleGuide(.body)
+                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .accessibilityIdentifier("BankAccountNumberEntry")
+            } accessoryContent: {
+                PasswordVisibilityButton(
+                    accessibilityIdentifier: "ShowBankAccountNumberButton",
+                    isPasswordVisible: isVisible,
+                ) {
+                    store.send(
+                        .bankAccountItemAction(
+                            .toggleAccountNumberVisibilityChanged(!isVisible),
+                        ),
+                    )
+                }
+
+                copyButton(value: value, field: .bankAccountNumber, identifier: "BankCopyAccountNumberButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var routingNumberItem: some View {
+        let value = store.state.routingNumber
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.routingNumber,
+                value: value,
+                valueAccessibilityIdentifier: "BankRoutingNumberEntry",
+            ) {
+                copyButton(value: value, field: .bankRoutingNumber, identifier: "BankCopyRoutingNumberButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var branchNumberItem: some View {
+        let value = store.state.branchNumber
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.branchNumber,
+                value: value,
+                valueAccessibilityIdentifier: "BankBranchNumberEntry",
+            ) {
+                copyButton(value: value, field: .bankBranchNumber, identifier: "BankCopyBranchNumberButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var pinItem: some View {
+        let value = store.state.pin
+        let isVisible = store.state.isPinVisible
+        if !value.isEmpty {
+            BitwardenField(title: Localizations.pin) {
+                PasswordText(password: value, isPasswordVisible: isVisible)
+                    .styleGuide(.body)
+                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .accessibilityIdentifier("BankPinEntry")
+            } accessoryContent: {
+                PasswordVisibilityButton(
+                    accessibilityIdentifier: "ShowBankPinButton",
+                    isPasswordVisible: isVisible,
+                ) {
+                    store.send(
+                        .bankAccountItemAction(
+                            .togglePinVisibilityChanged(!isVisible),
+                        ),
+                    )
+                }
+
+                copyButton(value: value, field: .bankPin, identifier: "BankCopyPinButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var swiftCodeItem: some View {
+        let value = store.state.swiftCode
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.swiftCode,
+                value: value,
+                valueAccessibilityIdentifier: "BankSwiftCodeEntry",
+            ) {
+                copyButton(value: value, field: .bankSwiftCode, identifier: "BankCopySwiftCodeButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var ibanItem: some View {
+        let value = store.state.iban
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.iban,
+                value: value,
+                valueAccessibilityIdentifier: "BankIbanEntry",
+            ) {
+                copyButton(value: value, field: .bankIban, identifier: "BankCopyIbanButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    @ViewBuilder private var bankPhoneItem: some View {
+        let value = store.state.bankPhone
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: Localizations.bankContactPhone,
+                value: value,
+                valueAccessibilityIdentifier: "BankPhoneEntry",
+            ) {
+                copyButton(value: value, field: .bankPhone, identifier: "BankCopyPhoneButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    /// Helper to render a copy button.
+    @ViewBuilder
+    private func copyButton(value: String, field: CopyableField, identifier: String) -> some View {
+        Button {
+            store.send(.copyPressed(value: value, field: field))
+        } label: {
+            SharedAsset.Icons.copy24.swiftUIImage
+                .imageStyle(.accessoryIcon24)
+        }
+        .accessibilityLabel(Localizations.copy)
+        .accessibilityIdentifier(identifier)
+    }
+}
+
+#if DEBUG
+struct ViewBankAccountItemView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ScrollView {
+                ViewBankAccountItemView(
+                    store: Store(
+                        processor: StateProcessor(
+                            state: {
+                                var state = BankAccountItemState()
+                                state.bankName = "Bitwarden Bank"
+                                state.nameOnAccount = "Bitwarden User"
+                                state.accountType = .custom(.checking)
+                                state.accountNumber = "1234567890"
+                                state.routingNumber = "011000015"
+                                state.pin = "1234"
+                                state.iban = "GB82WEST12345698765432"
+                                return state
+                            }() as (any ViewBankAccountItemState),
+                        ),
+                    ),
+                )
+                .padding(16)
+            }
+            .background(SharedAsset.Colors.backgroundPrimary.swiftUIColor)
+            .navigationBar(title: "Bank Account", titleDisplayMode: .inline)
+        }
+        .previewDisplayName("Populated View State")
+    }
+}
+#endif

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -6,6 +6,9 @@ import BitwardenResources
 
 /// Actions that can be processed by a `ViewItemProcessor`.
 enum ViewItemAction: Equatable, Sendable {
+    /// A bank account item action.
+    case bankAccountItemAction(ViewBankAccountItemAction)
+
     /// A card item action
     case cardItemAction(ViewCardItemAction)
 
@@ -56,6 +59,33 @@ enum ViewItemAction: Equatable, Sendable {
 /// The text fields within the `ViewItemView` that can be copied.
 ///
 enum CopyableField {
+    /// The bank account number field.
+    case bankAccountNumber
+
+    /// The bank branch number field.
+    case bankBranchNumber
+
+    /// The bank IBAN field.
+    case bankIban
+
+    /// The bank name field.
+    case bankName
+
+    /// The name-on-account field.
+    case bankNameOnAccount
+
+    /// The bank contact phone number.
+    case bankPhone
+
+    /// The bank account PIN field.
+    case bankPin
+
+    /// The bank routing number field.
+    case bankRoutingNumber
+
+    /// The bank SWIFT / BIC code field.
+    case bankSwiftCode
+
     /// The card number field.
     case cardNumber
 
@@ -119,7 +149,7 @@ enum CopyableField {
     /// The event to collect when copying the field.
     var eventOnCopy: EventType? {
         switch self {
-        case .customHiddenField:
+        case .bankAccountNumber, .bankPin, .customHiddenField:
             .cipherClientCopiedHiddenField
         case .password:
             .cipherClientCopiedPassword
@@ -134,6 +164,24 @@ enum CopyableField {
     /// The localized name for each field.
     var localizedName: String? {
         switch self {
+        case .bankAccountNumber:
+            Localizations.accountNumber
+        case .bankBranchNumber:
+            Localizations.branchNumber
+        case .bankIban:
+            Localizations.iban
+        case .bankName:
+            Localizations.bankName
+        case .bankNameOnAccount:
+            Localizations.nameOnAccount
+        case .bankPhone:
+            Localizations.bankContactPhone
+        case .bankPin:
+            Localizations.pin
+        case .bankRoutingNumber:
+            Localizations.routingNumber
+        case .bankSwiftCode:
+            Localizations.swiftCode
         case .cardNumber:
             Localizations.number
         case .customHiddenField,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -300,6 +300,14 @@ struct ViewItemDetailsView: View { // swiftlint:disable:this type_body_length
     @ViewBuilder private var itemInformationSection: some View {
         // check for type
         switch store.state.type {
+        case .bankAccount:
+            ViewBankAccountItemView(
+                store: store.child(
+                    state: { _ in store.state.bankAccountItemViewState },
+                    mapAction: { $0 },
+                    mapEffect: nil,
+                ),
+            )
         case .card:
             ViewCardItemView(
                 store: store.child(

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -28,6 +28,9 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
         /// An action that requires data has been performed while loading.
         case dataNotLoaded(String)
 
+        /// An error for bank account action handling on a non-bank-account type.
+        case nonBankAccountTypeToggle(String)
+
         /// An error for card action handling
         case nonCardTypeToggle(String)
 
@@ -139,6 +142,8 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
 
     override func receive(_ action: ViewItemAction) { // swiftlint:disable:this function_body_length
         switch action {
+        case let .bankAccountItemAction(bankAccountAction):
+            handleBankAccountAction(bankAccountAction)
         case let .cardItemAction(cardAction):
             handleCardAction(cardAction)
         case .clearURL:
@@ -363,6 +368,51 @@ private extension ViewItemProcessor {
         }
     }
 
+    /// Handles `ViewBankAccountItemAction` events.
+    ///
+    /// - Parameter bankAccountAction: The action to handle.
+    ///
+    private func handleBankAccountAction(_ bankAccountAction: ViewBankAccountItemAction) {
+        guard case var .data(cipherState) = state.loadingState else {
+            services.errorReporter.log(
+                error: ActionError.dataNotLoaded("Cannot handle bank account action without loaded data"),
+            )
+            return
+        }
+        guard case .bankAccount = cipherState.type else {
+            services.errorReporter.log(
+                error: ActionError.nonBankAccountTypeToggle(
+                    "Cannot handle bank account action on non-bank-account type",
+                ),
+            )
+            return
+        }
+        switch bankAccountAction {
+        case let .toggleAccountNumberVisibilityChanged(isVisible):
+            cipherState.bankAccountState.isAccountNumberVisible = isVisible
+            state.loadingState = .data(cipherState)
+            if isVisible {
+                Task {
+                    await services.eventService.collect(
+                        eventType: .cipherClientToggledHiddenFieldVisible,
+                        cipherId: cipherState.cipher.id,
+                    )
+                }
+            }
+        case let .togglePinVisibilityChanged(isVisible):
+            cipherState.bankAccountState.isPinVisible = isVisible
+            state.loadingState = .data(cipherState)
+            if isVisible {
+                Task {
+                    await services.eventService.collect(
+                        eventType: .cipherClientToggledHiddenFieldVisible,
+                        cipherId: cipherState.cipher.id,
+                    )
+                }
+            }
+        }
+    }
+
     /// Handles `ViewCardItemAction` events.
     ///
     /// - Parameter cardAction: The action to handle.
@@ -574,6 +624,7 @@ private extension ViewItemProcessor {
                 }
 
                 let isArchiveVaultItemsFFEnabled: Bool = await services.configService.getFeatureFlag(.archiveVaultItems)
+                let isNewItemTypesFFEnabled: Bool = await services.configService.getFeatureFlag(.newItemTypes)
 
                 guard var newState = ViewItemState(
                     cipherView: cipher,
@@ -589,6 +640,7 @@ private extension ViewItemProcessor {
                     itemState.ownershipOptions = ownershipOptions
                     itemState.showWebIcons = showWebIcons
                     itemState.isArchiveVaultItemsFFEnabled = isArchiveVaultItemsFFEnabled
+                    itemState.isNewItemTypesFFEnabled = isNewItemTypesFFEnabled
 
                     newState.loadingState = .data(itemState)
                 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -391,25 +391,39 @@ private extension ViewItemProcessor {
         case let .toggleAccountNumberVisibilityChanged(isVisible):
             cipherState.bankAccountState.isAccountNumberVisible = isVisible
             state.loadingState = .data(cipherState)
-            if isVisible {
-                Task {
-                    await services.eventService.collect(
-                        eventType: .cipherClientToggledHiddenFieldVisible,
-                        cipherId: cipherState.cipher.id,
-                    )
-                }
-            }
+            collectHiddenFieldVisibilityEventIfNeeded(
+                isVisible: isVisible,
+                cipherId: cipherState.cipher.id,
+            )
         case let .togglePinVisibilityChanged(isVisible):
             cipherState.bankAccountState.isPinVisible = isVisible
             state.loadingState = .data(cipherState)
-            if isVisible {
-                Task {
-                    await services.eventService.collect(
-                        eventType: .cipherClientToggledHiddenFieldVisible,
-                        cipherId: cipherState.cipher.id,
-                    )
-                }
-            }
+            collectHiddenFieldVisibilityEventIfNeeded(
+                isVisible: isVisible,
+                cipherId: cipherState.cipher.id,
+            )
+        }
+    }
+
+    /// Emits the `.cipherClientToggledHiddenFieldVisible` telemetry event when a
+    /// hidden field is revealed in the view state. Suppressed when the field is being
+    /// hidden rather than revealed.
+    ///
+    /// Extracted to avoid duplicating the same five-line `Task { eventService.collect
+    /// }` block at each hidden-field visibility toggle site. PR 2 (Driver's License)
+    /// and PR 3 (Passport) will reuse this helper.
+    ///
+    /// - Parameters:
+    ///   - isVisible: Whether the field was revealed (`true`) or hidden (`false`).
+    ///   - cipherId: The id of the cipher whose hidden field was toggled, if any.
+    ///
+    private func collectHiddenFieldVisibilityEventIfNeeded(isVisible: Bool, cipherId: String?) {
+        guard isVisible else { return }
+        Task {
+            await services.eventService.collect(
+                eventType: .cipherClientToggledHiddenFieldVisible,
+                cipherId: cipherId,
+            )
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemState.swift
@@ -35,6 +35,7 @@ struct ViewItemState: Equatable, Sendable {
     var navigationTitle: String {
         guard let item = loadingState.data else { return "" }
         return switch item.type {
+        case .bankAccount: Localizations.viewBankAccount
         case .card: Localizations.viewCard
         case .identity: Localizations.viewIdentity
         case .login: Localizations.viewLogin

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
@@ -13,6 +13,19 @@ extension CipherView {
 
     // MARK: Methods
 
+    /// Creates a `BankAccountItemState` representation of the cipher.
+    ///
+    /// - Returns: A `BankAccountItemState` representing the bank account information of the
+    ///   cipher. Currently returns an empty state because `BitwardenSdk.CipherView` does not yet
+    ///   expose a bank account property.
+    ///
+    func bankAccountItemState() -> BankAccountItemState {
+        // TODO: PM-32009 Blocked on SDK — return `BankAccountItemState.fromAPIModel(...)`
+        // populated from `self.bankAccount` (or equivalent) once the SDK exposes it on
+        // `CipherView`.
+        BankAccountItemState()
+    }
+
     /// Creates a `CardItemState` representation of the cipher.
     ///
     /// This function converts the `card` information of the cipher into a `CardItemState`, which
@@ -175,6 +188,9 @@ extension CipherView {
         // Cap the size of the password history list to 5.
         passwordHistory = passwordHistory?.suffix(5)
 
+        // TODO: PM-32009 Blocked on SDK — pass `bankAccount: (addEditState.type == .bankAccount)
+        // ? addEditState.bankAccountState.bankAccountView : nil` once `CipherView.init` accepts
+        // a `bankAccount:` parameter.
         // Return the updated cipher.
         return CipherView(
             id: id,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/CipherView+Update.swift
@@ -200,7 +200,13 @@ extension CipherView {
             key: key,
             name: addEditState.name,
             notes: addEditState.notes.nilIfEmpty,
-            type: BitwardenSdk.CipherType(addEditState.type),
+            // Fails closed when `addEditState.type` is not yet supported by the SDK
+            // (e.g., `.bankAccount` before PM-32009 SDK work lands). The save
+            // flow in `AddEditItemProcessor` must reject those types before
+            // reaching this builder; the `.secureNote` fallback is defensive
+            // only and `BitwardenSdk.CipherType.init?(_:)` trips an assertion
+            // in Debug if hit.
+            type: BitwardenSdk.CipherType(addEditState.type) ?? .secureNote,
             login: (addEditState.type == .login) ? .init(loginView: login, loginState: loginState) : nil,
             identity: (addEditState.type == .identity) ? addEditState.identityState.identityView : nil,
             card: (addEditState.type == .card) ? addEditState.cardItemState.cardView : nil,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewVaultItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewVaultItemState.swift
@@ -10,6 +10,9 @@ protocol ViewVaultItemState: Sendable, VaultItemWithDecorativeIcon {
     /// The item's attachments.
     var attachments: [AttachmentView]? { get }
 
+    /// The bank account item state.
+    var bankAccountItemViewState: any ViewBankAccountItemState { get }
+
     /// Whether the item belongs to multiple collections.
     var belongsToMultipleCollections: Bool { get }
 


### PR DESCRIPTION
## 🎟️ Tracking

- [PM-32809](https://bitwarden.atlassian.net/browse/PM-32809) — [iOS] Add Bank Account item type
- Epic: [PM-32009](https://bitwarden.atlassian.net/browse/PM-32009) (PR 1 of 6)

## 📔 Objective

Adds the Bank Account cipher type end-to-end on iOS behind the `pm-32009-new-item-types` feature flag. Covers `CipherType.bankAccount = 6`, `BankAccountType` enum, add/edit/view surfaces, vault list integration, and XCTest coverage.

### SDK dependency

`BitwardenSdk` currently stops at `.sshKey = 5`. All SDK-facing paths route through `NewItemTypesSdkBridge` (single source of truth). `isBankAccountAvailable` stays `false` and the LaunchDarkly flag **must remain OFF** until the SDK ships Bank Account support — coordinate with [PM-34060](https://bitwarden.atlassian.net/browse/PM-34060).

### Fail-closed invariants

Three defenses prevent silent `.bankAccount → .secureNote` coercion:
1. `BitwardenSdk.CipherType(_:)` is failable; `.bankAccount` returns `nil` until the bridge flips.
2. Debug `assertionFailure` tripwire on the fallback path.
3. `AddEditItemProcessor.saveItem()` rejects the save before any `CipherView` builder runs.

`CipherType.init(type:)` and `init(_:)` are also failable with `@unknown default: return nil` so the next SDK bump does not force a closed-switch compile break.

### Follow-ups

- Icon swap once [PM-34128](https://bitwarden.atlassian.net/browse/PM-34128) delivers the final asset (one-line change via `CipherType.iconPlaceholder`).
- Snapshot tests when the project-wide suite is re-enabled.

### Test plan

- [x] `mint run swiftformat .` / `mint run swiftlint` — clean
- [x] `xcodebuild build -scheme BitwardenShared` — clean (one pre-existing unrelated error remains)
- [x] XCTest coverage: `CipherBankAccountModelTests`, `BankAccountTypeTests`, `BankAccountItemStateTests`, expanded `CipherTypeTests` + `VaultRepositoryTests`
- [ ] Full `xcodebuild test -testPlan Bitwarden-Unit` — CI (local missing watchOS 26.1 runtime)
- [ ] Simulator smoke (flag OFF: no Bank Account in `+` menu / list) — CI or reviewer
- [ ] Simulator smoke (flag ON) — after SDK bump lands

## 📸 Screenshots

N/A for this PR — flag is OFF by default and the SDK is not yet shipping Bank Account support, so there are no user-visible changes in the merged default configuration. Screenshots to follow in the SDK-enablement PR.


[PM-32809]: https://bitwarden.atlassian.net/browse/PM-32809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-32009]: https://bitwarden.atlassian.net/browse/PM-32009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-34060]: https://bitwarden.atlassian.net/browse/PM-34060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-34128]: https://bitwarden.atlassian.net/browse/PM-34128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ