### PR TITLE
[PM-35680] chore: Update Claude skills to use generate-mocks.sh script

### DIFF
--- a/.claude/skills/testing-ios-code/SKILL.md
+++ b/.claude/skills/testing-ios-code/SKILL.md
@@ -138,7 +138,7 @@ BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift  ← same directory
 
 New protocols need mocks:
 1. Add `// sourcery: AutoMockable` as a trailing comment on the protocol declaration line
-2. Run `./Scripts/generate-mocks.sh BitwardenShared` (requires `BUILD_DIR` — see script header)
+2. Run `./Scripts/generate-mocks.sh <Framework>` where `<Framework>` matches the target (e.g. `BitwardenShared`, `AuthenticatorShared`, `BitwardenKit`, `AuthenticatorBridgeKit`) — requires `BUILD_DIR`, see script header
 3. Or just build — Sourcery runs automatically in pre-build phase
 
 See `references/mock-generation.md` for full details.

--- a/.claude/skills/testing-ios-code/SKILL.md
+++ b/.claude/skills/testing-ios-code/SKILL.md
@@ -138,7 +138,7 @@ BitwardenShared/UI/Auth/Login/LoginProcessorTests.swift  ← same directory
 
 New protocols need mocks:
 1. Add `// sourcery: AutoMockable` as a trailing comment on the protocol declaration line
-2. Run `mint run sourcery --config BitwardenShared/Sourcery/sourcery.yml`
+2. Run `./Scripts/generate-mocks.sh BitwardenShared` (requires `BUILD_DIR` — see script header)
 3. Or just build — Sourcery runs automatically in pre-build phase
 
 See `references/mock-generation.md` for full details.

--- a/.claude/skills/testing-ios-code/references/mock-generation.md
+++ b/.claude/skills/testing-ios-code/references/mock-generation.md
@@ -19,17 +19,11 @@ This generates `MockFeatureService` in the `Sourcery/Generated/` directory of th
 Mock generation runs automatically as a pre-build phase. To run manually:
 
 ```bash
-# For BitwardenShared
-mint run sourcery --config BitwardenShared/Sourcery/sourcery.yml
-
-# For AuthenticatorShared
-mint run sourcery --config AuthenticatorShared/Sourcery/sourcery.yml
-
-# For BitwardenKit
-mint run sourcery --config BitwardenKit/Sourcery/sourcery.yml
-
-# For AuthenticatorBridgeKit
-mint run sourcery --config AuthenticatorBridgeKit/Sourcery/sourcery.yml
+# Requires BUILD_DIR — see script header for how to supply it standalone.
+./Scripts/generate-mocks.sh BitwardenShared
+./Scripts/generate-mocks.sh AuthenticatorShared
+./Scripts/generate-mocks.sh BitwardenKit
+./Scripts/generate-mocks.sh AuthenticatorBridgeKit
 ```
 
 ## Generated File Locations


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35680](https://bitwarden.atlassian.net/browse/PM-35680)

## 📔 Objective
Updates the `testing-ios-code` Claude skill to use `./Scripts/generate-mocks.sh` instead of invoking `mint run sourcery` directly. This reflects the change introduced in #2581, which wraps Sourcery in a script that sets the required `BITWARDEN_SDK_PATH` environment variable.


[PM-35680]: https://bitwarden.atlassian.net/browse/PM-35680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ