### PR TITLE
[PM-37719] feat: Upcoming charge is not read as a dollar amount by VoiceOver

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -35,6 +35,15 @@ struct PremiumPlanState: Equatable {
         return formatDate(canceled)
     }
 
+    /// The accessibility label for the description text, using a screen-reader-friendly currency format.
+    var descriptionAccessibilityLabel: String {
+        guard planStatus == .active else { return descriptionText }
+        return Localizations.yourNextChargeIsForXDueOnY(
+            nextChargeAmountAccessibilityLabel,
+            nextChargeDate,
+        )
+    }
+
     /// The description text for the current plan status.
     var descriptionText: String {
         switch planStatus {
@@ -77,6 +86,12 @@ struct PremiumPlanState: Equatable {
     var nextChargeAmount: String {
         guard let subscription, subscription.nextCharge != nil else { return "" }
         return formatCurrencyCode(subscription.totalAmount)
+    }
+
+    /// The next charge amount formatted for screen readers (e.g. "USD $24.35").
+    var nextChargeAmountAccessibilityLabel: String {
+        guard let subscription, subscription.nextCharge != nil else { return "" }
+        return "USD \(formatCurrency(subscription.totalAmount))"
     }
 
     /// The next charge date, formatted for display.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -32,6 +32,37 @@ struct PremiumPlanStateTests {
         #expect(state.billingAmount.isEmpty)
     }
 
+    // MARK: Tests - descriptionAccessibilityLabel
+
+    /// `descriptionAccessibilityLabel` returns a screen-reader-friendly description for the active plan status.
+    @Test
+    func descriptionAccessibilityLabel_active() {
+        var state = PremiumPlanState()
+        state.planStatus = .active
+        state.subscription = .fixture(
+            estimatedTax: 4.55,
+            nextCharge: testDate,
+        )
+        let label = state.descriptionAccessibilityLabel
+        #expect(label.contains("USD $"))
+        #expect(label.contains(state.nextChargeDate))
+    }
+
+    /// `descriptionAccessibilityLabel` returns `descriptionText` unchanged for non-active plan statuses.
+    @Test(arguments: [PremiumPlanStatus.canceled, .pastDue, .unknown, .updatePayment])
+    func descriptionAccessibilityLabel_nonActive(planStatus: PremiumPlanStatus) {
+        var state = PremiumPlanState()
+        state.planStatus = planStatus
+        state.subscription = .fixture(
+            cancelAt: testDate,
+            canceled: testDate,
+            gracePeriod: 14,
+            status: planStatus,
+            suspension: testDate,
+        )
+        #expect(state.descriptionAccessibilityLabel == state.descriptionText)
+    }
+
     // MARK: Tests - descriptionText
 
     /// `descriptionText` returns the correct text for the active plan status.
@@ -126,6 +157,26 @@ struct PremiumPlanStateTests {
         var state = PremiumPlanState()
         state.subscription = .fixture(estimatedTax: 0)
         #expect(state.estimatedTax.isEmpty)
+    }
+
+    // MARK: Tests - nextChargeAmountAccessibilityLabel
+
+    /// `nextChargeAmountAccessibilityLabel` returns a screen-reader-friendly amount (e.g. "USD $24.35").
+    @Test
+    func nextChargeAmountAccessibilityLabel() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(
+            estimatedTax: 4.55,
+            nextCharge: testDate,
+        )
+        #expect(state.nextChargeAmountAccessibilityLabel.hasPrefix("USD $"))
+    }
+
+    /// `nextChargeAmountAccessibilityLabel` returns empty when subscription is nil.
+    @Test
+    func nextChargeAmountAccessibilityLabel_nil() {
+        let state = PremiumPlanState()
+        #expect(state.nextChargeAmountAccessibilityLabel.isEmpty)
     }
 
     // MARK: Tests - showBillingDetails

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -90,6 +90,7 @@ struct PremiumPlanView: View {
         Text(LocalizedStringKey(store.state.descriptionText))
             .styleGuide(.callout)
             .foregroundColor(Color(asset: SharedAsset.Colors.textSecondary))
+            .accessibilityLabel(store.state.descriptionAccessibilityLabel)
     }
 
     /// The header section with title, badge, and description.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37719

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When using VoiceOver on the Plan page, the upcoming charge amount was announced as "19 dot 80 USD" instead of a recognisable dollar amount. This adds an accessibility label to the description text so VoiceOver announces it as "USD $19.80".