### PR TITLE
Update SDK to 02747b1 (2.0.0-4846-c74b7d1)

### DIFF
--- a/AuthenticatorShared/Core/Auth/Services/TestHelpers/MockCryptoClient.swift
+++ b/AuthenticatorShared/Core/Auth/Services/TestHelpers/MockCryptoClient.swift
@@ -36,6 +36,9 @@ class MockCryptoClient: CryptoClientProtocol {
         ),
     )
 
+    var getUpgradedUserKeyUpgradeToken: V2UpgradeToken?
+    var getUpgradedUserKeyResult: Result<B64, Error> = .success("UPGRADED_USER_KEY")
+
     var getUserEncryptionKeyResult: Result<String, Error> = .success("USER_ENCRYPTION_KEY")
 
     var initializeOrgCryptoRequest: InitOrgCryptoRequest?
@@ -110,6 +113,11 @@ class MockCryptoClient: CryptoClientProtocol {
     func enrollPinWithEncryptedPin(encryptedPin: EncString) throws -> EnrollPinResponse {
         enrollPinWithEncryptedPinEncryptedPin = encryptedPin
         return try enrollPinWithEncryptedPinResult.get()
+    }
+
+    func getUpgradedUserKey(upgradeToken: V2UpgradeToken?) throws -> B64 {
+        getUpgradedUserKeyUpgradeToken = upgradeToken
+        return try getUpgradedUserKeyResult.get()
     }
 
     func getUserEncryptionKey() async throws -> String {

--- a/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/bitwarden/sdk-swift",
       "state" : {
-        "revision" : "0ea18f04f87a0e50dd474f0712de06c35b0c74db"
+        "revision" : "02747b1758a9d59c5e5ff2903308df50b73c5a9f"
       }
     },
     {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1493,6 +1493,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
     }
@@ -1635,6 +1636,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
     }
@@ -2085,6 +2087,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2256,6 +2259,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                     securityState: "SECURITY_STATE",
                 ),
                 method: .decryptedKey(decryptedUserKey: "DECRYPTED_USER_KEY"),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2301,6 +2305,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 email: "user@bitwarden.com",
                 accountCryptographicState: .v1(privateKey: "private"),
                 method: .keyConnector(masterKey: "key", userKey: "user"),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(keyConnectorService.convertNewUserToKeyConnectorCalled)
@@ -2353,6 +2358,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 email: "user@bitwarden.com",
                 accountCryptographicState: .v1(privateKey: "private"),
                 method: .keyConnector(masterKey: "key", userKey: "user"),
+                upgradeToken: nil,
             ),
         )
         XCTAssertTrue(keyConnectorService.convertNewUserToKeyConnectorCalled)
@@ -2461,6 +2467,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2521,6 +2528,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2576,6 +2584,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2735,6 +2744,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                     requestPrivateKey: "AUTH_REQUEST_PRIVATE_KEY",
                     method: .masterKey(protectedMasterKey: "KEY", authRequestKey: "USER_KEY"),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
@@ -2774,6 +2784,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                     requestPrivateKey: "AUTH_REQUEST_PRIVATE_KEY",
                     method: .userKey(protectedUserKey: "KEY"),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertTrue(vaultTimeoutService.unlockVaultHadUserInteraction)
@@ -2826,6 +2837,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2894,6 +2906,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -2962,6 +2975,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                         salt: "SALT",
                     ),
                 ),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -3013,6 +3027,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                     securityState: "SECURITY_STATE",
                 ),
                 method: .pin(pin: "123", pinProtectedUserKey: "pinProtectedUserKey"),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))
@@ -3057,6 +3072,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                     securityState: "SECURITY_STATE",
                 ),
                 method: .pinEnvelope(pin: "123", pinProtectedUserKeyEnvelope: "pinProtectedUserKeyEnvelope"),
+                upgradeToken: nil,
             ),
         )
         XCTAssertFalse(vaultTimeoutService.isLocked(userId: "1"))

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockCryptoClient.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockCryptoClient.swift
@@ -37,6 +37,9 @@ class MockCryptoClient: CryptoClientProtocol {
         ),
     )
 
+    var getUpgradedUserKeyUpgradeToken: V2UpgradeToken?
+    var getUpgradedUserKeyResult: Result<B64, Error> = .success("UPGRADED_USER_KEY")
+
     var getUserEncryptionKeyCalled = false
     var getUserEncryptionKeyResult: Result<String, Error> = .success("USER_ENCRYPTION_KEY")
 
@@ -112,6 +115,11 @@ class MockCryptoClient: CryptoClientProtocol {
     func enrollPinWithEncryptedPin(encryptedPin: EncString) throws -> EnrollPinResponse {
         enrollPinWithEncryptedPinEncryptedPin = encryptedPin
         return try enrollPinWithEncryptedPinResult.get()
+    }
+
+    func getUpgradedUserKey(upgradeToken: V2UpgradeToken?) throws -> B64 {
+        getUpgradedUserKeyUpgradeToken = upgradeToken
+        return try getUpgradedUserKeyResult.get()
     }
 
     func getUserEncryptionKey() async throws -> String {

--- a/BitwardenShared/Core/Platform/Services/CryptoClientProtocol+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Services/CryptoClientProtocol+Extensions.swift
@@ -30,6 +30,7 @@ extension CryptoClientProtocol {
                 email: account.profile.email,
                 accountCryptographicState: accountCryptographicState,
                 method: method,
+                upgradeToken: nil,
             ),
         )
     }

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -602,7 +602,6 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         )
         let sdkRepositoryFactory = DefaultSdkRepositoryFactory(
             cipherDataStore: dataStore,
-            errorReporter: errorReporter,
             serverCommunicationConfigStateService: stateService,
         )
         let clientService = DefaultClientService(
@@ -1082,7 +1081,6 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             errorReporter: errorReporter,
             sdkRepositoryFactory: DefaultSdkRepositoryFactory(
                 cipherDataStore: dataStore,
-                errorReporter: errorReporter,
                 serverCommunicationConfigStateService: stateService,
             ),
             stateService: stateService,

--- a/BitwardenShared/Core/Vault/Repositories/SdkCipherRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/SdkCipherRepository.swift
@@ -42,10 +42,36 @@ final class SdkCipherRepository: BitwardenSdk.CipherRepository {
         try await cipherDataStore.deleteCipher(id: id, userId: userId)
     }
 
+    func removeAll() async throws {
+        try await cipherDataStore.deleteAllCiphers(userId: userId)
+    }
+
+    func removeBulk(keys: [String]) async throws {
+        for key in keys {
+            try await cipherDataStore.deleteCipher(id: key, userId: userId)
+        }
+    }
+
     func set(id: String, value: BitwardenSdk.Cipher) async throws {
         guard id == value.id else {
             throw BitwardenError.dataError("CipherRepository: Trying to update a cipher with mismatch IDs")
         }
         try await cipherDataStore.upsertCipher(value, userId: userId)
+    }
+
+    func setBulk(values: [String: BitwardenSdk.Cipher]) async throws {
+        let validEntries = values.filter { id, cipher in
+            guard id == cipher.id else {
+                errorReporter.log(error: BitwardenError.dataError(
+                    "CipherRepository: Trying to update a cipher with mismatch IDs",
+                ))
+                return false
+            }
+            return true
+        }
+        guard !validEntries.isEmpty else { return }
+        for cipher in validEntries.values {
+            try await cipherDataStore.upsertCipher(cipher, userId: userId)
+        }
     }
 }

--- a/BitwardenShared/Core/Vault/Repositories/SdkCipherRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/SdkCipherRepository.swift
@@ -5,23 +5,18 @@ import BitwardenSdk
 final class SdkCipherRepository: BitwardenSdk.CipherRepository {
     /// The data store for managing the persisted ciphers for the user.
     let cipherDataStore: CipherDataStore
-    /// The service used by the application to report non-fatal errors.
-    let errorReporter: ErrorReporter
     /// The user ID of the SDK instance this repository belongs to.
     let userId: String
 
     /// Initializes a `SdkCipherRepository`.
     /// - Parameters:
     ///   - cipherDataStore: The data store for managing the persisted ciphers for the user.
-    ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - userId: The user ID of the SDK instance this repository belongs to
     init(
         cipherDataStore: CipherDataStore,
-        errorReporter: ErrorReporter,
         userId: String,
     ) {
         self.cipherDataStore = cipherDataStore
-        self.errorReporter = errorReporter
         self.userId = userId
     }
 
@@ -47,6 +42,7 @@ final class SdkCipherRepository: BitwardenSdk.CipherRepository {
     }
 
     func removeBulk(keys: [String]) async throws {
+        // TODO: PM-35829
         for key in keys {
             try await cipherDataStore.deleteCipher(id: key, userId: userId)
         }
@@ -60,17 +56,13 @@ final class SdkCipherRepository: BitwardenSdk.CipherRepository {
     }
 
     func setBulk(values: [String: BitwardenSdk.Cipher]) async throws {
-        let validEntries = values.filter { id, cipher in
+        // TODO: PM-35829
+        for (id, cipher) in values {
             guard id == cipher.id else {
-                errorReporter.log(error: BitwardenError.dataError(
-                    "CipherRepository: Trying to update a cipher with mismatch IDs",
-                ))
-                return false
+                throw BitwardenError.dataError("CipherRepository: Trying to update a cipher with mismatch IDs")
             }
-            return true
         }
-        guard !validEntries.isEmpty else { return }
-        for cipher in validEntries.values {
+        for cipher in values.values {
             try await cipherDataStore.upsertCipher(cipher, userId: userId)
         }
     }

--- a/BitwardenShared/Core/Vault/Repositories/SdkCipherRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/SdkCipherRepositoryTests.swift
@@ -98,4 +98,50 @@ class SdkCipherRepositoryTests: BitwardenTestCase {
 
         XCTAssertNil(cipherDataStore.upsertCipherValue)
     }
+
+    /// `removeAll()` deletes all ciphers for the user ID.
+    func test_removeAll() async throws {
+        try await subject.removeAll()
+        XCTAssertEqual(cipherDataStore.deleteAllCiphersUserId, expectedUserId)
+    }
+
+    /// `removeBulk(keys:)` deletes each cipher by ID for the user.
+    func test_removeBulk() async throws {
+        try await subject.removeBulk(keys: ["1", "2", "3"])
+        XCTAssertEqual(cipherDataStore.deleteCipherIds, ["1", "2", "3"])
+        XCTAssertEqual(cipherDataStore.deleteCipherUserId, expectedUserId)
+    }
+
+    /// `removeBulk(keys:)` with an empty list performs no deletions.
+    func test_removeBulk_empty() async throws {
+        try await subject.removeBulk(keys: [])
+        XCTAssertTrue(cipherDataStore.deleteCipherIds.isEmpty)
+    }
+
+    /// `setBulk(values:)` upserts all ciphers whose key matches the cipher's ID.
+    func test_setBulk() async throws {
+        try await subject.setBulk(values: ["1": .fixture(id: "1"), "2": .fixture(id: "2")])
+        XCTAssertEqual(cipherDataStore.upsertCipherValues.compactMap(\.id).sorted(), ["1", "2"])
+        XCTAssertEqual(cipherDataStore.upsertCipherUserId, expectedUserId)
+    }
+
+    /// `setBulk(values:)` skips entries whose key doesn't match the cipher's ID and logs an error.
+    func test_setBulk_withMismatch() async throws {
+        try await subject.setBulk(values: ["1": .fixture(id: "1"), "2": .fixture(id: "99")])
+        XCTAssertEqual(cipherDataStore.upsertCipherValues.compactMap(\.id), ["1"])
+        XCTAssertEqual(errorReporter.errors.count, 1)
+    }
+
+    /// `setBulk(values:)` performs no upserts when all entries have mismatched IDs.
+    func test_setBulk_allMismatched() async throws {
+        try await subject.setBulk(values: ["1": .fixture(id: "99"), "2": .fixture(id: "98")])
+        XCTAssertTrue(cipherDataStore.upsertCipherValues.isEmpty)
+        XCTAssertEqual(errorReporter.errors.count, 2)
+    }
+
+    /// `setBulk(values:)` with an empty map performs no upserts.
+    func test_setBulk_empty() async throws {
+        try await subject.setBulk(values: [:])
+        XCTAssertTrue(cipherDataStore.upsertCipherValues.isEmpty)
+    }
 }

--- a/BitwardenShared/Core/Vault/Repositories/SdkCipherRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/SdkCipherRepositoryTests.swift
@@ -10,7 +10,6 @@ class SdkCipherRepositoryTests: BitwardenTestCase {
     // MARK: Properties
 
     var cipherDataStore: MockCipherDataStore!
-    var errorReporter: MockErrorReporter!
     var subject: SdkCipherRepository!
     let expectedUserId = "1"
 
@@ -20,10 +19,8 @@ class SdkCipherRepositoryTests: BitwardenTestCase {
         super.setUp()
 
         cipherDataStore = MockCipherDataStore()
-        errorReporter = MockErrorReporter()
         subject = SdkCipherRepository(
             cipherDataStore: cipherDataStore,
-            errorReporter: errorReporter,
             userId: expectedUserId,
         )
     }
@@ -32,7 +29,6 @@ class SdkCipherRepositoryTests: BitwardenTestCase {
         super.tearDown()
 
         cipherDataStore = nil
-        errorReporter = nil
         subject = nil
     }
 
@@ -125,18 +121,20 @@ class SdkCipherRepositoryTests: BitwardenTestCase {
         XCTAssertEqual(cipherDataStore.upsertCipherUserId, expectedUserId)
     }
 
-    /// `setBulk(values:)` skips entries whose key doesn't match the cipher's ID and logs an error.
+    /// `setBulk(values:)` throws when any entry's key doesn't match the cipher's ID.
     func test_setBulk_withMismatch() async throws {
-        try await subject.setBulk(values: ["1": .fixture(id: "1"), "2": .fixture(id: "99")])
-        XCTAssertEqual(cipherDataStore.upsertCipherValues.compactMap(\.id), ["1"])
-        XCTAssertEqual(errorReporter.errors.count, 1)
+        await assertAsyncThrows {
+            try await subject.setBulk(values: ["1": .fixture(id: "1"), "2": .fixture(id: "99")])
+        }
+        XCTAssertTrue(cipherDataStore.upsertCipherValues.isEmpty)
     }
 
-    /// `setBulk(values:)` performs no upserts when all entries have mismatched IDs.
+    /// `setBulk(values:)` throws when all entries have mismatched IDs.
     func test_setBulk_allMismatched() async throws {
-        try await subject.setBulk(values: ["1": .fixture(id: "99"), "2": .fixture(id: "98")])
+        await assertAsyncThrows {
+            try await subject.setBulk(values: ["1": .fixture(id: "99")])
+        }
         XCTAssertTrue(cipherDataStore.upsertCipherValues.isEmpty)
-        XCTAssertEqual(errorReporter.errors.count, 2)
     }
 
     /// `setBulk(values:)` with an empty map performs no upserts.

--- a/BitwardenShared/Core/Vault/Repositories/SdkRepositoryFactory.swift
+++ b/BitwardenShared/Core/Vault/Repositories/SdkRepositoryFactory.swift
@@ -20,8 +20,6 @@ struct DefaultSdkRepositoryFactory: SdkRepositoryFactory {
 
     /// The data store for managing the persisted ciphers for the user.
     private let cipherDataStore: CipherDataStore
-    /// The service used by the application to report non-fatal errors.
-    private let errorReporter: ErrorReporter
     /// The service that provides state management functionality for the
     /// server communication configuration.
     private let serverCommunicationConfigStateService: ServerCommunicationConfigStateService
@@ -31,16 +29,13 @@ struct DefaultSdkRepositoryFactory: SdkRepositoryFactory {
     /// Initializes a `DefaultSdkRepositoryFactory`.
     /// - Parameters:
     ///   - cipherDataStore: The data store for managing the persisted ciphers for the user.
-    ///   - errorReporter: The service used by the application to report non-fatal errors.
     ///   - serverCommunicationConfigStateService: The service that provides state management functionality for the
     /// server communication configuration.
     init(
         cipherDataStore: CipherDataStore,
-        errorReporter: ErrorReporter,
         serverCommunicationConfigStateService: ServerCommunicationConfigStateService,
     ) {
         self.cipherDataStore = cipherDataStore
-        self.errorReporter = errorReporter
         self.serverCommunicationConfigStateService = serverCommunicationConfigStateService
     }
 
@@ -49,7 +44,6 @@ struct DefaultSdkRepositoryFactory: SdkRepositoryFactory {
     func makeCipherRepository(userId: String) -> BitwardenSdk.CipherRepository {
         SdkCipherRepository(
             cipherDataStore: cipherDataStore,
-            errorReporter: errorReporter,
             userId: userId,
         )
     }

--- a/BitwardenShared/Core/Vault/Repositories/SdkRepositoryFactoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/SdkRepositoryFactoryTests.swift
@@ -1,4 +1,3 @@
-import BitwardenKitMocks
 import XCTest
 
 @testable import BitwardenShared
@@ -10,7 +9,6 @@ class SdkRepositoryFactoryTests: BitwardenTestCase {
     // MARK: Properties
 
     var cipherDataStore: MockCipherDataStore!
-    var errorReporter: MockErrorReporter!
     var serverCommunicationConfigStateService: MockServerCommunicationConfigStateService!
     var subject: SdkRepositoryFactory!
 
@@ -20,11 +18,9 @@ class SdkRepositoryFactoryTests: BitwardenTestCase {
         super.setUp()
 
         cipherDataStore = MockCipherDataStore()
-        errorReporter = MockErrorReporter()
         serverCommunicationConfigStateService = MockServerCommunicationConfigStateService()
         subject = DefaultSdkRepositoryFactory(
             cipherDataStore: cipherDataStore,
-            errorReporter: errorReporter,
             serverCommunicationConfigStateService: serverCommunicationConfigStateService,
         )
     }
@@ -33,7 +29,6 @@ class SdkRepositoryFactoryTests: BitwardenTestCase {
         super.tearDown()
 
         cipherDataStore = nil
-        errorReporter = nil
         serverCommunicationConfigStateService = nil
         subject = nil
     }

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockSdkCipherRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockSdkCipherRepository.swift
@@ -9,9 +9,14 @@ final class MockSdkCipherRepository: BitwardenSdk.CipherRepository {
     var listResult: Result<[BitwardenSdk.Cipher], Error> = .success([])
     var removeResult: Result<Void, Error> = .success(())
     var removeReceivedId: String?
+    var removeBulkReceivedKeys: [String]?
+    var removeBulkResult: Result<Void, Error> = .success(())
+    var removeAllResult: Result<Void, Error> = .success(())
     var setReceivedId: String?
     var setReceivedCipher: Cipher?
     var setResult: Result<Void, Error> = .success(())
+    var setBulkReceivedValues: [String: BitwardenSdk.Cipher]?
+    var setBulkResult: Result<Void, Error> = .success(())
 
     func get(id: String) async throws -> BitwardenSdk.Cipher? {
         try getResult.get()
@@ -34,5 +39,19 @@ final class MockSdkCipherRepository: BitwardenSdk.CipherRepository {
         setReceivedId = id
         setReceivedCipher = value
         try setResult.get()
+    }
+
+    func setBulk(values: [String: BitwardenSdk.Cipher]) async throws {
+        setBulkReceivedValues = values
+        try setBulkResult.get()
+    }
+
+    func removeBulk(keys: [String]) async throws {
+        removeBulkReceivedKeys = keys
+        try removeBulkResult.get()
+    }
+
+    func removeAll() async throws {
+        try removeAllResult.get()
     }
 }

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockSdkCipherRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockSdkCipherRepository.swift
@@ -7,11 +7,11 @@ final class MockSdkCipherRepository: BitwardenSdk.CipherRepository {
     var getResult: Result<BitwardenSdk.Cipher, Error> = .success(.fixture())
     var hasResult: Result<Bool, Error> = .success(true)
     var listResult: Result<[BitwardenSdk.Cipher], Error> = .success([])
-    var removeResult: Result<Void, Error> = .success(())
-    var removeReceivedId: String?
+    var removeAllResult: Result<Void, Error> = .success(())
     var removeBulkReceivedKeys: [String]?
     var removeBulkResult: Result<Void, Error> = .success(())
-    var removeAllResult: Result<Void, Error> = .success(())
+    var removeReceivedId: String?
+    var removeResult: Result<Void, Error> = .success(())
     var setReceivedId: String?
     var setReceivedCipher: Cipher?
     var setResult: Result<Void, Error> = .success(())
@@ -35,6 +35,15 @@ final class MockSdkCipherRepository: BitwardenSdk.CipherRepository {
         try removeResult.get()
     }
 
+    func removeAll() async throws {
+        try removeAllResult.get()
+    }
+
+    func removeBulk(keys: [String]) async throws {
+        removeBulkReceivedKeys = keys
+        try removeBulkResult.get()
+    }
+
     func set(id: String, value: BitwardenSdk.Cipher) async throws {
         setReceivedId = id
         setReceivedCipher = value
@@ -44,14 +53,5 @@ final class MockSdkCipherRepository: BitwardenSdk.CipherRepository {
     func setBulk(values: [String: BitwardenSdk.Cipher]) async throws {
         setBulkReceivedValues = values
         try setBulkResult.get()
-    }
-
-    func removeBulk(keys: [String]) async throws {
-        removeBulkReceivedKeys = keys
-        try removeBulkResult.get()
-    }
-
-    func removeAll() async throws {
-        try removeAllResult.get()
     }
 }

--- a/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
+++ b/BitwardenShared/Core/Vault/Services/Stores/TestHelpers/MockCipherDataStore.swift
@@ -13,6 +13,7 @@ class MockCipherDataStore: CipherDataStore {
     var deleteAllCiphersUserId: String?
 
     var deleteCipherId: String?
+    var deleteCipherIds: [String] = []
     var deleteCipherUserId: String?
 
     var fetchAllCiphersUserId: String?
@@ -29,6 +30,7 @@ class MockCipherDataStore: CipherDataStore {
     var replaceCiphersUserId: String?
 
     var upsertCipherValue: Cipher?
+    var upsertCipherValues: [Cipher] = []
     var upsertCipherUserId: String?
 
     func cipherCount(userId: String) async throws -> Int {
@@ -62,6 +64,7 @@ class MockCipherDataStore: CipherDataStore {
 
     func deleteCipher(id: String, userId: String) async throws {
         deleteCipherId = id
+        deleteCipherIds.append(id)
         deleteCipherUserId = userId
     }
 
@@ -88,6 +91,7 @@ class MockCipherDataStore: CipherDataStore {
 
     func upsertCipher(_ cipher: Cipher, userId: String) async throws {
         upsertCipherValue = cipher
+        upsertCipherValues.append(cipher)
         upsertCipherUserId = userId
     }
 }

--- a/project-common.yml
+++ b/project-common.yml
@@ -14,7 +14,7 @@ include:
 packages:
   BitwardenSdk:
     url: https://github.com/bitwarden/sdk-swift
-    revision: 0ea18f04f87a0e50dd474f0712de06c35b0c74db # 2.0.0-4735-26e2b10
+    revision: 02747b1758a9d59c5e5ff2903308df50b73c5a9f # 2.0.0-4846-c74b7d1
     branch: km/fix-cherry-pick
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
[PM-35125](https://bitwarden.atlassian.net/browse/PM-35125)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
  Adapts the iOS client for two breaking changes introduced by the SDK update (2.0.0-4846-c74b7d1):

  - [PM-28926] Implements the new setBulk, removeBulk, and removeAll methods on SdkCipherRepository to conform to the updated CipherRepository protocol. Includes tests and mock updates.
  - [PM-31051] Passes upgradeToken: nil to InitUserCryptoRequest and adds getUpgradedUserKey to MockCryptoClient to conform to the updated CryptoClientProtocol.

## What's Changed

- bitwarden/sdk-internal#800
- bitwarden/sdk-internal#801
- bitwarden/sdk-internal#777
- bitwarden/sdk-internal#804
- bitwarden/sdk-internal#785
- bitwarden/sdk-internal#807
- chore(bindings): Update Identity bindings to 88fa59ae807d5a005533ce6efc30c829d51dddfd
- chore(ownership): Remove Platform as codeowners for binding updates on Identity
- bitwarden/sdk-internal#819


[PM-35125]: https://bitwarden.atlassian.net/browse/PM-35125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-28926]: https://bitwarden.atlassian.net/browse/PM-28926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-31051]: https://bitwarden.atlassian.net/browse/PM-31051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ