### PR TITLE
[PM-37973] chore: Remove unreachable catch branch after EmptyInputValidator typed throw

### DIFF
--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
@@ -82,12 +82,8 @@ final class ManualEntryProcessor: StateProcessor<ManualEntryState, ManualEntryAc
             try EmptyInputValidator(fieldName: Localizations.key)
                 .validate(input: state.authenticatorKey)
             coordinator.navigate(to: .addManual(key: key, name: name, sendToBitwarden: sendToBitwarden))
-        } catch let error as InputValidationError {
-            coordinator.showAlert(Alert.inputValidationAlert(error: error))
-            return
         } catch {
-            coordinator.showAlert(.networkResponseError(error))
-            services.errorReporter.log(error: error)
+            coordinator.showAlert(Alert.inputValidationAlert(error: error))
         }
     }
 }

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessor.swift
@@ -77,7 +77,7 @@ final class ManualEntryProcessor: StateProcessor<ManualEntryState, ManualEntryAc
     ///
     private func addItem(key: String, name: String, sendToBitwarden: Bool) {
         do {
-            try EmptyInputValidator(fieldName: Localizations.service)
+            try EmptyInputValidator(fieldName: Localizations.name)
                 .validate(input: state.name)
             try EmptyInputValidator(fieldName: Localizations.key)
                 .validate(input: state.authenticatorKey)

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
@@ -1,4 +1,6 @@
+import BitwardenKit
 import BitwardenKitMocks
+import BitwardenResources
 import XCTest
 
 @testable import AuthenticatorShared
@@ -91,6 +93,36 @@ final class ManualEntryProcessorTests: BitwardenTestCase {
                                                            name: "NewYork",
                                                            sendToBitwarden: false)
         XCTAssertEqual(coordinator.routes, [route])
+    }
+
+    /// `receive()` with `.addPressed(:)` shows an alert when the key is empty.
+    @MainActor
+    func test_receive_addPressed_emptyKey() {
+        subject.state.authenticatorKey = ""
+        subject.state.name = "NewYork"
+        subject.receive(.addPressed(code: "", name: "NewYork", sendToBitwarden: false))
+        XCTAssertTrue(coordinator.routes.isEmpty)
+        XCTAssertEqual(
+            coordinator.alertShown.last,
+            .inputValidationAlert(error: InputValidationError(
+                message: Localizations.validationFieldRequired(Localizations.key),
+            )),
+        )
+    }
+
+    /// `receive()` with `.addPressed(:)` shows an alert when the name is empty.
+    @MainActor
+    func test_receive_addPressed_emptyName() {
+        subject.state.authenticatorKey = "YouNeedUniqueNewYork"
+        subject.state.name = ""
+        subject.receive(.addPressed(code: "YouNeedUniqueNewYork", name: "", sendToBitwarden: false))
+        XCTAssertTrue(coordinator.routes.isEmpty)
+        XCTAssertEqual(
+            coordinator.alertShown.last,
+            .inputValidationAlert(error: InputValidationError(
+                message: Localizations.validationFieldRequired(Localizations.service),
+            )),
+        )
     }
 
     /// `receive()` with `.authenticatorKeyChanged(:)` updates the state.

--- a/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
+++ b/AuthenticatorShared/UI/Vault/VaultItem/AuthenticatorKeyCapture/ManualEntryProcessorTests.swift
@@ -120,7 +120,7 @@ final class ManualEntryProcessorTests: BitwardenTestCase {
         XCTAssertEqual(
             coordinator.alertShown.last,
             .inputValidationAlert(error: InputValidationError(
-                message: Localizations.validationFieldRequired(Localizations.service),
+                message: Localizations.validationFieldRequired(Localizations.name),
             )),
         )
     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-37973](https://bitwarden.atlassian.net/browse/PM-37973)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

`EmptyInputValidator` was previously updated to use typed throws. This created a build warning for an unreachable branch in the `ManualEntryProcessor` catch block.

- Removes unreachable catch block since only `InputValidationError` types are thrown.
- Adds missing test coverage for empty field input validation. 
- Updated the field name in the missing name validation error.

<img width="640"  alt="Screenshot 2026-05-22 at 11 01 09 AM" src="https://github.com/user-attachments/assets/091be7af-3044-487c-9ce5-353c36fef457" />



[PM-37973]: https://bitwarden.atlassian.net/browse/PM-37973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ