### PR TITLE
[PM-24224] feat: Support v2 encryption on password account registration

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -5,6 +5,9 @@ import Foundation
 
 /// An enum to represent a feature flag sent by the server
 extension FeatureFlag: @retroactive CaseIterable {
+    /// Flag to enable/disable V2 password-based registration using the SDK registration client.
+    static let accountEncryptionV2PasswordRegistration = FeatureFlag(rawValue: "pm-27278-v2-password-registration")
+
     /// A feature flag to enable/disable scanning a card to autocomplete its details in add/edit cipher.
     static let cardScanner = FeatureFlag(rawValue: "pm-34171-card-scanner")
 
@@ -39,6 +42,7 @@ extension FeatureFlag: @retroactive CaseIterable {
 
     public static var allCases: [FeatureFlag] {
         [
+            .accountEncryptionV2PasswordRegistration,
             .cardScanner,
             .cipherKeyEncryption,
             .debugDisableSelfHostPremiumCheck,

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -54,6 +54,7 @@ class CompleteRegistrationProcessor: StateProcessor<
         & HasAuthRepository
         & HasAuthService
         & HasClientService
+        & HasConfigService
         & HasEnvironmentService
         & HasErrorReporter
         & HasStateService
@@ -179,35 +180,57 @@ class CompleteRegistrationProcessor: StateProcessor<
 
     /// Performs an API request to create the user's account.
     private func createAccount() async throws {
-        let kdfConfig = KdfConfig.defaultKdfConfig
+        if await services.configService.getFeatureFlag(.accountEncryptionV2PasswordRegistration, isPreAuth: true) {
+            _ = try await services.clientService.auth(isPreAuth: true)
+                .registration()
+                .postKeysForUserPasswordRegistration(
+                    request: UserMasterPasswordRegistrationRequest(
+                        email: state.userEmail,
+                        salt: state.userEmail,
+                        masterPassword: state.passwordText,
+                        masterPasswordHint: state.passwordHintText.nilIfEmpty,
+                        emailVerificationToken: state.emailVerificationToken,
+                        organizationUserId: nil,
+                        orgInviteToken: nil,
+                        orgSponsoredFreeFamilyPlanToken: nil,
+                        acceptEmergencyAccessInviteToken: nil,
+                        acceptEmergencyAccessId: nil,
+                        providerInviteToken: nil,
+                        providerUserId: nil,
+                    ),
+                )
+        } else {
+            // V1 path — to be removed with FeatureFlag.accountEncryptionV2PasswordRegistration
+            let kdfConfig = KdfConfig.defaultKdfConfig
 
-        let keys = try await services.clientService.auth(isPreAuth: true).makeRegisterKeys(
-            email: state.userEmail,
-            password: state.passwordText,
-            kdf: kdfConfig.sdkKdf,
-        )
-
-        let hashedPassword = try await services.clientService.auth(isPreAuth: true).hashPassword(
-            email: state.userEmail,
-            password: state.passwordText,
-            kdfParams: kdfConfig.sdkKdf,
-            purpose: .serverAuthorization,
-        )
-
-        _ = try await services.accountAPIService.registerFinish(
-            body: RegisterFinishRequestModel(
+            let keys = try await services.clientService.auth(isPreAuth: true).makeRegisterKeys(
                 email: state.userEmail,
-                emailVerificationToken: state.emailVerificationToken,
-                kdfConfig: kdfConfig,
-                masterPasswordHash: hashedPassword,
-                masterPasswordHint: state.passwordHintText,
-                userSymmetricKey: keys.encryptedUserKey,
-                userAsymmetricKeys: KeysRequestModel(
-                    encryptedPrivateKey: keys.keys.private,
-                    publicKey: keys.keys.public,
+                password: state.passwordText,
+                kdf: kdfConfig.sdkKdf,
+            )
+
+            let hashedPassword = try await services.clientService.auth(isPreAuth: true).hashPassword(
+                email: state.userEmail,
+                password: state.passwordText,
+                kdfParams: kdfConfig.sdkKdf,
+                purpose: .serverAuthorization,
+            )
+
+            _ = try await services.accountAPIService.registerFinish(
+                body: RegisterFinishRequestModel(
+                    email: state.userEmail,
+                    emailVerificationToken: state.emailVerificationToken,
+                    kdfConfig: kdfConfig,
+                    masterPasswordHash: hashedPassword,
+                    masterPasswordHint: state.passwordHintText,
+                    userSymmetricKey: keys.encryptedUserKey,
+                    userAsymmetricKeys: KeysRequestModel(
+                        encryptedPrivateKey: keys.keys.private,
+                        publicKey: keys.keys.public,
+                    ),
                 ),
-            ),
-        )
+            )
+        }
 
         state.didCreateAccount = true
     }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -179,27 +179,11 @@ class CompleteRegistrationProcessor: StateProcessor<
     }
 
     /// Performs an API request to create the user's account.
-    private func createAccount() async throws {
-        if await services.configService.getFeatureFlag(.accountEncryptionV2PasswordRegistration, isPreAuth: true) {
-            _ = try await services.clientService.auth(isPreAuth: true)
-                .registration()
-                .postKeysForUserPasswordRegistration(
-                    request: UserMasterPasswordRegistrationRequest(
-                        email: state.userEmail,
-                        salt: state.userEmail,
-                        masterPassword: state.passwordText,
-                        masterPasswordHint: state.passwordHintText.nilIfEmpty,
-                        emailVerificationToken: state.emailVerificationToken,
-                        organizationUserId: nil,
-                        orgInviteToken: nil,
-                        orgSponsoredFreeFamilyPlanToken: nil,
-                        acceptEmergencyAccessInviteToken: nil,
-                        acceptEmergencyAccessId: nil,
-                        providerInviteToken: nil,
-                        providerUserId: nil,
-                    ),
-                )
-        } else {
+    private func createAccount() async throws { // swiftlint:disable:this function_body_length
+        guard await services.configService.getFeatureFlag(
+            .accountEncryptionV2PasswordRegistration,
+            isPreAuth: true,
+        ) else {
             // V1 path — to be removed with FeatureFlag.accountEncryptionV2PasswordRegistration
             let kdfConfig = KdfConfig.defaultKdfConfig
 
@@ -230,7 +214,28 @@ class CompleteRegistrationProcessor: StateProcessor<
                     ),
                 ),
             )
+            state.didCreateAccount = true
+            return
         }
+
+        _ = try await services.clientService.auth(isPreAuth: true)
+            .registration()
+            .postKeysForUserPasswordRegistration(
+                request: UserMasterPasswordRegistrationRequest(
+                    email: state.userEmail,
+                    salt: state.userEmail,
+                    masterPassword: state.passwordText,
+                    masterPasswordHint: state.passwordHintText.nilIfEmpty,
+                    emailVerificationToken: state.emailVerificationToken,
+                    organizationUserId: nil,
+                    orgInviteToken: nil,
+                    orgSponsoredFreeFamilyPlanToken: nil,
+                    acceptEmergencyAccessInviteToken: nil,
+                    acceptEmergencyAccessId: nil,
+                    providerInviteToken: nil,
+                    providerUserId: nil,
+                ),
+            )
 
         state.didCreateAccount = true
     }

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessorTests.swift
@@ -3,6 +3,7 @@ import BitwardenKit
 import BitwardenKitMocks
 import BitwardenResources
 import BitwardenSdk
+import BitwardenSdkMocks
 import Networking
 import TestHelpers
 import XCTest
@@ -24,6 +25,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     var coordinator: MockCoordinator<AuthRoute, AuthEvent>!
     var environmentService: MockEnvironmentService!
     var errorReporter: MockErrorReporter!
+    var mockRegistrationClient: MockRegistrationClientProtocol!
     var subject: CompleteRegistrationProcessor!
     var stateService: MockStateService!
 
@@ -39,6 +41,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         coordinator = MockCoordinator<AuthRoute, AuthEvent>()
         environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
+        mockRegistrationClient = MockRegistrationClientProtocol()
         stateService = MockStateService()
 
         authClient.hashPasswordReturnValue = "hash password"
@@ -46,6 +49,16 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
             masterPasswordHash: "masterPasswordHash",
             encryptedUserKey: "encryptedUserKey",
             keys: RsaKeyPair(public: "public", private: "private"),
+        )
+        authClient.registrationReturnValue = mockRegistrationClient
+        mockRegistrationClient.postKeysForUserPasswordRegistrationReturnValue = UserMasterPasswordRegistrationResponse(
+            accountCryptographicState: .v1(privateKey: "privateKey"),
+            masterPasswordUnlock: MasterPasswordUnlockData(
+                kdf: .pbkdf2(iterations: 600_000),
+                masterKeyWrappedUserKey: "masterKeyWrappedUserKey",
+                salt: "salt",
+            ),
+            userKey: "userKey",
         )
 
         subject = CompleteRegistrationProcessor(
@@ -76,6 +89,7 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         coordinator = nil
         configService = nil
         errorReporter = nil
+        mockRegistrationClient = nil
         subject = nil
         stateService = nil
     }
@@ -381,27 +395,25 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         )
     }
 
-    /// `perform(_:)` with `.completeRegistration` presents an alert when the email has already been taken.
+    /// `perform(_:)` with `.completeRegistration` and V2 flag enabled calls `postKeysForUserPasswordRegistration`.
     @MainActor
-    func test_perform_completeRegistration_accountAlreadyExists() async {
+    func test_perform_completeRegistration_callsPostKeysForUserPasswordRegistration() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
         subject.state = .fixture()
-
-        let response = HTTPResponse.failure(
-            statusCode: 400,
-            body: APITestData.registerFinishAccountAlreadyExists.data,
-        )
-
-        guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
-        let error = ServerError.error(errorResponse: errorResponse)
-        client.result = .httpFailure(error)
 
         await subject.perform(.completeRegistration)
 
-        XCTAssertEqual(client.requests.count, 1)
-        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
-
+        XCTAssertTrue(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+        let request = try XCTUnwrap(mockRegistrationClient.postKeysForUserPasswordRegistrationReceivedRequest)
+        XCTAssertEqual(request.email, "email@example.com")
+        XCTAssertEqual(request.salt, "email@example.com")
+        XCTAssertEqual(request.masterPassword, "password1234")
+        XCTAssertNil(request.masterPasswordHint)
+        XCTAssertEqual(request.emailVerificationToken, "emailVerificationToken")
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
+        XCTAssertEqual(coordinator.events, [.didCompleteAuth])
+        XCTAssertTrue(subject.state.didCreateAccount)
     }
 
     /// `perform(_:)` with `.completeRegistration` presents an alert when the password field is empty.
@@ -416,6 +428,52 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         XCTAssertEqual(client.requests.count, 0)
         XCTAssertEqual(coordinator.alertShown.last, .validationFieldRequired(fieldName: "Master password"))
         XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
+    }
+
+    /// `perform(_:)` with `.completeRegistration` and V2 flag enabled propagates errors from the SDK.
+    @MainActor
+    func test_perform_completeRegistration_errorPropagates() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        mockRegistrationClient.postKeysForUserPasswordRegistrationThrowableError = BitwardenTestError.example
+        subject.state = .fixture()
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertTrue(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+        XCTAssertFalse(subject.state.didCreateAccount)
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? BitwardenTestError, .example)
+    }
+
+    /// `perform(_:)` with `.completeRegistration` navigates to login if the create account request
+    /// succeeds, but login fails.
+    @MainActor
+    func test_perform_completeRegistration_loginError() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        authService.loginWithMasterPasswordResult = .failure(BitwardenTestError.example)
+        subject.state = .fixture()
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertTrue(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+        XCTAssertTrue(subject.state.didCreateAccount)
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(
+            coordinator.loadingOverlaysShown,
+            [
+                LoadingOverlayState(title: Localizations.creatingAccount),
+            ],
+        )
+        XCTAssertEqual(coordinator.routes.count, 1)
+        guard case let .dismissWithAction(dismissAction) = coordinator.routes.first else {
+            return XCTFail("Unable to find dismiss action.")
+        }
+        dismissAction?.action()
+        XCTAssertEqual(coordinator.routes.count, 2)
+        XCTAssertEqual(coordinator.routes[1], .login(username: "email@example.com", isNewAccount: true))
+        XCTAssertEqual(coordinator.toastsShown, [Toast(title: Localizations.accountSuccessfullyCreated)])
     }
 
     /// `perform(_:)` with `.completeRegistration` presents an alert when the password matches the hint.
@@ -439,9 +497,133 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         ))
     }
 
+    /// `perform(_:)` with `.completeRegistration` presents an alert when password confirmation is incorrect.
+    @MainActor
+    func test_perform_completeRegistration_passwordsDontMatch() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        subject.state = .fixture(passwordText: "123456789012", retypePasswordText: "123456789000")
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertEqual(coordinator.alertShown.last, .passwordsDontMatch)
+        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
+        XCTAssertFalse(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+    }
+
+    /// `perform(_:)` with `.completeRegistration` presents an alert when the password isn't long enough.
+    @MainActor
+    func test_perform_completeRegistration_passwordsTooShort() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        subject.state = .fixture(passwordText: "123", retypePasswordText: "123")
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertEqual(coordinator.alertShown.last, .passwordIsTooShort)
+        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
+        XCTAssertFalse(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+    }
+
+    /// `perform(_:)` with `.completeRegistration` navigates to login if the create account and
+    /// login requests succeed, but vault unlocking fails.
+    @MainActor
+    func test_perform_completeRegistration_unlockError() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        authRepository.unlockWithPasswordResult = .failure(BitwardenTestError.example)
+        subject.state = .fixture()
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertTrue(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+        XCTAssertTrue(subject.state.didCreateAccount)
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(
+            coordinator.loadingOverlaysShown,
+            [
+                LoadingOverlayState(title: Localizations.creatingAccount),
+            ],
+        )
+        XCTAssertEqual(coordinator.routes.count, 1)
+        guard case let .dismissWithAction(dismissAction) = coordinator.routes.first else {
+            return XCTFail("Unable to find dismiss action.")
+        }
+        dismissAction?.action()
+        XCTAssertEqual(coordinator.routes.count, 2)
+        XCTAssertEqual(coordinator.routes[1], .login(username: "email@example.com", isNewAccount: true))
+        XCTAssertEqual(coordinator.toastsShown, [Toast(title: Localizations.accountSuccessfullyCreated)])
+    }
+
+    /// `perform(_:)` with `.completeRegistration` and V2 flag enabled passes a non-empty hint in the request.
+    @MainActor
+    func test_perform_completeRegistration_withPasswordHint_setsHintInRequest() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        subject.state = .fixture(passwordHintText: "my hint")
+
+        await subject.perform(.completeRegistration)
+
+        let request = try XCTUnwrap(mockRegistrationClient.postKeysForUserPasswordRegistrationReceivedRequest)
+        XCTAssertEqual(request.masterPasswordHint, "my hint")
+    }
+
+    /// `perform(_:)` with `.completeRegistration` and V2 flag enabled passes nil when hint is empty.
+    @MainActor
+    func test_perform_completeRegistration_withPasswordHintEmpty_setsNilHintInRequest() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = true
+        subject.state = .fixture(passwordHintText: "")
+
+        await subject.perform(.completeRegistration)
+
+        let request = try XCTUnwrap(mockRegistrationClient.postKeysForUserPasswordRegistrationReceivedRequest)
+        XCTAssertNil(request.masterPasswordHint)
+    }
+
+    /// `perform(_:)` with `.completeRegistration` presents an alert when the email has already been taken.
+    @MainActor
+    func test_perform_completeRegistration_v1_accountAlreadyExists() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
+        subject.state = .fixture()
+
+        let response = HTTPResponse.failure(
+            statusCode: 400,
+            body: APITestData.registerFinishAccountAlreadyExists.data,
+        )
+
+        guard let errorResponse = try? ErrorResponseModel(response: response) else { return }
+        let error = ServerError.error(errorResponse: errorResponse)
+        client.result = .httpFailure(error)
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(coordinator.errorAlertsWithRetryShown.last?.error as? ServerError, error)
+
+        XCTAssertFalse(coordinator.isLoadingOverlayShowing)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.creatingAccount)])
+    }
+
+    /// `perform(_:)` with `.completeRegistration` and V2 flag disabled calls `registerFinish` (V1 path).
+    @MainActor
+    func test_perform_completeRegistration_v1_callsRegisterFinish() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
+        client.result = .httpSuccess(testData: .registerFinishRequest)
+        subject.state = .fixture()
+
+        await subject.perform(.completeRegistration)
+
+        XCTAssertFalse(mockRegistrationClient.postKeysForUserPasswordRegistrationCalled)
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(
+            client.requests[0].url,
+            URL(string: "https://example.com/identity/accounts/register/finish"),
+        )
+        XCTAssertTrue(subject.state.didCreateAccount)
+    }
+
     /// `perform(_:)` with `.completeRegistration` presents an alert when the password hint is too long.
     @MainActor
-    func test_perform_completeRegistration_hintTooLong() async {
+    func test_perform_completeRegistration_v1_hintTooLong() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
         subject.state = .fixture(passwordHintText: """
         ajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajajaj
         ajajajajajajajajajajajajajajajajajajajajajajajajajajajajajsjajajajajaj
@@ -467,7 +649,8 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
 
     /// `perform(_:)` with `.completeRegistration` presents an alert when the email is in an invalid format.
     @MainActor
-    func test_perform_completeRegistration_invalidEmailFormat() async {
+    func test_perform_completeRegistration_v1_invalidEmailFormat() async {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
         subject.state = .fixture(userEmail: "∫@ø.com")
 
         let response = HTTPResponse.failure(
@@ -491,7 +674,8 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.completeRegistration` navigates to login if the create account request
     /// succeeds, but login fails.
     @MainActor
-    func test_perform_completeRegistration_loginError() async throws {
+    func test_perform_completeRegistration_v1_loginError() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
         authService.loginWithMasterPasswordResult = .failure(BitwardenTestError.example)
         client.result = .httpSuccess(testData: .registerFinishRequest)
         subject.state = .fixture()
@@ -522,7 +706,8 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.completeRegistration` navigates to login if the create account and
     /// login requests succeed, but vault unlocking fails.
     @MainActor
-    func test_perform_completeRegistration_unlockError() async throws {
+    func test_perform_completeRegistration_v1_unlockError() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
         authRepository.unlockWithPasswordResult = .failure(BitwardenTestError.example)
         client.result = .httpSuccess(testData: .registerFinishRequest)
         subject.state = .fixture()
@@ -553,7 +738,8 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.completeRegistration` presents an alert when there is no internet connection.
     /// When the user taps `Try again`, the create account request is made again.
     @MainActor
-    func test_perform_completeRegistration_noInternetConnection() async throws {
+    func test_perform_completeRegistration_v1_noInternetConnection() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
         authService.loginWithMasterPasswordResult = .success(())
         subject.state = .fixture()
 
@@ -585,38 +771,11 @@ class CompleteRegistrationProcessorTests: BitwardenTestCase {
         )
     }
 
-    /// `perform(_:)` with `.completeRegistration` presents an alert when password confirmation is incorrect.
-    @MainActor
-    func test_perform_completeRegistration_passwordsDontMatch() async {
-        subject.state = .fixture(passwordText: "123456789012", retypePasswordText: "123456789000")
-
-        client.result = .httpSuccess(testData: .registerFinishRequest)
-
-        await subject.perform(.completeRegistration)
-
-        XCTAssertEqual(client.requests.count, 0)
-        XCTAssertEqual(coordinator.alertShown.last, .passwordsDontMatch)
-        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
-    }
-
-    /// `perform(_:)` with `.completeRegistration` presents an alert when the password isn't long enough.
-    @MainActor
-    func test_perform_completeRegistration_passwordsTooShort() async {
-        subject.state = .fixture(passwordText: "123", retypePasswordText: "123")
-
-        client.result = .httpSuccess(testData: .registerFinishRequest)
-
-        await subject.perform(.completeRegistration)
-
-        XCTAssertEqual(client.requests.count, 0)
-        XCTAssertEqual(coordinator.alertShown.last, .passwordIsTooShort)
-        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
-    }
-
     /// `perform(_:)` with `.completeRegistration` presents an alert when the request times out.
     /// When the user taps `Try again`, the create account request is made again.
     @MainActor
-    func test_perform_completeRegistration_timeout() async throws {
+    func test_perform_completeRegistration_v1_timeout() async throws {
+        configService.featureFlagsBoolPreAuth[.accountEncryptionV2PasswordRegistration] = false
         authService.loginWithMasterPasswordResult = .success(())
         subject.state = .fixture()
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24224](https://bitwarden.atlassian.net/browse/PM-24224)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables support for v2 encryption on password account registration. Most of the existing logic that was implemented in the app, including API requests, has been moved into the SDK (via the `postKeysForUserPasswordRegistration(request:)` function).

These changes are behind the `pm-27278-v2-password-registration` feature flag.

[PM-24224]: https://bitwarden.atlassian.net/browse/PM-24224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ