### PR TITLE
[PM-37920] fix: Align Plan screen cart summary with web 

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1058,6 +1058,7 @@
 "StorageCost" = "Storage cost";
 "Discount" = "Discount";
 "EstimatedTax" = "Estimated tax";
+"Total" = "Total";
 "ManagePlan" = "Manage plan";
 "CancelPremium" = "Cancel Premium";
 "CancelNow" = "Cancel now";

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
@@ -103,7 +103,7 @@ struct PremiumPlanProcessorTests {
         #expect(subject.state.nextChargeAmount.contains("USD"))
         #expect(subject.state.nextChargeAmount.contains("24.35"))
         #expect(!subject.state.nextChargeDate.isEmpty)
-        #expect(!subject.state.showStorageCost)
+        #expect(subject.state.storageCostLabel.contains("$0.00"))
     }
 
     /// `receive(_:)` with `.cancelPremiumTapped` shows the confirmation alert.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -76,8 +76,7 @@ struct PremiumPlanState: Equatable {
         return Localizations.negativeX(formatCurrency(subscription.discount))
     }
 
-    /// The estimated tax label (e.g. "$4.55" or "$0.00"). Always renders when a
-    /// subscription exists, mirroring web's cart-summary always-render behavior.
+    /// The estimated tax label (e.g. "$4.55" or "$0.00").
     var estimatedTax: String {
         guard let subscription else { return "" }
         return formatCurrency(subscription.estimatedTax)
@@ -116,14 +115,9 @@ struct PremiumPlanState: Equatable {
         !discount.isEmpty
     }
 
-    /// Whether the storage cost row should be shown.
-    var showStorageCost: Bool {
-        (subscription?.storageCost ?? 0) > 0
-    }
-
-    /// The storage cost label (e.g. "$4.00").
+    /// The storage cost label (e.g. "$4.00" or "$0.00").
     var storageCostLabel: String {
-        guard let subscription, subscription.storageCost > 0 else { return "" }
+        guard let subscription else { return "" }
         return formatCurrency(subscription.storageCost)
     }
 
@@ -137,8 +131,7 @@ struct PremiumPlanState: Equatable {
         return ""
     }
 
-    /// The total label (e.g. "$25.55 / year"). Mirrors web's cart-summary
-    /// Total line, including the cadence suffix.
+    /// The total label (e.g. "$25.55 / year").
     var totalLabel: String {
         guard let subscription else { return "" }
         return Localizations.xAmountPerCadence(

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -76,9 +76,10 @@ struct PremiumPlanState: Equatable {
         return Localizations.negativeX(formatCurrency(subscription.discount))
     }
 
-    /// The estimated tax label (e.g. "$4.55").
+    /// The estimated tax label (e.g. "$4.55" or "$0.00"). Always renders when a
+    /// subscription exists, mirroring web's cart-summary always-render behavior.
     var estimatedTax: String {
-        guard let subscription, subscription.estimatedTax > 0 else { return "" }
+        guard let subscription else { return "" }
         return formatCurrency(subscription.estimatedTax)
     }
 
@@ -115,11 +116,6 @@ struct PremiumPlanState: Equatable {
         !discount.isEmpty
     }
 
-    /// Whether the estimated tax row should be shown.
-    var showEstimatedTax: Bool {
-        !estimatedTax.isEmpty
-    }
-
     /// Whether the storage cost row should be shown.
     var showStorageCost: Bool {
         (subscription?.storageCost ?? 0) > 0
@@ -139,6 +135,16 @@ struct PremiumPlanState: Equatable {
             return formatDate(cancelAt)
         }
         return ""
+    }
+
+    /// The total label (e.g. "$25.55 / year"). Mirrors web's cart-summary
+    /// Total line, including the cadence suffix.
+    var totalLabel: String {
+        guard let subscription else { return "" }
+        return Localizations.xAmountPerCadence(
+            formatCurrency(subscription.totalAmount),
+            subscription.cadence.label,
+        )
     }
 
     // MARK: Private Methods

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -151,11 +151,18 @@ struct PremiumPlanStateTests {
         #expect(state.estimatedTax == "$4.55")
     }
 
-    /// `estimatedTax` returns empty when tax is zero.
+    /// `estimatedTax` returns the formatted zero amount when tax is zero.
     @Test
     func estimatedTax_zero() {
         var state = PremiumPlanState()
         state.subscription = .fixture(estimatedTax: 0)
+        #expect(state.estimatedTax == "$0.00")
+    }
+
+    /// `estimatedTax` returns empty when subscription is nil.
+    @Test
+    func estimatedTax_nil() {
+        let state = PremiumPlanState()
         #expect(state.estimatedTax.isEmpty)
     }
 
@@ -229,24 +236,6 @@ struct PremiumPlanStateTests {
         #expect(!state.showDiscount)
     }
 
-    // MARK: Tests - showEstimatedTax
-
-    /// `showEstimatedTax` is true when estimated tax is greater than zero.
-    @Test
-    func showEstimatedTax_true() {
-        var state = PremiumPlanState()
-        state.subscription = .fixture(estimatedTax: 4.55)
-        #expect(state.showEstimatedTax)
-    }
-
-    /// `showEstimatedTax` is false when estimated tax is zero.
-    @Test
-    func showEstimatedTax_false() {
-        var state = PremiumPlanState()
-        state.subscription = .fixture(estimatedTax: 0)
-        #expect(!state.showEstimatedTax)
-    }
-
     // MARK: Tests - showStorageCost
 
     /// `showStorageCost` is true when storage cost is greater than zero.
@@ -307,5 +296,42 @@ struct PremiumPlanStateTests {
         var state = PremiumPlanState()
         state.subscription = .fixture()
         #expect(state.subscriptionEndDate.isEmpty)
+    }
+
+    // MARK: Tests - totalLabel
+
+    /// `totalLabel` returns the formatted total with cadence suffix.
+    @Test
+    func totalLabel() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(
+            cadence: .annually,
+            discount: 0,
+            estimatedTax: 4.55,
+            seatsCost: 19.80,
+            storageCost: 1.20,
+        )
+        #expect(state.totalLabel.contains("$25.55"))
+        #expect(state.totalLabel.contains(Localizations.perYear))
+    }
+
+    /// `totalLabel` floors at zero when discounts exceed costs.
+    @Test
+    func totalLabel_flooredAtZero() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(
+            discount: 100,
+            estimatedTax: 0,
+            seatsCost: 10,
+            storageCost: 0,
+        )
+        #expect(state.totalLabel.contains("$0.00"))
+    }
+
+    /// `totalLabel` returns empty when subscription is nil.
+    @Test
+    func totalLabel_nil() {
+        let state = PremiumPlanState()
+        #expect(state.totalLabel.isEmpty)
     }
 }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -236,24 +236,6 @@ struct PremiumPlanStateTests {
         #expect(!state.showDiscount)
     }
 
-    // MARK: Tests - showStorageCost
-
-    /// `showStorageCost` is true when storage cost is greater than zero.
-    @Test
-    func showStorageCost_true() {
-        var state = PremiumPlanState()
-        state.subscription = .fixture(storageCost: 4)
-        #expect(state.showStorageCost)
-    }
-
-    /// `showStorageCost` is false when storage cost is zero.
-    @Test
-    func showStorageCost_false() {
-        var state = PremiumPlanState()
-        state.subscription = .fixture(storageCost: 0)
-        #expect(!state.showStorageCost)
-    }
-
     // MARK: Tests - storageCostLabel
 
     /// `storageCostLabel` returns the formatted storage cost.
@@ -264,11 +246,18 @@ struct PremiumPlanStateTests {
         #expect(state.storageCostLabel == "$8.00")
     }
 
-    /// `storageCostLabel` returns empty when storage cost is zero.
+    /// `storageCostLabel` returns the formatted zero amount when storage cost is zero.
     @Test
-    func storageCostLabel_noStorage() {
+    func storageCostLabel_zero() {
         var state = PremiumPlanState()
         state.subscription = .fixture(storageCost: 0)
+        #expect(state.storageCostLabel == "$0.00")
+    }
+
+    /// `storageCostLabel` returns empty when subscription is nil.
+    @Test
+    func storageCostLabel_nil() {
+        let state = PremiumPlanState()
         #expect(state.storageCostLabel.isEmpty)
     }
 

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+ViewInspectorTests.swift
@@ -86,11 +86,62 @@ class PremiumPlanViewTests: BitwardenTestCase {
         XCTAssertNotNil(button)
     }
 
+    /// The estimated tax row renders as $0.00 when tax is zero and the
+    /// plan is active. Matches the canonical web cart-summary behavior.
+    @MainActor
+    func test_estimatedTax_visible_whenZero() throws {
+        processor.state.planStatus = .active
+        processor.state.subscription = PremiumSubscription(
+            cadence: .monthly,
+            cancelAt: nil,
+            canceled: nil,
+            discount: 0,
+            estimatedTax: 0,
+            gracePeriod: nil,
+            nextCharge: nil,
+            seatsCost: Decimal(string: "1.65")!,
+            status: .active,
+            storageCost: 0,
+            suspension: nil,
+        )
+        XCTAssertNotNil(try subject.inspect().find(text: Localizations.estimatedTax))
+        XCTAssertNotNil(try subject.inspect().find(text: processor.state.estimatedTax))
+    }
+
     /// Tapping the manage plan button dispatches the `.managePlanTapped` effect.
     @MainActor
     func test_managePlanButton_tap() async throws {
         let button = try subject.inspect().find(asyncButton: Localizations.managePlan)
         try await button.tap()
         XCTAssertEqual(processor.effects.last, .managePlanTapped)
+    }
+
+    /// The Total row is hidden when the plan is canceled (whole section
+    /// suppressed by `showBillingDetails`).
+    @MainActor
+    func test_totalRow_hidden_whenCanceled() throws {
+        processor.state.planStatus = .canceled
+        XCTAssertThrowsError(try subject.inspect().find(text: Localizations.total))
+    }
+
+    /// The Total row renders with cadence suffix when the plan is active.
+    @MainActor
+    func test_totalRow_visible_whenActive() throws {
+        processor.state.planStatus = .active
+        processor.state.subscription = PremiumSubscription(
+            cadence: .monthly,
+            cancelAt: nil,
+            canceled: nil,
+            discount: 0,
+            estimatedTax: 0,
+            gracePeriod: nil,
+            nextCharge: nil,
+            seatsCost: Decimal(string: "1.65")!,
+            status: .active,
+            storageCost: 0,
+            suspension: nil,
+        )
+        XCTAssertNotNil(try subject.inspect().find(text: Localizations.total))
+        XCTAssertNotNil(try subject.inspect().find(text: processor.state.totalLabel))
     }
 }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+ViewInspectorTests.swift
@@ -86,8 +86,7 @@ class PremiumPlanViewTests: BitwardenTestCase {
         XCTAssertNotNil(button)
     }
 
-    /// The estimated tax row renders as $0.00 when tax is zero and the
-    /// plan is active. Matches the canonical web cart-summary behavior.
+    /// The estimated tax row renders as $0.00 when tax is zero and the plan is active.
     @MainActor
     func test_estimatedTax_visible_whenZero() throws {
         processor.state.planStatus = .active
@@ -116,8 +115,7 @@ class PremiumPlanViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.effects.last, .managePlanTapped)
     }
 
-    /// The Total row is hidden when the plan is canceled (whole section
-    /// suppressed by `showBillingDetails`).
+    /// The Total row is hidden when the plan is canceled.
     @MainActor
     func test_totalRow_hidden_whenCanceled() throws {
         processor.state.planStatus = .canceled

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -62,13 +62,17 @@ struct PremiumPlanView: View {
                 valueColor: SharedAsset.Colors.statusStrong.swiftUIColor,
             )
         }
-        if store.state.showEstimatedTax {
-            billingRow(
-                label: Localizations.estimatedTax,
-                value: store.state.estimatedTax,
-                valueColor: Color(asset: SharedAsset.Colors.textPrimary),
-            )
-        }
+        billingRow(
+            label: Localizations.estimatedTax,
+            value: store.state.estimatedTax,
+            valueColor: Color(asset: SharedAsset.Colors.textPrimary),
+        )
+        billingRow(
+            label: Localizations.total,
+            value: store.state.totalLabel,
+            valueColor: Color(asset: SharedAsset.Colors.textPrimary),
+            font: .bodyBold,
+        )
     }
 
     /// The cancel premium button.
@@ -154,21 +158,24 @@ struct PremiumPlanView: View {
     ///   - label: The label text displayed on the left.
     ///   - value: The value text displayed on the right.
     ///   - valueColor: The color to use for the value text.
+    ///   - font: The style guide font applied to both the label and the value. Defaults to `.body`;
+    ///     the Total row passes `.bodyBold` to match the design's emphasized total typography.
     ///
     private func billingRow(
         label: String,
         value: String,
         valueColor: Color,
+        font: StyleGuideFont = .body,
     ) -> some View {
         HStack {
             Text(label)
-                .styleGuide(.body)
+                .styleGuide(font)
                 .foregroundColor(Color(asset: SharedAsset.Colors.textSecondary))
 
             Spacer()
 
             Text(value)
-                .styleGuide(.body)
+                .styleGuide(font)
                 .foregroundColor(valueColor)
         }
         .padding(.vertical, 20)

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -41,20 +41,18 @@ struct PremiumPlanView: View {
 
     // MARK: Private Views
 
-    /// The billing details section with rows for billing amount, storage cost, and discount.
+    /// The billing details section with rows for billing amount, storage cost, and discount
     @ViewBuilder private var billingSection: some View {
         billingRow(
             label: Localizations.billingAmount,
             value: store.state.billingAmount,
             valueColor: Color(asset: SharedAsset.Colors.textPrimary),
         )
-        if store.state.showStorageCost {
-            billingRow(
-                label: Localizations.storageCost,
-                value: store.state.storageCostLabel,
-                valueColor: Color(asset: SharedAsset.Colors.textPrimary),
-            )
-        }
+        billingRow(
+            label: Localizations.storageCost,
+            value: store.state.storageCostLabel,
+            valueColor: Color(asset: SharedAsset.Colors.textPrimary),
+        )
         if store.state.showDiscount {
             billingRow(
                 label: Localizations.discount,
@@ -71,7 +69,7 @@ struct PremiumPlanView: View {
             label: Localizations.total,
             value: store.state.totalLabel,
             valueColor: Color(asset: SharedAsset.Colors.textPrimary),
-            font: .bodyBold,
+            labelWeight: .bold,
         )
     }
 
@@ -158,24 +156,23 @@ struct PremiumPlanView: View {
     ///   - label: The label text displayed on the left.
     ///   - value: The value text displayed on the right.
     ///   - valueColor: The color to use for the value text.
-    ///   - font: The style guide font applied to both the label and the value. Defaults to `.body`;
-    ///     the Total row passes `.bodyBold` to match the design's emphasized total typography.
+    ///   - labelWeight: The font weight applied to the label.
     ///
     private func billingRow(
         label: String,
         value: String,
         valueColor: Color,
-        font: StyleGuideFont = .body,
+        labelWeight: SwiftUI.Font.Weight = .regular,
     ) -> some View {
         HStack {
             Text(label)
-                .styleGuide(font)
+                .styleGuide(.body, weight: labelWeight)
                 .foregroundColor(Color(asset: SharedAsset.Colors.textSecondary))
 
             Spacer()
 
             Text(value)
-                .styleGuide(font)
+                .styleGuide(.body)
                 .foregroundColor(valueColor)
         }
         .padding(.vertical, 20)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37920](https://bitwarden.atlassian.net/browse/PM-37920)

## 📔 Objective

Aligns the Plan screen's billing section with the canonical web cart-summary contract:

- **Estimated Tax** now always renders when a subscription exists (formats to `$0.00` at zero) instead of being hidden.
- **Storage cost** now always renders within the billing section (formats to `$0.00` when zero) instead of being hidden at zero.
- **New Total row** renders below tax with the cadence suffix (e.g. `$25.55 / year`), backed by `PremiumSubscription.totalAmount`.

Total typography uses `labelWeight: .bold` (via `.styleGuide(.body, weight: .bold)`) to mirror web's `bodyLargeEmphasis` (Android equivalent: DM Sans W700, 15sp/20sp). The shared `billingRow` helper gained an optional `labelWeight:` parameter so other rows are unaffected.

## 📸 Screenshots

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/383a8258-9756-4df6-aeb3-39674da22baf" /> | <img width="365" src="https://github.com/user-attachments/assets/874a4718-65da-4b79-9254-041fa473818d" /> | 


[PM-37920]: https://bitwarden.atlassian.net/browse/PM-37920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ