### PR TITLE
[PM-35498] chore: add shared Xcode search custom scopes and setup script

### DIFF
--- a/Docs/XcodeSearchScopes.md
+++ b/Docs/XcodeSearchScopes.md
@@ -1,0 +1,51 @@
+# Xcode Search Custom Scopes
+
+## What are Xcode Search Scopes?
+
+Xcode's Find navigator supports custom search scopes that let you filter which files are searched. For example, you can limit a search to Swift source files only, or exclude test and localization files to focus on production code.
+
+Custom scopes are stored in `xcuserdata/`, which is gitignored because it contains per-user Xcode state. This folder provides a shared template and a script to install the scopes into your local workspace without committing user-specific paths.
+
+## Setup
+
+Run the setup script from the repo root:
+
+```bash
+bash Scripts/setup-search-scopes.sh
+```
+
+The script installs the scopes into:
+```
+Bitwarden.xcworkspace/xcuserdata/<your-username>.xcuserdatad/IDEFindNavigatorScopes.plist
+```
+
+If a `IDEFindNavigatorScopes.plist` file already exists (e.g. you have your own custom scopes), the script will prompt you to:
+- **Overwrite** — replace entirely with the shared template
+- **Merge** — append only the template scopes not already present (matched by name)
+- **Cancel** — make no changes
+
+**Note:** This script is not run automatically by `bootstrap.sh`. Run it manually whenever the shared scopes are updated.
+
+After running the script, **restart Xcode** for the new scopes to appear in the Find navigator.
+
+## Available Scopes
+
+| Name | Description |
+|---|---|
+| **Not Tests** | Excludes files whose names end in `Tests.swift`. Useful when searching for production code without noise from test files. |
+| **Not in Localizations** | Excludes `Localizable.strings` and `Localizations.swift`. Useful when searching for code references without matching localization keys or generated string accessors. |
+
+## Using a Scope
+
+1. Open the Find navigator (⌘3) and switch to the **Find** tab.
+2. Click the scope dropdown (defaults to "In Workspace") next to the search field.
+3. Select a custom scope from the list.
+
+## Adding a New Scope
+
+1. In Xcode's Find navigator, click the scope dropdown and choose **New Scope…**
+2. Configure the scope's name, predicates, and source in the editor.
+3. Save the scope — Xcode writes it to your local `IDEFindNavigatorScopes.plist`.
+4. Open `Bitwarden.xcworkspace/xcuserdata/<your-username>.xcuserdatad/IDEFindNavigatorScopes.plist` and copy the new `<dict>` entry for your scope.
+5. Paste it into `Xcode/SearchScopes/IDEFindNavigatorScopes.plist` in the repo.
+6. Open a PR with the change so teammates can merge it via the setup script.

--- a/Scripts/setup-search-scopes.sh
+++ b/Scripts/setup-search-scopes.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+#
+# Script to install Xcode Search Custom Scopes for the Bitwarden workspace.
+# Run manually — not called automatically by bootstrap.sh.
+#
+# Usage: bash Scripts/setup-search-scopes.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+TEMPLATE="$REPO_ROOT/Xcode/SearchScopes/IDEFindNavigatorScopes.plist"
+TARGET_DIR="$REPO_ROOT/Bitwarden.xcworkspace/xcuserdata/$(whoami).xcuserdatad"
+TARGET="$TARGET_DIR/IDEFindNavigatorScopes.plist"
+
+if [ ! -f "$TEMPLATE" ]; then
+    echo "❌ Template not found: $TEMPLATE"
+    exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+
+if [ ! -f "$TARGET" ]; then
+    cp "$TEMPLATE" "$TARGET"
+    echo "✅ Search scopes installed."
+    echo "ℹ️  Restart Xcode for the scopes to appear in the Find navigator."
+    exit 0
+fi
+
+echo "IDEFindNavigatorScopes.plist already exists at:"
+echo "  $TARGET"
+echo ""
+echo "Choose an action:"
+echo "  [o] Overwrite — replace with the template (existing custom scopes will be lost)"
+echo "  [m] Merge     — add template scopes not already present (matched by name)"
+echo "  [c] Cancel    — abort without changes"
+echo ""
+
+while true; do
+    read -r -p "Enter choice [o/m/c]: " choice
+    case "$choice" in
+        o|O)
+            cp "$TEMPLATE" "$TARGET"
+            echo "✅ Search scopes overwritten."
+            echo "ℹ️  Restart Xcode for the scopes to appear in the Find navigator."
+            exit 0
+            ;;
+        m|M)
+            if ! command -v python3 &> /dev/null; then
+                echo "❌ python3 is required for merge but was not found."
+                echo "   Try the overwrite option instead, or install Python 3."
+                exit 1
+            fi
+            result=$(python3 - "$TEMPLATE" "$TARGET" <<'PYEOF'
+import sys
+import plistlib
+
+template_path = sys.argv[1]
+target_path = sys.argv[2]
+
+with open(template_path, "rb") as f:
+    template_scopes = plistlib.load(f)
+
+with open(target_path, "rb") as f:
+    existing_scopes = plistlib.load(f)
+
+existing_names = {s["name"] for s in existing_scopes}
+added = 0
+skipped = 0
+
+for scope in template_scopes:
+    if scope["name"] in existing_names:
+        skipped += 1
+    else:
+        existing_scopes.append(scope)
+        added += 1
+
+with open(target_path, "wb") as f:
+    plistlib.dump(existing_scopes, f, fmt=plistlib.FMT_XML, sort_keys=False)
+
+print(f"{added} {skipped}")
+PYEOF
+)
+            added=$(echo "$result" | awk '{print $1}')
+            skipped=$(echo "$result" | awk '{print $2}')
+            echo "✅ Merge complete: added $added scope(s), skipped $skipped (already present)."
+            echo "ℹ️  Restart Xcode for the scopes to appear in the Find navigator."
+            exit 0
+            ;;
+        c|C)
+            echo "Cancelled. No changes made."
+            exit 0
+            ;;
+        *)
+            echo "Invalid choice. Please enter o, m, or c."
+            ;;
+    esac
+done

--- a/Xcode/SearchScopes/IDEFindNavigatorScopes.plist
+++ b/Xcode/SearchScopes/IDEFindNavigatorScopes.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array>
+	<dict>
+		<key>name</key>
+		<string>Not Tests</string>
+		<key>predicate</key>
+		<dict>
+			<key>predicates</key>
+			<array>
+				<dict>
+					<key>operand</key>
+					<string>Tests.swift</string>
+					<key>operator</key>
+					<string>ends-with</string>
+					<key>rule</key>
+					<string>file-name</string>
+				</dict>
+			</array>
+			<key>rule</key>
+			<string>none</string>
+		</dict>
+		<key>source</key>
+		<dict>
+			<key>file-source</key>
+			<string>workspace</string>
+		</dict>
+	</dict>
+	<dict>
+		<key>name</key>
+		<string>Not in Localizations</string>
+		<key>predicate</key>
+		<dict>
+			<key>predicates</key>
+			<array>
+				<dict>
+					<key>operand</key>
+					<string>Localizable.strings</string>
+					<key>operator</key>
+					<string>is-not-equal-to</string>
+					<key>rule</key>
+					<string>file-name</string>
+				</dict>
+				<dict>
+					<key>operand</key>
+					<string>Localizations.swift</string>
+					<key>operator</key>
+					<string>is-not-equal-to</string>
+					<key>rule</key>
+					<string>file-name</string>
+				</dict>
+			</array>
+			<key>rule</key>
+			<string>all</string>
+		</dict>
+		<key>source</key>
+		<dict>
+			<key>file-source</key>
+			<string>workspace</string>
+		</dict>
+	</dict>
+</array>
+</plist>


### PR DESCRIPTION
## 🎟️ Tracking
[PM-35498](https://bitwarden.atlassian.net/browse/PM-35498)

## 📔 Objective
Adds a shared folder structure for Xcode Search Custom Scopes so the whole team can benefit from the same productivity filters in the Find navigator.

Xcode stores custom scopes in `xcuserdata/` (gitignored), so they can't be committed directly. This PR adds:
- `Xcode/SearchScopes/IDEFindNavigatorScopes.plist` — template with two pre-defined scopes: **Not Tests** and **Not in Localizations**
- `Scripts/setup-search-scopes.sh` — interactive installer that copies the template into the developer's workspace-level `xcuserdata/`; if a file already exists it prompts to overwrite, merge, or cancel
- `Docs/XcodeSearchScopes.md` — explains the scopes, how to run the setup script, and how to contribute new scopes back

The script is run manually and is not wired into `bootstrap.sh`.

[PM-35498]: https://bitwarden.atlassian.net/browse/PM-35498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ