### PR TITLE
llm: Capture review learnings on alphabetization, comments, localization, and what-not-to-test

### DIFF
--- a/.claude/skills/implementing-ios-code/SKILL.md
+++ b/.claude/skills/implementing-ios-code/SKILL.md
@@ -53,6 +53,12 @@ For new screens, create all required files together (see `templates.md`):
 6. **Processor** — `StateProcessor` subclass, business logic only
 7. **View** — SwiftUI view using `store.binding`, `store.perform`, `@ObservedObject`
 
+**New localization keys** (`BitwardenResources/.../Localizable.strings`):
+
+- Key name mirrors the English string: `Archive` for "Archive", not `MoveToArchive` or `ArchiveTitle`.
+  - Exception: long descriptive strings (~70-80+ chars) use a `DescriptionLong` suffix on a shortened opening phrase. Example: `PassphrasesAreOftenEasierToRememberDescriptionLong`.
+- Translator-facing `/* … */` comments describe meaning, placement, or constraints that affect translation — translators are the audience, not internal engineers.
+
 ## Step 4: Wire Dependency Injection
 
 After creating a new service/repository:

--- a/.claude/skills/reviewing-changes/checklists/feature-addition.md
+++ b/.claude/skills/reviewing-changes/checklists/feature-addition.md
@@ -47,8 +47,12 @@ Read `reference/ios-architecture-patterns.md` for full patterns and code example
 
 **6. Code Quality:**
 - All new public types/methods have DocC (`///`) documentation
-- `TODO` comments include JIRA ticket reference
+- `TODO` comments include JIRA ticket reference, and the ticket is the one where the work will land — not the umbrella epic
+- Comments document why the current code is the way it is, not what future PRs will add (no multi-paragraph "Part 2/3 will…" blocks)
 - `Has*` / `Default*` / `Mock*` naming conventions followed
+- Enum cases and tests are alphabetized (unless raw type encodes order — see `reference/ios-style-patterns.md`)
+- New tests pin project behavior (server contracts, custom encoding, business logic) rather than Swift-synthesized `CaseIterable`/`Codable` for plain raw-value enums — see `testing-ios-code/references/testing-gotchas.md`
+- New localization keys mirror the English string closely (`BankAccount` for "Bank account", not `TypeBankAccount`); translator-facing comments describe meaning, not internal phasing
 
 ## Prioritizing Findings
 

--- a/.claude/skills/reviewing-changes/checklists/feature-addition.md
+++ b/.claude/skills/reviewing-changes/checklists/feature-addition.md
@@ -52,7 +52,7 @@ Read `reference/ios-architecture-patterns.md` for full patterns and code example
 - `Has*` / `Default*` / `Mock*` naming conventions followed
 - Enum cases and tests are alphabetized (unless raw type encodes order — see `reference/ios-style-patterns.md`)
 - New tests pin project behavior (server contracts, custom encoding, business logic) rather than Swift-synthesized `CaseIterable`/`Codable` for plain raw-value enums — see `testing-ios-code/references/testing-gotchas.md`
-- New localization keys mirror the English string closely (`BankAccount` for "Bank account", not `TypeBankAccount`); translator-facing comments describe meaning, not internal phasing
+- New localization keys mirror the English string closely (`Archive` for "Archive", not `MoveToArchive`); translator-facing comments describe meaning, not internal phasing
 
 ## Prioritizing Findings
 

--- a/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
@@ -13,6 +13,30 @@ Bitwarden-specific style rules enforced by tooling. Do not flag issues that Swif
 
 - [ ] All `TODO` comments include a JIRA ticket: `// TODO: PM-12345 - description`
 - [ ] `todo_without_jira` SwiftLint rule enforced — missing tickets will block CI
+- [ ] The referenced ticket is **the ticket where the work will actually land**, not the umbrella epic. Pointing a TODO at a long-lived parent ticket leaves it adrift after the parent closes; pointing it at the specific child PR/ticket gives a future reader a closable signal.
+
+## Alphabetization
+
+Source: [contributing.bitwarden.com — Swift style: Alphabetization](https://contributing.bitwarden.com/contributing/code-style/swift#alphabetization).
+
+- [ ] Enum cases are alphabetized — unless the raw type encodes ordering (e.g., `Int` raw values that line up with server error codes or persisted indices). Document the carve-out inline if you take it.
+- [ ] Tests within a test file are alphabetized by function name.
+- [ ] Static members and computed properties within a section are alphabetized.
+
+Protocol conformance ordering is **not** an enforced project rule; don't flag it during review even if a reviewer expresses a personal preference.
+
+## Comments
+
+- [ ] Comments document *why the current code is the way it is* — invariants, hidden constraints, surprising decisions. They do not narrate what future PRs will add.
+- [ ] Avoid multi-paragraph blocks that pre-stage upcoming work ("Part 2/3 will wire this; Part 3/3 will…"). The PR description and the linked ticket carry that context. Comments rot when the plan changes; tickets don't.
+- [ ] If a TODO captures the future intent, the TODO line is the comment — no surrounding prose needed.
+
+## Localization
+
+Source: [contributing.bitwarden.com — Swift style: Localization](https://contributing.bitwarden.com/contributing/code-style/swift#localization).
+
+- [ ] Localization keys mirror the English string closely. `BankAccount` for "Bank account", not `TypeBankAccount` or `BankAccountTitle`.
+- [ ] Translator-facing comments (`/* … */` above a key) describe meaning, placement, or constraints that affect translation — not internal phasing or ticket bookkeeping. Translators are the audience.
 
 ## Module Imports
 

--- a/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
@@ -20,7 +20,7 @@ Bitwarden-specific style rules enforced by tooling. Do not flag issues that Swif
 Source: [contributing.bitwarden.com — Swift style: Alphabetization](https://contributing.bitwarden.com/contributing/code-style/swift#alphabetization).
 
 - [ ] Enum cases are alphabetized — unless the raw type encodes ordering (e.g., `Int` raw values that line up with server error codes or persisted indices). Document the carve-out inline if you take it.
-- [ ] Tests within a test file are alphabetized by function name.
+- [ ] Tests within a test file are alphabetized by function name. Within a group of tests for the same function, error-case tests are commonly placed at the end of the group rather than strictly alphabetized.
 - [ ] Static members and computed properties within a section are alphabetized.
 
 Protocol conformance ordering is **not** an enforced project rule; don't flag it during review even if a reviewer expresses a personal preference.
@@ -35,7 +35,7 @@ Protocol conformance ordering is **not** an enforced project rule; don't flag it
 
 Source: [contributing.bitwarden.com — Swift style: Localization](https://contributing.bitwarden.com/contributing/code-style/swift#localization).
 
-- [ ] Localization keys mirror the English string closely. `BankAccount` for "Bank account", not `TypeBankAccount` or `BankAccountTitle`.
+- [ ] Localization keys mirror the English string closely. `Archive` for "Archive", not `MoveToArchive` or `ArchiveTitle`.
 - [ ] Translator-facing comments (`/* … */` above a key) describe meaning, placement, or constraints that affect translation — not internal phasing or ticket bookkeeping. Translators are the audience.
 
 ## Module Imports

--- a/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
@@ -36,6 +36,7 @@ Protocol conformance ordering is **not** an enforced project rule; don't flag it
 Source: [contributing.bitwarden.com — Swift style: Localization](https://contributing.bitwarden.com/contributing/code-style/swift#localization).
 
 - [ ] Localization keys mirror the English string closely. `Archive` for "Archive", not `MoveToArchive` or `ArchiveTitle`.
+  - Exception: long descriptive strings (~70-80+ chars) use a `DescriptionLong` suffix on a shortened opening phrase rather than mirroring the full sentence. Example: `PassphrasesAreOftenEasierToRememberDescriptionLong` for the multi-sentence description that begins "Passphrases are often easier to remember…".
 - [ ] Translator-facing comments (`/* … */` above a key) describe meaning, placement, or constraints that affect translation — not internal phasing or ticket bookkeeping. Translators are the audience.
 
 ## Module Imports

--- a/.claude/skills/testing-ios-code/references/testing-gotchas.md
+++ b/.claude/skills/testing-ios-code/references/testing-gotchas.md
@@ -60,3 +60,28 @@ func test_perform_appeared_loadsData() async {
 ```
 
 Service tests do NOT need `@MainActor` unless the service itself dispatches to main.
+
+## Don't Test Swift-Synthesized Conformances
+
+Tests should pin behavior the project owns — server contracts, custom encoding, branch logic, side effects. They should not exercise Swift's auto-synthesized conformances, which the language guarantees:
+
+- For a `String`-backed enum, `Codable` synthesis serializes each case as `"<rawValue>"`. Writing a `codable_roundTrip` test only verifies the language; it doesn't catch a bug we could realistically introduce.
+- `CaseIterable` synthesis populates `allCases` in declaration order. A test asserting `allCases == [.a, .b, .c]` is asserting against the language, not against project intent.
+
+When the on-wire shape matters (and it usually does for Codable enums), the test that earns its keep is the one that pins each case's `rawValue` to the **server contract**:
+
+```swift
+@Test
+func rawValues_matchServerContract() {
+    #expect(BankAccountType.checking.rawValue == "checking")
+    #expect(BankAccountType.savings.rawValue == "savings")
+    // ... one assertion per case
+}
+```
+
+If a case is renamed or its `rawValue` accidentally diverges from the server, this test fails and points the reader straight at the contract — without the noise of also re-testing `JSONEncoder`.
+
+**Carve-outs.** Write the round-trip test when:
+- The encoding is **not** synthesized (custom `encode(to:)`/`init(from:)`, custom `CodingKeys`, key-encoding strategies on the encoder).
+- The shape is non-obvious (nested types, polymorphic discriminators, `@DocumentID`-style wrappers).
+- The round-trip pins behavior across a serialization boundary the project actually controls.

--- a/.claude/skills/testing-ios-code/references/testing-gotchas.md
+++ b/.claude/skills/testing-ios-code/references/testing-gotchas.md
@@ -73,8 +73,8 @@ When the on-wire shape matters (and it usually does for Codable enums), the test
 ```swift
 @Test
 func rawValues_matchServerContract() {
-    #expect(BankAccountType.checking.rawValue == "checking")
-    #expect(BankAccountType.savings.rawValue == "savings")
+    #expect(Status.active.rawValue == "active")
+    #expect(Status.archived.rawValue == "archived")
     // ... one assertion per case
 }
 ```


### PR DESCRIPTION
## 🎟️ Tracking

No ticket — captures review learnings from #2573.

## 📔 Objective

Roll learnings from PR #2573 review into the project's iOS skill set so the same feedback doesn't have to be given on every new feature PR.

**Style guidance** (`.claude/skills/reviewing-changes/reference/ios-style-patterns.md`):
- New "Alphabetization" section citing the [contributing.bitwarden.com Swift style guide](https://contributing.bitwarden.com/contributing/code-style/swift#alphabetization), with the raw-type-imposes-order carve-out.
- Tightened "TODO Comments" — the referenced ticket should be the ticket where the work will land, not the umbrella epic.
- New "Comments" section — comments document why current code is the way it is, not what future PRs will add.
- New "Localization" section citing the [localization style anchor](https://contributing.bitwarden.com/contributing/code-style/swift#localization) — keys mirror English, translator-facing comments target translators.

**Testing guidance** (`.claude/skills/testing-ios-code/references/testing-gotchas.md`):
- New "Don't Test Swift-Synthesized Conformances" section. Tests should pin project behavior (server contracts, custom encoding, business logic), not Swift's auto-synthesized `Codable` / `CaseIterable` for plain raw-value enums. Includes a worked `BankAccountType`-style example and explicit carve-outs for non-synthesized cases.

**Feature-review checklist** (`.claude/skills/reviewing-changes/checklists/feature-addition.md`):
- Code-quality bullets extended to flag alphabetization, language-feature tests, and localization-key conventions during review.