### PR TITLE
[PM-37726] feat: Add Password Health - Reused Passwords screen

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -294,6 +294,10 @@
 "CheckingPassword" = "Checking password…";
 "CheckPassword" = "Check if password has been exposed.";
 "PasswordSafe" = "This password was not found in any known data breaches. It should be safe to use.";
+"PasswordHealth" = "Password health";
+"ReusedPasswords" = "Reused passwords";
+"NoReusedPasswords" = "No reused passwords detected.";
+"XAccountsUseThisPassword" = "%1$d accounts use this password";
 "IdentityName" = "Identity name";
 "Value" = "Value";
 "PasswordHistory" = "Password history";

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthAction.swift
@@ -1,0 +1,10 @@
+import BitwardenSdk
+
+// MARK: - PasswordHealthAction
+
+/// Actions handled by the `PasswordHealthProcessor`.
+///
+enum PasswordHealthAction: Equatable {
+    /// The user tapped on a cipher item in the list.
+    case itemPressed(CipherListView)
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthEffect.swift
@@ -1,0 +1,8 @@
+// MARK: - PasswordHealthEffect
+
+/// Effects that can be processed by a `PasswordHealthProcessor`.
+///
+enum PasswordHealthEffect: Equatable {
+    /// Load the password health data from the vault.
+    case loadData
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthProcessor.swift
@@ -1,0 +1,135 @@
+import BitwardenKit
+import BitwardenSdk
+import CryptoKit
+import Foundation
+
+// MARK: - PasswordHealthProcessor
+
+/// The processor used to manage state and handle actions for the `PasswordHealthView`.
+///
+final class PasswordHealthProcessor: StateProcessor<
+    PasswordHealthState,
+    PasswordHealthAction,
+    PasswordHealthEffect,
+> {
+    // MARK: Types
+
+    typealias Services = HasErrorReporter
+        & HasVaultRepository
+
+    // MARK: Properties
+
+    /// The coordinator used to manage navigation.
+    private let coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>
+
+    /// The services used by this processor.
+    private let services: Services
+
+    // MARK: Initialization
+
+    /// Initializes a new `PasswordHealthProcessor`.
+    ///
+    /// - Parameters:
+    ///   - coordinator: The coordinator used to manage navigation.
+    ///   - services: The services used by this processor.
+    ///   - state: The initial state of the processor.
+    ///
+    init(
+        coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>,
+        services: Services,
+        state: PasswordHealthState,
+    ) {
+        self.coordinator = coordinator
+        self.services = services
+        super.init(state: state)
+    }
+
+    // MARK: Methods
+
+    override func perform(_ effect: PasswordHealthEffect) async {
+        switch effect {
+        case .loadData:
+            await loadData()
+        }
+    }
+
+    override func receive(_ action: PasswordHealthAction) {
+        switch action {
+        case .itemPressed:
+            break
+        }
+    }
+
+    // MARK: Private
+
+    /// Loads all vault ciphers, decrypts them fully, and computes the reused password groups.
+    ///
+    private func loadData() async {
+        state.loadingState = .loading(nil)
+        do {
+            // Collect the current snapshot of all cipher list views.
+            var cipherListViews: [CipherListView] = []
+            for try await ciphers in try await services.vaultRepository.cipherPublisher() {
+                cipherListViews = ciphers
+                break
+            }
+
+            // Filter to login ciphers that have an id, then fetch their full CipherView
+            // (which contains the decrypted password).
+            let loginListViews = cipherListViews.filter { $0.type.isLogin && $0.id != nil }
+            var loginCipherViews: [(listView: CipherListView, cipherView: CipherView)] = []
+            for listView in loginListViews {
+                guard let cipherView = try await services.vaultRepository.fetchCipher(withId: listView.id!) else {
+                    continue
+                }
+                loginCipherViews.append((listView: listView, cipherView: cipherView))
+            }
+
+            let groups = reusedPasswordGroups(from: loginCipherViews)
+            state.loadingState = .data(groups)
+        } catch {
+            services.errorReporter.log(error: error)
+            state.loadingState = .data([])
+        }
+    }
+
+    /// Computes groups of login ciphers that share the same password.
+    ///
+    /// Passwords are compared by their SHA256 hash so plaintext passwords are not persisted
+    /// or retained as dictionary keys beyond the scope of this function.
+    ///
+    /// - Parameter pairs: Pairs of `CipherListView` (for display) and `CipherView` (for password access).
+    /// - Returns: An array of `ReusedPasswordGroup` values, each containing 2 or more ciphers
+    ///     that share the same password, sorted by descending cipher count.
+    ///
+    func reusedPasswordGroups(
+        from pairs: [(listView: CipherListView, cipherView: CipherView)],
+    ) -> [ReusedPasswordGroup] {
+        // Keep only ciphers with a non-empty password.
+        let withPasswords = pairs.filter { pair in
+            guard let password = pair.cipherView.login?.password else { return false }
+            return !password.isEmpty
+        }
+
+        // Group by the SHA256 hash of the password.
+        var grouped = [String: [CipherListView]]()
+        for pair in withPasswords {
+            guard let password = pair.cipherView.login?.password else { continue }
+            let hash = SHA256.hash(data: Data(password.utf8))
+                .compactMap { String(format: "%02x", $0) }
+                .joined()
+            grouped[hash, default: []].append(pair.listView)
+        }
+
+        // Keep only groups with 2 or more ciphers.
+        return grouped
+            .filter { $0.value.count >= 2 }
+            .map { hash, listViews in
+                ReusedPasswordGroup(
+                    id: hash,
+                    ciphers: listViews.sorted { $0.name < $1.name },
+                )
+            }
+            .sorted { $0.ciphers.count > $1.ciphers.count }
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthProcessorTests.swift
@@ -1,0 +1,186 @@
+import BitwardenKitMocks
+import BitwardenSdk
+import TestHelpers
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+class PasswordHealthProcessorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
+    var errorReporter: MockErrorReporter!
+    var vaultRepository: MockVaultRepository!
+    var subject: PasswordHealthProcessor!
+
+    // MARK: Setup and Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        coordinator = MockCoordinator<SettingsRoute, SettingsEvent>()
+        errorReporter = MockErrorReporter()
+        vaultRepository = MockVaultRepository()
+
+        subject = PasswordHealthProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                errorReporter: errorReporter,
+                vaultRepository: vaultRepository,
+            ),
+            state: PasswordHealthState(),
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        coordinator = nil
+        errorReporter = nil
+        vaultRepository = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `perform(_:)` with `.loadData` sets the loading state to `.data([])` when the vault
+    /// contains no login ciphers.
+    @MainActor
+    func test_perform_loadData_empty() async {
+        vaultRepository.ciphersSubject.send([])
+
+        await subject.perform(.loadData)
+
+        XCTAssertEqual(subject.state.loadingState, .data([]))
+    }
+
+    /// `perform(_:)` with `.loadData` logs an error and falls back to `.data([])` when the
+    /// cipher publisher fails.
+    @MainActor
+    func test_perform_loadData_error() async {
+        vaultRepository.ciphersSubject.send(completion: .failure(BitwardenTestError.example))
+
+        await subject.perform(.loadData)
+
+        XCTAssertEqual(subject.state.loadingState, .data([]))
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    // MARK: reusedPasswordGroups Tests
+
+    /// `reusedPasswordGroups(from:)` returns an empty array when no passwords are reused.
+    @MainActor
+    func test_reusedPasswordGroups_noReuse() {
+        let cipher1 = CipherListView.fixture(id: "1", name: "Alpha")
+        let cipher2 = CipherListView.fixture(id: "2", name: "Beta")
+
+        let cipherView1 = CipherView.fixture(id: "1", login: .fixture(password: "unique-password-1"))
+        let cipherView2 = CipherView.fixture(id: "2", login: .fixture(password: "unique-password-2"))
+
+        let groups = subject.reusedPasswordGroups(from: [
+            (listView: cipher1, cipherView: cipherView1),
+            (listView: cipher2, cipherView: cipherView2),
+        ])
+
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    /// `reusedPasswordGroups(from:)` returns groups for ciphers that share the same password.
+    @MainActor
+    func test_reusedPasswordGroups_returnsGroups() throws {
+        let cipher1 = CipherListView.fixture(id: "1", name: "Alpha")
+        let cipher2 = CipherListView.fixture(id: "2", name: "Beta")
+        let cipher3 = CipherListView.fixture(id: "3", name: "Gamma")
+
+        let sharedPassword = "shared-secret"
+        let uniquePassword = "unique-secret"
+
+        let cipherView1 = CipherView.fixture(id: "1", login: .fixture(password: sharedPassword))
+        let cipherView2 = CipherView.fixture(id: "2", login: .fixture(password: sharedPassword))
+        let cipherView3 = CipherView.fixture(id: "3", login: .fixture(password: uniquePassword))
+
+        let groups = subject.reusedPasswordGroups(from: [
+            (listView: cipher1, cipherView: cipherView1),
+            (listView: cipher2, cipherView: cipherView2),
+            (listView: cipher3, cipherView: cipherView3),
+        ])
+
+        XCTAssertEqual(groups.count, 1)
+        let group = try XCTUnwrap(groups.first)
+        XCTAssertEqual(group.ciphers.count, 2)
+        // Names should be sorted alphabetically within the group.
+        XCTAssertEqual(group.ciphers.map(\.name), ["Alpha", "Beta"])
+    }
+
+    /// `reusedPasswordGroups(from:)` ignores ciphers with empty passwords.
+    @MainActor
+    func test_reusedPasswordGroups_ignoresEmptyPasswords() {
+        let cipher1 = CipherListView.fixture(id: "1", name: "Alpha")
+        let cipher2 = CipherListView.fixture(id: "2", name: "Beta")
+
+        let cipherView1 = CipherView.fixture(id: "1", login: .fixture(password: ""))
+        let cipherView2 = CipherView.fixture(id: "2", login: .fixture(password: ""))
+
+        let groups = subject.reusedPasswordGroups(from: [
+            (listView: cipher1, cipherView: cipherView1),
+            (listView: cipher2, cipherView: cipherView2),
+        ])
+
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    /// `reusedPasswordGroups(from:)` ignores ciphers that have no login password (nil).
+    @MainActor
+    func test_reusedPasswordGroups_ignoresNilPasswords() {
+        let cipher1 = CipherListView.fixture(id: "1", name: "Alpha")
+        let cipher2 = CipherListView.fixture(id: "2", name: "Beta")
+
+        let cipherView1 = CipherView.fixture(id: "1", login: .fixture(password: nil))
+        let cipherView2 = CipherView.fixture(id: "2", login: .fixture(password: nil))
+
+        let groups = subject.reusedPasswordGroups(from: [
+            (listView: cipher1, cipherView: cipherView1),
+            (listView: cipher2, cipherView: cipherView2),
+        ])
+
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    /// `reusedPasswordGroups(from:)` sorts groups by descending cipher count.
+    @MainActor
+    func test_reusedPasswordGroups_sortedByCount() {
+        let cipher1 = CipherListView.fixture(id: "1", name: "A")
+        let cipher2 = CipherListView.fixture(id: "2", name: "B")
+        let cipher3 = CipherListView.fixture(id: "3", name: "C")
+        let cipher4 = CipherListView.fixture(id: "4", name: "D")
+        let cipher5 = CipherListView.fixture(id: "5", name: "E")
+
+        let cipherView1 = CipherView.fixture(id: "1", login: .fixture(password: "aaa"))
+        let cipherView2 = CipherView.fixture(id: "2", login: .fixture(password: "aaa"))
+        let cipherView3 = CipherView.fixture(id: "3", login: .fixture(password: "aaa"))
+        let cipherView4 = CipherView.fixture(id: "4", login: .fixture(password: "bbb"))
+        let cipherView5 = CipherView.fixture(id: "5", login: .fixture(password: "bbb"))
+
+        let groups = subject.reusedPasswordGroups(from: [
+            (listView: cipher1, cipherView: cipherView1),
+            (listView: cipher2, cipherView: cipherView2),
+            (listView: cipher3, cipherView: cipherView3),
+            (listView: cipher4, cipherView: cipherView4),
+            (listView: cipher5, cipherView: cipherView5),
+        ])
+
+        XCTAssertEqual(groups.count, 2)
+        XCTAssertEqual(groups[0].ciphers.count, 3) // "aaa" group has 3
+        XCTAssertEqual(groups[1].ciphers.count, 2) // "bbb" group has 2
+    }
+
+    /// `receive(_:)` with `.itemPressed` does not navigate (future TODO).
+    @MainActor
+    func test_receive_itemPressed() {
+        let cipher = CipherListView.fixture()
+        subject.receive(.itemPressed(cipher))
+
+        XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthState.swift
@@ -1,0 +1,22 @@
+import BitwardenSdk
+
+// MARK: - ReusedPasswordGroup
+
+/// A group of login ciphers that share the same password.
+///
+struct ReusedPasswordGroup: Equatable, Identifiable {
+    /// A stable identifier for the group, derived from the password hash.
+    let id: String
+
+    /// The cipher list views that share this password.
+    let ciphers: [CipherListView]
+}
+
+// MARK: - PasswordHealthState
+
+/// The state used to present the `PasswordHealthView`.
+///
+struct PasswordHealthState: Equatable {
+    /// The loading state of the password health screen.
+    var loadingState: LoadingState<[ReusedPasswordGroup]> = .loading(nil)
+}

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/PasswordHealth/PasswordHealthView.swift
@@ -1,0 +1,177 @@
+import BitwardenKit
+import BitwardenResources
+import BitwardenSdk
+import SwiftUI
+
+// MARK: - PasswordHealthView
+
+/// A view that shows password health information for the user's vault, starting with reused passwords.
+///
+struct PasswordHealthView: View {
+    // MARK: Properties
+
+    /// The `Store` for this view.
+    @ObservedObject var store: Store<PasswordHealthState, PasswordHealthAction, PasswordHealthEffect>
+
+    // MARK: View
+
+    var body: some View {
+        LoadingView(state: store.state.loadingState) { groups in
+            if groups.isEmpty {
+                emptyReusedPasswords
+                    .scrollView(centerContentVertically: true)
+            } else {
+                reusedPasswordsList(groups)
+                    .scrollView()
+            }
+        }
+        .navigationBar(title: Localizations.passwordHealth, titleDisplayMode: .inline)
+        .background(SharedAsset.Colors.backgroundPrimary.swiftUIColor.ignoresSafeArea())
+        .task {
+            await store.perform(.loadData)
+        }
+    }
+
+    // MARK: Private Views
+
+    /// The empty state shown when no reused passwords are detected.
+    private var emptyReusedPasswords: some View {
+        VStack(spacing: 12) {
+            Image(asset: SharedAsset.Icons.check24)
+                .resizable()
+                .scaledToFit()
+                .frame(width: 50, height: 50)
+                .foregroundStyle(SharedAsset.Colors.iconSecondary.swiftUIColor)
+
+            Text(Localizations.reusedPasswords)
+                .styleGuide(.title2, weight: .semibold)
+                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+
+            Text(Localizations.noReusedPasswords)
+                .styleGuide(.body)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 16)
+        }
+        .accessibilityIdentifier("NoReusedPasswordsView")
+    }
+
+    /// The list of reused password groups.
+    ///
+    /// - Parameter groups: The reused password groups to display.
+    ///
+    private func reusedPasswordsList(_ groups: [ReusedPasswordGroup]) -> some View {
+        VStack(alignment: .leading, spacing: 20) {
+            Text(Localizations.reusedPasswords)
+                .styleGuide(.title3, weight: .semibold)
+                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .padding(.horizontal, 16)
+                .padding(.top, 16)
+
+            ForEach(groups) { group in
+                reusedPasswordGroup(group)
+            }
+        }
+        .padding(.bottom, 16)
+    }
+
+    /// A section for a single group of ciphers that share the same password.
+    ///
+    /// - Parameter group: The reused password group to display.
+    ///
+    private func reusedPasswordGroup(_ group: ReusedPasswordGroup) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(Localizations.xAccountsUseThisPassword(group.ciphers.count))
+                .styleGuide(.footnote, weight: .semibold)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 6)
+
+            ContentBlock(dividerLeadingPadding: 16) {
+                ForEach(group.ciphers, id: \.id) { cipher in
+                    Button {
+                        store.send(.itemPressed(cipher))
+                    } label: {
+                        cipherRow(for: cipher)
+                    }
+                    .accessibilityIdentifier("ReusedPasswordCipherItem")
+                }
+            }
+        }
+    }
+
+    /// A row displaying a single cipher's name and username.
+    ///
+    /// - Parameter cipher: The `CipherListView` to display.
+    ///
+    private func cipherRow(for cipher: CipherListView) -> some View {
+        HStack {
+            Image(asset: SharedAsset.Icons.globe24)
+                .imageStyle(.rowIcon)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(cipher.name)
+                    .styleGuide(.body)
+                    .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .lineLimit(1)
+
+                if let username = cipher.type.loginListView?.username, !username.isEmpty {
+                    Text(username)
+                        .styleGuide(.subheadline)
+                        .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("No Reused Passwords") {
+    NavigationView {
+        PasswordHealthView(
+            store: Store(
+                processor: StateProcessor(
+                    state: PasswordHealthState(loadingState: .data([])),
+                ),
+            ),
+        )
+    }
+}
+
+#Preview("Reused Passwords") {
+    NavigationView {
+        PasswordHealthView(
+            store: Store(
+                processor: StateProcessor(
+                    state: PasswordHealthState(
+                        loadingState: .data([
+                            ReusedPasswordGroup(
+                                id: "abc123",
+                                ciphers: [
+                                    .fixture(
+                                        id: "1",
+                                        login: .fixture(username: "user@example.com"),
+                                        name: "Example Site",
+                                    ),
+                                    .fixture(
+                                        id: "2",
+                                        login: .fixture(username: "user@example.com"),
+                                        name: "Another Site",
+                                    ),
+                                ],
+                            ),
+                        ]),
+                    ),
+                ),
+            ),
+        )
+    }
+}
+#endif

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsAction.swift
@@ -9,6 +9,9 @@ enum VaultSettingsAction {
     /// The export vault button was tapped.
     case exportVaultTapped
 
+    /// The password health button was tapped.
+    case passwordHealthTapped
+
     /// The folders button was tapped.
     case foldersTapped
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsProcessor.swift
@@ -55,6 +55,8 @@ final class VaultSettingsProcessor: StateProcessor<VaultSettingsState, VaultSett
             state.url = nil
         case .exportVaultTapped:
             coordinator.navigate(to: .exportVault)
+        case .passwordHealthTapped:
+            coordinator.navigate(to: .passwordHealth)
         case .foldersTapped:
             coordinator.navigate(to: .folders)
         case .importItemsTapped:

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsProcessorTests.swift
@@ -111,6 +111,14 @@ class VaultSettingsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .exportVault)
     }
 
+    /// `receive(_:)` with `.passwordHealthTapped` navigates to the password health screen.
+    @MainActor
+    func test_receive_passwordHealthTapped() {
+        subject.receive(.passwordHealthTapped)
+
+        XCTAssertEqual(coordinator.routes.last, .passwordHealth)
+    }
+
     /// `receive(_:)` with  `.foldersTapped` navigates to the folders screen.
     @MainActor
     func test_receive_foldersTapped() {

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/VaultSettingsView.swift
@@ -69,6 +69,11 @@ struct VaultSettingsView: View {
             }
             .accessibilityIdentifier("ExportVaultLabel")
 
+            SettingsListItem(Localizations.passwordHealth) {
+                store.send(.passwordHealthTapped)
+            }
+            .accessibilityIdentifier("PasswordHealthLabel")
+
             SettingsListItem(Localizations.importItems) {
                 store.send(.importItemsTapped)
             } trailingContent: {

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -187,6 +187,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             showLoginRequest(loginRequest, delegate: context as? LoginRequestDelegate)
         case .other:
             showOtherScreen()
+        case .passwordHealth:
+            showPasswordHealth()
         case .passwordAutoFill:
             showPasswordAutoFill(delegate: context as? PasswordAutoFillProcessorDelegate)
         case .pendingLoginRequests:
@@ -458,6 +460,20 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         )
         coordinator.start()
         coordinator.navigate(to: .passwordAutofill(mode: .settings), context: delegate)
+    }
+
+    /// Shows the password health screen.
+    ///
+    private func showPasswordHealth() {
+        let processor = PasswordHealthProcessor(
+            coordinator: asAnyCoordinator(),
+            services: services,
+            state: PasswordHealthState(),
+        )
+        let view = PasswordHealthView(store: Store(processor: processor))
+        let viewController = UIHostingController(rootView: view)
+        viewController.navigationItem.largeTitleDisplayMode = .never
+        stackNavigator?.push(viewController, navigationTitle: Localizations.passwordHealth)
     }
 
     /// Shows the pending login requests screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
@@ -62,6 +62,9 @@ public enum SettingsRoute: Equatable, Hashable {
     /// A route to the other view.
     case other
 
+    /// A route to the password health screen.
+    case passwordHealth
+
     /// A route to the password auto-fill screen.
     case passwordAutoFill
 


### PR DESCRIPTION
Adds a new "Password health" entry to Settings > Vault that identifies login items sharing the same password. Grouped results are sorted by descending reuse count, with ciphers within each group sorted alphabetically.

- PasswordHealthState / Action / Effect types
- PasswordHealthProcessor: fetches all logins, groups by SHA256 hash of password, surfaces groups with 2+ members
- PasswordHealthView: loading / empty / grouped-list states
- Wired into SettingsCoordinator via new .passwordHealth route
- Entry point added to VaultSettingsView alongside Export/Import Vault
- Localization strings: PasswordHealth, ReusedPasswords, NoReusedPasswords, XAccountsUseThisPassword
- Unit tests: PasswordHealthProcessorTests (8 cases), VaultSettingsProcessorTests (1 new case)

Generated with [Devin](https://cli.devin.ai/docs)

## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
