### PR TITLE
[PM-37721] feat: Add upgrade to premium button on Attachments premium alert

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1004,6 +1004,8 @@
 "OnceArchivedThisItemWillBeExcludedDescriptionLong" = "Once archived, this item will be excluded from search results and autofill suggestions.";
 "ArchiveUnavailable" = "Archive unavailable";
 "ArchivingItemsIsAPremiumFeatureDescriptionLong" = "Archiving items is a Premium feature. Your current plan does not include access to this feature.";
+"AddingAttachmentsIsAPremiumFeatureDescriptionLong" = "Adding attachments is a Premium feature. Your current plan does not include access to this feature.";
+"AttachmentsUnavailable" = "Attachments unavailable";
 "UpgradeToPremium" = "Upgrade to premium";
 "ThisItemIsArchived" = "This item is archived.";
 "YourPremiumSubscriptionEnded" = "Your Premium subscription ended";

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -31,6 +31,29 @@ extension Alert {
         return alert
     }
 
+    /// Returns an alert for when attachments are unavailable.
+    ///
+    /// - Parameters:
+    ///   - action: A closure to execute on upgrading to premium.
+    /// - Returns: The alert when attachments are unavailable.
+    static func attachmentsUnavailable(
+        action: @escaping () async -> Void,
+    ) -> Alert {
+        let preferredAction = AlertAction(title: Localizations.upgradeToPremium, style: .default) { _ in
+            await action()
+        }
+        let alert = Alert(
+            title: Localizations.attachmentsUnavailable,
+            message: Localizations.addingAttachmentsIsAPremiumFeatureDescriptionLong,
+            alertActions: [
+                preferredAction,
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ],
+        )
+        alert.preferredAction = preferredAction
+        return alert
+    }
+
     /// Returns an alert for when the "Specific People" Send feature is unavailable due to
     /// lack of premium subscription.
     ///

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsAction.swift
@@ -9,6 +9,9 @@ enum AttachmentsAction: Equatable, Sendable {
     /// The choose file button was pressed.
     case chooseFilePressed
 
+    /// The URL has been opened and should be cleared.
+    case clearURL
+
     /// The delete button was pressed for an attachment.
     case deletePressed(AttachmentView)
 

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -149,9 +149,7 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
                 .validate(input: state.fileName)
 
             // Dismiss and show the upgrade alert if the user doesn't have premium.
-            guard state.hasPremium else {
-                return await loadPremiumStatus()
-            }
+            await loadPremiumStatus()
 
             // Display an alert if the attachment is too large.
             guard let fileSize = state.fileData?.count, fileSize < Constants.maxFileSize else {

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -10,7 +10,10 @@ import Foundation
 class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, AttachmentsEffect> {
     // MARK: Types
 
-    typealias Services = HasConfigService
+    typealias Services = HasBillingRepository
+        & HasBillingService
+        & HasConfigService
+        & HasEnvironmentService
         & HasErrorReporter
         & HasVaultRepository
 
@@ -18,6 +21,13 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
 
     /// The `Coordinator` that handles navigation.
     private var coordinator: AnyCoordinator<VaultItemRoute, VaultItemEvent>
+
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
+    )
 
     /// The services used by this processor.
     private var services: Services
@@ -57,6 +67,8 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
         switch action {
         case .chooseFilePressed:
             presentFileSelectionAlert()
+        case .clearURL:
+            state.url = nil
         case let .deletePressed(attachment):
             confirmDeleteAttachment(attachment)
         case .dismissPressed:
@@ -101,13 +113,22 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
 
     /// Load the user's premium status and display an alert if they do not have access to premium features.
     private func loadPremiumStatus() async {
-        // Fetch the user's premium status.
         state.hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
-
-        // If the user does not have access to premium features, show an alert.
         if !state.hasPremium {
-            coordinator.showAlert(.defaultAlert(title: Localizations.premiumRequired))
+            coordinator.navigate(to: .dismiss(DismissAction { [weak self] in
+                guard let self else { return }
+                coordinator.showAlert(.attachmentsUnavailable {
+                    await self.navigateToPremiumUpgrade()
+                })
+            }))
         }
+    }
+
+    /// Navigates to the premium upgrade flow. Uses the in-app upgrade path when available;
+    /// otherwise opens the web vault upgrade URL as a fallback.
+    ///
+    private func navigateToPremiumUpgrade() async {
+        await premiumUpgradeHelper.navigateToPremiumUpgrade()
     }
 
     /// Presents the file selection alert.

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -115,12 +115,9 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
     private func loadPremiumStatus() async {
         state.hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
         if !state.hasPremium {
-            coordinator.navigate(to: .dismiss(DismissAction { [weak self] in
-                guard let self else { return }
-                coordinator.showAlert(.attachmentsUnavailable {
-                    await self.navigateToPremiumUpgrade()
-                })
-            }))
+            coordinator.showAlert(.attachmentsUnavailable {
+                await self.navigateToPremiumUpgrade()
+            })
         }
     }
 
@@ -148,8 +145,9 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
             try EmptyInputValidator(fieldName: Localizations.file)
                 .validate(input: state.fileName)
 
-            // Dismiss and show the upgrade alert if the user doesn't have premium.
+            // Show the upgrade alert and stop if the user doesn't have premium.
             await loadPremiumStatus()
+            guard state.hasPremium else { return }
 
             // Display an alert if the attachment is too large.
             guard let fileSize = state.fileData?.count, fileSize < Constants.maxFileSize else {

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessor.swift
@@ -148,13 +148,9 @@ class AttachmentsProcessor: StateProcessor<AttachmentsState, AttachmentsAction, 
             try EmptyInputValidator(fieldName: Localizations.file)
                 .validate(input: state.fileName)
 
-            // Display an alert and don't allow the user to continue if
-            // they don't have access to premium features.
+            // Dismiss and show the upgrade alert if the user doesn't have premium.
             guard state.hasPremium else {
-                return coordinator.showAlert(.defaultAlert(
-                    title: Localizations.anErrorHasOccurred,
-                    message: Localizations.premiumRequired,
-                ))
+                return await loadPremiumStatus()
             }
 
             // Display an alert if the attachment is too large.

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -58,7 +58,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.fileData, data)
     }
 
-    /// `perform(_:)` with `.loadPremiumStatus` dismisses the view and then displays an alert.
+    /// `perform(_:)` with `.loadPremiumStatus` shows the premium upgrade alert if the user lacks premium.
     @MainActor
     func test_perform_loadPremiumStatus() async throws {
         vaultRepository.doesActiveAccountHavePremiumResult = false
@@ -66,15 +66,10 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         await subject.perform(.loadPremiumStatus)
 
         XCTAssertFalse(subject.state.hasPremium)
-        guard case let .dismiss(dismissAction) = coordinator.routes.last else {
-            XCTFail("Expected dismiss route with action")
-            return
-        }
-        dismissAction?.action()
         XCTAssertEqual(coordinator.alertShown.last, .attachmentsUnavailable(action: {}))
     }
 
-    /// `perform(_:)` with `.loadPremiumStatus` does not dismiss the view when the user has premium.
+    /// `perform(_:)` with `.loadPremiumStatus` does not show an alert when the user has premium.
     @MainActor
     func test_perform_loadPremiumStatus_hasPremium() async throws {
         vaultRepository.doesActiveAccountHavePremiumResult = true
@@ -82,7 +77,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         await subject.perform(.loadPremiumStatus)
 
         XCTAssertTrue(subject.state.hasPremium)
-        XCTAssertTrue(coordinator.routes.isEmpty)
+        XCTAssertNil(coordinator.alertShown.last)
     }
 
     /// `perform(_:)` with `.loadPremiumStatus` navigates to premium upgrade when tapping the upgrade button.
@@ -91,12 +86,6 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         vaultRepository.doesActiveAccountHavePremiumResult = false
 
         await subject.perform(.loadPremiumStatus)
-
-        guard case let .dismiss(dismissAction) = coordinator.routes.last else {
-            XCTFail("Expected dismiss route with action")
-            return
-        }
-        dismissAction?.action()
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.upgradeToPremium)
@@ -148,7 +137,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         )
     }
 
-    /// `perform(_:)` with `.save` dismisses the view and shows the upgrade alert if the user doesn't have premium.
+    /// `perform(_:)` with `.save` shows the premium upgrade alert if the user doesn't have premium.
     @MainActor
     func test_perform_save_noPremium() async throws {
         subject.state.fileName = "only cool people can see this file.txt"
@@ -157,11 +146,6 @@ class AttachmentsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.save)
 
-        guard case let .dismiss(dismissAction) = coordinator.routes.last else {
-            XCTFail("Expected dismiss route with action")
-            return
-        }
-        dismissAction?.action()
         XCTAssertEqual(coordinator.alertShown.last, .attachmentsUnavailable(action: {}))
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -148,21 +148,21 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         )
     }
 
-    /// `perform(_:)` with `.save` displays an error if the user doesn't have premium.
+    /// `perform(_:)` with `.save` dismisses the view and shows the upgrade alert if the user doesn't have premium.
     @MainActor
     func test_perform_save_noPremium() async throws {
         subject.state.fileName = "only cool people can see this file.txt"
         subject.state.hasPremium = false
+        vaultRepository.doesActiveAccountHavePremiumResult = false
 
         await subject.perform(.save)
 
-        XCTAssertEqual(
-            coordinator.alertShown.last,
-            .defaultAlert(
-                title: Localizations.anErrorHasOccurred,
-                message: Localizations.premiumRequired,
-            ),
-        )
+        guard case let .dismiss(dismissAction) = coordinator.routes.last else {
+            XCTFail("Expected dismiss route with action")
+            return
+        }
+        dismissAction?.action()
+        XCTAssertEqual(coordinator.alertShown.last, .attachmentsUnavailable(action: {}))
     }
 
     /// `perform(_:)` with `.save` shows an alert if the file is too large.

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -5,12 +5,14 @@ import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
 class AttachmentsProcessorTests: BitwardenTestCase {
     // MARK: Properties
 
     var coordinator: MockCoordinator<VaultItemRoute, VaultItemEvent>!
     var errorReporter: MockErrorReporter!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var subject: AttachmentsProcessor!
     var vaultRepository: MockVaultRepository!
 
@@ -21,6 +23,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
 
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         vaultRepository = MockVaultRepository()
 
         subject = AttachmentsProcessor(
@@ -31,6 +34,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
             ),
             state: AttachmentsState(),
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
@@ -38,6 +42,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
 
         coordinator = nil
         errorReporter = nil
+        premiumUpgradeHelper = nil
         subject = nil
         vaultRepository = nil
     }
@@ -53,7 +58,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.fileData, data)
     }
 
-    /// `perform(_:)` with `.loadPremiumStatus` loads the premium status and displays an alert if necessary.
+    /// `perform(_:)` with `.loadPremiumStatus` dismisses the view and then displays an alert.
     @MainActor
     func test_perform_loadPremiumStatus() async throws {
         vaultRepository.doesActiveAccountHavePremiumResult = false
@@ -61,7 +66,41 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         await subject.perform(.loadPremiumStatus)
 
         XCTAssertFalse(subject.state.hasPremium)
-        XCTAssertEqual(coordinator.alertShown.last, .defaultAlert(title: Localizations.premiumRequired))
+        guard case let .dismiss(dismissAction) = coordinator.routes.last else {
+            XCTFail("Expected dismiss route with action")
+            return
+        }
+        dismissAction?.action()
+        XCTAssertEqual(coordinator.alertShown.last, .attachmentsUnavailable(action: {}))
+    }
+
+    /// `perform(_:)` with `.loadPremiumStatus` does not dismiss the view when the user has premium.
+    @MainActor
+    func test_perform_loadPremiumStatus_hasPremium() async throws {
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+
+        await subject.perform(.loadPremiumStatus)
+
+        XCTAssertTrue(subject.state.hasPremium)
+        XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+
+    /// `perform(_:)` with `.loadPremiumStatus` navigates to premium upgrade when tapping the upgrade button.
+    @MainActor
+    func test_perform_loadPremiumStatus_tapUpgrade() async throws {
+        vaultRepository.doesActiveAccountHavePremiumResult = false
+
+        await subject.perform(.loadPremiumStatus)
+
+        guard case let .dismiss(dismissAction) = coordinator.routes.last else {
+            XCTFail("Expected dismiss route with action")
+            return
+        }
+        dismissAction?.action()
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.upgradeToPremium)
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `perform(_:)` with `.save` saves the attachment and updates the view.
@@ -78,7 +117,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.cipher, .fixture())
         XCTAssertNil(subject.state.fileName)
         XCTAssertNil(subject.state.fileData)
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.attachementAdded))
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.attachmentAdded))
     }
 
     /// `perform(_:)` with `.save` handles any errors.
@@ -159,6 +198,14 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         try await alert.tapAction(title: Localizations.photos)
         XCTAssertEqual(coordinator.routes.last, .fileSelection(.photo))
         XCTAssertIdentical(coordinator.contexts.last as? FileSelectionDelegate, subject)
+    }
+
+    /// `receive(_:)` with `.clearURL` clears the URL from the state.
+    @MainActor
+    func test_receive_clearURL() {
+        subject.state.url = .example
+        subject.receive(.clearURL)
+        XCTAssertNil(subject.state.url)
     }
 
     /// `.receive(_:)` with `.deletePressed(_)` presents the confirm alert and deletes the attachment.

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsProcessorTests.swift
@@ -117,7 +117,7 @@ class AttachmentsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.cipher, .fixture())
         XCTAssertNil(subject.state.fileName)
         XCTAssertNil(subject.state.fileData)
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.attachmentAdded))
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.attachementAdded))
     }
 
     /// `perform(_:)` with `.save` handles any errors.

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsState.swift
@@ -21,4 +21,7 @@ struct AttachmentsState: Equatable, Sendable {
 
     /// A toast message to show in the view.
     var toast: Toast?
+
+    /// The URL to open in the device's web browser.
+    var url: URL?
 }

--- a/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/Attachments/AttachmentsView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct AttachmentsView: View {
     // MARK: Properties
 
+    /// An environment variable used to open URLs.
+    @Environment(\.openURL) private var openURL
+
     /// The `Store` for this view.
     @ObservedObject var store: Store<AttachmentsState, AttachmentsAction, AttachmentsEffect>
 
@@ -34,6 +37,11 @@ struct AttachmentsView: View {
         }
         .task {
             await store.perform(.loadPremiumStatus)
+        }
+        .onChange(of: store.state.url) { newValue in
+            guard let url = newValue else { return }
+            openURL(url)
+            store.send(.clearURL)
         }
         .toast(store.binding(
             get: \.toast,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37721
https://bitwarden.atlassian.net/browse/PM-37722

## 📔 Objective

When a non-premium user opened the Attachments screen, the app showed a plain alert with no way to upgrade. This PR fixes the issue by showing an "Attachments unavailable" alert (with an "Upgrade to Premium" button) on the parent screen. Tapping the button navigates to the premium upgrade flow; tapping Cancel simply closes the alert.

## 📸 Screenshots


https://github.com/user-attachments/assets/97d6fe24-40f8-4134-ac89-6200cc9b4d06


The error at the end is due to the network vpn.

https://github.com/user-attachments/assets/47cc6a85-85e7-4682-8a02-284cc08bf001


