### PR TITLE
[PM-37697] feat: Show "Continue to web app?" alert when tapping Manage plan

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/EnvironmentService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/EnvironmentService.swift
@@ -61,6 +61,10 @@ extension DefaultEnvironmentService {
         environmentURLs.importItemsURL
     }
 
+    var manageSubscriptionURL: URL {
+        environmentURLs.manageSubscriptionURL
+    }
+
     var proxyCookieRedirectConnectorURL: URL {
         environmentURLs.proxyCookieRedirectConnectorURL
     }

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
@@ -83,6 +83,11 @@ public extension EnvironmentURLData {
         subpageURL(additionalPath: "tools/import")
     }
 
+    /// The URL for managing the subscription plan.
+    var manageSubscriptionURL: URL? {
+        subpageURL(additionalPath: "settings/subscription")
+    }
+
     /// Whether all of the environment URLs are not set.
     var isEmpty: Bool {
         api == nil

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
@@ -26,6 +26,9 @@ public struct EnvironmentURLs: Equatable {
     /// The URL for importing items.
     public let importItemsURL: URL
 
+    /// The URL for managing the subscription plan.
+    public let manageSubscriptionURL: URL
+
     /// The URL for a proxy on cookie redirect (used on SSO sync error).
     public let proxyCookieRedirectConnectorURL: URL
 
@@ -57,6 +60,7 @@ public struct EnvironmentURLs: Equatable {
     ///   - iconsURL: The URL for the icons API.
     ///   - identityURL: The URL for the identity API.
     ///   - importItemsURL: The URL for importing items.
+    ///   - manageSubscriptionURL: The URL for managing the subscription plan.
     ///   - proxyCookieRedirectConnectorURL: The URL for a proxy on cookie redirect (used on SSO sync error).
     ///   - recoveryCodeURL: The URL for the recovery code help page.
     ///   - sendShareURL: The URL for sharing a send.
@@ -72,6 +76,7 @@ public struct EnvironmentURLs: Equatable {
         iconsURL: URL,
         identityURL: URL,
         importItemsURL: URL,
+        manageSubscriptionURL: URL,
         proxyCookieRedirectConnectorURL: URL,
         recoveryCodeURL: URL,
         sendShareURL: URL,
@@ -87,6 +92,7 @@ public struct EnvironmentURLs: Equatable {
         self.iconsURL = iconsURL
         self.identityURL = identityURL
         self.importItemsURL = importItemsURL
+        self.manageSubscriptionURL = manageSubscriptionURL
         self.proxyCookieRedirectConnectorURL = proxyCookieRedirectConnectorURL
         self.recoveryCodeURL = recoveryCodeURL
         self.sendShareURL = sendShareURL
@@ -126,6 +132,9 @@ public extension EnvironmentURLs {
             webVaultURL = environmentURLData.webVault ?? URL(string: "https://vault.bitwarden.com")!
         }
         importItemsURL = environmentURLData.importItemsURL ?? URL(string: "https://vault.bitwarden.com/#/tools/import")!
+        manageSubscriptionURL = environmentURLData.manageSubscriptionURL ?? URL(
+            string: "https://vault.bitwarden.com/#/settings/subscription",
+        )!
         recoveryCodeURL = environmentURLData.recoveryCodeURL ?? URL(
             string: "https://vault.bitwarden.com/#/recover-2fa",
         )!

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
@@ -132,15 +132,13 @@ public extension EnvironmentURLs {
             webVaultURL = environmentURLData.webVault ?? URL(string: "https://vault.bitwarden.com")!
         }
         importItemsURL = environmentURLData.importItemsURL ?? URL(string: "https://vault.bitwarden.com/#/tools/import")!
-        manageSubscriptionURL = environmentURLData.manageSubscriptionURL ?? URL(
-            string: "https://vault.bitwarden.com/#/settings/subscription",
-        )!
         recoveryCodeURL = environmentURLData.recoveryCodeURL ?? URL(
             string: "https://vault.bitwarden.com/#/recover-2fa",
         )!
         sendShareURL = environmentURLData.sendShareURL ?? URL(string: "https://send.bitwarden.com/#")!
         settingsURL = environmentURLData.settingsURL ?? webVaultURL
         changeEmailURL = environmentURLData.changeEmailURL ?? settingsURL
+        manageSubscriptionURL = environmentURLData.manageSubscriptionURL ?? settingsURL
         proxyCookieRedirectConnectorURL = environmentURLData.proxyCookieRedirectConnectorURL ?? webVaultURL
         setUpTwoFactorURL = environmentURLData.setUpTwoFactorURL ?? settingsURL
         upgradeToPremiumURL = environmentURLData.upgradeToPremiumURL ?? settingsURL

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests.swift
@@ -20,6 +20,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://icons.bitwarden.net")!,
                 identityURL: URL(string: "https://identity.bitwarden.com")!,
                 importItemsURL: URL(string: "https://vault.bitwarden.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden.com/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html",
                 )!,
@@ -50,6 +51,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://icons.bitwarden.eu")!,
                 identityURL: URL(string: "https://identity.bitwarden.eu")!,
                 importItemsURL: URL(string: "https://vault.bitwarden.eu/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden.eu/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://vault.bitwarden.eu/proxy-cookie-redirect-connector.html",
                 )!,
@@ -81,6 +83,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://example.com/icons")!,
                 identityURL: URL(string: "https://example.com/identity")!,
                 importItemsURL: URL(string: "https://example.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://example.com/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://example.com/proxy-cookie-redirect-connector.html",
                 )!,
@@ -111,6 +114,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://icons.bitwarden.eu")!,
                 identityURL: URL(string: "https://identity.bitwarden.eu")!,
                 importItemsURL: URL(string: "https://vault.bitwarden.eu/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden.eu/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://vault.bitwarden.eu/proxy-cookie-redirect-connector.html",
                 )!,
@@ -141,6 +145,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://icons.bitwarden.net")!,
                 identityURL: URL(string: "https://identity.bitwarden.com")!,
                 importItemsURL: URL(string: "https://vault.bitwarden.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden.com/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html",
                 )!,
@@ -171,6 +176,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://example.com/icons")!,
                 identityURL: URL(string: "https://example.com/identity")!,
                 importItemsURL: URL(string: "https://example.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://example.com/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://example.com/proxy-cookie-redirect-connector.html",
                 )!,
@@ -207,6 +213,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://icons.example.com")!,
                 identityURL: URL(string: "https://identity.example.com")!,
                 importItemsURL: URL(string: "https://example.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://example.com/#/settings/subscription")!,
                 proxyCookieRedirectConnectorURL: URL(
                     string: "https://example.com/proxy-cookie-redirect-connector.html",
                 )!,
@@ -235,6 +242,7 @@ class EnvironmentURLsTests: BitwardenTestCase {
                 iconsURL: URL(string: "https://icons.bitwarden.net")!,
                 identityURL: URL(string: "https://identity.bitwarden.com")!,
                 importItemsURL: URL(string: "https://vault.bitwarden.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden.com")!,
                 proxyCookieRedirectConnectorURL: URL(string: "https://vault.bitwarden.com")!,
                 recoveryCodeURL: URL(string: "https://vault.bitwarden.com/#/recover-2fa")!,
                 sendShareURL: URL(string: "https://send.bitwarden.com/#")!,

--- a/BitwardenKit/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenKit/Core/Platform/Services/EnvironmentService.swift
@@ -29,6 +29,9 @@ public protocol EnvironmentService {
     /// The URL for importing items.
     var importItemsURL: URL { get }
 
+    /// The URL for managing the subscription plan.
+    var manageSubscriptionURL: URL { get }
+
     /// The URL for a proxy on cookie redirect (used on SSO sync error).
     var proxyCookieRedirectConnectorURL: URL { get }
 

--- a/BitwardenKit/Core/Platform/Services/Mocks/MockEnvironmentService.swift
+++ b/BitwardenKit/Core/Platform/Services/Mocks/MockEnvironmentService.swift
@@ -15,6 +15,7 @@ public class MockEnvironmentService: EnvironmentService {
     public var iconsURL = URL(string: "https://example.com/icons")!
     public var identityURL = URL(string: "https://example.com/identity")!
     public var importItemsURL = URL(string: "https://example.com/#/tools/import")!
+    public var manageSubscriptionURL = URL(string: "https://example.com/#/settings/subscription")!
     public var proxyCookieRedirectConnectorURL = URL(string: "https://example.com/proxy-cookie-redirect-connector")!
     public var recoveryCodeURL = URL(string: "https://example.com/#/recover-2fa")!
     public var region = RegionType.selfHosted

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -748,6 +748,7 @@
 "BitwardenTools" = "Bitwarden tools";
 "ImportSuccessful" = "Import successful!";
 "ManageYourLoginsFromAnywhereWithBitwardenToolsForWebAndDesktop" = "Manage your logins from anywhere with Bitwarden tools for web and desktop.";
+"ManageYourSubscriptionPlanInTheBitwardenWebApp" = "Manage your subscription plan in the Bitwarden web app.";
 "DownloadTheBrowserExtension" = "Download the browser extension";
 "GoToBitwardenToIntegrateBitwardenIntoYourFavoriteBrowserForASeamlessExperience" = "Go to bitwarden.com/download to integrate Bitwarden into your favorite browser for a seamless experience.";
 "UseTheWebApp" = "Use the web app";

--- a/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
@@ -147,6 +147,10 @@ extension DefaultEnvironmentService {
         environmentURLs.importItemsURL
     }
 
+    var manageSubscriptionURL: URL {
+        environmentURLs.manageSubscriptionURL
+    }
+
     var proxyCookieRedirectConnectorURL: URL {
         environmentURLs.proxyCookieRedirectConnectorURL
     }

--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -32,6 +32,9 @@ extension ExternalLinksConstants {
     /// A link to Bitwarden's help page for learning more about Premium features.
     static let learnMoreAboutPremium = URL(string: "https://bitwarden.com/help/password-manager-plans/")!
 
+    /// A link to the subscription management page in the Bitwarden web app.
+    static let manageSubscription = URL(string: "https://vault.bitwarden.com/#/settings/subscription")!
+
     /// A link to the password options within the passwords section of the settings menu.
     static let passwordOptions = URL(string: "App-prefs:PASSWORDS&path=PASSWORD_OPTIONS")!
 

--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -32,9 +32,6 @@ extension ExternalLinksConstants {
     /// A link to Bitwarden's help page for learning more about Premium features.
     static let learnMoreAboutPremium = URL(string: "https://bitwarden.com/help/password-manager-plans/")!
 
-    /// A link to the subscription management page in the Bitwarden web app.
-    static let manageSubscription = URL(string: "https://vault.bitwarden.com/#/settings/subscription")!
-
     /// A link to the password options within the passwords section of the settings menu.
     static let passwordOptions = URL(string: "App-prefs:PASSWORDS&path=PASSWORD_OPTIONS")!
 

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
@@ -50,7 +50,7 @@ final class PremiumPlanProcessor: StateProcessor<
         case .appeared:
             await loadPremiumPlan()
         case .managePlanTapped:
-            await openPortalUrl()
+            showManageSubscriptionAlert()
         }
     }
 
@@ -64,6 +64,16 @@ final class PremiumPlanProcessor: StateProcessor<
     }
 
     // MARK: Private Methods
+
+    /// Shows the "Continue to web app?" alert for managing the subscription plan.
+    ///
+    private func showManageSubscriptionAlert() {
+        coordinator.showAlert(
+            .manageSubscriptionPlanAlert { [weak self] in
+                self?.state.urlToOpen = ExternalLinksConstants.manageSubscription
+            },
+        )
+    }
 
     /// Fetches the portal URL from the billing service and sets it on state.
     ///

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
@@ -14,6 +14,7 @@ final class PremiumPlanProcessor: StateProcessor<
     // MARK: Types
 
     typealias Services = HasBillingService
+        & HasEnvironmentService
         & HasErrorReporter
 
     // MARK: Private Properties
@@ -68,9 +69,10 @@ final class PremiumPlanProcessor: StateProcessor<
     /// Shows the "Continue to web app?" alert for managing the subscription plan.
     ///
     private func showManageSubscriptionAlert() {
+        let webVaultURL = services.environmentService.webVaultURL
         coordinator.showAlert(
             .manageSubscriptionPlanAlert { [weak self] in
-                self?.state.urlToOpen = ExternalLinksConstants.manageSubscription
+                self?.state.urlToOpen = URL(string: webVaultURL.absoluteString + "/#/settings/subscription")
             },
         )
     }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
@@ -69,10 +69,10 @@ final class PremiumPlanProcessor: StateProcessor<
     /// Shows the "Continue to web app?" alert for managing the subscription plan.
     ///
     private func showManageSubscriptionAlert() {
-        let webVaultURL = services.environmentService.webVaultURL
+        let manageSubscriptionURL = services.environmentService.manageSubscriptionURL
         coordinator.showAlert(
             .manageSubscriptionPlanAlert { [weak self] in
-                self?.state.urlToOpen = URL(string: webVaultURL.absoluteString + "/#/settings/subscription")
+                self?.state.urlToOpen = manageSubscriptionURL
             },
         )
     }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
@@ -69,10 +69,9 @@ final class PremiumPlanProcessor: StateProcessor<
     /// Shows the "Continue to web app?" alert for managing the subscription plan.
     ///
     private func showManageSubscriptionAlert() {
-        let manageSubscriptionURL = services.environmentService.manageSubscriptionURL
         coordinator.showAlert(
             .manageSubscriptionPlanAlert { [weak self] in
-                self?.state.urlToOpen = manageSubscriptionURL
+                self?.state.urlToOpen = self?.services.environmentService.manageSubscriptionURL
             },
         )
     }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
@@ -16,6 +16,7 @@ struct PremiumPlanProcessorTests {
 
     let billingService: MockBillingService
     let coordinator: MockCoordinator<BillingRoute, Void>
+    let environmentService: MockEnvironmentService
     let errorReporter: MockErrorReporter
     let subject: PremiumPlanProcessor
 
@@ -24,9 +25,11 @@ struct PremiumPlanProcessorTests {
     init() {
         billingService = MockBillingService()
         coordinator = MockCoordinator<BillingRoute, Void>()
+        environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         let services = ServiceContainer.withMocks(
             billingService: billingService,
+            environmentService: environmentService,
             errorReporter: errorReporter,
         )
         subject = PremiumPlanProcessor(
@@ -153,27 +156,29 @@ struct PremiumPlanProcessorTests {
         #expect(subject.state.urlToOpen == nil)
     }
 
-    /// `perform(_:)` with `.managePlanTapped` fetches portal URL and sets state.
+    /// `perform(_:)` with `.managePlanTapped` shows the "Continue to web app?" alert.
     @Test
-    func perform_managePlanTapped_setsPortalUrl() async {
-        let portalURL = URL(string: "https://billing.stripe.com/portal/session")!
-        billingService.getPortalUrlReturnValue = portalURL
-
+    func perform_managePlanTapped_showsAlert() async {
         await subject.perform(.managePlanTapped)
 
-        #expect(billingService.getPortalUrlCallsCount == 1)
-        #expect(subject.state.urlToOpen == portalURL)
+        #expect(coordinator.alertShown.count == 1)
+        #expect(coordinator.alertShown.first?.title == Localizations.continueToWebApp)
+        #expect(
+            coordinator.alertShown.first?.message == Localizations.manageYourSubscriptionPlanInTheBitwardenWebApp,
+        )
+        #expect(coordinator.alertShown.first?.alertActions.count == 2)
+        #expect(coordinator.alertShown.first?.alertActions.first?.title == Localizations.cancel)
+        #expect(coordinator.alertShown.first?.alertActions.last?.title == Localizations.continue)
     }
 
-    /// `perform(_:)` with `.managePlanTapped` logs error and shows alert on failure.
+    /// `perform(_:)` with `.managePlanTapped`, after confirming, sets `urlToOpen` to the subscription URL.
     @Test
-    func perform_managePlanTapped_serviceError() async {
-        billingService.getPortalUrlThrowableError = BitwardenTestError.example
-
+    func perform_managePlanTapped_continue_setsSubscriptionUrl() async throws {
         await subject.perform(.managePlanTapped)
 
-        #expect(errorReporter.errors.first as? BitwardenTestError == .example)
-        #expect(coordinator.errorAlertsShown.count == 1)
-        #expect(subject.state.urlToOpen == nil)
+        let continueAction = try #require(coordinator.alertShown.first?.alertActions.last)
+        await continueAction.handler?(continueAction, [])
+
+        #expect(subject.state.urlToOpen == environmentService.manageSubscriptionURL)
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/Alert+Settings.swift
@@ -149,6 +149,24 @@ extension Alert {
         )
     }
 
+    /// An alert that asks if the user wants to navigate to the subscription management page in the web app.
+    ///
+    /// - Parameter action: The action taken if they select continue.
+    /// - Returns: An alert that asks if the user wants to navigate to the subscription page in the web app.
+    ///
+    static func manageSubscriptionPlanAlert(action: @escaping () -> Void) -> Alert {
+        Alert(
+            title: Localizations.continueToWebApp,
+            message: Localizations.manageYourSubscriptionPlanInTheBitwardenWebApp,
+            alertActions: [
+                AlertAction(title: Localizations.cancel, style: .cancel),
+                AlertAction(title: Localizations.continue, style: .default) { _ in
+                    action()
+                },
+            ],
+        )
+    }
+
     /// Confirms that the user wants to set their vault timeout to never.
     ///
     /// - Parameter action: The action performed when they select `Yes`.

--- a/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Extensions/AlertSettingsTests.swift
@@ -122,6 +122,26 @@ class AlertSettingsTests: BitwardenTestCase {
         XCTAssertEqual(subject.message, Localizations.vaultTimeoutLogOutConfirmation)
     }
 
+    /// `manageSubscriptionPlanAlert(action:)` constructs an `Alert`
+    /// with the correct title, message, and Cancel and Continue buttons.
+    func test_manageSubscriptionPlanAlert() async throws {
+        var actionCalled = false
+        let subject = Alert.manageSubscriptionPlanAlert { actionCalled = true }
+
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.title, Localizations.continueToWebApp)
+        XCTAssertEqual(subject.message, Localizations.manageYourSubscriptionPlanInTheBitwardenWebApp)
+        XCTAssertEqual(subject.alertActions.count, 2)
+        XCTAssertEqual(subject.alertActions.first?.title, Localizations.cancel)
+        XCTAssertEqual(subject.alertActions.first?.style, .cancel)
+        XCTAssertEqual(subject.alertActions.last?.title, Localizations.continue)
+        XCTAssertEqual(subject.alertActions.last?.style, .default)
+
+        let action = try XCTUnwrap(subject.alertActions.last)
+        await action.handler?(action, [])
+        XCTAssertTrue(actionCalled)
+    }
+
     /// `neverLockAlert(encrypted:action:)` constructs an `Alert`
     /// with the correct title, message, and Yes and Cancel buttons.
     func test_neverLockAlert() {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37697

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When tapping "Manage plan" on the Premium Plan screen, instead of opening Stripe in the browser, a "Continue to web app?" confirmation alert is shown. Tapping Continue opens the Bitwarden web app subscription page (`https://vault.bitwarden.com/#/settings/subscription`).

## 📸 Screenshots

https://github.com/user-attachments/assets/1e6afc51-10e1-4027-a7bd-55dbf50a106b

