### PR TITLE
[PM-13621] ci: Enable xcodegen Renovate manager for SPM dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,8 +9,12 @@
     "github-actions",
     "mint",
     "custom.regex",
-    "swift"
+    "swift",
+    "xcodegen"
   ],
+  "xcodegen": {
+    "managerFilePatterns": ["/project(-[a-z]+)?\\.yml$/"]
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -35,6 +39,10 @@
         "minor",
         "patch"
       ]
+    },
+    {
+      "matchPackageNames": ["bitwarden/sdk-swift"],
+      "enabled": false
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,7 @@
     "swift",
     "xcodegen"
   ],
+  "ignoreDeps": ["bitwarden/sdk-swift"],
   "xcodegen": {
     "managerFilePatterns": ["/project(-[a-z]+)?\\.yml$/"]
   },
@@ -39,10 +40,6 @@
         "minor",
         "patch"
       ]
-    },
-    {
-      "matchPackageNames": ["bitwarden/sdk-swift"],
-      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-13621

## 📔 Objective

Enables Renovate to track and update SPM packages declared in our XcodeGen project YAML files (`project-common.yml`, `project-bwa.yml`, `project-bwk.yml`, etc.).

Previously, Renovate's `swift` manager only handled `Package.swift` files, leaving all XcodeGen-declared SPM dependencies unmanaged. As of Renovate 43.123.0 a native `xcodegen` manager exists. This PR:

- Adds `xcodegen` to `enabledManagers`
- Overrides `managerFilePatterns` to match our `project-*.yml` naming convention (the default only matches `project.yml`)
- Adds a `packageRules` entry to disable Renovate for `bitwarden/sdk-swift`, which uses a commit `revision` rather than a semver version and is managed by the dedicated SDK update workflow

Renovate dry-run confirmed it correctly picks up Firebase, SnapshotTesting, ViewInspector, SwiftProtobuf, and SwiftUIIntrospect, and automatically skips BitwardenSdk (`unversioned-reference`).

Relevant links:

* https://docs.renovatebot.com/modules/manager/xcodegen/
* https://github.com/renovatebot/renovate/pull/41889
* https://github.com/renovatebot/renovate/issues/20504
* https://github.com/renovatebot/renovate/discussions/43488