### PR TITLE
[PM-37642] feat: Add debug menu flag to disable self-host premium checks

### DIFF
--- a/BitwardenShared/Core/Billing/Services/BillingService.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingService.swift
@@ -42,6 +42,11 @@ protocol BillingService: AnyObject { // sourcery: AutoMockable
     ///
     func premiumCheckoutStatusPublisher() -> AnyPublisher<PremiumCheckoutStatus, Never>
 
+    /// Returns whether the current environment is effectively self-hosted for premium upgrade checks.
+    /// Returns `false` when the debug override flag is enabled, regardless of the actual region.
+    ///
+    func isSelfHosted() async -> Bool
+
     /// Notifies that a premium status change was detected (via deep link or push notification),
     /// triggers a sync, and publishes status updates.
     ///
@@ -147,6 +152,11 @@ class DefaultBillingService: BillingService {
         premiumCheckoutStatusSubject.send(nil)
     }
 
+    func isSelfHosted() async -> Bool {
+        guard environmentService.region == .selfHosted else { return false }
+        return await !configService.getFeatureFlag(.debugDisableSelfHostPremiumCheck)
+    }
+
     func premiumCheckoutStatusPublisher() -> AnyPublisher<PremiumCheckoutStatus, Never> {
         premiumCheckoutStatusSubject
             .compactMap(\.self)
@@ -155,7 +165,7 @@ class DefaultBillingService: BillingService {
     }
 
     func premiumStatusChanged() async {
-        guard environmentService.region != .selfHosted,
+        guard await !isSelfHosted(),
               await configService.getFeatureFlag(.premiumUpgradePath),
               await !stateService.doesActiveAccountHavePremium()
         else {

--- a/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingServiceTests.swift
@@ -413,6 +413,38 @@ struct BillingServiceTests { // swiftlint:disable:this type_body_length
         #expect(syncService.didFetchSync)
     }
 
+    /// `isSelfHosted()` returns `false` when the region is not self-hosted.
+    @Test
+    func isSelfHosted_cloudRegion_returnsFalse() async {
+        environmentService.region = .unitedStates
+
+        let result = await subject.isSelfHosted()
+
+        #expect(result == false)
+    }
+
+    /// `isSelfHosted()` returns `true` when self-hosted and the debug flag is off.
+    @Test
+    func isSelfHosted_selfHostedRegion_debugFlagOff_returnsTrue() async {
+        environmentService.region = .selfHosted
+        configService.featureFlagsBool[.debugDisableSelfHostPremiumCheck] = false
+
+        let result = await subject.isSelfHosted()
+
+        #expect(result == true)
+    }
+
+    /// `isSelfHosted()` returns `false` when self-hosted but the debug override flag is enabled.
+    @Test
+    func isSelfHosted_selfHostedRegion_debugFlagOn_returnsFalse() async {
+        environmentService.region = .selfHosted
+        configService.featureFlagsBool[.debugDisableSelfHostPremiumCheck] = true
+
+        let result = await subject.isSelfHosted()
+
+        #expect(result == false)
+    }
+
     /// `premiumStatusChanged()` returns early without syncing when the environment is self-hosted.
     @Test
     func premiumStatusChanged_selfHosted() async throws {
@@ -426,6 +458,22 @@ struct BillingServiceTests { // swiftlint:disable:this type_body_length
 
         #expect(statuses.isEmpty)
         #expect(!syncService.didFetchSync)
+    }
+
+    /// `premiumStatusChanged()` syncs when self-hosted region is overridden by the debug flag.
+    @Test
+    func premiumStatusChanged_selfHosted_debugFlagEnabled_syncs() async throws {
+        environmentService.region = .selfHosted
+        configService.featureFlagsBool[.debugDisableSelfHostPremiumCheck] = true
+        stateService.doesActiveAccountHavePremiumResult = false
+        var statuses = [PremiumCheckoutStatus]()
+        let cancellable = subject.premiumCheckoutStatusPublisher()
+            .sink { statuses.append($0) }
+
+        await subject.premiumStatusChanged()
+
+        try await waitForAsync { !statuses.isEmpty }
+        #expect(syncService.didFetchSync)
     }
 
     /// `premiumStatusChanged()` reports the error and publishes `.pending` when sync fails.

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -11,6 +11,11 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// Flag to enable/disable individual cipher encryption configured remotely.
     static let cipherKeyEncryption = FeatureFlag(rawValue: "cipher-key-encryption")
 
+    /// Debug flag to disable self-hosted checks in premium upgrade flows for QA testing.
+    static let debugDisableSelfHostPremiumCheck = FeatureFlag(
+        rawValue: "debug-disable-self-host-premium-check"
+    )
+
     /// Flag to enable/disable Device Auth Key flows.
     static let deviceAuthKey = FeatureFlag(rawValue: "pm-27581-device-auth-key")
 
@@ -36,6 +41,7 @@ extension FeatureFlag: @retroactive CaseIterable {
         [
             .cardScanner,
             .cipherKeyEncryption,
+            .debugDisableSelfHostPremiumCheck,
             .deviceAuthKey,
             .enableCipherKeyEncryption,
             .forceUpdateKdfSettings,

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
@@ -15,7 +15,6 @@ final class PremiumUpgradeProcessor: StateProcessor<
     // MARK: Types
 
     typealias Services = HasBillingService
-        & HasEnvironmentService
         & HasErrorReporter
 
     // MARK: Properties
@@ -56,7 +55,7 @@ final class PremiumUpgradeProcessor: StateProcessor<
     override func perform(_ effect: PremiumUpgradeEffect) async {
         switch effect {
         case .appeared:
-            state.isSelfHosted = services.environmentService.region == .selfHosted
+            state.isSelfHosted = await services.billingService.isSelfHosted()
             if !state.isSelfHosted {
                 await fetchPremiumPrice()
             }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
@@ -17,7 +17,6 @@ struct PremiumUpgradeProcessorTests {
 
     let billingService: MockBillingService
     let coordinator: MockCoordinator<BillingRoute, Void>
-    let environmentService: MockEnvironmentService
     let errorReporter: MockErrorReporter
     let subject: PremiumUpgradeProcessor
 
@@ -25,6 +24,7 @@ struct PremiumUpgradeProcessorTests {
 
     init() {
         billingService = MockBillingService()
+        billingService.isSelfHostedReturnValue = false
         billingService.getPremiumPlanReturnValue = PremiumPlanResponseModel(
             available: true,
             legacyYear: nil,
@@ -35,11 +35,9 @@ struct PremiumUpgradeProcessorTests {
         billingService.premiumCheckoutStatusPublisherReturnValue = PassthroughSubject<PremiumCheckoutStatus, Never>()
             .eraseToAnyPublisher()
         coordinator = MockCoordinator<BillingRoute, Void>()
-        environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         let services = ServiceContainer.withMocks(
             billingService: billingService,
-            environmentService: environmentService,
             errorReporter: errorReporter,
         )
         subject = PremiumUpgradeProcessor(
@@ -54,8 +52,6 @@ struct PremiumUpgradeProcessorTests {
     /// `perform(_:)` with `.appeared` fetches the premium price and sets it in state on success.
     @Test
     func perform_appeared_fetchesPremiumPrice_success() async {
-        environmentService.region = .unitedStates
-
         await subject.perform(.appeared)
 
         #expect(subject.state.premiumPrice != nil)
@@ -68,7 +64,6 @@ struct PremiumUpgradeProcessorTests {
     /// `perform(_:)` with `.appeared` shows the pricing error banner on failure.
     @Test
     func perform_appeared_fetchesPremiumPrice_failure() async {
-        environmentService.region = .unitedStates
         billingService.getPremiumPlanThrowableError = BitwardenTestError.example
 
         await subject.perform(.appeared)
@@ -80,25 +75,34 @@ struct PremiumUpgradeProcessorTests {
         #expect(coordinator.isLoadingOverlayShowing == false)
     }
 
-    /// `perform(_:)` with `.appeared` sets `isSelfHosted` to `false` when the environment is not self-hosted.
+    /// `perform(_:)` with `.appeared` sets `isSelfHosted` to `false` when the billing service reports not self-hosted.
     @Test
     func perform_appeared_notSelfHosted() async {
-        environmentService.region = .unitedStates
-
         await subject.perform(.appeared)
 
         #expect(subject.state.isSelfHosted == false)
     }
 
-    /// `perform(_:)` with `.appeared` sets `isSelfHosted` to `true` when the environment is self-hosted.
+    /// `perform(_:)` with `.appeared` sets `isSelfHosted` to `true` and skips price fetch when self-hosted.
     @Test
     func perform_appeared_selfHosted() async {
-        environmentService.region = .selfHosted
+        billingService.isSelfHostedReturnValue = true
 
         await subject.perform(.appeared)
 
         #expect(subject.state.isSelfHosted == true)
         #expect(!billingService.getPremiumPlanCalled)
+    }
+
+    /// `perform(_:)` with `.appeared` fetches price when billing service overrides self-hosted for QA.
+    @Test
+    func perform_appeared_selfHosted_debugOverrideEnabled_fetchesPremiumPrice() async {
+        billingService.isSelfHostedReturnValue = false
+
+        await subject.perform(.appeared)
+
+        #expect(subject.state.isSelfHosted == false)
+        #expect(billingService.getPremiumPlanCalled)
     }
 
     /// `perform(_:)` with `.retryFetchPriceTapped` hides the banner and shows price on success.

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -20,8 +20,8 @@ protocol SettingsProcessorDelegate: AnyObject {
 final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, SettingsEffect> {
     // MARK: Types
 
-    typealias Services = HasConfigService
-        & HasEnvironmentService
+    typealias Services = HasBillingService
+        & HasConfigService
         & HasErrorReporter
         & HasStateService
         & HasVaultRepository
@@ -89,7 +89,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             let featureEnabled = await services.configService
                 .getFeatureFlag(.premiumUpgradePath, defaultValue: false)
             let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
-            let isSelfHosted = services.environmentService.region == .selfHosted
+            let isSelfHosted = await services.billingService.isSelfHosted()
             state.hasPremium = hasPremium
             state.showPlanRow = featureEnabled && !isSelfHosted
         }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -7,10 +7,10 @@ import XCTest
 class SettingsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
+    var billingService: MockBillingService!
     var configService: MockConfigService!
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
     var delegate: MockSettingsProcessorDelegate!
-    var environmentService: MockEnvironmentService!
     var errorReporter: MockErrorReporter!
     var subject: SettingsProcessor!
     var stateService: MockStateService!
@@ -21,10 +21,11 @@ class SettingsProcessorTests: BitwardenTestCase {
     override func setUp() {
         super.setUp()
 
+        billingService = MockBillingService()
+        billingService.isSelfHostedReturnValue = false
         configService = MockConfigService()
         coordinator = MockCoordinator()
         delegate = MockSettingsProcessorDelegate()
-        environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         stateService = MockStateService()
         vaultRepository = MockVaultRepository()
@@ -35,10 +36,10 @@ class SettingsProcessorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        billingService = nil
         configService = nil
         coordinator = nil
         delegate = nil
-        environmentService = nil
         errorReporter = nil
         subject = nil
         stateService = nil
@@ -51,8 +52,8 @@ class SettingsProcessorTests: BitwardenTestCase {
             coordinator: coordinator.asAnyCoordinator(),
             delegate: delegate,
             services: ServiceContainer.withMocks(
+                billingService: billingService,
                 configService: configService,
-                environmentService: environmentService,
                 errorReporter: errorReporter,
                 stateService: stateService,
                 vaultRepository: vaultRepository,
@@ -183,7 +184,6 @@ class SettingsProcessorTests: BitwardenTestCase {
     func test_perform_appeared_hidesPlanRow_featureFlagOff() async {
         configService.featureFlagsBool[.premiumUpgradePath] = false
         vaultRepository.doesActiveAccountHavePremiumResult = true
-        environmentService.region = .unitedStates
 
         await subject.perform(.appeared)
 
@@ -195,7 +195,6 @@ class SettingsProcessorTests: BitwardenTestCase {
     func test_perform_appeared_showsPlanRow_freeUser() async {
         configService.featureFlagsBool[.premiumUpgradePath] = true
         vaultRepository.doesActiveAccountHavePremiumResult = false
-        environmentService.region = .unitedStates
 
         await subject.perform(.appeared)
 
@@ -203,12 +202,12 @@ class SettingsProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.hasPremium)
     }
 
-    /// `perform(.appeared)` hides the plan row when the user is self-hosted.
+    /// `perform(.appeared)` hides the plan row when the billing service reports self-hosted.
     @MainActor
     func test_perform_appeared_hidesPlanRow_selfHosted() async {
+        billingService.isSelfHostedReturnValue = true
         configService.featureFlagsBool[.premiumUpgradePath] = true
         vaultRepository.doesActiveAccountHavePremiumResult = true
-        environmentService.region = .selfHosted
 
         await subject.perform(.appeared)
 
@@ -220,12 +219,23 @@ class SettingsProcessorTests: BitwardenTestCase {
     func test_perform_appeared_showsPlanRow_hasPremium() async {
         configService.featureFlagsBool[.premiumUpgradePath] = true
         vaultRepository.doesActiveAccountHavePremiumResult = true
-        environmentService.region = .unitedStates
 
         await subject.perform(.appeared)
 
         XCTAssertTrue(subject.state.showPlanRow)
         XCTAssertTrue(subject.state.hasPremium)
+    }
+
+    /// `perform(.appeared)` shows the plan row for a self-hosted user when the debug override is enabled.
+    @MainActor
+    func test_perform_appeared_showsPlanRow_selfHosted_debugOverrideEnabled() async {
+        billingService.isSelfHostedReturnValue = false
+        configService.featureFlagsBool[.premiumUpgradePath] = true
+        vaultRepository.doesActiveAccountHavePremiumResult = false
+
+        await subject.perform(.appeared)
+
+        XCTAssertTrue(subject.state.showPlanRow)
     }
 }
 

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -69,6 +69,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasAuthRepository
         & HasAuthService
         & HasAutofillCredentialService
+        & HasBillingService
         & HasBiometricsRepository
         & HasConfigService
         & HasEnvironmentService


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37642

## 📔 Objective

Adds a debug menu toggle (`debug-disable-self-host-premium-check`) that allows QA to test premium upgrade flows in self-hosted test environments.

When enabled, `BillingService.isSelfHosted()` returns `false` regardless of the actual region, which unblocks:
- The "Plan" row in Settings (previously hidden for self-hosted users)
- The `PremiumUpgradeView` upgrade UI (previously showed a read-only banner)
- `BillingService.premiumStatusChanged()` premium sync (previously short-circuited)

