### PR TITLE
[PM-31721] fix: Fall back to unauthenticated config endpoint on keychain item-not-found

### DIFF
--- a/BitwardenShared/Core/Platform/Services/API/ConfigAPIService.swift
+++ b/BitwardenShared/Core/Platform/Services/API/ConfigAPIService.swift
@@ -2,6 +2,7 @@
 
 import BitwardenKit
 import Networking
+import Security
 
 extension APIService: ConfigAPIService {
     func getConfig() async throws -> ConfigResponseModel {

--- a/BitwardenShared/Core/Platform/Services/API/ConfigAPIService.swift
+++ b/BitwardenShared/Core/Platform/Services/API/ConfigAPIService.swift
@@ -9,6 +9,15 @@ extension APIService: ConfigAPIService {
         guard isAuthenticated == true else {
             return try await apiUnauthenticatedService.send(ConfigRequest())
         }
-        return try await apiService.send(ConfigRequest())
+        do {
+            return try await apiService.send(ConfigRequest())
+        } catch KeychainServiceError.osStatusError(errSecItemNotFound),
+                KeychainServiceError.keyNotFound {
+            // The access token was removed between the isAuthenticated check and the
+            // actual request (e.g., logout during a background config refresh).
+            // The config endpoint returns the same response regardless of auth state,
+            // so falling back to the unauthenticated endpoint is safe.
+            return try await apiUnauthenticatedService.send(ConfigRequest())
+        }
     }
 }

--- a/BitwardenShared/Core/Platform/Services/API/ConfigAPIService.swift
+++ b/BitwardenShared/Core/Platform/Services/API/ConfigAPIService.swift
@@ -15,8 +15,7 @@ extension APIService: ConfigAPIService {
                 KeychainServiceError.keyNotFound {
             // The access token was removed between the isAuthenticated check and the
             // actual request (e.g., logout during a background config refresh).
-            // The config endpoint returns the same response regardless of auth state,
-            // so falling back to the unauthenticated endpoint is safe.
+            // Fall back to the unauthenticated endpoint.
             return try await apiUnauthenticatedService.send(ConfigRequest())
         }
     }

--- a/BitwardenShared/Core/Platform/Services/API/ConfigAPIServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/ConfigAPIServiceTests.swift
@@ -10,6 +10,7 @@ import XCTest
 class ConfigAPIServiceTests: BitwardenTestCase {
     // MARK: Properties
 
+    var accountTokenProvider: MockAccountTokenProvider!
     var activeAccountStateProvider: MockActiveAccountStateProvider!
     var client: MockHTTPClient!
     var stateService: MockStateService!
@@ -20,10 +21,13 @@ class ConfigAPIServiceTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        accountTokenProvider = MockAccountTokenProvider()
+        accountTokenProvider.getTokenReturnValue = "ACCESS_TOKEN"
         activeAccountStateProvider = MockActiveAccountStateProvider()
         client = MockHTTPClient()
         stateService = MockStateService()
         subject = APIService(
+            accountTokenProvider: accountTokenProvider,
             activeAccountStateProvider: activeAccountStateProvider,
             client: client,
             stateService: stateService,
@@ -33,6 +37,7 @@ class ConfigAPIServiceTests: BitwardenTestCase {
     override func tearDown() async throws {
         try await super.tearDown()
 
+        accountTokenProvider = nil
         activeAccountStateProvider = nil
         client = nil
         stateService = nil
@@ -84,5 +89,54 @@ class ConfigAPIServiceTests: BitwardenTestCase {
         XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
         XCTAssertNil(request.body)
         XCTAssertNil(request.headers["Authorization"])
+    }
+
+    /// `getConfig()` falls back to the unauthenticated endpoint when the token provider throws
+    /// `KeychainServiceError.osStatusError(errSecItemNotFound)`, covering the race condition where
+    /// the user logs out between the `isAuthenticated` check and the actual token lookup.
+    func test_getConfig_keychainItemNotFound_fallsBackToUnauthenticated() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.isAuthenticated[account.profile.userId] = true
+        client.result = .httpSuccess(testData: .validServerConfig)
+        accountTokenProvider.getTokenThrowableError = KeychainServiceError.osStatusError(errSecItemNotFound)
+
+        _ = try await subject.getConfig()
+
+        let request = try XCTUnwrap(client.requests.last)
+        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
+        XCTAssertNil(request.headers["Authorization"])
+    }
+
+    /// `getConfig()` falls back to the unauthenticated endpoint when the token provider throws
+    /// `KeychainServiceError.keyNotFound`, covering the race condition where the user logs out
+    /// between the `isAuthenticated` check and the actual token lookup.
+    func test_getConfig_keychainKeyNotFound_fallsBackToUnauthenticated() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.isAuthenticated[account.profile.userId] = true
+        client.result = .httpSuccess(testData: .validServerConfig)
+        accountTokenProvider.getTokenThrowableError = KeychainServiceError.keyNotFound(
+            MockKeychainItem(unformattedKey: "accessToken"),
+        )
+
+        _ = try await subject.getConfig()
+
+        let request = try XCTUnwrap(client.requests.last)
+        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
+        XCTAssertNil(request.headers["Authorization"])
+    }
+
+    /// `getConfig()` propagates errors from the token provider that are not keychain item-not-found
+    /// errors, ensuring unrelated failures are not accidentally swallowed.
+    func test_getConfig_nonKeychainError_propagates() async throws {
+        let account = Account.fixture()
+        stateService.activeAccount = account
+        stateService.isAuthenticated[account.profile.userId] = true
+        accountTokenProvider.getTokenThrowableError = KeychainServiceError.accessControlFailed(nil)
+
+        await assertAsyncThrows(error: KeychainServiceError.accessControlFailed(nil)) {
+            _ = try await subject.getConfig()
+        }
     }
 }

--- a/BitwardenShared/Core/Platform/Services/API/ConfigAPIServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/API/ConfigAPIServiceTests.swift
@@ -1,26 +1,25 @@
 import BitwardenKit
 import BitwardenKitMocks
+import Security
+import Testing
 import TestHelpers
-import XCTest
 
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
 @MainActor
-class ConfigAPIServiceTests: BitwardenTestCase {
+struct ConfigAPIServiceTests {
     // MARK: Properties
 
-    var accountTokenProvider: MockAccountTokenProvider!
-    var activeAccountStateProvider: MockActiveAccountStateProvider!
-    var client: MockHTTPClient!
-    var stateService: MockStateService!
-    var subject: ConfigAPIService!
+    let accountTokenProvider: MockAccountTokenProvider
+    let activeAccountStateProvider: MockActiveAccountStateProvider
+    let client: MockHTTPClient
+    let stateService: MockStateService
+    let subject: ConfigAPIService
 
-    // MARK: Setup & Teardown
+    // MARK: Initialization
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         accountTokenProvider = MockAccountTokenProvider()
         accountTokenProvider.getTokenReturnValue = "ACCESS_TOKEN"
         activeAccountStateProvider = MockActiveAccountStateProvider()
@@ -34,20 +33,11 @@ class ConfigAPIServiceTests: BitwardenTestCase {
         )
     }
 
-    override func tearDown() async throws {
-        try await super.tearDown()
-
-        accountTokenProvider = nil
-        activeAccountStateProvider = nil
-        client = nil
-        stateService = nil
-        subject = nil
-    }
-
     // MARK: Tests
 
     /// `getConfig()` performs the config request authenticated.
-    func test_getConfig() async throws {
+    @Test
+    func getConfig() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.isAuthenticated[account.profile.userId] = true
@@ -55,15 +45,16 @@ class ConfigAPIServiceTests: BitwardenTestCase {
 
         _ = try await subject.getConfig()
 
-        let request = try XCTUnwrap(client.requests.last)
-        XCTAssertEqual(request.method, .get)
-        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
-        XCTAssertNil(request.body)
-        XCTAssertNotNil(request.headers["Authorization"])
+        let request = try #require(client.requests.last)
+        #expect(request.method == .get)
+        #expect(request.url.absoluteString == "https://example.com/api/config")
+        #expect(request.body == nil)
+        #expect(request.headers["Authorization"] != nil)
     }
 
     /// `getConfig()` performs the config request unauthenticated.
-    func test_getConfig_unauthenticated() async throws {
+    @Test
+    func getConfig_unauthenticated() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.isAuthenticated[account.profile.userId] = false
@@ -71,30 +62,32 @@ class ConfigAPIServiceTests: BitwardenTestCase {
 
         _ = try await subject.getConfig()
 
-        let request = try XCTUnwrap(client.requests.last)
-        XCTAssertEqual(request.method, .get)
-        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
-        XCTAssertNil(request.body)
-        XCTAssertNil(request.headers["Authorization"])
+        let request = try #require(client.requests.last)
+        #expect(request.method == .get)
+        #expect(request.url.absoluteString == "https://example.com/api/config")
+        #expect(request.body == nil)
+        #expect(request.headers["Authorization"] == nil)
     }
 
     /// `getConfig()` performs the config request unauthenticated because there is no active account.
-    func test_getConfig_unauthenticatedNoAccount() async throws {
+    @Test
+    func getConfig_unauthenticatedNoAccount() async throws {
         client.result = .httpSuccess(testData: .validServerConfig)
 
         _ = try await subject.getConfig()
 
-        let request = try XCTUnwrap(client.requests.last)
-        XCTAssertEqual(request.method, .get)
-        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
-        XCTAssertNil(request.body)
-        XCTAssertNil(request.headers["Authorization"])
+        let request = try #require(client.requests.last)
+        #expect(request.method == .get)
+        #expect(request.url.absoluteString == "https://example.com/api/config")
+        #expect(request.body == nil)
+        #expect(request.headers["Authorization"] == nil)
     }
 
     /// `getConfig()` falls back to the unauthenticated endpoint when the token provider throws
     /// `KeychainServiceError.osStatusError(errSecItemNotFound)`, covering the race condition where
     /// the user logs out between the `isAuthenticated` check and the actual token lookup.
-    func test_getConfig_keychainItemNotFound_fallsBackToUnauthenticated() async throws {
+    @Test
+    func getConfig_keychainItemNotFound_fallsBackToUnauthenticated() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.isAuthenticated[account.profile.userId] = true
@@ -103,15 +96,16 @@ class ConfigAPIServiceTests: BitwardenTestCase {
 
         _ = try await subject.getConfig()
 
-        let request = try XCTUnwrap(client.requests.last)
-        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
-        XCTAssertNil(request.headers["Authorization"])
+        let request = try #require(client.requests.last)
+        #expect(request.url.absoluteString == "https://example.com/api/config")
+        #expect(request.headers["Authorization"] == nil)
     }
 
     /// `getConfig()` falls back to the unauthenticated endpoint when the token provider throws
     /// `KeychainServiceError.keyNotFound`, covering the race condition where the user logs out
     /// between the `isAuthenticated` check and the actual token lookup.
-    func test_getConfig_keychainKeyNotFound_fallsBackToUnauthenticated() async throws {
+    @Test
+    func getConfig_keychainKeyNotFound_fallsBackToUnauthenticated() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.isAuthenticated[account.profile.userId] = true
@@ -122,20 +116,21 @@ class ConfigAPIServiceTests: BitwardenTestCase {
 
         _ = try await subject.getConfig()
 
-        let request = try XCTUnwrap(client.requests.last)
-        XCTAssertEqual(request.url.absoluteString, "https://example.com/api/config")
-        XCTAssertNil(request.headers["Authorization"])
+        let request = try #require(client.requests.last)
+        #expect(request.url.absoluteString == "https://example.com/api/config")
+        #expect(request.headers["Authorization"] == nil)
     }
 
     /// `getConfig()` propagates errors from the token provider that are not keychain item-not-found
     /// errors, ensuring unrelated failures are not accidentally swallowed.
-    func test_getConfig_nonKeychainError_propagates() async throws {
+    @Test
+    func getConfig_nonKeychainError_propagates() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.isAuthenticated[account.profile.userId] = true
         accountTokenProvider.getTokenThrowableError = KeychainServiceError.accessControlFailed(nil)
 
-        await assertAsyncThrows(error: KeychainServiceError.accessControlFailed(nil)) {
+        await #expect(throws: KeychainServiceError.accessControlFailed(nil)) {
             _ = try await subject.getConfig()
         }
     }


### PR DESCRIPTION
## 🎟️ Tracking
[PM-31721](https://bitwarden.atlassian.net/browse/PM-31721)

## 📔 Objective
Fixes a race condition in `ConfigAPIService.getConfig()` that was generating errSecItemNotFound (25300) non-fatals in Crashlytics.

`isAuthenticated()` and the subsequent `apiService.send()` each perform a separate keychain lookup for the access token. If the user logs out between those two calls (e.g., during a background config refresh), the token is gone by the time the token provider calls it, and the resulting `KeychainServiceError` propagates up to `updateConfigFromServer` and gets logged. The fix catches the two item-not-found variants in `getConfig()` and falls back to the unauthenticated endpoint, which is safe because `/config` returns the same response regardless of auth state.

This looks like it will fix one of our continuing occurrances of 25300 errors; I'll keep a lookout for more cases for future PRs

[PM-31721]: https://bitwarden.atlassian.net/browse/PM-31721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ