### PR TITLE
[PM-37253] feat: Extract PremiumUpgradeHelper to centralise premium upgrade navigation

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -3,6 +3,24 @@ import BitwardenResources
 import Combine
 import Foundation
 
+// MARK: - PremiumUpgradeRoute
+
+/// A route type that supports premium upgrade navigation.
+///
+protocol PremiumUpgradeRoute {
+    /// The route to the premium upgrade screen.
+    static var premiumUpgrade: Self { get }
+
+    /// The route to dismiss the current screen with an optional action.
+    ///
+    /// - Parameter action: The action to perform on dismiss.
+    ///
+    static func dismiss(_ action: DismissAction?) -> Self
+}
+
+extension VaultItemRoute: PremiumUpgradeRoute {}
+extension VaultRoute: PremiumUpgradeRoute {}
+
 // MARK: - PremiumUpgradeHelper
 
 /// A helper that centralizes the premium upgrade navigation flow.
@@ -35,7 +53,7 @@ extension PremiumUpgradeHelper {
 /// The default implementation of `PremiumUpgradeHelper`.
 ///
 @MainActor
-class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
+class DefaultPremiumUpgradeHelper<Route: PremiumUpgradeRoute, Event>: PremiumUpgradeHelper {
     // MARK: Types
 
     typealias Services = HasBillingRepository
@@ -47,14 +65,8 @@ class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
     /// A cancellable for the premium checkout status subscription.
     private var premiumStatusChangedCancellable: AnyCancellable?
 
-    /// A closure called to hide the loading overlay.
-    private let hideLoadingOverlay: () -> Void
-
-    /// A closure called to navigate to a dismiss route.
-    private let navigateToDismiss: (DismissAction) -> Void
-
-    /// A closure called to navigate to the premium upgrade screen.
-    private let navigateToPremiumRoute: () -> Void
+    /// The coordinator used for navigation.
+    private let coordinator: any Coordinator<Route, Event>
 
     /// An optional closure called inside the pending dismiss action before showing the upgrade
     /// pending alert. Use to dismiss action cards or perform other per-screen cleanup.
@@ -66,37 +78,25 @@ class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
     /// A closure called to open a URL (used for the web-based upgrade fallback).
     private let setURL: (URL) -> Void
 
-    /// A closure called to show an alert.
-    private let showAlert: (Alert) -> Void
-
     // MARK: Initialization
 
     /// Creates a new `DefaultPremiumUpgradeHelper`.
     ///
     /// - Parameters:
     ///   - services: The services used by this helper.
-    ///   - navigateToPremiumRoute: Navigates to the premium upgrade screen.
+    ///   - coordinator: The coordinator used for navigation.
     ///   - setURL: Opens a URL (used for the web-based upgrade fallback).
-    ///   - navigateToDismiss: Navigates to a dismiss route with an action.
-    ///   - showAlert: Shows an alert.
-    ///   - hideLoadingOverlay: Hides the loading overlay.
     ///   - onPendingDismiss: Called when a pending upgrade is dismissed, before the pending alert.
     ///
     init(
         services: Services,
-        navigateToPremiumRoute: @escaping () -> Void,
+        coordinator: any Coordinator<Route, Event>,
         setURL: @escaping (URL) -> Void,
-        navigateToDismiss: @escaping (DismissAction) -> Void,
-        showAlert: @escaping (Alert) -> Void,
-        hideLoadingOverlay: @escaping () -> Void,
         onPendingDismiss: (() -> Void)? = nil,
     ) {
         self.services = services
-        self.navigateToPremiumRoute = navigateToPremiumRoute
+        self.coordinator = coordinator
         self.setURL = setURL
-        self.navigateToDismiss = navigateToDismiss
-        self.showAlert = showAlert
-        self.hideLoadingOverlay = hideLoadingOverlay
         self.onPendingDismiss = onPendingDismiss
     }
 
@@ -112,7 +112,7 @@ class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
 
     func startInAppPremiumUpgrade(onConfirmed: (() async -> Void)? = nil) {
         subscribeToPremiumCheckoutStatus(onConfirmed: onConfirmed)
-        navigateToPremiumRoute()
+        coordinator.navigate(to: .premiumUpgrade)
     }
 
     // MARK: Private Methods
@@ -132,14 +132,14 @@ class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
                         Task { @MainActor in await onConfirmed() }
                     }
                 case .pending:
-                    navigateToDismiss(DismissAction { [weak self] in
+                    coordinator.navigate(to: .dismiss(DismissAction { [weak self] in
                         guard let self else { return }
-                        hideLoadingOverlay()
+                        coordinator.hideLoadingOverlay()
                         onPendingDismiss?()
-                        showAlert(.upgradePending {
+                        coordinator.showAlert(.upgradePending {
                             await self.services.billingService.premiumStatusChanged()
                         })
-                    })
+                    }))
                 case .syncing:
                     // PremiumUpgradeProcessor shows the loading overlay on the upgrade screen.
                     break

--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -1,0 +1,149 @@
+import BitwardenKit
+import BitwardenResources
+import Combine
+import Foundation
+
+// MARK: - PremiumUpgradeHelper
+
+/// A helper that centralizes the premium upgrade navigation flow.
+///
+protocol PremiumUpgradeHelper { // sourcery: AutoMockable
+    /// Checks if in-app upgrade is available and navigates accordingly: to the upgrade screen
+    /// if available, or opens the web vault upgrade URL as a fallback.
+    ///
+    /// - Parameter onConfirmed: An optional closure called when the upgrade is confirmed.
+    ///
+    func navigateToPremiumUpgrade(onConfirmed: (() async -> Void)?) async
+
+    /// Subscribes to checkout status and navigates directly to the premium upgrade screen,
+    /// skipping the availability check. Use when availability is already known (e.g., action card tap).
+    ///
+    /// - Parameter onConfirmed: An optional closure called when the upgrade is confirmed.
+    ///
+    func startInAppPremiumUpgrade(onConfirmed: (() async -> Void)?)
+}
+
+extension PremiumUpgradeHelper {
+    /// Convenience overload that passes no `onConfirmed` callback.
+    func navigateToPremiumUpgrade() async {
+        await navigateToPremiumUpgrade(onConfirmed: nil)
+    }
+}
+
+// MARK: - DefaultPremiumUpgradeHelper
+
+/// The default implementation of `PremiumUpgradeHelper`.
+///
+@MainActor
+class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
+    // MARK: Types
+
+    typealias Services = HasBillingRepository
+        & HasBillingService
+        & HasEnvironmentService
+
+    // MARK: Private Properties
+
+    /// A cancellable for the premium checkout status subscription.
+    private var premiumStatusChangedCancellable: AnyCancellable?
+
+    /// A closure called to hide the loading overlay.
+    private let hideLoadingOverlay: () -> Void
+
+    /// A closure called to navigate to a dismiss route.
+    private let navigateToDismiss: (DismissAction) -> Void
+
+    /// A closure called to navigate to the premium upgrade screen.
+    private let navigateToPremiumRoute: () -> Void
+
+    /// An optional closure called inside the pending dismiss action before showing the upgrade
+    /// pending alert. Use to dismiss action cards or perform other per-screen cleanup.
+    private let onPendingDismiss: (() -> Void)?
+
+    /// The services used by this helper.
+    private let services: Services
+
+    /// A closure called to open a URL (used for the web-based upgrade fallback).
+    private let setURL: (URL) -> Void
+
+    /// A closure called to show an alert.
+    private let showAlert: (Alert) -> Void
+
+    // MARK: Initialization
+
+    /// Creates a new `DefaultPremiumUpgradeHelper`.
+    ///
+    /// - Parameters:
+    ///   - services: The services used by this helper.
+    ///   - navigateToPremiumRoute: Navigates to the premium upgrade screen.
+    ///   - setURL: Opens a URL (used for the web-based upgrade fallback).
+    ///   - navigateToDismiss: Navigates to a dismiss route with an action.
+    ///   - showAlert: Shows an alert.
+    ///   - hideLoadingOverlay: Hides the loading overlay.
+    ///   - onPendingDismiss: Called when a pending upgrade is dismissed, before the pending alert.
+    ///
+    init(
+        services: Services,
+        navigateToPremiumRoute: @escaping () -> Void,
+        setURL: @escaping (URL) -> Void,
+        navigateToDismiss: @escaping (DismissAction) -> Void,
+        showAlert: @escaping (Alert) -> Void,
+        hideLoadingOverlay: @escaping () -> Void,
+        onPendingDismiss: (() -> Void)? = nil,
+    ) {
+        self.services = services
+        self.navigateToPremiumRoute = navigateToPremiumRoute
+        self.setURL = setURL
+        self.navigateToDismiss = navigateToDismiss
+        self.showAlert = showAlert
+        self.hideLoadingOverlay = hideLoadingOverlay
+        self.onPendingDismiss = onPendingDismiss
+    }
+
+    // MARK: Methods
+
+    func navigateToPremiumUpgrade(onConfirmed: (() async -> Void)? = nil) async {
+        guard await services.billingRepository.isInAppUpgradeAvailable() else {
+            setURL(services.environmentService.upgradeToPremiumURL)
+            return
+        }
+        startInAppPremiumUpgrade(onConfirmed: onConfirmed)
+    }
+
+    func startInAppPremiumUpgrade(onConfirmed: (() async -> Void)? = nil) {
+        subscribeToPremiumCheckoutStatus(onConfirmed: onConfirmed)
+        navigateToPremiumRoute()
+    }
+
+    // MARK: Private Methods
+
+    private func subscribeToPremiumCheckoutStatus(onConfirmed: (() async -> Void)?) {
+        premiumStatusChangedCancellable = services.billingService
+            .premiumCheckoutStatusPublisher()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in
+                guard let self else { return }
+                switch status {
+                case .canceled:
+                    break
+                case .confirmed:
+                    premiumStatusChangedCancellable = nil
+                    if let onConfirmed {
+                        Task { await onConfirmed() }
+                    }
+                case .pending:
+                    navigateToDismiss(DismissAction { [weak self] in
+                        guard let self else { return }
+                        hideLoadingOverlay()
+                        onPendingDismiss?()
+                        showAlert(.upgradePending {
+                            await self.services.billingService.premiumStatusChanged()
+                        })
+                    })
+                case .syncing:
+                    // PremiumUpgradeProcessor shows the loading overlay on the upgrade screen.
+                    break
+                }
+            }
+    }
+}

--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -129,7 +129,7 @@ class DefaultPremiumUpgradeHelper: PremiumUpgradeHelper {
                 case .confirmed:
                     premiumStatusChangedCancellable = nil
                     if let onConfirmed {
-                        Task { await onConfirmed() }
+                        Task { @MainActor in await onConfirmed() }
                     }
                 case .pending:
                     navigateToDismiss(DismissAction { [weak self] in

--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -117,6 +117,11 @@ class DefaultPremiumUpgradeHelper<Route: PremiumUpgradeRoute, Event>: PremiumUpg
 
     // MARK: Private Methods
 
+    /// Subscribes to checkout status updates. On `.confirmed`, calls `onConfirmed`.
+    /// On `.pending`, navigates to dismiss and shows the upgrade pending alert.
+    ///
+    /// - Parameter onConfirmed: An optional closure called when the upgrade is confirmed.
+    ///
     private func subscribeToPremiumCheckoutStatus(onConfirmed: (() async -> Void)?) {
         premiumStatusChangedCancellable = services.billingService
             .premiumCheckoutStatusPublisher()

--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelperTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelperTests.swift
@@ -1,0 +1,261 @@
+import BitwardenKit
+import BitwardenKitMocks
+import BitwardenResources
+import Combine
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - PremiumUpgradeHelperTests
+
+@MainActor
+struct PremiumUpgradeHelperTests {
+    // MARK: Properties
+
+    let billingRepository: MockBillingRepository
+    let billingService: MockBillingService
+    let environmentService: MockEnvironmentService
+
+    // MARK: Initialization
+
+    init() {
+        billingRepository = MockBillingRepository()
+        billingService = MockBillingService()
+        environmentService = MockEnvironmentService()
+    }
+
+    // MARK: Tests — navigateToPremiumUpgrade
+
+    /// `navigateToPremiumUpgrade(onConfirmed:)` navigates to the premium upgrade route when
+    /// in-app upgrade is available.
+    @Test
+    func navigateToPremiumUpgrade_inAppAvailable() async {
+        billingRepository.isInAppUpgradeAvailableReturnValue = true
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var navigateCalled = false
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: { navigateCalled = true },
+            setURL: { _ in },
+            navigateToDismiss: { _ in },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+        )
+
+        await subject.navigateToPremiumUpgrade()
+
+        #expect(navigateCalled)
+    }
+
+    /// `navigateToPremiumUpgrade(onConfirmed:)` sets the URL to the web fallback when in-app
+    /// upgrade is not available.
+    @Test
+    func navigateToPremiumUpgrade_inAppNotAvailable() async {
+        billingRepository.isInAppUpgradeAvailableReturnValue = false
+        var capturedURL: URL?
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: {},
+            setURL: { capturedURL = $0 },
+            navigateToDismiss: { _ in },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+        )
+
+        await subject.navigateToPremiumUpgrade()
+
+        #expect(capturedURL == environmentService.upgradeToPremiumURL)
+    }
+
+    // MARK: Tests — startInAppPremiumUpgrade
+
+    /// `startInAppPremiumUpgrade(onConfirmed:)` navigates directly without checking availability.
+    @Test
+    func startInAppPremiumUpgrade_navigatesWithoutAvailabilityCheck() {
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var navigateCalled = false
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: { navigateCalled = true },
+            setURL: { _ in },
+            navigateToDismiss: { _ in },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+        )
+
+        subject.startInAppPremiumUpgrade()
+
+        #expect(navigateCalled)
+        #expect(!billingRepository.isInAppUpgradeAvailableCalled)
+    }
+
+    // MARK: Tests — subscribeToPremiumCheckoutStatus
+
+    /// When the billing service emits `.canceled`, nothing happens.
+    @Test
+    func subscribeToPremiumCheckoutStatus_canceled() async throws {
+        billingRepository.isInAppUpgradeAvailableReturnValue = true
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var navigateToDismissCalled = false
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: {},
+            setURL: { _ in },
+            navigateToDismiss: { _ in navigateToDismissCalled = true },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+        )
+        await subject.navigateToPremiumUpgrade()
+
+        statusSubject.send(.canceled)
+        // Yield to let the `.receive(on: DispatchQueue.main)` dispatch run.
+        await Task.yield()
+
+        #expect(!navigateToDismissCalled)
+    }
+
+    /// When the billing service emits `.confirmed`, the `onConfirmed` closure is called and
+    /// the cancellable is released.
+    @Test
+    func subscribeToPremiumCheckoutStatus_confirmed() async throws {
+        billingRepository.isInAppUpgradeAvailableReturnValue = true
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var onConfirmedCalled = false
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: {},
+            setURL: { _ in },
+            navigateToDismiss: { _ in },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+        )
+        await subject.navigateToPremiumUpgrade(onConfirmed: {
+            onConfirmedCalled = true
+        })
+
+        statusSubject.send(.confirmed)
+
+        try await waitForAsync { onConfirmedCalled }
+        #expect(onConfirmedCalled)
+    }
+
+    /// When the billing service emits `.pending`, `navigateToDismiss` is called. Executing the
+    /// dismiss action hides the overlay and shows the upgrade pending alert.
+    @Test
+    func subscribeToPremiumCheckoutStatus_pending_noOnPendingDismiss() async throws {
+        billingRepository.isInAppUpgradeAvailableReturnValue = true
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var capturedDismissAction: DismissAction?
+        var hideLoadingOverlayCalled = false
+        var shownAlerts: [Alert] = []
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: {},
+            setURL: { _ in },
+            navigateToDismiss: { capturedDismissAction = $0 },
+            showAlert: { shownAlerts.append($0) },
+            hideLoadingOverlay: { hideLoadingOverlayCalled = true },
+        )
+        await subject.navigateToPremiumUpgrade()
+
+        statusSubject.send(.pending)
+
+        try await waitForAsync { capturedDismissAction != nil }
+        let dismissAction = try #require(capturedDismissAction)
+        dismissAction.action()
+
+        #expect(hideLoadingOverlayCalled)
+        #expect(shownAlerts.last?.title == Localizations.upgradePending)
+    }
+
+    /// When the billing service emits `.pending`, executing the dismiss action calls `onPendingDismiss`.
+    @Test
+    func subscribeToPremiumCheckoutStatus_pending_callsOnPendingDismiss() async throws {
+        billingRepository.isInAppUpgradeAvailableReturnValue = true
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var capturedDismissAction: DismissAction?
+        var onPendingDismissCalled = false
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: {},
+            setURL: { _ in },
+            navigateToDismiss: { capturedDismissAction = $0 },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+            onPendingDismiss: { onPendingDismissCalled = true },
+        )
+        await subject.navigateToPremiumUpgrade()
+
+        statusSubject.send(.pending)
+
+        try await waitForAsync { capturedDismissAction != nil }
+        capturedDismissAction?.action()
+        #expect(onPendingDismissCalled)
+    }
+
+    /// When the billing service emits `.syncing`, nothing happens (the loading overlay is shown
+    /// by `PremiumUpgradeProcessor`).
+    @Test
+    func subscribeToPremiumCheckoutStatus_syncing() async throws {
+        billingRepository.isInAppUpgradeAvailableReturnValue = true
+        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
+        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        var navigateToDismissCalled = false
+        let subject = DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            navigateToPremiumRoute: {},
+            setURL: { _ in },
+            navigateToDismiss: { _ in navigateToDismissCalled = true },
+            showAlert: { _ in },
+            hideLoadingOverlay: {},
+        )
+        await subject.navigateToPremiumUpgrade()
+
+        statusSubject.send(.syncing)
+        // Yield to let the `.receive(on: DispatchQueue.main)` dispatch run.
+        await Task.yield()
+
+        #expect(!navigateToDismissCalled)
+    }
+}

--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelperTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelperTests.swift
@@ -17,6 +17,7 @@ struct PremiumUpgradeHelperTests {
 
     let billingRepository: MockBillingRepository
     let billingService: MockBillingService
+    let coordinator: MockCoordinator<VaultRoute, AuthAction>
     let environmentService: MockEnvironmentService
 
     // MARK: Initialization
@@ -24,7 +25,23 @@ struct PremiumUpgradeHelperTests {
     init() {
         billingRepository = MockBillingRepository()
         billingService = MockBillingService()
+        coordinator = MockCoordinator()
         environmentService = MockEnvironmentService()
+    }
+
+    // MARK: Helpers
+
+    private func makeSubject(onPendingDismiss: (() -> Void)? = nil) -> DefaultPremiumUpgradeHelper<VaultRoute, AuthAction> {
+        DefaultPremiumUpgradeHelper(
+            services: ServiceContainer.withMocks(
+                billingRepository: billingRepository,
+                billingService: billingService,
+                environmentService: environmentService,
+            ),
+            coordinator: coordinator.asAnyCoordinator(),
+            setURL: { _ in },
+            onPendingDismiss: onPendingDismiss,
+        )
     }
 
     // MARK: Tests — navigateToPremiumUpgrade
@@ -36,23 +53,21 @@ struct PremiumUpgradeHelperTests {
         billingRepository.isInAppUpgradeAvailableReturnValue = true
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        var navigateCalled = false
+        var capturedURL: URL?
         let subject = DefaultPremiumUpgradeHelper(
             services: ServiceContainer.withMocks(
                 billingRepository: billingRepository,
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: { navigateCalled = true },
-            setURL: { _ in },
-            navigateToDismiss: { _ in },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
+            coordinator: coordinator.asAnyCoordinator(),
+            setURL: { capturedURL = $0 },
         )
 
         await subject.navigateToPremiumUpgrade()
 
-        #expect(navigateCalled)
+        #expect(coordinator.routes.last == .premiumUpgrade)
+        #expect(capturedURL == nil)
     }
 
     /// `navigateToPremiumUpgrade(onConfirmed:)` sets the URL to the web fallback when in-app
@@ -67,16 +82,14 @@ struct PremiumUpgradeHelperTests {
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: {},
+            coordinator: coordinator.asAnyCoordinator(),
             setURL: { capturedURL = $0 },
-            navigateToDismiss: { _ in },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
         )
 
         await subject.navigateToPremiumUpgrade()
 
         #expect(capturedURL == environmentService.upgradeToPremiumURL)
+        #expect(coordinator.routes.last != .premiumUpgrade)
     }
 
     // MARK: Tests — startInAppPremiumUpgrade
@@ -86,23 +99,19 @@ struct PremiumUpgradeHelperTests {
     func startInAppPremiumUpgrade_navigatesWithoutAvailabilityCheck() {
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        var navigateCalled = false
         let subject = DefaultPremiumUpgradeHelper(
             services: ServiceContainer.withMocks(
                 billingRepository: billingRepository,
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: { navigateCalled = true },
+            coordinator: coordinator.asAnyCoordinator(),
             setURL: { _ in },
-            navigateToDismiss: { _ in },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
         )
 
         subject.startInAppPremiumUpgrade()
 
-        #expect(navigateCalled)
+        #expect(coordinator.routes.last == .premiumUpgrade)
         #expect(!billingRepository.isInAppUpgradeAvailableCalled)
     }
 
@@ -114,26 +123,23 @@ struct PremiumUpgradeHelperTests {
         billingRepository.isInAppUpgradeAvailableReturnValue = true
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        var navigateToDismissCalled = false
         let subject = DefaultPremiumUpgradeHelper(
             services: ServiceContainer.withMocks(
                 billingRepository: billingRepository,
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: {},
+            coordinator: coordinator.asAnyCoordinator(),
             setURL: { _ in },
-            navigateToDismiss: { _ in navigateToDismissCalled = true },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
         )
         await subject.navigateToPremiumUpgrade()
+        let routeCountBeforeSend = coordinator.routes.count
 
         statusSubject.send(.canceled)
         // Yield to let the `.receive(on: DispatchQueue.main)` dispatch run.
         await Task.yield()
 
-        #expect(!navigateToDismissCalled)
+        #expect(coordinator.routes.count == routeCountBeforeSend)
     }
 
     /// When the billing service emits `.confirmed`, the `onConfirmed` closure is called and
@@ -150,11 +156,8 @@ struct PremiumUpgradeHelperTests {
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: {},
+            coordinator: coordinator.asAnyCoordinator(),
             setURL: { _ in },
-            navigateToDismiss: { _ in },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
         )
         await subject.navigateToPremiumUpgrade(onConfirmed: {
             onConfirmedCalled = true
@@ -166,38 +169,38 @@ struct PremiumUpgradeHelperTests {
         #expect(onConfirmedCalled)
     }
 
-    /// When the billing service emits `.pending`, `navigateToDismiss` is called. Executing the
-    /// dismiss action hides the overlay and shows the upgrade pending alert.
+    /// When the billing service emits `.pending`, the coordinator navigates to `.dismiss`.
+    /// Executing the dismiss action hides the overlay and shows the upgrade pending alert.
     @Test
     func subscribeToPremiumCheckoutStatus_pending_noOnPendingDismiss() async throws {
         billingRepository.isInAppUpgradeAvailableReturnValue = true
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        var capturedDismissAction: DismissAction?
-        var hideLoadingOverlayCalled = false
-        var shownAlerts: [Alert] = []
         let subject = DefaultPremiumUpgradeHelper(
             services: ServiceContainer.withMocks(
                 billingRepository: billingRepository,
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: {},
+            coordinator: coordinator.asAnyCoordinator(),
             setURL: { _ in },
-            navigateToDismiss: { capturedDismissAction = $0 },
-            showAlert: { shownAlerts.append($0) },
-            hideLoadingOverlay: { hideLoadingOverlayCalled = true },
         )
         await subject.navigateToPremiumUpgrade()
 
         statusSubject.send(.pending)
 
-        try await waitForAsync { capturedDismissAction != nil }
-        let dismissAction = try #require(capturedDismissAction)
-        dismissAction.action()
+        try await waitForAsync {
+            guard case let .dismiss(action) = self.coordinator.routes.last else { return false }
+            return action != nil
+        }
+        guard case let .dismiss(action) = coordinator.routes.last else {
+            Issue.record("Expected .dismiss route")
+            return
+        }
+        action?.action()
 
-        #expect(hideLoadingOverlayCalled)
-        #expect(shownAlerts.last?.title == Localizations.upgradePending)
+        #expect(coordinator.alertShown.last?.title == Localizations.upgradePending)
+        #expect(!coordinator.isLoadingOverlayShowing)
     }
 
     /// When the billing service emits `.pending`, executing the dismiss action calls `onPendingDismiss`.
@@ -206,27 +209,21 @@ struct PremiumUpgradeHelperTests {
         billingRepository.isInAppUpgradeAvailableReturnValue = true
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        var capturedDismissAction: DismissAction?
         var onPendingDismissCalled = false
-        let subject = DefaultPremiumUpgradeHelper(
-            services: ServiceContainer.withMocks(
-                billingRepository: billingRepository,
-                billingService: billingService,
-                environmentService: environmentService,
-            ),
-            navigateToPremiumRoute: {},
-            setURL: { _ in },
-            navigateToDismiss: { capturedDismissAction = $0 },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
-            onPendingDismiss: { onPendingDismissCalled = true },
-        )
+        let subject = makeSubject(onPendingDismiss: { onPendingDismissCalled = true })
         await subject.navigateToPremiumUpgrade()
 
         statusSubject.send(.pending)
 
-        try await waitForAsync { capturedDismissAction != nil }
-        capturedDismissAction?.action()
+        try await waitForAsync {
+            guard case let .dismiss(action) = self.coordinator.routes.last else { return false }
+            return action != nil
+        }
+        guard case let .dismiss(action) = coordinator.routes.last else {
+            Issue.record("Expected .dismiss route")
+            return
+        }
+        action?.action()
         #expect(onPendingDismissCalled)
     }
 
@@ -237,25 +234,22 @@ struct PremiumUpgradeHelperTests {
         billingRepository.isInAppUpgradeAvailableReturnValue = true
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        var navigateToDismissCalled = false
         let subject = DefaultPremiumUpgradeHelper(
             services: ServiceContainer.withMocks(
                 billingRepository: billingRepository,
                 billingService: billingService,
                 environmentService: environmentService,
             ),
-            navigateToPremiumRoute: {},
+            coordinator: coordinator.asAnyCoordinator(),
             setURL: { _ in },
-            navigateToDismiss: { _ in navigateToDismissCalled = true },
-            showAlert: { _ in },
-            hideLoadingOverlay: {},
         )
         await subject.navigateToPremiumUpgrade()
+        let routeCountBeforeSend = coordinator.routes.count
 
         statusSubject.send(.syncing)
         // Yield to let the `.receive(on: DispatchQueue.main)` dispatch run.
         await Task.yield()
 
-        #expect(!navigateToDismissCalled)
+        #expect(coordinator.routes.count == routeCountBeforeSend)
     }
 }

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -14,9 +14,11 @@ extension Alert {
     ///   - action: A closure to execute on upgrading to premium.
     /// - Returns: The alert when archive is unavailable.
     static func archiveUnavailable(
-        action: @escaping () -> Void,
+        action: @escaping () async -> Void,
     ) -> Alert {
-        let preferredAction = AlertAction(title: Localizations.upgradeToPremium, style: .default) { _ in action() }
+        let preferredAction = AlertAction(title: Localizations.upgradeToPremium, style: .default) { _ in
+            await action()
+        }
         let alert = Alert(
             title: Localizations.archiveUnavailable,
             message: Localizations.archivingItemsIsAPremiumFeatureDescriptionLong,

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -41,23 +41,10 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
     /// The helper used to navigate to the premium upgrade flow.
     lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
         services: services,
-        navigateToPremiumRoute: { [weak self] in
-            self?.coordinator.navigate(to: .premiumUpgrade)
-        },
-        setURL: { [weak self] url in
-            self?.state.url = url
-        },
-        navigateToDismiss: { [weak self] action in
-            self?.coordinator.navigate(to: .dismiss(action))
-        },
-        showAlert: { [weak self] alert in
-            self?.coordinator.showAlert(alert)
-        },
-        hideLoadingOverlay: { [weak self] in
-            self?.coordinator.hideLoadingOverlay()
-        },
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
         onPendingDismiss: { [weak self] in
-            Task { await self?.dismissPremiumUpgradeActionCard() }
+            Task { @MainActor in await self?.dismissPremiumUpgradeActionCard() }
         },
     )
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -38,8 +38,28 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
     /// The helper to handle master password reprompts.
     private let masterPasswordRepromptHelper: MasterPasswordRepromptHelper
 
-    /// A cancellable for the premium checkout status subscription.
-    private var premiumStatusChangedCancellable: AnyCancellable?
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        navigateToPremiumRoute: { [weak self] in
+            self?.coordinator.navigate(to: .premiumUpgrade)
+        },
+        setURL: { [weak self] url in
+            self?.state.url = url
+        },
+        navigateToDismiss: { [weak self] action in
+            self?.coordinator.navigate(to: .dismiss(action))
+        },
+        showAlert: { [weak self] alert in
+            self?.coordinator.showAlert(alert)
+        },
+        hideLoadingOverlay: { [weak self] in
+            self?.coordinator.hideLoadingOverlay()
+        },
+        onPendingDismiss: { [weak self] in
+            Task { await self?.dismissPremiumUpgradeActionCard() }
+        },
+    )
 
     /// The services for this processor.
     private var services: Services
@@ -232,47 +252,9 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
     /// otherwise opens the web vault upgrade URL as a fallback.
     ///
     private func navigateToPremiumUpgrade() async {
-        guard await services.billingRepository.isInAppUpgradeAvailable() else {
-            state.url = services.environmentService.upgradeToPremiumURL
-            return
-        }
-        subscribeToPremiumCheckoutStatus()
-        coordinator.navigate(to: .premiumUpgrade)
-    }
-
-    /// Subscribes to premium checkout status updates. On `.confirmed`, reloads the vault group
-    /// to update the premium state. On `.pending`, shows an upgrade pending alert.
-    ///
-    private func subscribeToPremiumCheckoutStatus() {
-        premiumStatusChangedCancellable = services.billingService
-            .premiumCheckoutStatusPublisher()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] status in
-                guard let self else { return }
-                switch status {
-                case .canceled:
-                    break
-                case .confirmed:
-                    premiumStatusChangedCancellable = nil
-                    // PremiumUpgradeProcessor navigates to PremiumUpgradeComplete.
-                    // Refresh vault group in the background so it's ready when the user returns.
-                    Task { [weak self] in await self?.refreshVaultGroup() }
-                case .pending:
-                    coordinator.navigate(
-                        to: .dismiss(DismissAction { [weak self] in
-                            guard let self else { return }
-                            coordinator.hideLoadingOverlay()
-                            Task { await self.dismissPremiumUpgradeActionCard() }
-                            coordinator.showAlert(.upgradePending {
-                                await self.services.billingService.premiumStatusChanged()
-                            })
-                        }),
-                    )
-                case .syncing:
-                    // PremiumUpgradeProcessor shows the loading overlay on the upgrade screen.
-                    break
-                }
-            }
+        await premiumUpgradeHelper.navigateToPremiumUpgrade(onConfirmed: { [weak self] in
+            await self?.refreshVaultGroup()
+        })
     }
 
     /// Navigates to the view item view for the specified cipher. If the cipher requires master

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -27,6 +27,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
     var masterPasswordRepromptHelper: MockMasterPasswordRepromptHelper!
     var pasteboardService: MockPasteboardService!
     var policyService: MockPolicyService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var searchProcessorMediator: MockSearchProcessorMediator!
     var searchProcessorMediatorFactory: MockSearchProcessorMediatorFactory!
     var stateService: MockStateService!
@@ -55,6 +56,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         searchProcessorMediatorFactory = MockSearchProcessorMediatorFactory()
         searchProcessorMediatorFactory.makeReturnValue = searchProcessorMediator
 
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         stateService = MockStateService()
         timeProvider = MockTimeProvider(.mockTime(fixedDate))
         vaultItemMoreOptionsHelper = MockVaultItemMoreOptionsHelper()
@@ -83,6 +85,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
             ),
             vaultItemMoreOptionsHelper: vaultItemMoreOptionsHelper,
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
@@ -95,6 +98,7 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         coordinator = nil
         errorReporter = nil
         masterPasswordRepromptHelper = nil
+        premiumUpgradeHelper = nil
         pasteboardService = nil
         policyService = nil
         searchProcessorMediator = nil
@@ -293,121 +297,17 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(subject.state.url, url)
     }
 
-    /// `perform(_:)` with `.morePressed` navigates to the premium upgrade screen via in-app flow
-    /// when `isInAppUpgradeAvailable` returns `true`.
+    /// `perform(_:)` with `.morePressed` delegates to the premium upgrade helper when the
+    /// upgrade action is triggered.
     @MainActor
-    func test_perform_morePressed_navigateToPremiumUpgrade_inAppUpgradeAvailable() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-
+    func test_perform_morePressed_navigateToPremiumUpgrade() async throws {
         await subject.perform(.morePressed(.fixture()))
 
         let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
         await navigate()
-        try await waitForAsync { self.coordinator.routes.last == .premiumUpgrade }
+        try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-        XCTAssertNil(subject.state.url)
-        XCTAssertTrue(billingService.premiumCheckoutStatusPublisherCalled)
-    }
-
-    /// `perform(_:)` with `.morePressed` opens the web upgrade URL when `isInAppUpgradeAvailable`
-    /// returns `false`.
-    @MainActor
-    func test_perform_morePressed_navigateToPremiumUpgrade_inAppUpgradeNotAvailable() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = false
-
-        await subject.perform(.morePressed(.fixture()))
-
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        try await waitForAsync { self.subject.state.url != nil }
-
-        XCTAssertEqual(
-            subject.state.url,
-            URL(string: "https://example.com/#/settings/subscription/premium?callToAction=upgradeToPremium"),
-        )
-        XCTAssertNotEqual(coordinator.routes.last, .premiumUpgrade)
-    }
-
-    /// When the billing service emits `.canceled`, no new route is navigated.
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_canceled() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        let routeCountBeforeSend = coordinator.routes.count
-
-        statusSubject.send(.canceled)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBeforeSend }
-    }
-
-    /// When the billing service emits `.confirmed`, the processor refreshes the vault group without
-    /// dismissing (PremiumUpgradeProcessor owns the navigation to PremiumUpgradeComplete).
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_confirmed() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        let routeCountBefore = coordinator.routes.count
-
-        statusSubject.send(.confirmed)
-
-        try await waitForAsync { self.vaultRepository.fetchSyncCalled }
-        XCTAssertEqual(coordinator.routes.count, routeCountBefore)
-    }
-
-    /// When the billing service emits `.pending`, the processor navigates to `.dismiss` with a
-    /// `DismissAction` whose completion hides the overlay, dismisses the action card, and shows
-    /// the upgrade pending alert.
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_pending() async throws {
-        stateService.activeAccount = .fixture()
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-
-        statusSubject.send(.pending)
-
-        try await waitForAsync {
-            guard case let .dismiss(action) = self.coordinator.routes.last else { return false }
-            return action != nil
-        }
-        guard case let .dismiss(action) = coordinator.routes.last else { return XCTFail("Expected .dismiss route") }
-        action?.action()
-        try await waitForAsync { self.stateService.premiumUpgradeBannerDismissedByUserId["1"] ?? false }
-        XCTAssertTrue(stateService.premiumUpgradeBannerDismissedByUserId["1"] ?? false)
-        XCTAssertEqual(coordinator.alertShown.last?.title, Localizations.upgradePending)
-        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-    }
-
-    /// When the billing service emits `.syncing`, the processor does nothing (PremiumUpgradeProcessor
-    /// shows the loading overlay on the upgrade screen).
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_syncing() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        let routeCountBefore = coordinator.routes.count
-
-        statusSubject.send(.syncing)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBefore }
-        XCTAssertEqual(coordinator.routes.count, routeCountBefore)
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `perform(_:)` with `.refreshed` requests a fetch sync update with the vault repository.

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -30,8 +30,25 @@ class VaultItemSelectionProcessor: StateProcessor<
     /// The `Coordinator` that handles navigation.
     private var coordinator: AnyCoordinator<VaultRoute, AuthAction>
 
-    /// A cancellable for the premium checkout status subscription.
-    private var premiumStatusChangedCancellable: AnyCancellable?
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        navigateToPremiumRoute: { [weak self] in
+            self?.coordinator.navigate(to: .premiumUpgrade)
+        },
+        setURL: { [weak self] url in
+            self?.state.url = url
+        },
+        navigateToDismiss: { [weak self] action in
+            self?.coordinator.navigate(to: .dismiss(action))
+        },
+        showAlert: { [weak self] alert in
+            self?.coordinator.showAlert(alert)
+        },
+        hideLoadingOverlay: { [weak self] in
+            self?.coordinator.hideLoadingOverlay()
+        },
+    )
 
     /// The mediator between processors and search publisher/subscription behavior.
     private let searchProcessorMediator: SearchProcessorMediator
@@ -152,44 +169,7 @@ class VaultItemSelectionProcessor: StateProcessor<
     /// otherwise opens the web vault upgrade URL as a fallback.
     ///
     private func navigateToPremiumUpgrade() async {
-        guard await services.billingRepository.isInAppUpgradeAvailable() else {
-            state.url = services.environmentService.upgradeToPremiumURL
-            return
-        }
-        subscribeToPremiumCheckoutStatus()
-        coordinator.navigate(to: .premiumUpgrade)
-    }
-
-    /// Subscribes to premium checkout status updates. On `.confirmed`, dismisses the upgrade modal.
-    /// On `.pending`, shows an upgrade pending alert.
-    ///
-    private func subscribeToPremiumCheckoutStatus() {
-        premiumStatusChangedCancellable = services.billingService
-            .premiumCheckoutStatusPublisher()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] status in
-                guard let self else { return }
-                switch status {
-                case .canceled:
-                    break
-                case .confirmed:
-                    premiumStatusChangedCancellable = nil
-                // PremiumUpgradeProcessor navigates to PremiumUpgradeComplete.
-                case .pending:
-                    coordinator.navigate(
-                        to: .dismiss(DismissAction { [weak self] in
-                            guard let self else { return }
-                            coordinator.hideLoadingOverlay()
-                            coordinator.showAlert(.upgradePending {
-                                await self.services.billingService.premiumStatusChanged()
-                            })
-                        }),
-                    )
-                case .syncing:
-                    // PremiumUpgradeProcessor shows the loading overlay on the upgrade screen.
-                    break
-                }
-            }
+        await premiumUpgradeHelper.navigateToPremiumUpgrade()
     }
 
     /// Handles receiving a `ProfileSwitcherAction`.
@@ -396,4 +376,4 @@ extension VaultItemSelectionProcessor: ProfileSwitcherHandler {
     func showProfileSwitcher() {
         coordinator.navigate(to: .viewProfileSwitcher, context: self)
     }
-} // swiftlint:disable:this file_length
+}

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -33,21 +33,8 @@ class VaultItemSelectionProcessor: StateProcessor<
     /// The helper used to navigate to the premium upgrade flow.
     lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
         services: services,
-        navigateToPremiumRoute: { [weak self] in
-            self?.coordinator.navigate(to: .premiumUpgrade)
-        },
-        setURL: { [weak self] url in
-            self?.state.url = url
-        },
-        navigateToDismiss: { [weak self] action in
-            self?.coordinator.navigate(to: .dismiss(action))
-        },
-        showAlert: { [weak self] alert in
-            self?.coordinator.showAlert(alert)
-        },
-        hideLoadingOverlay: { [weak self] in
-            self?.coordinator.hideLoadingOverlay()
-        },
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
     )
 
     /// The mediator between processors and search publisher/subscription behavior.

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -21,6 +21,7 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
     var coordinator: MockCoordinator<VaultRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
     var pasteboardService: MockPasteboardService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var searchProcessorMediator: MockSearchProcessorMediator!
     var searchProcessorMediatorFactory: MockSearchProcessorMediatorFactory!
     var stateService: MockStateService!
@@ -46,6 +47,7 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         searchProcessorMediatorFactory = MockSearchProcessorMediatorFactory()
         searchProcessorMediatorFactory.makeReturnValue = searchProcessorMediator
 
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         stateService = MockStateService()
         userVerificationHelper = MockUserVerificationHelper()
         vaultItemMoreOptionsHelper = MockVaultItemMoreOptionsHelper()
@@ -70,6 +72,7 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
             userVerificationHelper: userVerificationHelper,
             vaultItemMoreOptionsHelper: vaultItemMoreOptionsHelper,
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
@@ -81,6 +84,7 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         coordinator = nil
         errorReporter = nil
         pasteboardService = nil
+        premiumUpgradeHelper = nil
         searchProcessorMediator = nil
         searchProcessorMediatorFactory = nil
         stateService = nil
@@ -175,117 +179,17 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertEqual(subject.state.url, url)
     }
 
-    /// `perform(_:)` with `.morePressed` navigates to the premium upgrade screen via in-app flow
-    /// when `isInAppUpgradeAvailable` returns `true`.
+    /// `perform(_:)` with `.morePressed` delegates to the premium upgrade helper when the
+    /// upgrade action is triggered.
     @MainActor
-    func test_perform_morePressed_navigateToPremiumUpgrade_inAppUpgradeAvailable() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-
+    func test_perform_morePressed_navigateToPremiumUpgrade() async throws {
         await subject.perform(.morePressed(.fixture()))
 
         let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
         await navigate()
-        try await waitForAsync { self.coordinator.routes.last == .premiumUpgrade }
+        try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-        XCTAssertNil(subject.state.url)
-        XCTAssertTrue(billingService.premiumCheckoutStatusPublisherCalled)
-    }
-
-    /// `perform(_:)` with `.morePressed` opens the web upgrade URL when `isInAppUpgradeAvailable`
-    /// returns `false`.
-    @MainActor
-    func test_perform_morePressed_navigateToPremiumUpgrade_inAppUpgradeNotAvailable() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = false
-
-        await subject.perform(.morePressed(.fixture()))
-
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        try await waitForAsync { self.subject.state.url != nil }
-
-        XCTAssertEqual(
-            subject.state.url,
-            URL(string: "https://example.com/#/settings/subscription/premium?callToAction=upgradeToPremium"),
-        )
-        XCTAssertNotEqual(coordinator.routes.last, .premiumUpgrade)
-    }
-
-    /// When the billing service emits `.canceled`, no new route is navigated.
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_canceled() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        let routeCountBeforeSend = coordinator.routes.count
-
-        statusSubject.send(.canceled)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBeforeSend }
-    }
-
-    /// When the billing service emits `.confirmed`, the processor cancels the subscription without
-    /// dismissing (PremiumUpgradeProcessor owns the navigation to PremiumUpgradeComplete).
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_confirmed() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        let routeCountBefore = coordinator.routes.count
-
-        statusSubject.send(.confirmed)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBefore }
-        XCTAssertEqual(coordinator.routes.count, routeCountBefore)
-    }
-
-    /// When the billing service emits `.pending`, the processor navigates to `.dismiss` with a
-    /// `DismissAction` whose completion shows the upgrade pending alert.
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_pending() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-
-        statusSubject.send(.pending)
-
-        try await waitForAsync {
-            guard case let .dismiss(action) = self.coordinator.routes.last else { return false }
-            return action != nil
-        }
-        guard case let .dismiss(action) = coordinator.routes.last else { return XCTFail("Expected .dismiss route") }
-        action?.action()
-        XCTAssertEqual(coordinator.alertShown.last?.title, Localizations.upgradePending)
-        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-    }
-
-    /// When the billing service emits `.syncing`, the processor does nothing (PremiumUpgradeProcessor
-    /// shows the loading overlay on the upgrade screen).
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_syncing() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        await subject.perform(.morePressed(.fixture()))
-        let navigate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertHandlePremiumUpgrade)
-        await navigate()
-        let routeCountBefore = coordinator.routes.count
-
-        statusSubject.send(.syncing)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBefore }
-        XCTAssertEqual(coordinator.routes.count, routeCountBefore)
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `perform(_:)` with `.profileSwitcher(.accountPressed)` updates the profile switcher's

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -596,16 +596,21 @@ extension VaultListProcessor {
         )
     }
 
+    /// Handles state updates after a premium upgrade is confirmed.
+    ///
+    private func handlePremiumUpgradeConfirmed() async {
+        await refreshVault(syncWithPeriodicCheck: false)
+        state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
+        state.shouldShowPremiumUpgradeActionCard = !state.hasPremium
+        state.shouldShowUpgradedToPremiumActionCard = state.hasPremium
+    }
+
     /// Navigates to the premium upgrade flow. Uses the in-app upgrade path when available;
     /// otherwise opens the web vault upgrade URL as a fallback.
     ///
     private func navigateToPremiumUpgrade() async {
         await premiumUpgradeHelper.navigateToPremiumUpgrade(onConfirmed: { [weak self] in
-            guard let self else { return }
-            await refreshVault(syncWithPeriodicCheck: false)
-            state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
-            state.shouldShowPremiumUpgradeActionCard = false
-            state.shouldShowUpgradedToPremiumActionCard = true
+            await self?.handlePremiumUpgradeConfirmed()
         })
     }
 
@@ -700,11 +705,7 @@ extension VaultListProcessor {
     /// Subscribes to premium checkout status and navigates to the upgrade screen.
     private func upgradeToPremium() {
         premiumUpgradeHelper.startInAppPremiumUpgrade(onConfirmed: { [weak self] in
-            guard let self else { return }
-            await refreshVault(syncWithPeriodicCheck: false)
-            state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
-            state.shouldShowPremiumUpgradeActionCard = !state.hasPremium
-            state.shouldShowUpgradedToPremiumActionCard = state.hasPremium
+            await self?.handlePremiumUpgradeConfirmed()
         })
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -703,8 +703,8 @@ extension VaultListProcessor {
             guard let self else { return }
             await refreshVault(syncWithPeriodicCheck: false)
             state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
-            state.shouldShowPremiumUpgradeActionCard = false
-            state.shouldShowUpgradedToPremiumActionCard = true
+            state.shouldShowPremiumUpgradeActionCard = !state.hasPremium
+            state.shouldShowUpgradedToPremiumActionCard = state.hasPremium
         })
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -49,8 +49,28 @@ final class VaultListProcessor: StateProcessor<
     /// The helper to handle master password reprompts.
     private let masterPasswordRepromptHelper: MasterPasswordRepromptHelper
 
-    /// Cancellable for the premium checkout status subscription.
-    private var premiumStatusChangedCancellable: AnyCancellable?
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        navigateToPremiumRoute: { [weak self] in
+            self?.coordinator.navigate(to: .premiumUpgrade)
+        },
+        setURL: { [weak self] url in
+            self?.state.url = url
+        },
+        navigateToDismiss: { [weak self] action in
+            self?.coordinator.navigate(to: .dismiss(action))
+        },
+        showAlert: { [weak self] alert in
+            self?.coordinator.showAlert(alert)
+        },
+        hideLoadingOverlay: { [weak self] in
+            self?.coordinator.hideLoadingOverlay()
+        },
+        onPendingDismiss: { [weak self] in
+            Task { await self?.dismissPremiumUpgradeActionCard() }
+        },
+    )
 
     /// The task that schedules the app review prompt.
     private(set) var reviewPromptTask: Task<Void, Never>?
@@ -593,53 +613,13 @@ extension VaultListProcessor {
     /// otherwise opens the web vault upgrade URL as a fallback.
     ///
     private func navigateToPremiumUpgrade() async {
-        guard await services.billingRepository.isInAppUpgradeAvailable() else {
-            state.url = services.environmentService.upgradeToPremiumURL
-            return
-        }
-        subscribeToPremiumCheckoutStatus()
-        coordinator.navigate(to: .premiumUpgrade)
-    }
-
-    /// Subscribes to premium checkout status updates. On `.confirmed`, reloads the vault list
-    /// to update the premium state. On `.pending`, shows an upgrade pending alert.
-    ///
-    private func subscribeToPremiumCheckoutStatus() {
-        premiumStatusChangedCancellable = services.billingService
-            .premiumCheckoutStatusPublisher()
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] status in
-                guard let self else { return }
-                switch status {
-                case .canceled:
-                    break
-                case .confirmed:
-                    premiumStatusChangedCancellable = nil
-                    // PremiumUpgradeProcessor navigates to PremiumUpgradeComplete.
-                    // Refresh vault in the background so it's ready when the user returns.
-                    Task { [weak self] in
-                        guard let self else { return }
-                        await refreshVault(syncWithPeriodicCheck: false)
-                        state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
-                        state.shouldShowPremiumUpgradeActionCard = false
-                        state.shouldShowUpgradedToPremiumActionCard = true
-                    }
-                case .pending:
-                    coordinator.navigate(
-                        to: .dismiss(DismissAction { [weak self] in
-                            guard let self else { return }
-                            coordinator.hideLoadingOverlay()
-                            Task { await self.dismissPremiumUpgradeActionCard() }
-                            coordinator.showAlert(.upgradePending {
-                                await self.services.billingService.premiumStatusChanged()
-                            })
-                        }),
-                    )
-                case .syncing:
-                    // PremiumUpgradeProcessor shows the loading overlay on the upgrade screen.
-                    break
-                }
-            }
+        await premiumUpgradeHelper.navigateToPremiumUpgrade(onConfirmed: { [weak self] in
+            guard let self else { return }
+            await refreshVault(syncWithPeriodicCheck: false)
+            state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
+            state.shouldShowPremiumUpgradeActionCard = false
+            state.shouldShowUpgradedToPremiumActionCard = true
+        })
     }
 
     /// Streams the user's account setup progress.
@@ -732,8 +712,13 @@ extension VaultListProcessor {
 
     /// Subscribes to premium checkout status and navigates to the upgrade screen.
     private func upgradeToPremium() {
-        subscribeToPremiumCheckoutStatus()
-        coordinator.navigate(to: .premiumUpgrade)
+        premiumUpgradeHelper.startInAppPremiumUpgrade(onConfirmed: { [weak self] in
+            guard let self else { return }
+            await refreshVault(syncWithPeriodicCheck: false)
+            state.hasPremium = await services.stateService.doesActiveAccountHavePremium()
+            state.shouldShowPremiumUpgradeActionCard = false
+            state.shouldShowUpgradedToPremiumActionCard = true
+        })
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -52,23 +52,10 @@ final class VaultListProcessor: StateProcessor<
     /// The helper used to navigate to the premium upgrade flow.
     lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
         services: services,
-        navigateToPremiumRoute: { [weak self] in
-            self?.coordinator.navigate(to: .premiumUpgrade)
-        },
-        setURL: { [weak self] url in
-            self?.state.url = url
-        },
-        navigateToDismiss: { [weak self] action in
-            self?.coordinator.navigate(to: .dismiss(action))
-        },
-        showAlert: { [weak self] alert in
-            self?.coordinator.showAlert(alert)
-        },
-        hideLoadingOverlay: { [weak self] in
-            self?.coordinator.hideLoadingOverlay()
-        },
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
         onPendingDismiss: { [weak self] in
-            Task { await self?.dismissPremiumUpgradeActionCard() }
+            Task { @MainActor in await self?.dismissPremiumUpgradeActionCard() }
         },
     )
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -32,6 +32,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
     var notificationService: MockNotificationService!
     var pasteboardService: MockPasteboardService!
     var policyService: MockPolicyService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var reviewPromptService: MockReviewPromptService!
     var searchProcessorMediator: MockSearchProcessorMediator!
     var searchProcessorMediatorFactory: MockSearchProcessorMediatorFactory!
@@ -78,6 +79,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         storefrontService = MockStorefrontService()
         syncService = MockSyncService()
         timeProvider = MockTimeProvider(.mockTime(Date(year: 2024, month: 6, day: 28)))
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         vaultItemMoreOptionsHelper = MockVaultItemMoreOptionsHelper()
         vaultRepository = MockVaultRepository()
         let services = ServiceContainer.withMocks(
@@ -109,6 +111,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
             state: VaultListState(),
             vaultItemMoreOptionsHelper: vaultItemMoreOptionsHelper,
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
@@ -127,6 +130,7 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         masterPasswordRepromptHelper = nil
         pasteboardService = nil
         policyService = nil
+        premiumUpgradeHelper = nil
         reviewPromptService = nil
         searchProcessorMediator = nil
         searchProcessorMediatorFactory = nil
@@ -663,80 +667,6 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
 
         XCTAssertFalse(subject.state.shouldShowPremiumUpgradeActionCard)
         XCTAssertTrue(stateService.premiumUpgradeBannerDismissedByUserId["1"] ?? false)
-    }
-
-    /// When the billing service emits `.canceled`, the processor does not navigate,
-    /// keeping the subscription alive so a cancel-and-retry can still be observed.
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_canceled() async throws {
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        subject.receive(.upgradeToPremium)
-        let routeCountBeforeSend = coordinator.routes.count
-
-        statusSubject.send(.canceled)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBeforeSend }
-    }
-
-    /// When the billing service emits `.confirmed`, the processor refreshes the vault and updates
-    /// state without dismissing (PremiumUpgradeProcessor owns the navigation to PremiumUpgradeComplete).
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_confirmed() async throws {
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        stateService.doesActiveAccountHavePremiumResult = true
-        subject.state.shouldShowPremiumUpgradeActionCard = true
-        subject.receive(.upgradeToPremium)
-        let routeCountBefore = coordinator.routes.count
-
-        statusSubject.send(.confirmed)
-
-        try await waitForAsync { self.subject.state.shouldShowUpgradedToPremiumActionCard }
-        XCTAssertFalse(subject.state.shouldShowPremiumUpgradeActionCard)
-        XCTAssertTrue(subject.state.hasPremium)
-        XCTAssertEqual(coordinator.routes.count, routeCountBefore)
-    }
-
-    /// When the billing service emits `.pending`, the processor navigates to `.dismiss` with a
-    /// `DismissAction` whose completion hides the overlay, dismisses the action card, and shows
-    /// the upgrade pending alert.
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_pending() async throws {
-        stateService.activeAccount = .fixture()
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        subject.state.shouldShowPremiumUpgradeActionCard = true
-        subject.receive(.upgradeToPremium)
-
-        statusSubject.send(.pending)
-
-        try await waitForAsync {
-            guard case let .dismiss(action) = self.coordinator.routes.last else { return false }
-            return action != nil
-        }
-        guard case let .dismiss(action) = coordinator.routes.last else { return XCTFail("Expected .dismiss route") }
-        action?.action()
-        try await waitForAsync { !self.subject.state.shouldShowPremiumUpgradeActionCard }
-        XCTAssertFalse(subject.state.shouldShowPremiumUpgradeActionCard)
-        XCTAssertTrue(stateService.premiumUpgradeBannerDismissedByUserId["1"] ?? false)
-        XCTAssertEqual(coordinator.alertShown.last?.title, Localizations.upgradePending)
-        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
-    }
-
-    /// When the billing service emits `.syncing`, the processor does nothing (PremiumUpgradeProcessor
-    /// shows the loading overlay on the upgrade screen).
-    @MainActor
-    func test_subscribeToPremiumCheckoutStatus_syncing() async throws {
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        subject.receive(.upgradeToPremium)
-        let routeCountBefore = coordinator.routes.count
-
-        statusSubject.send(.syncing)
-
-        try await waitForAsync { self.coordinator.routes.count == routeCountBefore }
-        XCTAssertEqual(coordinator.routes.count, routeCountBefore)
     }
 
     /// `perform(_:)` with `.dismissUpgradedToPremiumActionCard` hides the upgraded to premium card.
@@ -2105,14 +2035,10 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertTrue(coordinator.routes.isEmpty)
     }
 
-    /// `receive(_:)` with `.itemPressed` shows archive unavailable alert and navigates to the
-    /// premium upgrade screen when the in-app upgrade path is available.
+    /// `receive(_:)` with `.itemPressed` shows archive unavailable alert and delegates to the
+    /// premium upgrade helper when the action is tapped.
     @MainActor
-    func test_receive_itemPressed_archiveGroup_noPremium_noItems_actionTapped_inAppUpgradeEnabled() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-
+    func test_receive_itemPressed_archiveGroup_noPremium_noItems_actionTapped() async throws {
         subject.state.hasPremium = false
         let archiveItem = VaultListItem(id: "Archive", hasPremium: false, itemType: .group(.archive, 0))
 
@@ -2123,58 +2049,9 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(alert.message, Localizations.archivingItemsIsAPremiumFeatureDescriptionLong)
 
         try await alert.tapAction(title: Localizations.upgradeToPremium)
-        try await waitForAsync { self.coordinator.routes.last == .premiumUpgrade }
+        try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-        XCTAssertNil(subject.state.url)
-        XCTAssertTrue(billingService.premiumCheckoutStatusPublisherCalled)
-    }
-
-    /// `receive(_:)` with `.itemPressed` navigates to the premium upgrade screen even when the
-    /// banner has been dismissed, since the archive entry point bypasses the dismissal check.
-    @MainActor
-    func test_receive_itemPressed_archiveGroup_noPremium_noItems_actionTapped_bannerDismissed() async throws {
-        stateService.isPremiumUpgradeBannerDismissedResult = true
-        billingRepository.isInAppUpgradeAvailableReturnValue = true
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-
-        subject.state.hasPremium = false
-        let archiveItem = VaultListItem(id: "Archive", hasPremium: false, itemType: .group(.archive, 0))
-
-        subject.receive(.itemPressed(item: archiveItem))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.tapAction(title: Localizations.upgradeToPremium)
-        try await waitForAsync { self.coordinator.routes.last == .premiumUpgrade }
-
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-        XCTAssertNil(subject.state.url)
-    }
-
-    /// `receive(_:)` with `.itemPressed` shows archive unavailable alert and opens the web vault
-    /// upgrade URL when the in-app upgrade path is not available.
-    @MainActor
-    func test_receive_itemPressed_archiveGroup_noPremium_noItems_actionTapped_inAppUpgradeDisabled() async throws {
-        billingRepository.isInAppUpgradeAvailableReturnValue = false
-
-        subject.state.hasPremium = false
-        let archiveItem = VaultListItem(id: "Archive", hasPremium: false, itemType: .group(.archive, 0))
-
-        subject.receive(.itemPressed(item: archiveItem))
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, Localizations.archiveUnavailable)
-        XCTAssertEqual(alert.message, Localizations.archivingItemsIsAPremiumFeatureDescriptionLong)
-
-        try await alert.tapAction(title: Localizations.upgradeToPremium)
-        try await waitForAsync { self.subject.state.url != nil }
-
-        XCTAssertEqual(
-            subject.state.url,
-            URL(string: "https://example.com/#/settings/subscription/premium?callToAction=upgradeToPremium"),
-        )
-        XCTAssertNotEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `receive(_:)` with `.itemPressed` navigates to archive when user has premium.
@@ -2334,28 +2211,12 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state, initialState)
     }
 
-    /// `receive(_:)` with `.upgradeToPremium` navigates to the premium upgrade route and
-    /// sets up the billing service status subscription.
+    /// `receive(_:)` with `.upgradeToPremium` delegates to the premium upgrade helper.
     @MainActor
     func test_receive_upgradeToPremium() {
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-
         subject.receive(.upgradeToPremium)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-        XCTAssertTrue(billingService.premiumCheckoutStatusPublisherCalled)
-    }
-
-    /// `receive(_:)` with `.upgradeToPremium` subscribes to the billing service status publisher.
-    @MainActor
-    func test_receive_upgradeToPremium_subscribesToBillingService() {
-        let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
-        billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-
-        subject.receive(.upgradeToPremium)
-
-        XCTAssertTrue(billingService.premiumCheckoutStatusPublisherCalled)
+        XCTAssertTrue(premiumUpgradeHelper.startInAppPremiumUpgradeCalled)
     }
 
     /// `receive(_:)` with `.vaultFilterChanged` updates the state correctly.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -107,21 +107,8 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     /// The helper used to navigate to the premium upgrade flow.
     lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
         services: services,
-        navigateToPremiumRoute: { [weak self] in
-            self?.coordinator.navigate(to: .premiumUpgrade)
-        },
-        setURL: { [weak self] url in
-            self?.state.url = url
-        },
-        navigateToDismiss: { [weak self] action in
-            self?.coordinator.navigate(to: .dismiss(action))
-        },
-        showAlert: { [weak self] alert in
-            self?.coordinator.showAlert(alert)
-        },
-        hideLoadingOverlay: { [weak self] in
-            self?.coordinator.hideLoadingOverlay()
-        },
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
     )
 
     /// The services required by this processor.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -68,9 +68,12 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
 
     typealias Services = HasAPIService
         & HasAuthRepository
+        & HasBillingRepository
+        & HasBillingService
         & HasCameraService
         & HasCardTextParser
         & HasConfigService
+        & HasEnvironmentService
         & HasErrorReporter
         & HasEventService
         & HasFido2UserInterfaceHelper
@@ -100,6 +103,26 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
 
     /// The delegate that is notified when delete cipher item have occurred.
     private weak var delegate: CipherItemOperationDelegate?
+
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        navigateToPremiumRoute: { [weak self] in
+            self?.coordinator.navigate(to: .premiumUpgrade)
+        },
+        setURL: { [weak self] url in
+            self?.state.url = url
+        },
+        navigateToDismiss: { [weak self] action in
+            self?.coordinator.navigate(to: .dismiss(action))
+        },
+        showAlert: { [weak self] alert in
+            self?.coordinator.showAlert(alert)
+        },
+        hideLoadingOverlay: { [weak self] in
+            self?.coordinator.hideLoadingOverlay()
+        },
+    )
 
     /// The services required by this processor.
     private let services: Services
@@ -310,11 +333,18 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     /// Archives a cipher.
     ///
     private func archiveItem() async {
-        await vaultItemActionHelper.archive(cipher: state.cipher) { [weak self] url in
-            self?.state.url = url
+        await vaultItemActionHelper.archive(cipher: state.cipher) { [weak self] in
+            await self?.navigateToPremiumUpgrade()
         } completionHandler: { [weak self, delegate] in
             self?.dismiss { delegate?.itemArchived() }
         }
+    }
+
+    /// Navigates to the premium upgrade flow. Uses the in-app upgrade path when available;
+    /// otherwise opens the web vault upgrade URL as a fallback.
+    ///
+    private func navigateToPremiumUpgrade() async {
+        await premiumUpgradeHelper.navigateToPremiumUpgrade()
     }
 
     /// Dismisses with an action.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -18,6 +18,8 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 
     var authRepository: MockAuthRepository!
     var appExtensionDelegate: MockAppExtensionDelegate!
+    var billingRepository: MockBillingRepository!
+    var billingService: MockBillingService!
     var cameraService: MockCameraService!
     var cardTextParser: MockCardTextParser!
     var client: MockHTTPClient!
@@ -30,6 +32,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     var reviewPromptService: MockReviewPromptService!
     var pasteboardService: MockPasteboardService!
     var policyService: MockPolicyService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var settingsRepository: MockSettingsRepository!
     var stateService: MockStateService!
     var totpService: MockTOTPService!
@@ -46,6 +49,8 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 
         authRepository = MockAuthRepository()
         appExtensionDelegate = MockAppExtensionDelegate()
+        billingRepository = MockBillingRepository()
+        billingService = MockBillingService()
         cameraService = MockCameraService()
         cardTextParser = MockCardTextParser()
         client = MockHTTPClient()
@@ -61,6 +66,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         settingsRepository = MockSettingsRepository()
         stateService = MockStateService()
         totpService = MockTOTPService()
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         vaultItemActionHelper = MockVaultItemActionHelper()
         vaultRepository = MockVaultRepository()
         subject = AddEditItemProcessor(
@@ -69,6 +75,8 @@ class AddEditItemProcessorTests: BitwardenTestCase {
             delegate: delegate,
             services: ServiceContainer.withMocks(
                 authRepository: authRepository,
+                billingRepository: billingRepository,
+                billingService: billingService,
                 cameraService: cameraService,
                 cardTextParser: cardTextParser,
                 configService: configService,
@@ -96,12 +104,15 @@ class AddEditItemProcessorTests: BitwardenTestCase {
             ),
             vaultItemActionHelper: vaultItemActionHelper,
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
         super.tearDown()
         authRepository = nil
         appExtensionDelegate = nil
+        billingRepository = nil
+        billingService = nil
         cameraService = nil
         cardTextParser = nil
         client = nil
@@ -739,9 +750,9 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertEqual(vaultItemActionHelper.archiveReceivedArguments?.cipher.id, "123")
     }
 
-    /// `perform(_:)` with `.archivedPressed` handles URL opening and completion.
+    /// `perform(_:)` with `.archivedPressed` delegates to the premium upgrade helper.
     @MainActor
-    func test_perform_archivedPressed_withURLAndCompletion() async {
+    func test_perform_archivedPressed_navigateToPremiumUpgrade() async {
         subject.state = CipherItemState(
             existing: .loginFixture(id: "123"),
             hasPremium: false,
@@ -750,12 +761,24 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         await subject.perform(.archivedPressed)
 
         XCTAssertEqual(vaultItemActionHelper.archiveCalled, true)
-        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.handleOpenURL)
-        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.completionHandler)
+        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.handleNavigateToPremiumUpgrade)
 
-        let testURL = URL(string: "https://vault.bitwarden.com")!
-        vaultItemActionHelper.archiveReceivedArguments?.handleOpenURL(testURL)
-        XCTAssertEqual(subject.state.url, testURL)
+        await vaultItemActionHelper.archiveReceivedArguments?.handleNavigateToPremiumUpgrade()
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
+    }
+
+    /// `perform(_:)` with `.archivedPressed` handles completion.
+    @MainActor
+    func test_perform_archivedPressed_withCompletion() async {
+        subject.state = CipherItemState(
+            existing: .loginFixture(id: "123"),
+            hasPremium: false,
+        )!
+
+        await subject.perform(.archivedPressed)
+
+        XCTAssertEqual(vaultItemActionHelper.archiveCalled, true)
+        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.completionHandler)
 
         vaultItemActionHelper.archiveReceivedArguments?.completionHandler()
 

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
@@ -69,9 +69,7 @@ class DefaultVaultItemActionHelper: VaultItemActionHelper {
         guard await services.vaultRepository.doesActiveAccountHavePremium() else {
             await coordinator.showAlert(
                 Alert.archiveUnavailable(action: {
-                    Task { @MainActor in
-                        await handleNavigateToPremiumUpgrade()
-                    }
+                    await handleNavigateToPremiumUpgrade()
                 }),
             )
             return

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
@@ -9,11 +9,11 @@ protocol VaultItemActionHelper { // sourcery: AutoMockable
     ///
     /// - Parameters:
     ///   - cipher: The cipher to archive.
-    ///   - handleOpenURL: A closure to open a link.
+    ///   - handleNavigateToPremiumUpgrade: A closure called to navigate to the premium upgrade flow.
     ///   - completionHandler: The closure to execute when completing the archive process.
     func archive(
         cipher: CipherView,
-        handleOpenURL: @escaping (URL) -> Void,
+        handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         completionHandler: @escaping () -> Void,
     ) async
 
@@ -32,8 +32,7 @@ protocol VaultItemActionHelper { // sourcery: AutoMockable
 class DefaultVaultItemActionHelper: VaultItemActionHelper {
     // MARK: Types
 
-    typealias Services = HasEnvironmentService
-        & HasErrorReporter
+    typealias Services = HasErrorReporter
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -64,14 +63,15 @@ class DefaultVaultItemActionHelper: VaultItemActionHelper {
 
     func archive(
         cipher: CipherView,
-        handleOpenURL: @escaping (URL) -> Void,
+        handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         completionHandler: @escaping () -> Void,
     ) async {
         guard await services.vaultRepository.doesActiveAccountHavePremium() else {
             await coordinator.showAlert(
-                Alert.archiveUnavailable(action: { [weak self] in
-                    guard let self else { return }
-                    handleOpenURL(services.environmentService.upgradeToPremiumURL)
+                Alert.archiveUnavailable(action: {
+                    Task {
+                        await handleNavigateToPremiumUpgrade()
+                    }
                 }),
             )
             return

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelper.swift
@@ -69,7 +69,7 @@ class DefaultVaultItemActionHelper: VaultItemActionHelper {
         guard await services.vaultRepository.doesActiveAccountHavePremium() else {
             await coordinator.showAlert(
                 Alert.archiveUnavailable(action: {
-                    Task {
+                    Task { @MainActor in
                         await handleNavigateToPremiumUpgrade()
                     }
                 }),

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -59,8 +59,6 @@ struct VaultItemActionHelperTests {
         #expect(!completionCalled)
 
         try await alert.tapAction(title: Localizations.upgradeToPremium)
-        // The alert action fires a Task; yield to let it complete.
-        await Task.yield()
         #expect(navigatedToPremiumUpgrade)
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemActionHelperTests.swift
@@ -15,7 +15,6 @@ struct VaultItemActionHelperTests {
     // MARK: Properties
 
     let coordinator: MockCoordinator<VaultItemRoute, VaultItemEvent>
-    let environmentService: MockEnvironmentService
     let errorReporter: MockErrorReporter
     let vaultRepository: MockVaultRepository
     let subject: VaultItemActionHelper
@@ -24,13 +23,11 @@ struct VaultItemActionHelperTests {
 
     init() {
         coordinator = MockCoordinator<VaultItemRoute, VaultItemEvent>()
-        environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         vaultRepository = MockVaultRepository()
         subject = DefaultVaultItemActionHelper(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
-                environmentService: environmentService,
                 errorReporter: errorReporter,
                 vaultRepository: vaultRepository,
             ),
@@ -39,22 +36,19 @@ struct VaultItemActionHelperTests {
 
     // MARK: Tests
 
-    /// `archive(cipher:handleOpenURL:completionHandler:)` shows the archive unavailable alert
-    /// when the user does not have premium.
+    /// `archive(cipher:handleNavigateToPremiumUpgrade:completionHandler:)` shows the archive
+    /// unavailable alert when the user does not have premium.
     @Test
     func archive_noPremium() async throws {
-        var openedURL: URL?
+        var navigatedToPremiumUpgrade = false
         var completionCalled = false
         let cipher = CipherView.loginFixture(id: "123")
 
         vaultRepository.doesActiveAccountHavePremiumResult = false
-        environmentService.upgradeToPremiumURL = URL(
-            string: "https://example.com/someURLToUpgradeToPremium",
-        )!
 
         await subject.archive(
             cipher: cipher,
-            handleOpenURL: { openedURL = $0 },
+            handleNavigateToPremiumUpgrade: { navigatedToPremiumUpgrade = true },
             completionHandler: { completionCalled = true },
         )
 
@@ -65,11 +59,13 @@ struct VaultItemActionHelperTests {
         #expect(!completionCalled)
 
         try await alert.tapAction(title: Localizations.upgradeToPremium)
-        #expect(openedURL == URL(string: "https://example.com/someURLToUpgradeToPremium"))
+        // The alert action fires a Task; yield to let it complete.
+        await Task.yield()
+        #expect(navigatedToPremiumUpgrade)
     }
 
-    /// `archive(cipher:handleOpenURL:completionHandler:)` shows the confirmation alert and
-    /// archives the cipher when the user has premium and confirms.
+    /// `archive(cipher:handleNavigateToPremiumUpgrade:completionHandler:)` shows the confirmation
+    /// alert and archives the cipher when the user has premium and confirms.
     @Test
     func archive_success() async throws {
         var completionCalled = false
@@ -79,7 +75,7 @@ struct VaultItemActionHelperTests {
 
         await subject.archive(
             cipher: cipher,
-            handleOpenURL: { _ in },
+            handleNavigateToPremiumUpgrade: {},
             completionHandler: { completionCalled = true },
         )
 
@@ -97,8 +93,8 @@ struct VaultItemActionHelperTests {
         #expect(errorReporter.errors.isEmpty)
     }
 
-    /// `archive(cipher:handleOpenURL:completionHandler:)` does not archive when the user cancels
-    /// the confirmation alert.
+    /// `archive(cipher:handleNavigateToPremiumUpgrade:completionHandler:)` does not archive when
+    /// the user cancels the confirmation alert.
     @Test
     func archive_confirmationCancel() async throws {
         var completionCalled = false
@@ -108,7 +104,7 @@ struct VaultItemActionHelperTests {
 
         await subject.archive(
             cipher: cipher,
-            handleOpenURL: { _ in },
+            handleNavigateToPremiumUpgrade: {},
             completionHandler: { completionCalled = true },
         )
 
@@ -121,7 +117,8 @@ struct VaultItemActionHelperTests {
         #expect(!completionCalled)
     }
 
-    /// `archive(cipher:handleOpenURL:completionHandler:)` shows an error alert when archiving fails.
+    /// `archive(cipher:handleNavigateToPremiumUpgrade:completionHandler:)` shows an error alert
+    /// when archiving fails.
     @Test
     func archive_error() async throws {
         var completionCalled = false
@@ -132,7 +129,7 @@ struct VaultItemActionHelperTests {
 
         await subject.archive(
             cipher: cipher,
-            handleOpenURL: { _ in },
+            handleNavigateToPremiumUpgrade: {},
             completionHandler: { completionCalled = true },
         )
 

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinator.swift
@@ -12,6 +12,7 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
     // MARK: Types
 
     typealias Module = AddEditFolderModule
+        & BillingModule
         & FileSelectionModule
         & GeneratorModule
         & NavigatorBuilderModule
@@ -23,6 +24,8 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
         & HasAPIService
         & HasAppContextHelper
         & HasAuthRepository
+        & HasBillingRepository
+        & HasBillingService
         & HasCardTextParser
         & HasConfigService
         & HasEnvironmentService
@@ -138,6 +141,8 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
             showMoveToOrganization(cipher: cipher, delegate: context as? MoveToOrganizationProcessorDelegate)
         case let .passwordHistory(passwordHistory):
             showPasswordHistory(passwordHistory)
+        case .premiumUpgrade:
+            showPremiumUpgrade()
         case let .saveFile(temporaryUrl):
             showSaveFile(temporaryUrl)
         case .setupTotpManual:
@@ -445,6 +450,15 @@ class VaultItemCoordinator: NSObject, Coordinator, HasStackNavigator { // swiftl
         let coordinator = module.makePasswordHistoryCoordinator(stackNavigator: navigationController)
         coordinator.start()
         coordinator.navigate(to: .passwordHistoryList(.item(passwordHistory)))
+        stackNavigator?.present(navigationController)
+    }
+
+    /// Shows the premium upgrade screen.
+    ///
+    private func showPremiumUpgrade() {
+        let navigationController = module.makeNavigationController()
+        let coordinator = module.makeBillingCoordinator(stackNavigator: navigationController)
+        coordinator.navigate(to: .premiumUpgrade)
         stackNavigator?.present(navigationController)
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemCoordinatorTests.swift
@@ -446,6 +446,16 @@ class VaultItemCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(module.passwordHistoryCoordinator.routes.last, .passwordHistoryList(.item([.fixture()])))
     }
 
+    /// `navigate(to:)` with `.premiumUpgrade` presents the billing coordinator at the premium upgrade route.
+    @MainActor
+    func test_navigateTo_premiumUpgrade() throws {
+        subject.navigate(to: .premiumUpgrade)
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertEqual(module.billingCoordinator.routes, [.premiumUpgrade])
+    }
+
     /// `navigate(to:)` with `.setupTotpCamera` with context without conformance fails to present.
     @MainActor
     func test_navigateTo_setupTotpCamera_noConformance() async throws {

--- a/BitwardenShared/UI/Vault/VaultItem/VaultItemRoute.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/VaultItemRoute.swift
@@ -85,6 +85,9 @@ enum VaultItemRoute: Equatable, Hashable {
     ///
     case passwordHistory(_ passwordHistory: [PasswordHistoryView])
 
+    /// A route to the premium upgrade screen.
+    case premiumUpgrade
+
     /// A route to the file saving view.
     ///
     /// - Parameter temporaryUrl: The url where the file is currently stored.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -12,6 +12,8 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
 
     typealias Services = HasAPIService
         & HasAuthRepository
+        & HasBillingRepository
+        & HasBillingService
         & HasEnvironmentService
         & HasErrorReporter
         & HasEventService
@@ -56,6 +58,26 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
 
     /// The services used by this processor.
     private let services: Services
+
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        navigateToPremiumRoute: { [weak self] in
+            self?.coordinator.navigate(to: .premiumUpgrade)
+        },
+        setURL: { [weak self] url in
+            self?.state.url = url
+        },
+        navigateToDismiss: { [weak self] action in
+            self?.coordinator.navigate(to: .dismiss(action))
+        },
+        showAlert: { [weak self] alert in
+            self?.coordinator.showAlert(alert)
+        },
+        hideLoadingOverlay: { [weak self] in
+            self?.coordinator.hideLoadingOverlay()
+        },
+    )
 
     /// The task that streams cipher details.
     private(set) var streamCipherDetailsTask: Task<Void, Never>?
@@ -223,11 +245,18 @@ private extension ViewItemProcessor {
     ///
     private func archiveItem() async {
         guard case let .data(cipherState) = state.loadingState else { return }
-        await vaultItemActionHelper.archive(cipher: cipherState.cipher) { [weak self] url in
-            self?.state.url = url
+        await vaultItemActionHelper.archive(cipher: cipherState.cipher) { [weak self] in
+            await self?.navigateToPremiumUpgrade()
         } completionHandler: { [weak self, delegate] in
             self?.dismiss { delegate?.itemArchived() }
         }
+    }
+
+    /// Navigates to the premium upgrade flow. Uses the in-app upgrade path when available;
+    /// otherwise opens the web vault upgrade URL as a fallback.
+    ///
+    private func navigateToPremiumUpgrade() async {
+        await premiumUpgradeHelper.navigateToPremiumUpgrade()
     }
 
     /// Navigates to the clone item view. If the cipher contains FIDO2 credentials, an alert is

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -62,21 +62,8 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
     /// The helper used to navigate to the premium upgrade flow.
     lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
         services: services,
-        navigateToPremiumRoute: { [weak self] in
-            self?.coordinator.navigate(to: .premiumUpgrade)
-        },
-        setURL: { [weak self] url in
-            self?.state.url = url
-        },
-        navigateToDismiss: { [weak self] action in
-            self?.coordinator.navigate(to: .dismiss(action))
-        },
-        showAlert: { [weak self] alert in
-            self?.coordinator.showAlert(alert)
-        },
-        hideLoadingOverlay: { [weak self] in
-            self?.coordinator.hideLoadingOverlay()
-        },
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
     )
 
     /// The task that streams cipher details.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -14,6 +14,8 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     // MARK: Properties
 
     var authRepository: MockAuthRepository!
+    var billingRepository: MockBillingRepository!
+    var billingService: MockBillingService!
     var client: MockHTTPClient!
     var configService: MockConfigService!
     var coordinator: MockCoordinator<VaultItemRoute, VaultItemEvent>!
@@ -21,6 +23,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     var errorReporter: MockErrorReporter!
     var eventService: MockEventService!
     var pasteboardService: MockPasteboardService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var rehydrationHelper: MockRehydrationHelper!
     var stateService: MockStateService!
     var subject: ViewItemProcessor!
@@ -32,6 +35,8 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     override func setUp() {
         super.setUp()
         authRepository = MockAuthRepository()
+        billingRepository = MockBillingRepository()
+        billingService = MockBillingService()
         client = MockHTTPClient()
         configService = MockConfigService()
         coordinator = MockCoordinator<VaultItemRoute, VaultItemEvent>()
@@ -41,10 +46,13 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         pasteboardService = MockPasteboardService()
         rehydrationHelper = MockRehydrationHelper()
         stateService = MockStateService()
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         vaultItemActionHelper = MockVaultItemActionHelper()
         vaultRepository = MockVaultRepository()
         let services = ServiceContainer.withMocks(
             authRepository: authRepository,
+            billingRepository: billingRepository,
+            billingService: billingService,
             configService: configService,
             errorReporter: errorReporter,
             eventService: eventService,
@@ -62,11 +70,14 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             state: ViewItemState(),
             vaultItemActionHelper: vaultItemActionHelper,
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
         super.tearDown()
         authRepository = nil
+        billingRepository = nil
+        billingService = nil
         client = nil
         coordinator = nil
         errorReporter = nil
@@ -795,9 +806,9 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(vaultItemActionHelper.archiveReceivedArguments?.cipher.id, "123")
     }
 
-    /// `perform(_:)` with `.archivedPressed` handles URL opening and completion.
+    /// `perform(_:)` with `.archivedPressed` delegates to the premium upgrade helper.
     @MainActor
-    func test_perform_archivedPressed_withURLAndCompletion() async {
+    func test_perform_archivedPressed_navigateToPremiumUpgrade() async {
         let cipherState = CipherItemState(
             existing: CipherView.loginFixture(id: "123"),
             hasPremium: false,
@@ -811,12 +822,29 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await subject.perform(.archivedPressed)
 
         XCTAssertEqual(vaultItemActionHelper.archiveCalled, true)
-        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.handleOpenURL)
-        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.completionHandler)
+        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.handleNavigateToPremiumUpgrade)
 
-        let testURL = URL(string: "https://vault.bitwarden.com")!
-        vaultItemActionHelper.archiveReceivedArguments?.handleOpenURL(testURL)
-        XCTAssertEqual(subject.state.url, testURL)
+        await vaultItemActionHelper.archiveReceivedArguments?.handleNavigateToPremiumUpgrade()
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
+    }
+
+    /// `perform(_:)` with `.archivedPressed` handles completion.
+    @MainActor
+    func test_perform_archivedPressed_withCompletion() async {
+        let cipherState = CipherItemState(
+            existing: CipherView.loginFixture(id: "123"),
+            hasPremium: false,
+        )!
+
+        let state = ViewItemState(
+            loadingState: .data(cipherState),
+        )
+        subject.state = state
+
+        await subject.perform(.archivedPressed)
+
+        XCTAssertEqual(vaultItemActionHelper.archiveCalled, true)
+        XCTAssertNotNil(vaultItemActionHelper.archiveReceivedArguments?.completionHandler)
 
         vaultItemActionHelper.archiveReceivedArguments?.completionHandler()
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37253

## 📔 Objective

Introduces `DefaultPremiumUpgradeHelper` in `UI/Billing/` to eliminate the duplicated premium upgrade navigation pattern across five processors (`VaultListProcessor`, `VaultGroupProcessor`, `VaultItemSelectionProcessor`, `ViewItemProcessor`, `AddEditItemProcessor`).

Also fixes `DefaultVaultItemActionHelper.archive()` to route through `handleNavigateToPremiumUpgrade` instead of always opening the web vault URL, and adds a `.premiumUpgrade` route to `VaultItemRoute` / `VaultItemCoordinator` so the view/edit-item screens can present the billing upgrade screen.

**Key changes:**
- New `PremiumUpgradeHelper` protocol + `DefaultPremiumUpgradeHelper` in `UI/Billing/` with `navigateToPremiumUpgrade(onConfirmed:)` and `startInAppPremiumUpgrade(onConfirmed:)`
- `DefaultVaultItemActionHelper.archive()`: replaces `handleOpenURL` with `handleNavigateToPremiumUpgrade` so the archive unavailable alert uses the in-app flow
- `VaultItemRoute` + `VaultItemCoordinator`: adds `.premiumUpgrade` route for view/edit-item screens
- All five processors delegate to the helper via a `lazy var premiumUpgradeHelper`; per-processor `subscribeToPremiumCheckoutStatus` and `premiumStatusChangedCancellable` removed
- `PremiumUpgradeHelperTests` covers the full availability-check, subscribe, confirmed, pending, and syncing paths in one place