### PR TITLE
[PM-35680] chore: Convert CiphersClientProtocol to AutoMockable

### DIFF
--- a/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/AuthenticatorShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -8,7 +8,22 @@ import Foundation
 
 class MockVaultClientService: VaultClientService {
     var clientAttachments = MockAttachmentsClientProtocol()
-    var clientCiphers = MockClientCiphers()
+    var clientCiphers: MockCiphersClientProtocol = {
+        let mock = MockCiphersClientProtocol()
+        mock.decryptClosure = { CipherView(cipher: $0) }
+        mock.decryptFido2CredentialsReturnValue = []
+        mock.decryptListClosure = { $0.map { CipherListView(cipher: $0) } }
+        mock.decryptListWithFailuresClosure = { ciphers in
+            DecryptCipherListResult(successes: ciphers.map { CipherListView(cipher: $0) }, failures: [])
+        }
+        mock.encryptClosure = { cipherView in
+            EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: cipherView))
+        }
+        mock.moveToOrganizationReturnValue = .fixture()
+        mock.prepareCiphersForBulkShareReturnValue = []
+        return mock
+    }()
+
     var clientCollections: MockCollectionsClientProtocol = {
         let mock = MockCollectionsClientProtocol()
         mock.decryptClosure = { CollectionView(collection: $0) }
@@ -62,73 +77,5 @@ class MockVaultClientService: VaultClientService {
 
     func passwordHistory() -> PasswordHistoryClientProtocol {
         clientPasswordHistory
-    }
-}
-
-// MARK: - MockClientCiphers
-
-class MockClientCiphers: CiphersClientProtocol {
-    var decryptResult: (Cipher) throws -> CipherView = { cipher in
-        CipherView(cipher: cipher)
-    }
-
-    var decryptFido2CredentialsResult = [BitwardenSdk.Fido2CredentialView]()
-    var decryptListWithFailuresResult: DecryptCipherListResult?
-    var encryptCipherResult: Result<EncryptionContext, Error>?
-    var encryptError: Error?
-    var encryptedCiphers = [CipherView]()
-    var moveToOrganizationCipher: CipherView?
-    var moveToOrganizationOrganizationId: String?
-    var moveToOrganizationCalled: Bool?
-    var moveToOrganizationResult: Result<CipherView, Error> = .success(.fixture())
-    var prepareCiphersForBulkShareResult: Result<[EncryptionContext], Error> = .success([])
-
-    func decrypt(cipher: Cipher) throws -> CipherView {
-        try decryptResult(cipher)
-    }
-
-    func decryptFido2Credentials(cipherView: BitwardenSdk.CipherView) throws -> [BitwardenSdk.Fido2CredentialView] {
-        guard cipherView.login?.fido2Credentials != nil else {
-            return []
-        }
-        return decryptFido2CredentialsResult
-    }
-
-    func decryptList(ciphers: [Cipher]) throws -> [CipherListView] {
-        ciphers.map(CipherListView.init)
-    }
-
-    func decryptListWithFailures(ciphers: [Cipher]) -> DecryptCipherListResult {
-        decryptListWithFailuresResult ?? DecryptCipherListResult(
-            successes: ciphers.map(CipherListView.init),
-            failures: [],
-        )
-    }
-
-    func encrypt(cipherView: CipherView) throws -> BitwardenSdk.EncryptionContext {
-        encryptedCiphers.append(cipherView)
-        if let encryptError {
-            throw encryptError
-        }
-        return try encryptCipherResult?.get() ?? EncryptionContext(
-            encryptedFor: "1", cipher: Cipher(cipherView: cipherView),
-        )
-    }
-
-    func moveToOrganization(
-        cipher: CipherView,
-        organizationId: Uuid,
-    ) throws -> CipherView {
-        moveToOrganizationCipher = cipher
-        moveToOrganizationOrganizationId = organizationId
-        return try moveToOrganizationResult.get()
-    }
-
-    func prepareCiphersForBulkShare(
-        ciphers: [CipherView],
-        organizationId: OrganizationId,
-        collectionIds: [CollectionId],
-    ) async throws -> [EncryptionContext] {
-        try prepareCiphersForBulkShareResult.get()
     }
 }

--- a/BitwardenSdkMocks/BitwardenSdkMocks.swift
+++ b/BitwardenSdkMocks/BitwardenSdkMocks.swift
@@ -9,6 +9,7 @@
 import BitwardenSdk
 
 extension AttachmentsClientProtocol {}
+extension CiphersClientProtocol {}
 extension ClientManagedTokens {}
 extension CollectionsClientProtocol {}
 extension FoldersClientProtocol {}

--- a/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/AuthenticatorSyncServiceTests.swift
@@ -3,6 +3,7 @@ import AuthenticatorBridgeKitMocks
 import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import Combine
 import TestHelpers
 import XCTest
@@ -1020,9 +1021,7 @@ final class AuthenticatorSyncServiceTests: BitwardenTestCase { // swiftlint:disa
             self.keychainRepository.setAuthenticatorVaultKeyCalled
         }
 
-        authenticatorClientService.mockVault.clientCiphers.decryptResult = { _ in
-            throw BitwardenTestError.example
-        }
+        authenticatorClientService.mockVault.clientCiphers.decryptThrowableError = BitwardenTestError.example
         vaultTimeoutService.isClientLocked["1"] = true
         cipherDataStore.cipherSubjectByUserId["1"]?.send([
             .fixture(

--- a/BitwardenShared/Core/Platform/Services/WatchServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/WatchServiceTests.swift
@@ -1,5 +1,6 @@
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import Combine
 import TestHelpers
 import Testing
@@ -79,7 +80,7 @@ struct WatchServiceTests { // swiftlint:disable:this type_body_length
     /// When a `triggerSync` message is received, the service re-syncs.
     @Test
     func handleMessage_triggerSync_syncsCalled() async throws {
-        clientService.mockVault.clientCiphers.decryptResult = { _ in
+        clientService.mockVault.clientCiphers.decryptClosure = { _ in
             .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
         }
         stateService.connectToWatchByUserId["1"] = true
@@ -269,7 +270,7 @@ struct WatchServiceTests { // swiftlint:disable:this type_body_length
     /// connect to watch enabled.
     @Test
     func syncWithWatch_validState_sendsWatchData() async throws {
-        clientService.mockVault.clientCiphers.decryptResult = { _ in
+        clientService.mockVault.clientCiphers.decryptClosure = { _ in
             .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
         }
 
@@ -295,7 +296,7 @@ struct WatchServiceTests { // swiftlint:disable:this type_body_length
     /// `syncWithWatch()` re-syncs with new data when ciphers update.
     @Test
     func syncWithWatch_ciphersUpdate_resyncs() async throws {
-        clientService.mockVault.clientCiphers.decryptResult = { _ in
+        clientService.mockVault.clientCiphers.decryptClosure = { _ in
             .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
         }
 
@@ -329,7 +330,7 @@ struct WatchServiceTests { // swiftlint:disable:this type_body_length
     @Test
     func syncWithWatch_vaultLocked_skipsCipherSync() async throws {
         var decryptCallCount = 0
-        clientService.mockVault.clientCiphers.decryptResult = { _ in
+        clientService.mockVault.clientCiphers.decryptClosure = { _ in
             decryptCallCount += 1
             return .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
         }
@@ -357,7 +358,7 @@ struct WatchServiceTests { // swiftlint:disable:this type_body_length
     /// `syncWithWatch()` syncs ciphers after the vault becomes unlocked.
     @Test
     func syncWithWatch_vaultUnlocked_syncsAfterUnlock() async throws {
-        clientService.mockVault.clientCiphers.decryptResult = { _ in
+        clientService.mockVault.clientCiphers.decryptClosure = { _ in
             .fixture(id: "cipher-1", login: .fixture(totp: "totp-secret"))
         }
 

--- a/BitwardenShared/Core/Vault/Helpers/CipherEncryptionMediatorTests.swift
+++ b/BitwardenShared/Core/Vault/Helpers/CipherEncryptionMediatorTests.swift
@@ -1,4 +1,5 @@
 import BitwardenSdk
+import BitwardenSdkMocks
 import TestHelpers
 import XCTest
 
@@ -46,9 +47,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_encryptAndUpdateCipher_cipherViewHasNoKey_encryptionAddsKey_updatesWithServer() async throws {
         let cipherView = CipherView.fixture(key: nil)
         let encryptedCipher = Cipher.fixture(key: "encryptedKey")
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
 
         let result = try await subject.encryptAndUpdateCipher(cipherView)
 
@@ -65,7 +66,7 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
         let result = try await subject.encryptAndUpdateCipher(cipherView)
 
         XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
-        XCTAssertEqual(clientService.mockVault.clientCiphers.encryptedCiphers, [cipherView])
+        XCTAssertEqual(clientService.mockVault.clientCiphers.encryptReceivedCipherView, cipherView)
         XCTAssertNotNil(result)
     }
 
@@ -74,9 +75,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_encryptAndUpdateCipher_cipherViewHasNoKey_encryptedCipherHasNoKey_doesNotUpdateWithServer() async throws {
         let cipherView = CipherView.fixture(key: nil)
         let encryptedCipher = Cipher.fixture(key: nil)
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
 
         let result = try await subject.encryptAndUpdateCipher(cipherView)
 
@@ -87,7 +88,7 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     /// `encryptAndUpdateCipher(_:)` rethrows errors from the SDK encryption call.
     func test_encryptAndUpdateCipher_encryptThrows_throwsError() async throws {
         let cipherView = CipherView.fixture(key: nil)
-        clientService.mockVault.clientCiphers.encryptError = BitwardenTestError.example
+        clientService.mockVault.clientCiphers.encryptThrowableError = BitwardenTestError.example
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
             _ = try await self.subject.encryptAndUpdateCipher(cipherView)
@@ -98,9 +99,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_encryptAndUpdateCipher_updateWithServerThrows_throwsError() async throws {
         let cipherView = CipherView.fixture(key: nil)
         let encryptedCipher = Cipher.fixture(key: "encryptedKey")
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
         cipherService.updateCipherWithServerResult = .failure(BitwardenTestError.example)
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
@@ -117,7 +118,7 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
         let result = try await subject.updateCipherKeyIfNeeded(cipherView)
 
         XCTAssertEqual(result, cipherView)
-        XCTAssertTrue(clientService.mockVault.clientCiphers.encryptedCiphers.isEmpty)
+        XCTAssertFalse(clientService.mockVault.clientCiphers.encryptCalled)
         XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
     }
 
@@ -128,7 +129,7 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
         let result = try await subject.updateCipherKeyIfNeeded(cipherView)
 
         XCTAssertEqual(result, cipherView)
-        XCTAssertTrue(clientService.mockVault.clientCiphers.encryptedCiphers.isEmpty)
+        XCTAssertFalse(clientService.mockVault.clientCiphers.encryptCalled)
         XCTAssertTrue(cipherService.updateCipherWithServerCiphers.isEmpty)
     }
 
@@ -137,9 +138,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_updateCipherKeyIfNeeded_encryptedCipherHasNoKey_returnsOriginal() async throws {
         let cipherView = CipherView.fixture(id: "1", key: nil)
         let encryptedCipher = Cipher.fixture(key: nil)
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
 
         let result = try await subject.updateCipherKeyIfNeeded(cipherView)
 
@@ -153,9 +154,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
         let cipherView = CipherView.fixture(id: "1", key: nil)
         let encryptedCipher = Cipher.fixture(key: "encryptedKey")
         let updatedCipherView = CipherView.fixture(id: "1", key: "decryptedKey")
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
         delegate.fetchCipherReturnValue = updatedCipherView
         subject.setDelegate(delegate)
 
@@ -172,9 +173,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_updateCipherKeyIfNeeded_encryptionAddsKey_delegateReturnsNil_returnsOriginal() async throws {
         let cipherView = CipherView.fixture(id: "1", key: nil)
         let encryptedCipher = Cipher.fixture(key: "encryptedKey")
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
         delegate.fetchCipherReturnValue = nil
         subject.setDelegate(delegate)
 
@@ -187,9 +188,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_updateCipherKeyIfNeeded_encryptionAddsKey_noDelegate_returnsOriginal() async throws {
         let cipherView = CipherView.fixture(id: "1", key: nil)
         let encryptedCipher = Cipher.fixture(key: "encryptedKey")
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
 
         let result = try await subject.updateCipherKeyIfNeeded(cipherView)
 
@@ -200,7 +201,7 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     /// `updateCipherKeyIfNeeded(_:)` rethrows errors from the SDK encryption call.
     func test_updateCipherKeyIfNeeded_encryptThrows_throwsError() async throws {
         let cipherView = CipherView.fixture(id: "1", key: nil)
-        clientService.mockVault.clientCiphers.encryptError = BitwardenTestError.example
+        clientService.mockVault.clientCiphers.encryptThrowableError = BitwardenTestError.example
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
             _ = try await self.subject.updateCipherKeyIfNeeded(cipherView)
@@ -211,9 +212,9 @@ class CipherEncryptionMediatorTests: BitwardenTestCase {
     func test_updateCipherKeyIfNeeded_updateWithServerThrows_throwsError() async throws {
         let cipherView = CipherView.fixture(id: "1", key: nil)
         let encryptedCipher = Cipher.fixture(key: "encryptedKey")
-        clientService.mockVault.clientCiphers.encryptCipherResult = .success(
-            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher),
-        )
+        clientService.mockVault.clientCiphers.encryptClosure = { _ in
+            EncryptionContext(encryptedFor: "userId", cipher: encryptedCipher)
+        }
         cipherService.updateCipherWithServerResult = .failure(BitwardenTestError.example)
 
         await assertAsyncThrows(error: BitwardenTestError.example) {

--- a/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
+++ b/BitwardenShared/Core/Vault/Repositories/VaultRepositoryTests.swift
@@ -2,6 +2,7 @@ import BitwardenKit
 import BitwardenKitMocks
 import BitwardenResources
 import BitwardenSdk
+import BitwardenSdkMocks
 import Combine
 import InlineSnapshotTesting
 import TestHelpers
@@ -17,7 +18,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
     var cipherEncryptionMediator: MockCipherEncryptionMediator!
     var cipherService: MockCipherService!
     var client: MockHTTPClient!
-    var clientCiphers: MockClientCiphers!
+    var clientCiphers: MockCiphersClientProtocol!
     var clientService: MockClientService!
     var collectionHelper: MockCollectionHelper!
     var collectionService: MockCollectionService!
@@ -42,7 +43,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     // MARK: Setup & Teardown
 
-    override func setUp() { // swiftlint:disable:this function_body_length
+    override func setUp() {
         super.setUp()
 
         cipherEncryptionMediator = MockCipherEncryptionMediator()
@@ -55,7 +56,6 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         cipherService = MockCipherService()
         client = MockHTTPClient()
-        clientCiphers = MockClientCiphers()
         clientService = MockClientService()
         collectionHelper = MockCollectionHelper()
         collectionService = MockCollectionService()
@@ -71,8 +71,9 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         totpService = MockTOTPService()
         vaultListDirectorStrategyFactory = MockVaultListDirectorStrategyFactory()
         vaultTimeoutService = MockVaultTimeoutService()
-        clientService.mockVault.clientCiphers = clientCiphers
         stateService = MockStateService()
+
+        clientCiphers = clientService.mockVault.clientCiphers
 
         vaultListDirectorStrategy = MockVaultListDirectorStrategy()
         vaultListSearchDirectorStrategy = MockVaultListSearchDirectorStrategy()
@@ -133,7 +134,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let cipher = CipherView.fixture()
         try await subject.addCipher(cipher)
 
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, cipher)
 
         XCTAssertEqual(cipherService.addCipherWithServerCiphers.last, Cipher(cipherView: cipher))
         XCTAssertEqual(cipherService.addCipherWithServerEncryptedFor, "1")
@@ -141,7 +142,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `addCipher()` throws an error if encrypting the cipher fails.
     func test_addCipher_encryptError() async {
-        clientCiphers.encryptError = BitwardenTestError.example
+        clientCiphers.encryptThrowableError = BitwardenTestError.example
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
             try await subject.addCipher(.fixture())
@@ -186,7 +187,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
             EncryptionContext(encryptedFor: "1", cipher: .fixture(id: "1")),
             EncryptionContext(encryptedFor: "1", cipher: .fixture(id: "2")),
         ]
-        clientCiphers.prepareCiphersForBulkShareResult = .success(encryptionContexts)
+        clientCiphers.prepareCiphersForBulkShareReturnValue = encryptionContexts
 
         try await subject.bulkShareCiphers(ciphers, newOrganizationId: "org-123", newCollectionIds: ["col-1", "col-2"])
 
@@ -254,7 +255,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let encryptionContexts = [
             EncryptionContext(encryptedFor: "1", cipher: cipherAfterAttachmentDelete),
         ]
-        clientCiphers.prepareCiphersForBulkShareResult = .success(encryptionContexts)
+        clientCiphers.prepareCiphersForBulkShareReturnValue = encryptionContexts
 
         try await subject.bulkShareCiphers(
             [cipherViewOriginal],
@@ -280,7 +281,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         stateService.activeAccount = .fixtureAccountLogin()
 
         let ciphers = [CipherView.fixture(id: "1")]
-        clientCiphers.prepareCiphersForBulkShareResult = .success([])
+        clientCiphers.prepareCiphersForBulkShareReturnValue = []
 
         try await subject.bulkShareCiphers(ciphers, newOrganizationId: "org-123", newCollectionIds: ["col-1"])
 
@@ -1217,20 +1218,20 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         ]
 
         // Mock the prepareCiphersForBulkShare call.
-        clientService.mockVault.clientCiphers.prepareCiphersForBulkShareResult = .success([
+        clientCiphers.prepareCiphersForBulkShareReturnValue = [
             EncryptionContext(encryptedFor: "user-1", cipher: .fixture(id: "1")),
             EncryptionContext(encryptedFor: "user-1", cipher: .fixture(id: "2")),
             EncryptionContext(encryptedFor: "user-1", cipher: .fixture(id: "4")),
-        ])
+        ]
 
         try await subject.migratePersonalVault(to: "target-org")
 
         // Verify that prepareCiphersForBulkShare was called with only personal ciphers (IDs 1, 2, 4).
-        let cipherIds = clientService.mockVault.clientCiphers.prepareCiphersForBulkShareCiphers?.compactMap(\.id)
+        let cipherIds = clientCiphers.prepareCiphersForBulkShareReceivedArguments?.ciphers.compactMap(\.id)
         XCTAssertEqual(cipherIds?.sorted(), ["1", "2", "4"])
-        XCTAssertEqual(clientService.mockVault.clientCiphers.prepareCiphersForBulkShareOrganizationId, "target-org")
+        XCTAssertEqual(clientCiphers.prepareCiphersForBulkShareReceivedArguments?.organizationId, "target-org")
         XCTAssertEqual(
-            clientService.mockVault.clientCiphers.prepareCiphersForBulkShareCollectionIds,
+            clientCiphers.prepareCiphersForBulkShareReceivedArguments?.collectionIds,
             ["default-collection-id"],
         )
 
@@ -1376,9 +1377,9 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let updatedCipher = cipher.update(collectionIds: ["6", "7"])
 
         XCTAssertEqual(cipherService.shareCipherWithServerCiphers, [Cipher(cipherView: updatedCipher)])
-        XCTAssertEqual(clientCiphers.encryptedCiphers.last, updatedCipher)
-        XCTAssertEqual(clientCiphers.moveToOrganizationCipher, cipher)
-        XCTAssertEqual(clientCiphers.moveToOrganizationOrganizationId, "5")
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, updatedCipher)
+        XCTAssertEqual(clientCiphers.moveToOrganizationReceivedArguments?.cipher, cipher)
+        XCTAssertEqual(clientCiphers.moveToOrganizationReceivedArguments?.organizationId, "5")
 
         XCTAssertEqual(cipherService.shareCipherWithServerCiphers.last, Cipher(cipherView: updatedCipher))
         XCTAssertEqual(cipherService.shareCipherWithServerEncryptedFor, "1")
@@ -1419,9 +1420,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         )
         cipherService.deleteAttachmentWithServerResult = .success(cipherAfterAttachmentDelete)
         cipherService.fetchCipherResult = .success(cipherAfterAttachmentSave)
-        clientService.mockVault.clientCiphers.moveToOrganizationResult = .success(
-            CipherView(cipher: cipherAfterAttachmentDelete),
-        )
+        clientCiphers.moveToOrganizationReturnValue = CipherView(cipher: cipherAfterAttachmentDelete)
 
         // Temporary download file (would normally be created by the network layer).
         let downloadUrl = FileManager.default.temporaryDirectory.appendingPathComponent("file.txt")
@@ -1452,9 +1451,12 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         // Share cipher with updated attachments.
         XCTAssertEqual(cipherService.shareCipherWithServerCiphers, [Cipher(cipherView: updatedCipherView)])
-        XCTAssertEqual(clientCiphers.encryptedCiphers.last, updatedCipherView)
-        XCTAssertEqual(clientCiphers.moveToOrganizationCipher, CipherView(cipher: cipherAfterAttachmentDelete))
-        XCTAssertEqual(clientCiphers.moveToOrganizationOrganizationId, "5")
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, updatedCipherView)
+        XCTAssertEqual(
+            clientCiphers.moveToOrganizationReceivedArguments?.cipher,
+            CipherView(cipher: cipherAfterAttachmentDelete),
+        )
+        XCTAssertEqual(clientCiphers.moveToOrganizationReceivedArguments?.organizationId, "5")
     }
 
     /// `updateCipherCollections()` throws an error if one occurs.
@@ -1531,7 +1533,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `updateCipher()` throws on encryption errors.
     func test_updateCipher_encryptError() async throws {
-        clientCiphers.encryptError = BitwardenTestError.example
+        clientCiphers.encryptThrowableError = BitwardenTestError.example
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
             try await subject.updateCipher(.fixture(id: "1"))
@@ -1546,7 +1548,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let cipher = CipherView.fixture(id: "123")
         try await subject.updateCipher(cipher)
 
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, cipher)
         XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
     }
 
@@ -1562,7 +1564,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         // Verify cipher was unarchived before updating
         let unarchivedCipher = archivedCipher.update(archivedDate: nil)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [unarchivedCipher])
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, unarchivedCipher)
         XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
     }
 
@@ -1577,7 +1579,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.updateCipher(archivedCipher)
 
         // Verify cipher was NOT unarchived (kept archived)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [archivedCipher])
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, archivedCipher)
         XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
     }
 
@@ -1592,7 +1594,7 @@ class VaultRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_b
         try await subject.updateCipher(cipher)
 
         // Verify cipher was updated normally (no changes)
-        XCTAssertEqual(clientCiphers.encryptedCiphers, [cipher])
+        XCTAssertEqual(clientCiphers.encryptReceivedCipherView, cipher)
         XCTAssertEqual(cipherService.updateCipherWithServerEncryptedFor, "1")
     }
 

--- a/BitwardenShared/Core/Vault/Services/CiphersClientWrapperServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CiphersClientWrapperServiceTests.swift
@@ -1,5 +1,6 @@
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import TestHelpers
 import XCTest
 
@@ -11,6 +12,7 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
     // MARK: Properties
 
     var clientService: MockClientService!
+    var decryptListWithFailuresInvocations: [[Cipher]] = []
     var errorReporter: MockErrorReporter!
     var subject: CiphersClientWrapperService!
 
@@ -21,6 +23,12 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
 
         clientService = MockClientService()
         errorReporter = MockErrorReporter()
+
+        clientService.mockVault.clientCiphers.decryptListWithFailuresClosure = { [weak self] ciphers in
+            self?.decryptListWithFailuresInvocations.append(ciphers)
+            return DecryptCipherListResult(successes: ciphers.map { CipherListView(cipher: $0) }, failures: [])
+        }
+
         subject = DefaultCiphersClientWrapperService(clientService: clientService, errorReporter: errorReporter)
     }
 
@@ -56,8 +64,6 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
         )
 
         XCTAssertEqual(onCipherCallCount, 950)
-        let decryptListWithFailuresInvocations = clientService.mockVault.clientCiphers
-            .decryptListWithFailuresReceivedCiphersInvocations
         XCTAssertEqual(decryptListWithFailuresInvocations.count, 10)
         for invocationIndex in 0 ..< 9 {
             XCTAssertEqual(decryptListWithFailuresInvocations[invocationIndex].count, 100)
@@ -79,7 +85,8 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
             onCipherCallCount += 1
             decryptedCiphers.append(decryptedCipher)
         }
-        clientService.mockVault.clientCiphers.decryptListWithFailuresResultClosure = { ciphers in
+        clientService.mockVault.clientCiphers.decryptListWithFailuresClosure = { [weak self] ciphers in
+            self?.decryptListWithFailuresInvocations.append(ciphers)
             let successes = ciphers.filter { $0.id != "240" }.map { CipherListView(cipher: $0) }
             let failures = ciphers.filter { $0.id == "240" }
             return DecryptCipherListResult(successes: successes, failures: failures)
@@ -93,8 +100,6 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
         )
 
         XCTAssertEqual(onCipherCallCount, 950)
-        let decryptListWithFailuresInvocations = clientService.mockVault.clientCiphers
-            .decryptListWithFailuresReceivedCiphersInvocations
         XCTAssertEqual(decryptListWithFailuresInvocations.count, 10)
         for invocationIndex in 0 ..< 9 {
             XCTAssertEqual(decryptListWithFailuresInvocations[invocationIndex].count, 100)
@@ -135,8 +140,6 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
         )
 
         XCTAssertEqual(onCipherCallCount, 850)
-        let decryptListWithFailuresInvocations = clientService.mockVault.clientCiphers
-            .decryptListWithFailuresReceivedCiphersInvocations
         XCTAssertEqual(decryptListWithFailuresInvocations.count, 10)
         for invocationIndex in 0 ..< 9 {
             XCTAssertEqual(decryptListWithFailuresInvocations[invocationIndex].count, 100)
@@ -181,8 +184,6 @@ class CiphersClientWrapperServiceTests: BitwardenTestCase {
         XCTAssertEqual(decryptedCiphers.count, 475)
 
         // Verify decryption was called 10 times (10 batches)
-        let decryptListWithFailuresInvocations = clientService.mockVault.clientCiphers
-            .decryptListWithFailuresReceivedCiphersInvocations
         XCTAssertEqual(decryptListWithFailuresInvocations.count, 10)
 
         // Verify batch sizes after filtering (each batch should have ~50 items instead of 100)

--- a/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/Fido2CredentialStoreServiceTests.swift
@@ -1,5 +1,6 @@
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import TestHelpers
 import XCTest
 
@@ -100,7 +101,7 @@ class Fido2CredentialStoreServiceTests: BitwardenTestCase { // swiftlint:disable
                 type: .login,
             ),
         ])
-        clientService.mockVault.clientCiphers.decryptListError = BitwardenTestError.example
+        clientService.mockVault.clientCiphers.decryptListThrowableError = BitwardenTestError.example
 
         await assertAsyncThrows(error: BitwardenTestError.example) {
             _ = try await subject.allCredentials()
@@ -370,7 +371,7 @@ class Fido2CredentialStoreServiceTests: BitwardenTestCase { // swiftlint:disable
                 type: .login,
             ),
         ])
-        clientService.mockVault.clientCiphers.decryptResult = { _ in
+        clientService.mockVault.clientCiphers.decryptClosure = { _ in
             throw BitwardenTestError.example
         }
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockVaultClientService.swift
@@ -8,7 +8,22 @@ import Foundation
 
 class MockVaultClientService: VaultClientService {
     var clientAttachments = MockAttachmentsClientProtocol()
-    var clientCiphers = MockClientCiphers()
+    var clientCiphers: MockCiphersClientProtocol = {
+        let mock = MockCiphersClientProtocol()
+        mock.decryptClosure = { CipherView(cipher: $0) }
+        mock.decryptFido2CredentialsReturnValue = []
+        mock.decryptListClosure = { $0.map { CipherListView(cipher: $0) } }
+        mock.decryptListWithFailuresClosure = { ciphers in
+            DecryptCipherListResult(successes: ciphers.map { CipherListView(cipher: $0) }, failures: [])
+        }
+        mock.encryptClosure = { cipherView in
+            EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: cipherView))
+        }
+        mock.moveToOrganizationReturnValue = .fixture()
+        mock.prepareCiphersForBulkShareReturnValue = []
+        return mock
+    }()
+
     var clientCollections: MockCollectionsClientProtocol = {
         let mock = MockCollectionsClientProtocol()
         mock.decryptClosure = { CollectionView(collection: $0) }
@@ -76,96 +91,5 @@ class MockVaultClientService: VaultClientService {
 
     func passwordHistory() -> PasswordHistoryClientProtocol {
         clientPasswordHistory
-    }
-}
-
-// MARK: - MockClientCiphers
-
-class MockClientCiphers: CiphersClientProtocol {
-    var decryptResult: (Cipher) throws -> CipherView = { cipher in
-        CipherView(cipher: cipher)
-    }
-
-    var decryptFido2CredentialsResult = [BitwardenSdk.Fido2CredentialView]()
-    var decryptListError: Error?
-    var decryptListErrorWhenCiphers: (([Cipher]) -> Error?)?
-    var decryptListReceivedCiphersInvocations: [[Cipher]] = []
-    var decryptListWithFailuresReceivedCiphersInvocations: [[Cipher]] = [] // swiftlint:disable:this identifier_name
-    var decryptListWithFailuresResult: DecryptCipherListResult?
-    var decryptListWithFailuresResultClosure: (([Cipher]) -> DecryptCipherListResult)?
-    var encryptCipherResult: Result<EncryptionContext, Error>?
-    var encryptError: Error?
-    var encryptedCiphers = [CipherView]()
-    var moveToOrganizationCipher: CipherView?
-    var moveToOrganizationOrganizationId: String?
-    var moveToOrganizationCalled: Bool?
-    var moveToOrganizationResult: Result<CipherView, Error> = .success(.fixture())
-    var prepareCiphersForBulkShareCiphers: [CipherView]?
-    var prepareCiphersForBulkShareOrganizationId: String?
-    var prepareCiphersForBulkShareCollectionIds: [String]?
-    var prepareCiphersForBulkShareResult: Result<[EncryptionContext], Error> = .success([])
-
-    func decrypt(cipher: Cipher) throws -> CipherView {
-        try decryptResult(cipher)
-    }
-
-    func decryptFido2Credentials(cipherView: BitwardenSdk.CipherView) throws -> [BitwardenSdk.Fido2CredentialView] {
-        guard cipherView.login?.fido2Credentials != nil else {
-            return []
-        }
-        return decryptFido2CredentialsResult
-    }
-
-    func decryptList(ciphers: [Cipher]) throws -> [CipherListView] {
-        if let decryptListError {
-            throw decryptListError
-        }
-        if let decryptListErrorWhenCiphers, let error = decryptListErrorWhenCiphers(ciphers) {
-            throw error
-        }
-        decryptListReceivedCiphersInvocations.append(ciphers)
-        return ciphers.map { CipherListView(cipher: $0) }
-    }
-
-    func decryptListWithFailures(ciphers: [Cipher]) -> DecryptCipherListResult {
-        decryptListWithFailuresReceivedCiphersInvocations.append(ciphers)
-        if let decryptListWithFailuresResultClosure {
-            return decryptListWithFailuresResultClosure(ciphers)
-        }
-        return decryptListWithFailuresResult ?? DecryptCipherListResult(
-            successes: ciphers.map { CipherListView(cipher: $0) },
-            failures: [],
-        )
-    }
-
-    func encrypt(cipherView: CipherView) throws -> EncryptionContext {
-        encryptedCiphers.append(cipherView)
-        if let encryptError {
-            throw encryptError
-        }
-        return try encryptCipherResult?.get() ?? EncryptionContext(
-            encryptedFor: "1",
-            cipher: Cipher(cipherView: cipherView),
-        )
-    }
-
-    func moveToOrganization(
-        cipher: CipherView,
-        organizationId: Uuid,
-    ) throws -> CipherView {
-        moveToOrganizationCipher = cipher
-        moveToOrganizationOrganizationId = organizationId
-        return try moveToOrganizationResult.get()
-    }
-
-    func prepareCiphersForBulkShare(
-        ciphers: [CipherView],
-        organizationId: OrganizationId,
-        collectionIds: [CollectionId],
-    ) async throws -> [EncryptionContext] {
-        prepareCiphersForBulkShareCiphers = ciphers
-        prepareCiphersForBulkShareOrganizationId = organizationId
-        prepareCiphersForBulkShareCollectionIds = collectionIds
-        return try prepareCiphersForBulkShareResult.get()
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-35680](https://bitwarden.atlassian.net/browse/PM-35680)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates `CiphersClientProtocol` to AutoMockable.

[PM-35680]: https://bitwarden.atlassian.net/browse/PM-35680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ