### PR TITLE
[PM-37957] test: Fix SerialWorkerTests captured var concurrency warnings

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/SerialWorkerTests.swift
+++ b/BitwardenKit/Core/Platform/Utilities/SerialWorkerTests.swift
@@ -15,7 +15,7 @@ struct SerialWorkerTests {
     ///
     @Test
     func serialize_executesOperation() async throws {
-        var executed = false
+        nonisolated(unsafe) var executed = false
 
         try await subject.enqueue(userId: "u1") {
             executed = true
@@ -34,7 +34,7 @@ struct SerialWorkerTests {
             try await subject.enqueue(userId: "u1") { throw TestError() }
         }
 
-        var executed = false
+        nonisolated(unsafe) var executed = false
         try await subject.enqueue(userId: "u1") {
             executed = true
         }
@@ -46,8 +46,8 @@ struct SerialWorkerTests {
     ///
     @Test
     func serialize_differentUsers_bothOperationsRun() async throws {
-        var u1Ran = false
-        var u2Ran = false
+        nonisolated(unsafe) var u1Ran = false
+        nonisolated(unsafe) var u2Ran = false
 
         try await subject.enqueue(userId: "u1") { u1Ran = true }
         try await subject.enqueue(userId: "u2") { u2Ran = true }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-37957](https://bitwarden.atlassian.net/browse/PM-37957)

## 📔 Objective

Fixes a flaky CI failure in `SerialWorkerTests.serialize_differentUsers_bothOperationsRun`, which was intermittently hitting the 2-second per-test timeout (`-maximum-test-execution-time-allowance 2`).

**Root cause:** Swift Testing serializes mutations to captured `var` locals back through the test task's isolation context. Since the test task is suspended at `try await task.value` waiting for those mutations, a circular dependency can stall long enough to hit the timeout. The compiler also flagged these as: *"mutation of captured var in concurrently-executing code; this is an error in the Swift 6 language mode."*

**Fix:** Add `nonisolated(unsafe)` to the captured mutable vars in the three affected test functions (`serialize_executesOperation`, `serialize_failingPreviousOperation_nextOperationStillRuns`, `serialize_differentUsers_bothOperationsRun`). This is safe at runtime because `SerialWorker.enqueue` awaits `try await task.value` before returning, so each operation fully completes before the test reads the captured variable — there is no actual concurrent access. The pattern matches the existing usage in `serialize_sameUser_operationsRunInSubmissionOrder` in the same file.

[PM-37957]: https://bitwarden.atlassian.net/browse/PM-37957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ