### PR TITLE
[PM-37995] chore: Add pre-commit hook to lint changed Swift files

### DIFF
--- a/Scripts/lint-changes.sh
+++ b/Scripts/lint-changes.sh
@@ -16,14 +16,9 @@ if [ "${1:-}" == "--fix" ]; then
     FIX_MODE=true
 fi
 
-# Determine if we're running as a pre-commit hook
-if [ -n "${GIT_INDEX_FILE:-}" ]; then
-    # Running as pre-commit hook - check staged files
-    SWIFT_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "\.swift$" || true)
-else
-    # Running standalone - check all modified files (staged and unstaged)
-    SWIFT_FILES=$(git diff --name-only --diff-filter=ACMR HEAD | grep "\.swift$" || true)
-fi
+# Staged files only when running as pre-commit hook, all changed files when standalone
+DIFF_ARGS=$( [ -n "${GIT_INDEX_FILE:-}" ] && echo "--cached" || echo "HEAD" )
+SWIFT_FILES=$(git diff --name-only $DIFF_ARGS --diff-filter=ACMR | grep "\.swift$" || true)
 
 # Exit early if no Swift files changed
 if [ -z "$SWIFT_FILES" ]; then

--- a/Scripts/lint-changes.sh
+++ b/Scripts/lint-changes.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Script to run SwiftLint and SwiftFormat on changed Swift files
+# Can be used standalone or as a git pre-commit hook
+# Usage: ./Scripts/lint-changes.sh [--fix]
+
+set -euo pipefail
+
+# Track failures
+SWIFTFORMAT_FAILED=0
+SWIFTLINT_FAILED=0
+
+# Parse command line arguments
+FIX_MODE=false
+if [ "${1:-}" == "--fix" ]; then
+    FIX_MODE=true
+fi
+
+# Determine if we're running as a pre-commit hook
+if [ -n "${GIT_INDEX_FILE:-}" ]; then
+    # Running as pre-commit hook - check staged files
+    SWIFT_FILES=$(git diff --cached --name-only --diff-filter=ACMR | grep "\.swift$" || true)
+else
+    # Running standalone - check all modified files (staged and unstaged)
+    SWIFT_FILES=$(git diff --name-only --diff-filter=ACMR HEAD | grep "\.swift$" || true)
+fi
+
+# Exit early if no Swift files changed
+if [ -z "$SWIFT_FILES" ]; then
+    echo "No Swift files to lint"
+    exit 0
+fi
+
+# Convert file list to array
+FILE_ARRAY=()
+while IFS= read -r file; do
+    if [ -f "$file" ]; then
+        FILE_ARRAY+=("$file")
+    fi
+done <<< "$SWIFT_FILES"
+
+# Exit if no valid files found
+if [ ${#FILE_ARRAY[@]} -eq 0 ]; then
+    echo "No Swift files to lint"
+    exit 0
+fi
+
+if [ "$FIX_MODE" = true ]; then
+    echo "Formatting and linting ${#FILE_ARRAY[@]} Swift file(s)..."
+else
+    echo "Checking format and linting ${#FILE_ARRAY[@]} Swift file(s)..."
+fi
+
+for file in "${FILE_ARRAY[@]}"; do
+    echo "  $file"
+done
+
+# Run SwiftFormat
+echo ""
+echo "Running SwiftFormat..."
+if [ "$FIX_MODE" = true ]; then
+    # Format files
+    if ! mint run swiftformat --quiet "${FILE_ARRAY[@]}"; then
+        echo "❌ SwiftFormat failed"
+        SWIFTFORMAT_FAILED=1
+    fi
+else
+    # Check formatting without modifying files
+    if ! mint run swiftformat --lint "${FILE_ARRAY[@]}"; then
+        echo "❌ SwiftFormat found formatting issues"
+        SWIFTFORMAT_FAILED=1
+    fi
+fi
+
+# Run SwiftLint
+echo ""
+echo "Running SwiftLint..."
+if [ "$FIX_MODE" = true ]; then
+    mint run swiftlint lint --quiet --fix "${FILE_ARRAY[@]}" || true
+
+    # Re-run in check mode to surface any violations that couldn't be auto-fixed
+    echo ""
+    echo "Checking for remaining SwiftLint issues..."
+    if ! mint run swiftlint lint --strict "${FILE_ARRAY[@]}"; then
+        echo "⚠️  Some issues require manual fixes (see above)"
+        SWIFTLINT_FAILED=1
+    fi
+else
+    if ! mint run swiftlint lint --quiet --strict "${FILE_ARRAY[@]}"; then
+        echo "❌ SwiftLint found issues in modified files"
+        SWIFTLINT_FAILED=1
+    fi
+fi
+
+# Report results
+echo ""
+if [ $SWIFTFORMAT_FAILED -eq 1 ] || [ $SWIFTLINT_FAILED -eq 1 ]; then
+    if [ "$FIX_MODE" = false ]; then
+        echo "To auto-fix, run:"
+        echo "  ./Scripts/lint-changes.sh --fix"
+    fi
+    exit 1
+fi
+
+if [ "$FIX_MODE" = true ]; then
+    echo "✅ All files formatted and all fixable issues corrected"
+else
+    echo "✅ All modified Swift files passed formatting and linting checks"
+fi
+exit 0

--- a/Scripts/lint-changes.sh
+++ b/Scripts/lint-changes.sh
@@ -50,28 +50,35 @@ for file in "${FILE_ARRAY[@]}"; do
     echo "  $file"
 done
 
+run_swiftformat() {
+    if [ "$FIX_MODE" = true ]; then
+        if ! mint run swiftformat --quiet "${FILE_ARRAY[@]}"; then
+            echo "❌ SwiftFormat failed"
+            SWIFTFORMAT_FAILED=1
+        fi
+    else
+        if ! mint run swiftformat --lint "${FILE_ARRAY[@]}"; then
+            echo "❌ SwiftFormat found formatting issues"
+            SWIFTFORMAT_FAILED=1
+        fi
+    fi
+}
+
 # Run SwiftFormat
 echo ""
 echo "Running SwiftFormat..."
-if [ "$FIX_MODE" = true ]; then
-    # Format files
-    if ! mint run swiftformat --quiet "${FILE_ARRAY[@]}"; then
-        echo "❌ SwiftFormat failed"
-        SWIFTFORMAT_FAILED=1
-    fi
-else
-    # Check formatting without modifying files
-    if ! mint run swiftformat --lint "${FILE_ARRAY[@]}"; then
-        echo "❌ SwiftFormat found formatting issues"
-        SWIFTFORMAT_FAILED=1
-    fi
-fi
+run_swiftformat
 
 # Run SwiftLint
 echo ""
 echo "Running SwiftLint..."
 if [ "$FIX_MODE" = true ]; then
     mint run swiftlint lint --quiet --fix "${FILE_ARRAY[@]}" || true
+
+    # Re-run SwiftFormat to catch any formatting issues introduced by SwiftLint fixes
+    echo ""
+    echo "Re-running SwiftFormat after SwiftLint fixes..."
+    run_swiftformat
 
     # Re-run in check mode to surface any violations that couldn't be auto-fixed
     echo ""

--- a/Scripts/pre-commit
+++ b/Scripts/pre-commit
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
-# Pre-commit hook that runs spell check on staged files
+# Pre-commit hook that runs spell check and linting on staged files
 # This hook is set up automatically by Scripts/bootstrap.sh
 
-PATH=/usr/local/bin:$PATH
+PATH=/opt/homebrew/bin:/usr/local/bin:$PATH
 
 # Get the directory of this script
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
@@ -18,3 +18,6 @@ fi
 
 # Run spell check on staged files
 "$REPO_ROOT/Scripts/spellcheck-changes.sh" || exit 1
+
+# Run SwiftFormat and SwiftLint on staged Swift files
+"$REPO_ROOT/Scripts/lint-changes.sh" || exit 1


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-37995](https://bitwarden.atlassian.net/browse/PM-37995)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Extends the existing pre-commit hook to run SwiftFormat and SwiftLint on staged Swift files before each commit, catching formatting and lint violations locally before they reach CI.

- Adds `Scripts/lint-changes.sh` — runs SwiftFormat (format check or fix) and SwiftLint (lint or fix + re-check) on the set of staged Swift files, detected via `$GIT_INDEX_FILE`
- Can be run standalone with `./Scripts/lint-changes.sh` (checks modified files) or `./Scripts/lint-changes.sh --fix` (auto-fixes what it can, then reports any remaining violations that require manual fixes)
- Wires the script into `Scripts/pre-commit` after the existing spell check step
- Uses `--diff-filter=ACMR` to cover renamed files (not just added/modified/copied)

[PM-37995]: https://bitwarden.atlassian.net/browse/PM-37995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ