### PR TITLE
[PM-24114] fix: Prevent noActiveAccount errors when viewing pre-login Settings

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -89,6 +89,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
     override func perform(_ effect: SettingsEffect) async {
         switch effect {
         case .appeared:
+            guard state.presentationMode == .tab else { return }
             let featureEnabled = await services.configService
                 .getFeatureFlag(.premiumUpgradePath, defaultValue: false)
             let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -29,7 +29,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
     // MARK: Private Properties
 
     /// The task used to update the tab's badge count.
-    private var badgeUpdateTask: Task<Void, Never>?
+    private(set) var badgeUpdateTask: Task<Void, Never>?
 
     /// The `Coordinator` that handles navigation.
     private let coordinator: AnyCoordinator<SettingsRoute, SettingsEvent>
@@ -63,16 +63,19 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         super.init(state: state)
 
         // Kick off this task in init so that the tab bar badge will be updated immediately when
-        // the tab bar is shown vs once the user navigates to the settings tab.
-        badgeUpdateTask = Task { @MainActor [weak self] in
-            do {
-                guard let publisher = try await self?.services.stateService.settingsBadgePublisher() else { return }
-                for await badgeState in publisher.values {
-                    self?.delegate?.updateSettingsTabBadge(badgeState.badgeValue)
-                    self?.state.badgeState = badgeState
+        // the tab bar is shown vs once the user navigates to the settings tab. Badge updates
+        // require an active account, so this is skipped in pre-login presentation mode.
+        if state.presentationMode == .tab {
+            badgeUpdateTask = Task { @MainActor [weak self] in
+                do {
+                    guard let publisher = try await self?.services.stateService.settingsBadgePublisher() else { return }
+                    for await badgeState in publisher.values {
+                        self?.delegate?.updateSettingsTabBadge(badgeState.badgeValue)
+                        self?.state.badgeState = badgeState
+                    }
+                } catch {
+                    self?.services.errorReporter.log(error: error)
                 }
-            } catch {
-                self?.services.errorReporter.log(error: error)
             }
         }
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -47,7 +47,7 @@ class SettingsProcessorTests: BitwardenTestCase {
     }
 
     @MainActor
-    func setUpSubject() {
+    func setUpSubject(presentationMode: SettingsPresentationMode = .tab) {
         subject = SettingsProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             delegate: delegate,
@@ -58,11 +58,18 @@ class SettingsProcessorTests: BitwardenTestCase {
                 stateService: stateService,
                 vaultRepository: vaultRepository,
             ),
-            state: SettingsState(),
+            state: SettingsState(presentationMode: presentationMode),
         )
     }
 
     // MARK: Tests
+
+    /// `init()` does not subscribe to the badge publisher when the presentation mode is `.preLogin`.
+    @MainActor
+    func test_init_preLogin_doesNotSubscribeToBadgePublisher() async {
+        setUpSubject(presentationMode: .preLogin)
+        XCTAssertNil(subject.badgeUpdateTask)
+    }
 
     /// `init()` subscribes to the badge publisher and notifies the delegate to update the badge
     /// count when it changes.
@@ -70,6 +77,7 @@ class SettingsProcessorTests: BitwardenTestCase {
     func test_init_subscribesToBadgePublisher() async throws {
         stateService.activeAccount = .fixture()
         setUpSubject()
+        XCTAssertNotNil(subject.badgeUpdateTask)
 
         var badgeState = SettingsBadgeState.fixture(badgeValue: "1", vaultUnlockSetupProgress: .setUpLater)
         stateService.settingsBadgeSubject.send(badgeState)

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -198,6 +198,15 @@ class SettingsProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.showPlanRow)
     }
 
+    /// `perform(.appeared)` does nothing in pre-login presentation mode.
+    @MainActor
+    func test_perform_appeared_preLogin_doesNothing() async {
+        setUpSubject(presentationMode: .preLogin)
+        await subject.perform(.appeared)
+        XCTAssertFalse(subject.state.hasPremium)
+        XCTAssertFalse(subject.state.showPlanRow)
+    }
+
     /// `perform(.appeared)` shows the plan row for a free user when the feature flag is enabled.
     @MainActor
     func test_perform_appeared_showsPlanRow_freeUser() async {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-24114](https://bitwarden.atlassian.net/browse/PM-24114)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes a few `noActiveAccount` errors that end up being logged to Crashlytics when viewing pre-login Settings:

- The `badgeUpdateTask` doesn't need to be created for pre-login since badgers are only shown after logged in.
-  The premium check can be skipped because plan information isn't shown in pre-login.


[PM-24114]: https://bitwarden.atlassian.net/browse/PM-24114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ