### PR TITLE
[PM-35680] chore: Update SDK's collection, folder, attachment, and password history clients to AutoMockable

### DIFF
--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -11,7 +11,13 @@ class MockVaultClientService: VaultClientService {
     var clientCiphers = MockClientCiphers()
     var clientCollections = MockClientCollections()
     var clientFolders = MockClientFolders()
-    var clientPasswordHistory = MockClientPasswordHistory()
+    var clientPasswordHistory: MockPasswordHistoryClientProtocol = {
+        let mock = MockPasswordHistoryClientProtocol()
+        mock.encryptClosure = { PasswordHistory(passwordHistoryView: $0) }
+        mock.decryptListClosure = { $0.map(PasswordHistoryView.init) }
+        return mock
+    }()
+
     var generateTOTPCodeResult: Result<String, Error> = .success("123456")
     var timeProvider = MockTimeProvider(.currentTime)
     var totpPeriod: UInt32 = 30
@@ -165,21 +171,6 @@ class MockClientFolders: FoldersClientProtocol {
             throw encryptError
         }
         return Folder(folderView: folder)
-    }
-}
-
-// MARK: - MockClientPasswordHistory
-
-class MockClientPasswordHistory: PasswordHistoryClientProtocol {
-    var encryptedPasswordHistory = [PasswordHistoryView]()
-
-    func decryptList(list: [PasswordHistory]) throws -> [PasswordHistoryView] {
-        list.map(PasswordHistoryView.init)
-    }
-
-    func encrypt(passwordHistory: PasswordHistoryView) throws -> PasswordHistory {
-        encryptedPasswordHistory.append(passwordHistory)
-        return PasswordHistory(passwordHistoryView: passwordHistory)
     }
 }
 

--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -1,12 +1,13 @@
 import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import Foundation
 
 @testable import AuthenticatorShared
 
 class MockVaultClientService: VaultClientService {
-    var clientAttachments = MockClientAttachments()
+    var clientAttachments = MockAttachmentsClientProtocol()
     var clientCiphers = MockClientCiphers()
     var clientCollections = MockClientCollections()
     var clientFolders = MockClientFolders()
@@ -42,46 +43,6 @@ class MockVaultClientService: VaultClientService {
 
     func passwordHistory() -> PasswordHistoryClientProtocol {
         clientPasswordHistory
-    }
-}
-
-// MARK: - MockClientAttachments
-
-class MockClientAttachments: AttachmentsClientProtocol {
-    var encryptedFilePaths = [String]()
-    var decryptedBuffers = [Data]()
-    var encryptedBuffers = [Data]()
-
-    func decryptBuffer(cipher _: Cipher, attachment _: AttachmentView, buffer: Data) throws -> Data {
-        decryptedBuffers.append(buffer)
-        return buffer
-    }
-
-    func decryptFile(
-        cipher _: Cipher,
-        attachment _: AttachmentView,
-        encryptedFilePath: String,
-        decryptedFilePath _: String,
-    ) throws {
-        encryptedFilePaths.append(encryptedFilePath)
-    }
-
-    func encryptBuffer(
-        cipher _: Cipher,
-        attachment: AttachmentView,
-        buffer: Data,
-    ) throws -> AttachmentEncryptResult {
-        encryptedBuffers.append(buffer)
-        return AttachmentEncryptResult(attachment: Attachment(attachmentView: attachment), contents: buffer)
-    }
-
-    func encryptFile(
-        cipher _: Cipher,
-        attachment: AttachmentView,
-        decryptedFilePath _: String,
-        encryptedFilePath _: String,
-    ) throws -> Attachment {
-        Attachment(attachmentView: attachment)
     }
 }
 

--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -10,7 +10,14 @@ class MockVaultClientService: VaultClientService {
     var clientAttachments = MockAttachmentsClientProtocol()
     var clientCiphers = MockClientCiphers()
     var clientCollections = MockClientCollections()
-    var clientFolders = MockClientFolders()
+    var clientFolders: MockFoldersClientProtocol = {
+        let mock = MockFoldersClientProtocol()
+        mock.decryptClosure = { FolderView(folder: $0) }
+        mock.decryptListClosure = { $0.map(FolderView.init) }
+        mock.encryptClosure = { Folder(folderView: $0) }
+        return mock
+    }()
+
     var clientPasswordHistory: MockPasswordHistoryClientProtocol = {
         let mock = MockPasswordHistoryClientProtocol()
         mock.encryptClosure = { PasswordHistory(passwordHistoryView: $0) }
@@ -141,36 +148,6 @@ class MockClientCollections: CollectionsClientProtocol {
     func getCollectionTree(collections: [BitwardenSdk.CollectionView]) -> BitwardenSdk.CollectionViewTree {
         getCollectionTreeReceivedCollection = collections
         return getCollectionTreeReturnValue ?? BitwardenSdk.CollectionViewTree(noHandle: .init())
-    }
-}
-
-// MARK: - MockClientFolders
-
-class MockClientFolders: FoldersClientProtocol {
-    var decryptFolderValueToDecrypt: Folder?
-    var decryptFolderResult: Result<FolderView?, Error> = .success(nil)
-
-    var decryptedFolders = [Folder]()
-
-    var encryptError: Error?
-    var encryptedFolders = [FolderView]()
-
-    func decrypt(folder: Folder) throws -> FolderView {
-        decryptFolderValueToDecrypt = folder
-        return try decryptFolderResult.get() ?? FolderView(folder: folder)
-    }
-
-    func decryptList(folders: [Folder]) throws -> [FolderView] {
-        decryptedFolders = folders
-        return folders.map(FolderView.init)
-    }
-
-    func encrypt(folder: FolderView) throws -> Folder {
-        encryptedFolders.append(folder)
-        if let encryptError {
-            throw encryptError
-        }
-        return Folder(folderView: folder)
     }
 }
 

--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -9,7 +9,13 @@ import Foundation
 class MockVaultClientService: VaultClientService {
     var clientAttachments = MockAttachmentsClientProtocol()
     var clientCiphers = MockClientCiphers()
-    var clientCollections = MockClientCollections()
+    var clientCollections: MockCollectionsClientProtocol = {
+        let mock = MockCollectionsClientProtocol()
+        mock.decryptClosure = { CollectionView(collection: $0) }
+        mock.decryptListClosure = { $0.map(CollectionView.init) }
+        return mock
+    }()
+
     var clientFolders: MockFoldersClientProtocol = {
         let mock = MockFoldersClientProtocol()
         mock.decryptClosure = { FolderView(folder: $0) }
@@ -124,30 +130,6 @@ class MockClientCiphers: CiphersClientProtocol {
         collectionIds: [CollectionId],
     ) async throws -> [EncryptionContext] {
         try prepareCiphersForBulkShareResult.get()
-    }
-}
-
-// MARK: - MockClientCollections
-
-class MockClientCollections: CollectionsClientProtocol {
-    var decryptResult: (Collection) throws -> CollectionView = { collection in
-        CollectionView(collection: collection)
-    }
-
-    var getCollectionTreeReceivedCollection = [BitwardenSdk.CollectionView]()
-    var getCollectionTreeReturnValue: BitwardenSdk.CollectionViewTree?
-
-    func decrypt(collection: Collection) throws -> CollectionView {
-        try decryptResult(collection)
-    }
-
-    func decryptList(collections: [Collection]) throws -> [CollectionView] {
-        collections.map(CollectionView.init)
-    }
-
-    func getCollectionTree(collections: [BitwardenSdk.CollectionView]) -> BitwardenSdk.CollectionViewTree {
-        getCollectionTreeReceivedCollection = collections
-        return getCollectionTreeReturnValue ?? BitwardenSdk.CollectionViewTree(noHandle: .init())
     }
 }
 

--- a/BitwardenSdkMocks/BitwardenSdkMocks.swift
+++ b/BitwardenSdkMocks/BitwardenSdkMocks.swift
@@ -10,4 +10,5 @@ import BitwardenSdk
 
 extension AttachmentsClientProtocol {}
 extension ClientManagedTokens {}
+extension FoldersClientProtocol {}
 extension PasswordHistoryClientProtocol {}

--- a/BitwardenSdkMocks/BitwardenSdkMocks.swift
+++ b/BitwardenSdkMocks/BitwardenSdkMocks.swift
@@ -10,3 +10,4 @@ import BitwardenSdk
 
 extension AttachmentsClientProtocol {}
 extension ClientManagedTokens {}
+extension PasswordHistoryClientProtocol {}

--- a/BitwardenSdkMocks/BitwardenSdkMocks.swift
+++ b/BitwardenSdkMocks/BitwardenSdkMocks.swift
@@ -10,5 +10,6 @@ import BitwardenSdk
 
 extension AttachmentsClientProtocol {}
 extension ClientManagedTokens {}
+extension CollectionsClientProtocol {}
 extension FoldersClientProtocol {}
 extension PasswordHistoryClientProtocol {}

--- a/BitwardenSdkMocks/BitwardenSdkMocks.swift
+++ b/BitwardenSdkMocks/BitwardenSdkMocks.swift
@@ -8,4 +8,5 @@
 
 import BitwardenSdk
 
+extension AttachmentsClientProtocol {}
 extension ClientManagedTokens {}

--- a/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
+++ b/BitwardenShared/Core/Platform/Repositories/SettingsRepositoryTests.swift
@@ -58,21 +58,21 @@ class SettingsRepositoryTests: BitwardenTestCase {
         let folder = Folder.fixture(name: folderName)
         folderService.addFolderWithServerResult = .success(folder)
         let folderView = FolderView(folder: folder)
-        clientService.mockVault.clientFolders.decryptFolderResult = .success(folderView)
+        clientService.mockVault.clientFolders.decryptReturnValue = folderView
 
         let addedFolder = try await subject.addFolder(name: folderName)
 
         XCTAssertEqual(addedFolder, folderView)
-        XCTAssertEqual(clientService.mockVault.clientFolders.encryptedFolders.count, 1)
-        XCTAssertNil(clientService.mockVault.clientFolders.encryptedFolders.first?.id)
-        XCTAssertEqual(clientService.mockVault.clientFolders.encryptedFolders.first?.name, folderName)
-        XCTAssertEqual(clientService.mockVault.clientFolders.decryptFolderValueToDecrypt, folder)
+        XCTAssertEqual(clientService.mockVault.clientFolders.encryptCallsCount, 1)
+        XCTAssertNil(clientService.mockVault.clientFolders.encryptReceivedFolder?.id)
+        XCTAssertEqual(clientService.mockVault.clientFolders.encryptReceivedFolder?.name, folderName)
+        XCTAssertEqual(clientService.mockVault.clientFolders.decryptReceivedFolder, folder)
         XCTAssertEqual(folderService.addedFolderName, folderName)
     }
 
     /// `addFolder(name:)` throws an error if it's unable to decrypt the folder returned from the server.
     func test_addFolder_errorDecrypt() async throws {
-        clientService.mockVault.clientFolders.decryptFolderResult = .failure(BitwardenTestError.example)
+        clientService.mockVault.clientFolders.decryptThrowableError = BitwardenTestError.example
         await assertAsyncThrows(error: BitwardenTestError.example) {
             _ = try await subject.addFolder(name: "Test folder")
         }
@@ -114,7 +114,7 @@ class SettingsRepositoryTests: BitwardenTestCase {
     func test_editFolder() async throws {
         let folderName = "Test folder name"
         try await subject.editFolder(withID: "123456789", name: folderName)
-        XCTAssertEqual(clientService.mockVault.clientFolders.encryptedFolders.first?.name, folderName)
+        XCTAssertEqual(clientService.mockVault.clientFolders.encryptReceivedFolder?.name, folderName)
         XCTAssertEqual(folderService.editedFolderName, folderName)
     }
 
@@ -229,7 +229,7 @@ class SettingsRepositoryTests: BitwardenTestCase {
         try XCTAssertEqual(XCTUnwrap(publisherValue), [folderView2, folderView])
 
         // Ensure the folders were decrypted by the client vault.
-        XCTAssertEqual(clientService.mockVault.clientFolders.decryptedFolders, [folder, folder2])
+        XCTAssertEqual(clientService.mockVault.clientFolders.decryptListReceivedFolders, [folder, folder2])
     }
 
     /// `lastSyncTimePublisher` returns a publisher of the user's last sync time.

--- a/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/GeneratorRepositoryTests.swift
@@ -1,5 +1,6 @@
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import XCTest
 
 @testable import BitwardenShared
@@ -44,6 +45,12 @@ class GeneratorRepositoryTests: BitwardenTestCase { // swiftlint:disable:this ty
     func test_addPasswordHistory() async throws {
         stateService.activeAccount = .fixture(profile: .fixture(userId: "1"))
 
+        var encryptedPasswordHistoryView = [PasswordHistoryView]()
+        clientService.mockVault.clientPasswordHistory.encryptClosure = { passwordHistoryView in
+            encryptedPasswordHistoryView.append(passwordHistoryView)
+            return PasswordHistory(passwordHistoryView: passwordHistoryView)
+        }
+
         let passwordHistory1 = PasswordHistoryView.fixture(password: "PASSWORD")
         try await subject.addPasswordHistory(passwordHistory1)
 
@@ -61,7 +68,7 @@ class GeneratorRepositoryTests: BitwardenTestCase { // swiftlint:disable:this ty
             [passwordHistory1, passwordHistory2, passwordHistory3].map(PasswordHistory.init),
         )
         XCTAssertEqual(
-            clientService.mockVault.clientPasswordHistory.encryptedPasswordHistory,
+            encryptedPasswordHistoryView,
             [passwordHistory1, passwordHistory2, passwordHistory3],
         )
     }

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -858,11 +858,10 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `fetchFolder(withId:)` fetches and decrypts the folder with the specified id.
     func test_fetchFolder() async throws {
-        folderService.fetchFolderResult = .success(.fixture(id: "1"))
-        let expectedResult = FolderView.fixture(id: "1")
-        clientService.mockVault.clientFolders.decryptFolderResult = .success(expectedResult)
+        let folder = Folder.fixture(id: "1")
+        folderService.fetchFolderResult = .success(folder)
         let result = try await subject.fetchFolder(withId: "1")
-        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(result, FolderView(folder: folder))
     }
 
     /// `fetchFolder(withId:)` returns `nil` when can't be fetched.
@@ -883,7 +882,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     /// `fetchFolder(withId:)` throws when attempting to decrypt the folder.
     func test_fetchFolder_throwsDecrypting() async throws {
         folderService.fetchFolderResult = .success(.fixture(id: "1"))
-        clientService.mockVault.clientFolders.decryptFolderResult = .failure(BitwardenTestError.example)
+        clientService.mockVault.clientFolders.decryptThrowableError = BitwardenTestError.example
         await assertAsyncThrows(error: BitwardenTestError.example) {
             _ = try await subject.fetchFolder(withId: "1")
         }
@@ -906,7 +905,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
                 .fixture(id: "1", name: "Other Folder", revisionDate: Date(year: 2023, month: 12, day: 1)),
             ],
         )
-        XCTAssertEqual(clientService.mockVault.clientFolders.decryptedFolders, folders)
+        XCTAssertEqual(clientService.mockVault.clientFolders.decryptListReceivedFolders, folders)
     }
 
     /// `fetchOrganization(withId:)` fetches the organization by its id.

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -246,6 +246,11 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let decryptUrl = attachmentsUrl.appendingPathComponent("file.txt")
         try Data("🗂️".utf8).write(to: decryptUrl)
 
+        clientService.mockVault.clientAttachments.encryptBufferReturnValue = AttachmentEncryptResult(
+            attachment: .fixture(),
+            contents: Data(),
+        )
+
         let encryptionContexts = [
             EncryptionContext(encryptedFor: "1", cipher: cipherAfterAttachmentDelete),
         ]
@@ -727,7 +732,10 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         XCTAssertEqual(cipherService.downloadAttachmentId, attachment.id)
         XCTAssertEqual(cipherService.fetchCipherId, cipher.id)
-        XCTAssertEqual(clientService.mockVault.clientAttachments.encryptedFilePaths.last, downloadUrl.path)
+        XCTAssertEqual(
+            clientService.mockVault.clientAttachments.decryptFileReceivedArguments?.encryptedFilePath,
+            downloadUrl.path,
+        )
         XCTAssertEqual(resultUrl?.lastPathComponent, "sillyGoose.txt")
     }
 
@@ -1378,7 +1386,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `shareCipher()` migrates any attachments without an attachment key.
-    func test_shareCipher_attachmentMigration() async throws {
+    func test_shareCipher_attachmentMigration() async throws { // swiftlint:disable:this function_body_length
         let account = Account.fixtureAccountLogin()
         stateService.activeAccount = account
 
@@ -1426,6 +1434,11 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try FileManager.default.createDirectory(at: attachmentsUrl, withIntermediateDirectories: true)
         let decryptUrl = attachmentsUrl.appendingPathComponent("file.txt")
         try Data("🗂️".utf8).write(to: decryptUrl)
+
+        clientService.mockVault.clientAttachments.encryptBufferReturnValue = AttachmentEncryptResult(
+            attachment: .fixture(),
+            contents: Data(),
+        )
 
         try await subject.shareCipher(cipherViewOriginal, newOrganizationId: "5", newCollectionIds: ["6", "7"])
 
@@ -1677,17 +1690,27 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     /// `saveAttachment(cipherView:fileData:fileName:)` saves the attachment to the cipher.
     func test_saveAttachment() async throws {
         cipherService.saveAttachmentWithServerResult = .success(.fixture(id: "42"))
+        clientService.mockVault.clientAttachments.encryptBufferReturnValue = AttachmentEncryptResult(
+            attachment: .fixture(),
+            contents: Data("encrypted".utf8),
+        )
 
         let cipherView = CipherView.fixture()
+        let attachmentData = Data("unencrypted".utf8)
         let updatedCipher = try await subject.saveAttachment(
             cipherView: cipherView,
-            fileData: Data(),
+            fileData: attachmentData,
             fileName: "Pineapple on pizza",
         )
 
         // Ensure all the steps completed as expected.
         XCTAssertEqual(cipherEncryptionMediator.encryptAndUpdateCipherReceivedCipherView, cipherView)
-        XCTAssertEqual(clientService.mockVault.clientAttachments.encryptedBuffers, [Data()])
+        let encryptBufferReceivedArguments = clientService.mockVault.clientAttachments.encryptBufferReceivedArguments
+        XCTAssertEqual(
+            encryptBufferReceivedArguments?.attachment,
+            .fixture(fileName: "Pineapple on pizza", id: nil, size: "\(attachmentData.count)"),
+        )
+        XCTAssertEqual(encryptBufferReceivedArguments?.buffer, attachmentData)
         XCTAssertEqual(cipherService.saveAttachmentWithServerCipher, Cipher(cipherView: cipherView))
         XCTAssertEqual(updatedCipher.id, "42")
     }

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -9,7 +9,13 @@ import Foundation
 class MockVaultClientService: VaultClientService {
     var clientAttachments = MockAttachmentsClientProtocol()
     var clientCiphers = MockClientCiphers()
-    var clientCollections = MockClientCollections()
+    var clientCollections: MockCollectionsClientProtocol = {
+        let mock = MockCollectionsClientProtocol()
+        mock.decryptClosure = { CollectionView(collection: $0) }
+        mock.decryptListClosure = { $0.map(CollectionView.init) }
+        return mock
+    }()
+
     var clientFolders: MockFoldersClientProtocol = {
         let mock = MockFoldersClientProtocol()
         mock.decryptClosure = { FolderView(folder: $0) }
@@ -161,35 +167,6 @@ class MockClientCiphers: CiphersClientProtocol {
         prepareCiphersForBulkShareOrganizationId = organizationId
         prepareCiphersForBulkShareCollectionIds = collectionIds
         return try prepareCiphersForBulkShareResult.get()
-    }
-}
-
-// MARK: - MockClientCollections
-
-class MockClientCollections: CollectionsClientProtocol {
-    var decryptListError: Error?
-
-    var decryptResult: (Collection) throws -> CollectionView = { collection in
-        CollectionView(collection: collection)
-    }
-
-    var getCollectionTreeReceivedCollection = [BitwardenSdk.CollectionView]()
-    var getCollectionTreeReturnValue: BitwardenSdk.CollectionViewTree?
-
-    func decrypt(collection: Collection) throws -> CollectionView {
-        try decryptResult(collection)
-    }
-
-    func decryptList(collections: [Collection]) throws -> [CollectionView] {
-        if let decryptListError {
-            throw decryptListError
-        }
-        return collections.map(CollectionView.init)
-    }
-
-    func getCollectionTree(collections: [BitwardenSdk.CollectionView]) -> BitwardenSdk.CollectionViewTree {
-        getCollectionTreeReceivedCollection = collections
-        return getCollectionTreeReturnValue ?? BitwardenSdk.CollectionViewTree(noHandle: .init())
     }
 }
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -1,12 +1,13 @@
 import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import Foundation
 
 @testable import BitwardenShared
 
 class MockVaultClientService: VaultClientService {
-    var clientAttachments = MockClientAttachments()
+    var clientAttachments = MockAttachmentsClientProtocol()
     var clientCiphers = MockClientCiphers()
     var clientCollections = MockClientCollections()
     var clientFolders = MockClientFolders()
@@ -56,46 +57,6 @@ class MockVaultClientService: VaultClientService {
 
     func passwordHistory() -> PasswordHistoryClientProtocol {
         clientPasswordHistory
-    }
-}
-
-// MARK: - MockClientAttachments
-
-class MockClientAttachments: AttachmentsClientProtocol {
-    var encryptedFilePaths = [String]()
-    var decryptedBuffers = [Data]()
-    var encryptedBuffers = [Data]()
-
-    func decryptBuffer(cipher _: Cipher, attachment _: AttachmentView, buffer: Data) throws -> Data {
-        decryptedBuffers.append(buffer)
-        return buffer
-    }
-
-    func decryptFile(
-        cipher _: Cipher,
-        attachment _: AttachmentView,
-        encryptedFilePath: String,
-        decryptedFilePath _: String,
-    ) throws {
-        encryptedFilePaths.append(encryptedFilePath)
-    }
-
-    func encryptBuffer(
-        cipher _: Cipher,
-        attachment: AttachmentView,
-        buffer: Data,
-    ) throws -> AttachmentEncryptResult {
-        encryptedBuffers.append(buffer)
-        return AttachmentEncryptResult(attachment: Attachment(attachmentView: attachment), contents: buffer)
-    }
-
-    func encryptFile(
-        cipher _: Cipher,
-        attachment: AttachmentView,
-        decryptedFilePath _: String,
-        encryptedFilePath _: String,
-    ) throws -> Attachment {
-        Attachment(attachmentView: attachment)
     }
 }
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -10,7 +10,14 @@ class MockVaultClientService: VaultClientService {
     var clientAttachments = MockAttachmentsClientProtocol()
     var clientCiphers = MockClientCiphers()
     var clientCollections = MockClientCollections()
-    var clientFolders = MockClientFolders()
+    var clientFolders: MockFoldersClientProtocol = {
+        let mock = MockFoldersClientProtocol()
+        mock.decryptClosure = { FolderView(folder: $0) }
+        mock.decryptListClosure = { $0.map(FolderView.init) }
+        mock.encryptClosure = { Folder(folderView: $0) }
+        return mock
+    }()
+
     var clientPasswordHistory: MockPasswordHistoryClientProtocol = {
         let mock = MockPasswordHistoryClientProtocol()
         mock.encryptClosure = { PasswordHistory(passwordHistoryView: $0) }
@@ -183,36 +190,6 @@ class MockClientCollections: CollectionsClientProtocol {
     func getCollectionTree(collections: [BitwardenSdk.CollectionView]) -> BitwardenSdk.CollectionViewTree {
         getCollectionTreeReceivedCollection = collections
         return getCollectionTreeReturnValue ?? BitwardenSdk.CollectionViewTree(noHandle: .init())
-    }
-}
-
-// MARK: - MockClientFolders
-
-class MockClientFolders: FoldersClientProtocol {
-    var decryptFolderValueToDecrypt: Folder?
-    var decryptFolderResult: Result<FolderView?, Error> = .success(nil)
-
-    var decryptedFolders = [Folder]()
-
-    var encryptError: Error?
-    var encryptedFolders = [FolderView]()
-
-    func decrypt(folder: Folder) throws -> FolderView {
-        decryptFolderValueToDecrypt = folder
-        return try decryptFolderResult.get() ?? FolderView(folder: folder)
-    }
-
-    func decryptList(folders: [Folder]) throws -> [FolderView] {
-        decryptedFolders = folders
-        return folders.map(FolderView.init)
-    }
-
-    func encrypt(folder: FolderView) throws -> Folder {
-        encryptedFolders.append(folder)
-        if let encryptError {
-            throw encryptError
-        }
-        return Folder(folderView: folder)
     }
 }
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -11,7 +11,13 @@ class MockVaultClientService: VaultClientService {
     var clientCiphers = MockClientCiphers()
     var clientCollections = MockClientCollections()
     var clientFolders = MockClientFolders()
-    var clientPasswordHistory = MockClientPasswordHistory()
+    var clientPasswordHistory: MockPasswordHistoryClientProtocol = {
+        let mock = MockPasswordHistoryClientProtocol()
+        mock.encryptClosure = { PasswordHistory(passwordHistoryView: $0) }
+        mock.decryptListClosure = { $0.map(PasswordHistoryView.init) }
+        return mock
+    }()
+
     var generateTOTPCodeCipherParam: CipherListView?
     var generateTOTPCodeResult: Result<String, Error> = .success("123456")
     var timeProvider = MockTimeProvider(.currentTime)
@@ -207,21 +213,6 @@ class MockClientFolders: FoldersClientProtocol {
             throw encryptError
         }
         return Folder(folderView: folder)
-    }
-}
-
-// MARK: - MockClientPasswordHistory
-
-class MockClientPasswordHistory: PasswordHistoryClientProtocol {
-    var encryptedPasswordHistory = [PasswordHistoryView]()
-
-    func decryptList(list: [PasswordHistory]) throws -> [PasswordHistoryView] {
-        list.map(PasswordHistoryView.init)
-    }
-
-    func encrypt(passwordHistory: PasswordHistoryView) throws -> PasswordHistory {
-        encryptedPasswordHistory.append(passwordHistory)
-        return PasswordHistory(passwordHistoryView: passwordHistory)
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35680](https://bitwarden.atlassian.net/browse/PM-35680)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the following SDK protocols to AutoMockable:

- `AttachmentsClientProtocol`
- `CollectionsClientProtocol`
- `FoldersClientProtocol`
- `PasswordHistoryClientProtocol`

[PM-35680]: https://bitwarden.atlassian.net/browse/PM-35680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ