### PR TITLE
[PM-35295] fix: Prevent iOS autofill from clearing BitwardenTextField via local state buffer

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -30,6 +30,10 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
     /// post-fill verification doesn't see a binding-driven re-evaluation as a rejection.
     @State private var localText: String = ""
 
+    /// Tracks every value sent outward so that store echoes arriving out of order can be
+    /// identified and dropped rather than overwriting localText with a stale value.
+    @State private var pendingEchoes: [String: Int] = [:]
+
     /// Whether the placeholder text should be shown in the text field.
     private var showPlaceholder: Bool {
         !isFocused && localText.isEmpty
@@ -87,9 +91,15 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .contain)
         .onChange(of: localText) { newValue in
+            guard text != newValue else { return }
+            pendingEchoes[newValue, default: 0] += 1
             text = newValue
         }
         .onChange(of: text) { newValue in
+            if let count = pendingEchoes[newValue], count > 0 {
+                pendingEchoes[newValue] = count == 1 ? nil : count - 1
+                return
+            }
             guard newValue != localText else { return }
             localText = newValue
         }

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -26,9 +26,13 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
     /// A flag indicating if the text field is currently focused.
     @FocusState private var isTextFieldFocused
 
+    /// Local buffer decoupling the native text field from the external binding, so iOS autofill's
+    /// post-fill verification doesn't see a binding-driven re-evaluation as a rejection.
+    @State private var localText: String = ""
+
     /// Whether the placeholder text should be shown in the text field.
     private var showPlaceholder: Bool {
-        !isFocused && text.isEmpty
+        !isFocused && localText.isEmpty
     }
 
     // MARK: Properties
@@ -82,6 +86,13 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         )
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .contain)
+        .onChange(of: localText) { newValue in
+            text = newValue
+        }
+        .onChange(of: text) { newValue in
+            guard newValue != localText else { return }
+            localText = newValue
+        }
         .onTapGesture {
             let isPassword = isPasswordVisible != nil || canViewPassword == false
             let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
@@ -158,7 +169,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
                 let isPassword = isPasswordVisible != nil || canViewPassword == false
                 let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
                 let isPasswordMasked = !isPasswordVisible && isPassword
-                TextField("", text: $text)
+                TextField("", text: $localText)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
                     // After some investigation, we found that .accessibilityIdentifier(..)
@@ -180,7 +191,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
                     )
                     .disabled(isTextFieldDisabled)
                 if isPasswordMasked {
-                    SecureField("", text: $text)
+                    SecureField("", text: $localText)
                         .focused($isSecureFieldFocused)
                         .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                         .styleGuide(.bodyMonospaced, includeLineSpacing: false)
@@ -238,6 +249,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         self.canViewPassword = canViewPassword
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
         _text = text
+        _localText = State(initialValue: text.wrappedValue)
         self.title = title
         self.trailingContent = trailingContent()
     }
@@ -277,6 +289,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         self.canViewPassword = canViewPassword
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
         _text = text
+        _localText = State(initialValue: text.wrappedValue)
         self.title = title
         self.trailingContent = trailingContent()
     }
@@ -318,6 +331,7 @@ public extension BitwardenTextField where TrailingContent == EmptyView {
         self.isTextFieldDisabled = isTextFieldDisabled
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
         _text = text
+        _localText = State(initialValue: text.wrappedValue)
         self.title = title
         trailingContent = nil
     }
@@ -357,6 +371,7 @@ public extension BitwardenTextField where FooterContent == EmptyView, TrailingCo
         self.isTextFieldDisabled = isTextFieldDisabled
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
         _text = text
+        _localText = State(initialValue: text.wrappedValue)
         self.title = title
         trailingContent = nil
     }

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -39,6 +39,22 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         !isFocused && localText.isEmpty
     }
 
+    /// A binding for the native text fields that propagates user input outward inline in the
+    /// setter, rather than via `onChange`, so that test environments (e.g. ViewInspector) that
+    /// call the setter directly without triggering SwiftUI's observation cycle still dispatch
+    /// actions correctly.
+    private var textFieldBinding: Binding<String> {
+        Binding(
+            get: { localText },
+            set: { newValue in
+                guard localText != newValue else { return }
+                localText = newValue
+                pendingEchoes[newValue, default: 0] += 1
+                text = newValue
+            },
+        )
+    }
+
     // MARK: Properties
 
     /// The title of the text field.
@@ -90,11 +106,6 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         )
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .accessibilityElement(children: .contain)
-        .onChange(of: localText) { newValue in
-            guard text != newValue else { return }
-            pendingEchoes[newValue, default: 0] += 1
-            text = newValue
-        }
         .onChange(of: text) { newValue in
             if let count = pendingEchoes[newValue], count > 0 {
                 pendingEchoes[newValue] = count == 1 ? nil : count - 1
@@ -179,7 +190,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
                 let isPassword = isPasswordVisible != nil || canViewPassword == false
                 let isPasswordVisible = isPasswordVisible?.wrappedValue ?? false
                 let isPasswordMasked = !isPasswordVisible && isPassword
-                TextField("", text: $localText)
+                TextField("", text: textFieldBinding)
                     .focused($isTextFieldFocused)
                     .styleGuide(isPassword ? .bodyMonospaced : .body, includeLineSpacing: false)
                     // After some investigation, we found that .accessibilityIdentifier(..)
@@ -201,7 +212,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
                     )
                     .disabled(isTextFieldDisabled)
                 if isPasswordMasked {
-                    SecureField("", text: $localText)
+                    SecureField("", text: textFieldBinding)
                         .focused($isSecureFieldFocused)
                         .accessibilityIdentifier(accessibilityIdentifier ?? "BitwardenTextField")
                         .styleGuide(.bodyMonospaced, includeLineSpacing: false)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35295](https://bitwarden.atlassian.net/browse/PM-35295)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes https://github.com/bitwarden/ios/issues/2554

Fixes a bug where tapping an iOS keyboard autofill suggestion (e.g., from the QuickType bar) would clear a `BitwardenTextField` instead of populating it.

iOS autofill's post-fill verification phase seems to read the text field value after writing. Because the native `TextField`/`SecureField` was backed directly by an external binding, the SwiftUI binding re-evaluation that occurred during autofill's write cycle was seen as a rejection signal, causing autofill to revert the field to its pre-fill state (empty).

This fixes it by introducing a `@State private var localText` buffer that decouples the native text field from the external binding. Two `onChange` handlers keep them in sync:
- localText → text (user input flows outward)
- text → localText (external/programmatic updates flow inward, with a guard to prevent mutual-update loops)

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/f34ef88c-6f45-4c73-8e6c-4b97591955f0" /> | <video src="https://github.com/user-attachments/assets/50cdcf0d-1ddc-42ac-b9e5-a20cb299308a" /> | 





[PM-35295]: https://bitwarden.atlassian.net/browse/PM-35295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ