### PR TITLE
[PM-36479] test: Fix flaky onExpiration_oldDate in TOTPCountdownTimerTests

### DIFF
--- a/BitwardenKit/UI/Vault/Views/TOTPCountdownTimerTests.swift
+++ b/BitwardenKit/UI/Vault/Views/TOTPCountdownTimerTests.swift
@@ -11,22 +11,20 @@ struct TOTPCountdownTimerTests {
     /// `onExpiration` is called when the timer fires for a code whose generation date is in the past.
     @Test
     @MainActor
-    func onExpiration_oldDate() async {
+    func onExpiration_oldDate() {
         let expiredCode = TOTPCodeModel(
             code: "123456",
             codeGenerationDate: .distantPast,
             period: 3,
         )
-        // `subject` needs to be held strongly outside the block so it doesn't get deallocated
-        var subject: TOTPCountdownTimer?
-        await withContinuationTimeout { resume in
-            subject = TOTPCountdownTimer(
-                timeProvider: CurrentTime(),
-                timerInterval: 0.1,
-                totpCode: expiredCode,
-                onExpiration: { resume() },
-            )
-        }
+        var didExpire = false
+        let subject = TOTPCountdownTimer(
+            timeProvider: CurrentTime(),
+            timerInterval: 0.1,
+            totpCode: expiredCode,
+            onExpiration: { didExpire = true },
+        )
+        waitFor(didExpire)
         _ = subject
     }
 

--- a/TestHelpers/Support/SwiftTestingHelpers.swift
+++ b/TestHelpers/Support/SwiftTestingHelpers.swift
@@ -28,6 +28,33 @@ public func waitForAsync(
     #expect(condition(), failureMessage, sourceLocation: sourceLocation)
 }
 
+// MARK: - waitFor
+
+/// Synchronously spins the main run loop until `condition` returns `true` or
+/// the timeout elapses. Use this (instead of `waitForAsync`) when the code
+/// under test uses `Timer.scheduledTimer`, which requires the run loop to tick
+/// and is not driven by Swift Concurrency's task scheduler.
+///
+/// - Parameters:
+///   - condition: Return `true` to stop waiting, `false` to keep spinning.
+///   - timeout: How long to spin before failing. Defaults to 10 seconds.
+///   - failureMessage: The message recorded on timeout.
+///   - sourceLocation: The source location of the call site.
+///
+@MainActor
+public func waitFor(
+    _ condition: @autoclosure () -> Bool,
+    timeout: TimeInterval = 10.0,
+    failureMessage: Comment = "waitFor condition wasn't met within the time limit",
+    sourceLocation: SourceLocation = #_sourceLocation,
+) {
+    let deadline = Date(timeIntervalSinceNow: timeout)
+    while !condition(), Date() < deadline {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+    #expect(condition(), failureMessage, sourceLocation: sourceLocation)
+}
+
 // MARK: - withContinuationTimeout
 
 /// Waits for a callback-based async operation to call its `resume` closure, recording a test


### PR DESCRIPTION
## 🎟️ Tracking
[PM-36479](https://bitwarden.atlassian.net/browse/PM-36479)

## 📔 Objective
`onExpiration_oldDate()` in `TOTPCountdownTimerTests` was flaky in CI because `withContinuationTimeout` (async, `Task.sleep`-based) does not drive the main run loop, which `Timer.scheduledTimer` requires in order to fire. Under CI load the timer callback would sometimes not execute within the 10-second window.

Adds a synchronous `waitFor(_:)` helper to `SwiftTestingHelpers` that spins `RunLoop.main` in 50 ms slices — the same mechanism as the classic XCTest `waitFor` — and updates `onExpiration_oldDate` to use it instead of `withContinuationTimeout`. Verified passing 100/100 iterations locally.

[PM-36479]: https://bitwarden.atlassian.net/browse/PM-36479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ