### PR TITLE
[PM-34715] feat: Add confirmation prompt when archiving a vault item

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -993,6 +993,8 @@
 "ItemsTransferred" = "Items transferred";
 "ArchiveIsEmpty" = "Archive is empty";
 "ArchiveEmptyDescriptionLong" = "Fill your archive with items you don’t want to see in search results and autofill suggestions but might need someday.";
+"ArchiveItem" = "Archive item";
+"OnceArchivedThisItemWillBeExcludedDescriptionLong" = "Once archived, this item will be excluded from search results and autofill suggestions.";
 "ArchiveUnavailable" = "Archive unavailable";
 "ArchivingItemsIsAPremiumFeatureDescriptionLong" = "Archiving items is a Premium feature. Your current plan does not include access to this feature.";
 "UpgradeToPremium" = "Upgrade to premium";

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -88,6 +88,23 @@ extension Alert {
         )
     }
 
+    /// Returns an alert asking the user to confirm archiving a vault item.
+    ///
+    /// - Parameters:
+    ///   - action: A closure to execute when the user confirms archiving.
+    /// - Returns: An alert confirming the archive action.
+    ///
+    static func confirmArchiveItem(action: @escaping () async -> Void) -> Alert {
+        Alert(
+            title: Localizations.archiveItem,
+            message: Localizations.onceArchivedThisItemWillBeExcludedDescriptionLong,
+            alertActions: [
+                AlertAction(title: Localizations.archive, style: .default) { _, _ in await action() },
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ],
+        )
+    }
+
     /// Returns an alert confirming cancelling the Credential Exchange export process.
     /// - Parameter action: The action to perform if the user confirms.
     /// - Returns: An alert confirming cancelling the Credential Exchange export process.

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -36,6 +36,33 @@ class AlertVaultTests: BitwardenTestCase { // swiftlint:disable:this type_body_l
         XCTAssertFalse(called)
     }
 
+    /// `confirmArchiveItem(action:)` returns an `Alert` asking the user to confirm archiving a
+    /// vault item.
+    func test_confirmArchiveItem() async throws {
+        var actionCalled = false
+        let subject = Alert.confirmArchiveItem { actionCalled = true }
+
+        XCTAssertEqual(subject.title, Localizations.archiveItem)
+        XCTAssertEqual(subject.message, Localizations.onceArchivedThisItemWillBeExcludedDescriptionLong)
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.archive)
+        XCTAssertEqual(subject.alertActions[0].style, .default)
+        XCTAssertEqual(subject.alertActions[1].title, Localizations.cancel)
+        XCTAssertEqual(subject.alertActions[1].style, .cancel)
+
+        try await subject.tapAction(title: Localizations.archive)
+        XCTAssertTrue(actionCalled)
+    }
+
+    /// `confirmArchiveItem(action:)` does not invoke the action when cancel is tapped.
+    func test_confirmArchiveItem_cancel() async throws {
+        var actionCalled = false
+        let subject = Alert.confirmArchiveItem { actionCalled = true }
+
+        try await subject.tapCancel()
+        XCTAssertFalse(actionCalled)
+    }
+
     /// `specificPeopleUnavailable(action:)` returns an `Alert` notifying the user that the
     /// "Specific People" Send feature requires premium.
     func test_specificPeopleUnavailable() async throws {

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -139,15 +139,17 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             return
         }
 
-        await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipher) {
-            await self.performOperationAndShowToast(
-                handleDisplayToast: handleDisplayToast,
-                loadingTitle: Localizations.sendingToArchive,
-                toastTitle: Localizations.itemMovedToArchive,
-            ) {
-                try await self.services.vaultRepository.archiveCipher(cipher)
+        coordinator.showAlert(Alert.confirmArchiveItem {
+            await self.masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipher) {
+                await self.performOperationAndShowToast(
+                    handleDisplayToast: handleDisplayToast,
+                    loadingTitle: Localizations.sendingToArchive,
+                    toastTitle: Localizations.itemMovedToArchive,
+                ) {
+                    try await self.services.vaultRepository.archiveCipher(cipher)
+                }
             }
-        }
+        })
     }
 
     /// Generates and copies a TOTP code for the cipher's TOTP key.

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -92,16 +92,50 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         )
 
         let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
-
         XCTAssertTrue(optionsAlert.alertActions.contains(where: { $0.title == Localizations.archive }))
 
         coordinator.loadingOverlaysShown = []
-        vaultRepository.archiveCipherResult = .success(())
         try await optionsAlert.tapAction(title: Localizations.archive)
+
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+
+        vaultRepository.archiveCipherResult = .success(())
+        try await confirmAlert.tapAction(title: Localizations.archive)
 
         XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.sendingToArchive)
         XCTAssertEqual(vaultRepository.archiveCipher, [cipherView])
         XCTAssertEqual(toastToDisplay, Toast(title: Localizations.itemMovedToArchive))
+    }
+
+    /// `showMoreOptionsAlert()` does not archive when the user cancels the confirmation alert.
+    @MainActor
+    func test_showMoreOptionsAlert_archive_confirmationCancel() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+
+        let cipherView = CipherView.loginFixture(archivedDate: nil, deletedDate: nil)
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        var toastToDisplay: Toast?
+        await subject.showMoreOptionsAlert(
+            for: item,
+            handleDisplayToast: { toastToDisplay = $0 },
+            handleOpenURL: { _ in },
+        )
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.archive)
+
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+
+        try await confirmAlert.tapCancel()
+
+        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
+        XCTAssertNil(toastToDisplay)
     }
 
     /// `showMoreOptionsAlert()` and press `archive` presents master password re-prompt
@@ -130,6 +164,10 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         coordinator.loadingOverlaysShown = []
         vaultRepository.archiveCipherResult = .success(())
         try await optionsAlert.tapAction(title: Localizations.archive)
+
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+        try await confirmAlert.tapAction(title: Localizations.archive)
 
         // Validate master password re-prompt is shown.
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherView, cipherView)

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
@@ -77,13 +77,15 @@ class DefaultVaultItemActionHelper: VaultItemActionHelper {
             return
         }
 
-        await performOperation(
-            loadingTitle: Localizations.sendingToArchive,
-            operation: {
-                try await self.services.vaultRepository.archiveCipher(cipher)
-            },
-            completionHandler: completionHandler,
-        )
+        await coordinator.showAlert(Alert.confirmArchiveItem {
+            await self.performOperation(
+                loadingTitle: Localizations.sendingToArchive,
+                operation: {
+                    try await self.services.vaultRepository.archiveCipher(cipher)
+                },
+                completionHandler: completionHandler,
+            )
+        })
     }
 
     func unarchive(

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -90,7 +90,6 @@ class VaultItemActionHelperTests: BitwardenTestCase {
         let cipher = CipherView.loginFixture(id: "123")
 
         vaultRepository.doesActiveAccountHavePremiumResult = true
-        vaultRepository.archiveCipherResult = .success(())
 
         await subject.archive(
             cipher: cipher,
@@ -98,11 +97,42 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.sendingToArchive)
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
+        XCTAssertFalse(completionCalled)
 
+        vaultRepository.archiveCipherResult = .success(())
+        try await confirmAlert.tapAction(title: Localizations.archive)
+
+        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.sendingToArchive)
         XCTAssertEqual(vaultRepository.archiveCipher.last?.id, "123")
         XCTAssertTrue(completionCalled)
         XCTAssertNil(errorReporter.errors.first)
+    }
+
+    /// `archive(cipher:handleOpenURL:completionHandler:)` does not archive when the user cancels
+    /// the confirmation alert.
+    @MainActor
+    func test_archive_confirmationCancel() async throws {
+        var completionCalled = false
+        let cipher = CipherView.loginFixture(id: "123")
+
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+
+        await subject.archive(
+            cipher: cipher,
+            handleOpenURL: { _ in },
+            completionHandler: { completionCalled = true },
+        )
+
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+
+        try await confirmAlert.tapCancel()
+
+        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
+        XCTAssertFalse(completionCalled)
     }
 
     /// `archive(cipher:handleOpenURL:completionHandler:)` shows an error alert when archiving fails.
@@ -119,6 +149,9 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             handleOpenURL: { _ in },
             completionHandler: { completionCalled = true },
         )
+
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await confirmAlert.tapAction(title: Localizations.archive)
 
         XCTAssertEqual(coordinator.errorAlertsShown.count, 1)
         XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -10,7 +10,6 @@ import Testing
 
 // MARK: - VaultItemActionHelperTests
 
-@MainActor
 struct VaultItemActionHelperTests {
     // MARK: Properties
 

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -2,27 +2,27 @@ import BitwardenKit
 import BitwardenKitMocks
 import BitwardenResources
 import BitwardenSdk
+import Foundation
 import TestHelpers
-import XCTest
+import Testing
 
 @testable import BitwardenShared
 
 // MARK: - VaultItemActionHelperTests
 
-class VaultItemActionHelperTests: BitwardenTestCase {
+@MainActor
+struct VaultItemActionHelperTests {
     // MARK: Properties
 
-    var coordinator: MockCoordinator<VaultItemRoute, VaultItemEvent>!
-    var environmentService: MockEnvironmentService!
-    var errorReporter: MockErrorReporter!
-    var vaultRepository: MockVaultRepository!
-    var subject: VaultItemActionHelper!
+    let coordinator: MockCoordinator<VaultItemRoute, VaultItemEvent>
+    let environmentService: MockEnvironmentService
+    let errorReporter: MockErrorReporter
+    let vaultRepository: MockVaultRepository
+    let subject: VaultItemActionHelper
 
-    // MARK: Setup & Teardown
+    // MARK: Initialization
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         coordinator = MockCoordinator<VaultItemRoute, VaultItemEvent>()
         environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
@@ -37,22 +37,12 @@ class VaultItemActionHelperTests: BitwardenTestCase {
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
-
-        coordinator = nil
-        environmentService = nil
-        errorReporter = nil
-        vaultRepository = nil
-        subject = nil
-    }
-
     // MARK: Tests
 
     /// `archive(cipher:handleOpenURL:completionHandler:)` shows the archive unavailable alert
     /// when the user does not have premium.
-    @MainActor
-    func test_archive_noPremium() async {
+    @Test
+    func archive_noPremium() async throws {
         var openedURL: URL?
         var completionCalled = false
         let cipher = CipherView.loginFixture(id: "123")
@@ -68,24 +58,20 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let alert = coordinator.alertShown.last
-        XCTAssertEqual(alert?.title, Localizations.archiveUnavailable)
-        XCTAssertEqual(alert?.message, Localizations.archivingItemsIsAPremiumFeatureDescriptionLong)
+        let alert = try #require(coordinator.alertShown.last)
+        #expect(alert.title == Localizations.archiveUnavailable)
+        #expect(alert.message == Localizations.archivingItemsIsAPremiumFeatureDescriptionLong)
+        #expect(vaultRepository.archiveCipher.isEmpty)
+        #expect(!completionCalled)
 
-        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
-        XCTAssertFalse(completionCalled)
-
-        try? await alert?.tapAction(title: Localizations.upgradeToPremium)
-        XCTAssertEqual(
-            openedURL,
-            URL(string: "https://example.com/someURLToUpgradeToPremium"),
-        )
+        try await alert.tapAction(title: Localizations.upgradeToPremium)
+        #expect(openedURL == URL(string: "https://example.com/someURLToUpgradeToPremium"))
     }
 
     /// `archive(cipher:handleOpenURL:completionHandler:)` shows the confirmation alert and
     /// archives the cipher when the user has premium and confirms.
-    @MainActor
-    func test_archive_success() async throws {
+    @Test
+    func archive_success() async throws {
         var completionCalled = false
         let cipher = CipherView.loginFixture(id: "123")
 
@@ -97,24 +83,24 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
-        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
-        XCTAssertFalse(completionCalled)
+        let confirmAlert = try #require(coordinator.alertShown.last)
+        #expect(confirmAlert.title == Localizations.archiveItem)
+        #expect(vaultRepository.archiveCipher.isEmpty)
+        #expect(!completionCalled)
 
         vaultRepository.archiveCipherResult = .success(())
         try await confirmAlert.tapAction(title: Localizations.archive)
 
-        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.sendingToArchive)
-        XCTAssertEqual(vaultRepository.archiveCipher.last?.id, "123")
-        XCTAssertTrue(completionCalled)
-        XCTAssertNil(errorReporter.errors.first)
+        #expect(coordinator.loadingOverlaysShown.last?.title == Localizations.sendingToArchive)
+        #expect(vaultRepository.archiveCipher.last?.id == "123")
+        #expect(completionCalled)
+        #expect(errorReporter.errors.isEmpty)
     }
 
     /// `archive(cipher:handleOpenURL:completionHandler:)` does not archive when the user cancels
     /// the confirmation alert.
-    @MainActor
-    func test_archive_confirmationCancel() async throws {
+    @Test
+    func archive_confirmationCancel() async throws {
         var completionCalled = false
         let cipher = CipherView.loginFixture(id: "123")
 
@@ -126,18 +112,18 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+        let confirmAlert = try #require(coordinator.alertShown.last)
+        #expect(confirmAlert.title == Localizations.archiveItem)
 
         try await confirmAlert.tapCancel()
 
-        XCTAssertTrue(vaultRepository.archiveCipher.isEmpty)
-        XCTAssertFalse(completionCalled)
+        #expect(vaultRepository.archiveCipher.isEmpty)
+        #expect(!completionCalled)
     }
 
     /// `archive(cipher:handleOpenURL:completionHandler:)` shows an error alert when archiving fails.
-    @MainActor
-    func test_archive_error() async throws {
+    @Test
+    func archive_error() async throws {
         var completionCalled = false
         let cipher = CipherView.loginFixture(id: "123")
 
@@ -150,18 +136,18 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        let confirmAlert = try #require(coordinator.alertShown.last)
         try await confirmAlert.tapAction(title: Localizations.archive)
 
-        XCTAssertEqual(coordinator.errorAlertsShown.count, 1)
-        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-        XCTAssertFalse(completionCalled)
+        #expect(coordinator.errorAlertsShown.count == 1)
+        #expect(errorReporter.errors as? [BitwardenTestError] == [.example])
+        #expect(!completionCalled)
     }
 
     /// `unarchive(cipher:completionHandler:)` shows the confirmation alert and unarchives
     /// the cipher when the user confirms.
-    @MainActor
-    func test_unarchive_success() async throws {
+    @Test
+    func unarchive_success() async throws {
         var completionCalled = false
         let cipher = CipherView.loginFixture(archivedDate: .now, id: "123")
 
@@ -172,16 +158,15 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.movingItemToVault)
-
-        XCTAssertEqual(vaultRepository.unarchiveCipher.last?.id, "123")
-        XCTAssertTrue(completionCalled)
-        XCTAssertNil(errorReporter.errors.first)
+        #expect(coordinator.loadingOverlaysShown.last?.title == Localizations.movingItemToVault)
+        #expect(vaultRepository.unarchiveCipher.last?.id == "123")
+        #expect(completionCalled)
+        #expect(errorReporter.errors.isEmpty)
     }
 
     /// `unarchive(cipher:completionHandler:)` shows an error alert when unarchiving fails.
-    @MainActor
-    func test_unarchive_error() async throws {
+    @Test
+    func unarchive_error() async throws {
         var completionCalled = false
         let cipher = CipherView.loginFixture(archivedDate: .now, id: "123")
 
@@ -192,8 +177,8 @@ class VaultItemActionHelperTests: BitwardenTestCase {
             completionHandler: { completionCalled = true },
         )
 
-        XCTAssertEqual(coordinator.errorAlertsShown.count, 1)
-        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
-        XCTAssertFalse(completionCalled)
+        #expect(coordinator.errorAlertsShown.count == 1)
+        #expect(errorReporter.errors as? [BitwardenTestError] == [.example])
+        #expect(!completionCalled)
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 // MARK: - VaultItemActionHelperTests
 
+@MainActor
 struct VaultItemActionHelperTests {
     // MARK: Properties
 


### PR DESCRIPTION
## 🎟️ Tracking
[PM-34715](https://bitwarden.atlassian.net/browse/PM-34715)

## 📔 Objective
Adds a confirmation dialog before archiving a vault item, matching behavior already present on browser extension and desktop clients. The dialog appears in both the toolbar ··· menu (on ViewItem/AddEditItem screens) and the long-press context menu (from vault list and folder views), with the order: premium check → confirmation → master password reprompt (if needed) → execute.

## 📸 Screenshots
<img width="314" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-29 at 15 23 39" src="https://github.com/user-attachments/assets/32c0fba9-7696-4d2b-a5c5-30de1730977d" />

<img width="314" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-29 at 15 23 49" src="https://github.com/user-attachments/assets/45954d7e-948c-4214-aca3-663feca7ae12" />



[PM-34715]: https://bitwarden.atlassian.net/browse/PM-34715