### PR TITLE
[PM-36627] feat: Update upgraded to premium action card

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1081,8 +1081,7 @@
 "YourUpgradeIsBeingProcessedDescriptionLong" = "Your upgrade is being processed. You'll remain on the free plan until it's complete. Sync now to check, or continue and it will update automatically.";
 "UpgradedToPremium" = "Upgraded to Premium";
 "YouNowHaveAccessToAdvancedSecurityDescriptionLong" = "You now have access to advanced security features. Learn more about what's included with Premium.";
-"ViewPlanDetails" = "View plan details";
-"WelcomeToPremiumYouNowHaveAccessDescriptionLong" = "Welcome to Premium! You now have access to all advanced security features.";
+"YouNowHaveAccessToAllAdvancedSecurityFeatures" = "You now have access to all advanced security features.";
 "YoullGoToStripeSecureCheckoutToCompleteYourPurchase" = "You´ll go to Stripe´s secure checkout to complete your purchase.";
 "YoullContinueToHavePremiumAccessUntilX" = "You'll continue to have Premium access until %1$@.";
 "UserIDCopiedToTheClipboard" = "User ID copied to the clipboard";

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -274,8 +274,6 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
                 delegate: context as? CipherItemOperationDelegate,
                 masterPasswordRepromptCheckCompleted: masterPasswordRepromptCheckCompleted,
             )
-        case .viewPlanDetails:
-            delegate?.switchToSettingsTab(route: .premiumPlan)
         case let .switchAccount(userId: userId):
             delegate?.didTapAccount(userId: userId)
         case .viewProfileSwitcher:

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinatorTests.swift
@@ -263,13 +263,6 @@ class VaultCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(delegate.switchToSettingsTabRoute, .about)
     }
 
-    /// `navigate(to:)` with `.viewPlanDetails` delegates to the settings tab with `.premiumPlan`.
-    @MainActor
-    func test_navigateTo_viewPlanDetails() throws {
-        subject.navigate(to: .viewPlanDetails)
-        XCTAssertEqual(delegate.switchToSettingsTabRoute, .premiumPlan)
-    }
-
     /// `navigate(to:)` with `.autofillListForGroup` pushes the vault autofill list view
     /// onto the stack navigator filtered by a group.
     @MainActor

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
@@ -30,6 +30,9 @@ enum VaultListAction: Equatable {
     /// An item in the vault was pressed.
     case itemPressed(item: VaultListItem)
 
+    /// The "Learn more" button on the upgraded to premium action card was tapped.
+    case learnMoreAboutPremium
+
     /// The user tapped the go to settings button in the flight recorder banner.
     case navigateToFlightRecorderSettings
 
@@ -62,7 +65,4 @@ enum VaultListAction: Equatable {
 
     /// The selected vault filter changed.
     case vaultFilterChanged(VaultFilterType)
-
-    /// The "View plan details" button on the upgraded to premium action card was tapped.
-    case viewPlanDetails
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -156,6 +156,9 @@ final class VaultListProcessor: StateProcessor<
             coordinator.navigate(to: .group(.archive, filter: state.vaultFilterType))
         case let .itemPressed(item):
             handleItemTapped(item)
+        case .learnMoreAboutPremium:
+            state.url = ExternalLinksConstants.learnMoreAboutPremium
+            state.shouldShowUpgradedToPremiumActionCard = false
         case .navigateToFlightRecorderSettings:
             coordinator.navigate(to: .flightRecorderSettings)
         case let .profileSwitcher(profileAction):
@@ -177,9 +180,6 @@ final class VaultListProcessor: StateProcessor<
             upgradeToPremium()
         case let .vaultFilterChanged(newValue):
             state.vaultFilterType = newValue
-        case .viewPlanDetails:
-            coordinator.navigate(to: .viewPlanDetails)
-            state.shouldShowUpgradedToPremiumActionCard = false
         }
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -752,12 +752,14 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertFalse(subject.state.shouldShowUpgradedToPremiumActionCard)
     }
 
-    /// `receive(_:)` with `.viewPlanDetails` navigates to the view plan details route.
+    /// `receive(_:)` with `.learnMoreAboutPremium` opens the learn more about premium URL and hides the card.
     @MainActor
-    func test_receive_viewPlanDetails() {
-        subject.receive(.viewPlanDetails)
+    func test_receive_learnMoreAboutPremium() {
+        subject.state.shouldShowUpgradedToPremiumActionCard = true
+        subject.receive(.learnMoreAboutPremium)
 
-        XCTAssertEqual(coordinator.routes.last, .viewPlanDetails)
+        XCTAssertEqual(subject.state.url, ExternalLinksConstants.learnMoreAboutPremium)
+        XCTAssertFalse(subject.state.shouldShowUpgradedToPremiumActionCard)
     }
 
     /// `perform(_:)` with `.dismissFlightRecorderToastBanner` hides the flight recorder toast banner.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView+SnapshotTests.swift
@@ -164,6 +164,16 @@ class VaultListViewTests: BitwardenTestCase {
     }
 
     @MainActor
+    func disabletest_snapshot_myVaultUpgradedToPremium() {
+        processor.state.shouldShowUpgradedToPremiumActionCard = true
+        processor.state.loadingState = .data(VaultListViewTests.defaultVaultData)
+        assertSnapshots(
+            of: subject,
+            as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5],
+        )
+    }
+
+    @MainActor
     func disabletest_snapshot_withSearchResult() {
         processor.state.searchText = "Exam"
         processor.state.searchResults = [

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -114,9 +114,9 @@ private struct SearchableVaultListView: View { // swiftlint:disable:this type_bo
         if store.state.shouldShowUpgradedToPremiumActionCard {
             ActionCard(
                 title: Localizations.upgradedToPremium,
-                message: Localizations.welcomeToPremiumYouNowHaveAccessDescriptionLong,
-                actionButtonState: ActionCard.ButtonState(title: Localizations.viewPlanDetails) {
-                    store.send(.viewPlanDetails)
+                message: Localizations.youNowHaveAccessToAllAdvancedSecurityFeatures,
+                actionButtonState: ActionCard.ButtonState(title: Localizations.learnMore) {
+                    store.send(.learnMoreAboutPremium)
                 },
                 dismissButtonState: ActionCard.ButtonState(title: Localizations.dismiss) {
                     await store.perform(.dismissUpgradedToPremiumActionCard)

--- a/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultRoute.swift
@@ -92,9 +92,6 @@ public enum VaultRoute: Equatable, Hashable {
     ///
     case viewItem(id: String, masterPasswordRepromptCheckCompleted: Bool = false)
 
-    /// A route to view the premium plan details from the settings tab.
-    case viewPlanDetails
-
     /// A route to display the profile switcher.
     ///
     case viewProfileSwitcher


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-36627

## 📔 Objective

Updates the "Upgraded to Premium" action card in the vault list:
- Shortened message to "You now have access to all advanced security features."
- Changed action button from "View plan details" (navigating to settings) to "Learn more" (opens bitwarden.com/help/password-manager-plans/)
- Removes the now-unused `viewPlanDetails` localization strings, action, route, and coordinator case
- Adds snapshot test for the upgraded to premium card state

## 📸 Screenshots
<img width="243" height="511" alt="Screenshot 2026-05-12 at 10 37 46" src="https://github.com/user-attachments/assets/b510c753-5c9b-4656-958d-58bfff3c6c40" />
