### PR TITLE
[PM-36177] Pin bundler dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 ruby file: '.ruby-version'
 
-gem 'dotenv', groups: [:bwpm_prod, :bwpm_beta, :bwa_prod]
-gem 'fastlane'
+gem 'dotenv', '2.8.1', groups: [:bwpm_prod, :bwpm_beta, :bwa_prod]
+gem 'fastlane', '2.229.1'
 
 # Since ruby 3.4.0 these are not included in the standard library
 gem 'abbrev'

--- a/Gemfile
+++ b/Gemfile
@@ -8,10 +8,10 @@ gem 'dotenv', '2.8.1', groups: [:bwpm_prod, :bwpm_beta, :bwa_prod]
 gem 'fastlane', '2.229.1'
 
 # Since ruby 3.4.0 these are not included in the standard library
-gem 'abbrev'
-gem 'logger'
-gem 'mutex_m'
-gem 'csv'
+gem 'abbrev', '0.1.2'
+gem 'logger', '1.7.0'
+gem 'mutex_m', '0.3.0'
+gem 'csv', '3.3.5'
 
 # Starting with Ruby 3.5.0, these are not included in the standard library
-gem 'ostruct'
+gem 'ostruct', '0.6.3'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 ruby file: '.ruby-version'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,13 +228,13 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  abbrev
-  csv
-  dotenv
-  fastlane
-  logger
-  mutex_m
-  ostruct
+  abbrev (= 0.1.2)
+  csv (= 3.3.5)
+  dotenv (= 2.8.1)
+  fastlane (= 2.229.1)
+  logger (= 1.7.0)
+  mutex_m (= 0.3.0)
+  ostruct (= 0.6.3)
 
 RUBY VERSION
    ruby 3.4.2p28


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36177

## 📔 Objective

Renovate isn’t opening PRs to update ruby dependencies and we believe it’s due to them not being pinned in our Gemfile. This was a problem in the past when a Lock Maintenance PR was merged updating dependencies in bulk and one of them introduced an unexpected issue.
