### PR TITLE
[PM-37604] tool: Add fix-ellipsis subcommand to fix-localizable-strings

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -381,7 +381,7 @@
 "MasterPasswordPolicyValidationTitle" = "Invalid password";
 "MasterPasswordPolicyValidationMessage" = "Password does not meet organization requirements. Please check the policy information and try again.";
 "Loading" = "Loading";
-"LoadingSubscription" = "Loading subscription...";
+"LoadingSubscription" = "Loading subscription…";
 "AcceptPoliciesError" = "Terms of Service and Privacy Policy have not been acknowledged.";
 "PrivacyPolicy" = "Privacy Policy";
 "PersonalOwnershipPolicyInEffect" = "An organization policy is affecting your ownership options.";

--- a/Scripts/fix-localizable-strings.sh
+++ b/Scripts/fix-localizable-strings.sh
@@ -44,6 +44,7 @@ done
 for strings_file in "${STRINGS_FILES[@]}"; do
     echo "${strings_file}"
     python3 "${PYTHON}" delete-duplicates --strings "${REPO_ROOT}/${strings_file}" "$@"
+    python3 "${PYTHON}" fix-ellipsis --strings "${REPO_ROOT}/${strings_file}" "$@"
     # delete-unused only applies to the main Localizable.strings because it works
     # by scanning for Localizations.X references, which maps exclusively to the
     # SwiftGen-generated Localizations enum produced from that file. The other

--- a/Scripts/fix-localizable-strings/fix_ellipsis.py
+++ b/Scripts/fix-localizable-strings/fix_ellipsis.py
@@ -1,0 +1,77 @@
+"""
+fix_ellipsis
+
+Converts literal three-dot sequences (...) to the Unicode ellipsis character (…)
+in the values of Localizable.strings entries.
+"""
+
+import re
+
+# Matches a complete key/value entry line, capturing key and value separately.
+_ENTRY_VALUE_RE = re.compile(
+    r'^\s*"(?P<key>(?:[^"\\]|\\.)*)"'
+    r'\s*=\s*"'
+    r'(?P<value>(?:[^"\\]|\\.)*)'
+    r'"\s*;\s*$'
+)
+
+
+def fix_ellipsis(content: str) -> tuple[str, list[str]]:
+    """Replace three-dot sequences (...) with the Unicode ellipsis character (…)
+    in the values of Localizable.strings content.
+
+    Only the value portion of each entry is modified. Keys, comments, and blank
+    lines are passed through unchanged. Replacement is performed via character-
+    position slicing so the rest of each line (indentation, spacing, newline) is
+    preserved exactly.
+
+    Args:
+        content: The full text of the ``.strings`` file.
+
+    Returns:
+        A tuple of ``(new_content, changed_keys)`` where ``new_content`` is the
+        updated file text and ``changed_keys`` is a list of keys whose values
+        were modified, in the order they were encountered.
+    """
+    lines = content.splitlines(keepends=True)
+    output: list[str] = []
+    changed_keys: list[str] = []
+
+    for line in lines:
+        m = _ENTRY_VALUE_RE.match(line)
+        if m and "..." in m.group("value"):
+            start = m.start("value")
+            end = m.end("value")
+            new_value = m.group("value").replace("...", "…")
+            output.append(line[:start] + new_value + line[end:])
+            changed_keys.append(m.group("key"))
+        else:
+            output.append(line)
+
+    return "".join(output), changed_keys
+
+
+def fix_ellipsis_file(strings_path: str) -> list[str]:
+    """Replace three-dot sequences with … in a Localizable.strings file in place.
+
+    Reads the file, applies the conversion, and writes back only if changes were
+    made (preserving the original file modification time when there is nothing to
+    change).
+
+    Args:
+        strings_path: Path to the ``.strings`` file to process.
+
+    Returns:
+        A list of keys whose values were modified, in the order they were
+        encountered. Returns an empty list if no changes were made.
+    """
+    with open(strings_path, encoding="utf-8") as f:
+        content = f.read()
+
+    new_content, changed = fix_ellipsis(content)
+
+    if changed:
+        with open(strings_path, "w", encoding="utf-8") as f:
+            f.write(new_content)
+
+    return changed

--- a/Scripts/fix-localizable-strings/main.py
+++ b/Scripts/fix-localizable-strings/main.py
@@ -13,6 +13,10 @@ Usage:
         --strings <path/to/Localizable.strings> \\
         --swift-source <dir> [--swift-source <dir> ...] \\
         [--dry-run]
+
+    python Scripts/fix-localizable-strings/main.py fix-ellipsis \\
+        --strings <path/to/Localizable.strings> \\
+        [--dry-run]
 """
 
 import argparse
@@ -21,6 +25,7 @@ import sys
 
 from delete_duplicate_strings import delete_duplicates, deduplicate
 from delete_unused_strings import delete_unused, delete_unused_content, find_used_keys
+from fix_ellipsis import fix_ellipsis, fix_ellipsis_file
 
 
 def _pluralize(count: int, singular: str, plural: str) -> str:
@@ -85,6 +90,31 @@ def cmd_delete_unused(args: argparse.Namespace) -> None:
         print(f"    {key}")
 
 
+def cmd_fix_ellipsis(args: argparse.Namespace) -> None:
+    if args.dry_run:
+        with open(args.strings, encoding="utf-8") as f:
+            content = f.read()
+        _, changed = fix_ellipsis(content)
+        if not changed:
+            print("  No three-dot sequences found.")
+            return
+        noun = _pluralize(len(changed), "entry", "entries")
+        print(f"  Found {len(changed)} {noun} with three-dot sequences:")
+        for key in changed:
+            print(f"    {key}")
+        print("\n  Dry run — no changes written.")
+        return
+
+    changed = fix_ellipsis_file(args.strings)
+    if not changed:
+        print("  No three-dot sequences found.")
+        return
+    noun = _pluralize(len(changed), "entry", "entries")
+    print(f"  Fixed {len(changed)} {noun} with three-dot sequences:")
+    for key in changed:
+        print(f"    {key}")
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         description="Tools for maintaining Localizable.strings files."
@@ -131,6 +161,22 @@ def build_parser():
         help="Report unused keys without modifying the strings file.",
     )
 
+    ellipsis_parser = subparsers.add_parser(
+        "fix-ellipsis",
+        help="Replace three-dot sequences (...) with the Unicode ellipsis character (…) in string values.",
+    )
+    ellipsis_parser.add_argument(
+        "--strings",
+        required=True,
+        metavar="PATH",
+        help="Path to the Localizable.strings file to process.",
+    )
+    ellipsis_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Report affected entries without modifying the strings file.",
+    )
+
     return parser
 
 
@@ -142,6 +188,8 @@ def main():
         cmd_delete_duplicates(args)
     elif args.command == "delete-unused":
         cmd_delete_unused(args)
+    elif args.command == "fix-ellipsis":
+        cmd_fix_ellipsis(args)
     else:
         parser.print_help()
         sys.exit(1)

--- a/Scripts/fix-localizable-strings/tests/test_fix_ellipsis.py
+++ b/Scripts/fix-localizable-strings/tests/test_fix_ellipsis.py
@@ -79,15 +79,6 @@ class TestFixEllipsisConverts(unittest.TestCase):
         self.assertEqual(result, expected)
         self.assertEqual(changed, ["loading"])
 
-    def test_sentinel_entry_without_ellipsis_is_preserved(self):
-        # The "sentinel" entry has no ... and must survive completely unchanged.
-        content = (
-            '"sentinel" = "Sentinel value";\n'
-            '"loading" = "Loading...";\n'
-        )
-        result, _ = fix_ellipsis(content)
-        self.assertIn('"sentinel" = "Sentinel value";', result)
-
     def test_multiple_affected_entries_all_converted(self):
         content = (
             '"a" = "First...";\n'
@@ -168,11 +159,6 @@ class TestFixEllipsisKeyPreservation(unittest.TestCase):
 class TestFixEllipsisReturnedKeys(unittest.TestCase):
     """Verify the changed keys list is correct."""
 
-    def test_empty_list_when_no_changes(self):
-        content = '"a" = "A";\n"b" = "B";\n'
-        _, changed = fix_ellipsis(content)
-        self.assertEqual(changed, [])
-
     def test_changed_keys_are_in_encounter_order(self):
         content = (
             '"x" = "X...";\n'
@@ -181,18 +167,6 @@ class TestFixEllipsisReturnedKeys(unittest.TestCase):
         )
         _, changed = fix_ellipsis(content)
         self.assertEqual(changed, ["x", "z"])
-
-    def test_each_affected_entry_appears_once_in_changed_list(self):
-        content = (
-            '"a" = "A...";\n'
-            '"b" = "B...";\n'
-            '"c" = "C";\n'
-        )
-        _, changed = fix_ellipsis(content)
-        self.assertEqual(len(changed), 2)
-        self.assertIn("a", changed)
-        self.assertIn("b", changed)
-
 
 class TestFixEllipsisFileIO(unittest.TestCase):
     """Integration tests for the file I/O wrapper."""

--- a/Scripts/fix-localizable-strings/tests/test_fix_ellipsis.py
+++ b/Scripts/fix-localizable-strings/tests/test_fix_ellipsis.py
@@ -1,0 +1,236 @@
+"""Tests for the fix_ellipsis module."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from fix_ellipsis import fix_ellipsis, fix_ellipsis_file
+
+
+class TestFixEllipsisNoOp(unittest.TestCase):
+    """Cases where the file has no three-dot sequences and should be unchanged."""
+
+    def test_empty_file_is_unchanged(self):
+        content = ""
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_file_with_no_ellipsis_is_unchanged(self):
+        content = '"greeting" = "Hello";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_multiple_entries_without_ellipsis_are_unchanged(self):
+        content = (
+            '"alpha" = "First";\n'
+            '"beta" = "Second";\n'
+            '"gamma" = "Third";\n'
+        )
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_comment_only_file_is_unchanged(self):
+        content = "/* This file is intentionally left blank. */\n"
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_file_with_only_blank_lines_is_unchanged(self):
+        content = "\n\n\n"
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_already_unicode_ellipsis_is_unchanged(self):
+        content = '"loading" = "Loading…";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+
+class TestFixEllipsisConverts(unittest.TestCase):
+    """Cases where three-dot sequences are converted."""
+
+    def test_single_entry_with_ellipsis_is_converted(self):
+        content = '"loading" = "Loading...";\n'
+        expected = '"loading" = "Loading…";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["loading"])
+
+    def test_multiple_entries_only_affected_ones_change(self):
+        content = (
+            '"title" = "Title";\n'
+            '"loading" = "Loading...";\n'
+            '"done" = "Done";\n'
+        )
+        expected = (
+            '"title" = "Title";\n'
+            '"loading" = "Loading…";\n'
+            '"done" = "Done";\n'
+        )
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["loading"])
+
+    def test_sentinel_entry_without_ellipsis_is_preserved(self):
+        # The "sentinel" entry has no ... and must survive completely unchanged.
+        content = (
+            '"sentinel" = "Sentinel value";\n'
+            '"loading" = "Loading...";\n'
+        )
+        result, _ = fix_ellipsis(content)
+        self.assertIn('"sentinel" = "Sentinel value";', result)
+
+    def test_multiple_affected_entries_all_converted(self):
+        content = (
+            '"a" = "First...";\n'
+            '"b" = "Second...";\n'
+        )
+        expected = (
+            '"a" = "First…";\n'
+            '"b" = "Second…";\n'
+        )
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["a", "b"])
+
+    def test_ellipsis_in_middle_of_value_is_converted(self):
+        content = '"message" = "Wait...done";\n'
+        expected = '"message" = "Wait…done";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["message"])
+
+    def test_value_that_is_only_ellipsis_is_converted(self):
+        content = '"placeholder" = "...";\n'
+        expected = '"placeholder" = "…";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["placeholder"])
+
+
+class TestFixEllipsisBoundary(unittest.TestCase):
+    """Boundary cases for dot sequences."""
+
+    def test_four_dots_becomes_ellipsis_plus_dot(self):
+        content = '"key" = "....";\n'
+        expected = '"key" = "….";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["key"])
+
+    def test_six_dots_becomes_two_ellipses(self):
+        content = '"key" = "......";\n'
+        expected = '"key" = "……";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, expected)
+        self.assertEqual(changed, ["key"])
+
+    def test_two_dots_is_unchanged(self):
+        content = '"key" = "..";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_one_dot_is_unchanged(self):
+        content = '"key" = ".";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+
+class TestFixEllipsisKeyPreservation(unittest.TestCase):
+    """The key side of an entry is never modified."""
+
+    def test_key_containing_dots_is_not_converted(self):
+        # The key itself looks like it has dots, but the value does not.
+        # The key should pass through unchanged.
+        content = '"key...name" = "Value";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertEqual(result, content)
+        self.assertEqual(changed, [])
+
+    def test_key_with_dots_and_value_with_dots_only_value_changes(self):
+        content = '"key...name" = "Value...";\n'
+        result, changed = fix_ellipsis(content)
+        self.assertIn('"key...name"', result)
+        self.assertIn('"Value…"', result)
+        self.assertEqual(changed, ["key...name"])
+
+
+class TestFixEllipsisReturnedKeys(unittest.TestCase):
+    """Verify the changed keys list is correct."""
+
+    def test_empty_list_when_no_changes(self):
+        content = '"a" = "A";\n"b" = "B";\n'
+        _, changed = fix_ellipsis(content)
+        self.assertEqual(changed, [])
+
+    def test_changed_keys_are_in_encounter_order(self):
+        content = (
+            '"x" = "X...";\n'
+            '"y" = "Y";\n'
+            '"z" = "Z...";\n'
+        )
+        _, changed = fix_ellipsis(content)
+        self.assertEqual(changed, ["x", "z"])
+
+    def test_each_affected_entry_appears_once_in_changed_list(self):
+        content = (
+            '"a" = "A...";\n'
+            '"b" = "B...";\n'
+            '"c" = "C";\n'
+        )
+        _, changed = fix_ellipsis(content)
+        self.assertEqual(len(changed), 2)
+        self.assertIn("a", changed)
+        self.assertIn("b", changed)
+
+
+class TestFixEllipsisFileIO(unittest.TestCase):
+    """Integration tests for the file I/O wrapper."""
+
+    def _write(self, content: str) -> str:
+        f = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".strings", delete=False, encoding="utf-8"
+        )
+        f.write(content)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def test_modifies_file_in_place(self):
+        path = self._write('"loading" = "Loading...";\n')
+        fix_ellipsis_file(path)
+        with open(path, encoding="utf-8") as f:
+            result = f.read()
+        self.assertEqual(result, '"loading" = "Loading…";\n')
+
+    def test_returns_changed_keys(self):
+        path = self._write('"loading" = "Loading...";\n')
+        changed = fix_ellipsis_file(path)
+        self.assertEqual(changed, ["loading"])
+
+    def test_does_not_write_file_when_no_ellipsis_found(self):
+        path = self._write('"greeting" = "Hello";\n')
+        mtime_before = os.path.getmtime(path)
+        changed = fix_ellipsis_file(path)
+        mtime_after = os.path.getmtime(path)
+        self.assertEqual(changed, [])
+        self.assertEqual(mtime_before, mtime_after)
+
+    def test_returns_empty_list_when_no_changes(self):
+        path = self._write('"a" = "A";\n"b" = "B";\n')
+        changed = fix_ellipsis_file(path)
+        self.assertEqual(changed, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37604

## 📔 Objective

Adds a `fix-ellipsis` subcommand to the `fix-localizable-strings` script toolchain. The new module detects and converts three-dot sequences (`...`) in Localizable.strings values to the proper Unicode ellipsis character (`…`), matching existing style in our strings files.

The subcommand is wired into `fix-localizable-strings.sh` and runs against all English `.strings` files. Also fixes the one existing offender found in `BitwardenResources/Localizations/en.lproj/Localizable.strings` (`LoadingSubscription`).