### PR TITLE
[PM-35435] ci: Stop applying Change Type labels based on changed files

### DIFF
--- a/.github/label-pr.json
+++ b/.github/label-pr.json
@@ -42,44 +42,6 @@
       "AuthenticatorShared/",
       "project-bwa.yml",
       "swiftgen-bwa.yml"
-    ],
-    "t:feature": [
-      "TestHarness/",
-      "TestHarnessShared/",
-      "project-bwth.yml",
-      "swiftgen-bwth.yml"
-    ],
-    "t:ci": [
-      ".checkmarx/",
-      ".github/",
-      "Configs/",
-      "Configs-bwa/",
-      "Scripts/",
-      "Scripts-bwa/",
-      "fastlane/",
-      "crowdin.yml"
-    ],
-    "t:docs": [
-      "Docs/"
-    ],
-    "t:deps": [
-      "Brewfile",
-      "Gemfile",
-      "Gemfile.lock",
-      "Mintfile",
-      "Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved"
-    ],
-    "t:misc": [
-      "GlobalTestHelpers/",
-      "GlobalTestHelpers-bwa/",
-      "GlobalTestHelpers-bwth/",
-      "Sourcery/",
-      "TestHelpers/",
-      "TestPlans/",
-      "ViewInspectorTestHelpers/"
-    ],
-    "t:llm": [
-      ".claude/"
     ]
   }
 }


### PR DESCRIPTION
## 🎟️ Tracking

PM-35435

## 📔 Objective

Based on team feedback we’ll stop applying Change Type (t:) labels based on changed files. 

This decision was made based on:

1. Single Change Type label t: restriction, enforced by our Enforce Labels workflow, given that GitHub Release Notes Categories will only list a given PR in a single category.
2. Title convention has been the preferred option for the team.
3. Matching changed files leading to multiple labels being matched introducing unnecessary friction for the team.
