### PR TITLE
[PM-38024] fix: Retain cycle in DefaultTOTPExpirationManager

### DIFF
--- a/BitwardenShared/UI/Vault/Utilities/TOTPExpirationManager.swift
+++ b/BitwardenShared/UI/Vault/Utilities/TOTPExpirationManager.swift
@@ -62,8 +62,8 @@ class DefaultTOTPExpirationManager: TOTPExpirationManager {
         updateTimer = Timer.scheduledTimer(
             withTimeInterval: 0.25,
             repeats: true,
-            block: { _ in
-                self.checkForExpirations()
+            block: { [weak self] _ in
+                self?.checkForExpirations()
             },
         )
     }

--- a/BitwardenShared/UI/Vault/Utilities/TOTPExpirationManagerLeakTests.swift
+++ b/BitwardenShared/UI/Vault/Utilities/TOTPExpirationManagerLeakTests.swift
@@ -1,0 +1,40 @@
+import BitwardenKit
+import BitwardenKitMocks
+import XCTest
+
+@testable import BitwardenShared
+
+class TOTPExpirationManagerLeakTests: BitwardenTestCase {
+    /// Regression test for the retain cycle in `DefaultTOTPExpirationManager`
+    /// where the Timer scheduled in `init` captured `self` strongly,
+    /// preventing `deinit` (and therefore `cleanup()`) from ever running.
+    ///
+    /// Uses a weak reference to assert the manager deallocates after its
+    /// only strong reference is dropped. `leaks(1)`-based audits don't
+    /// catch this class of bug because the Timer is held by the main
+    /// RunLoop, keeping everything reachable from a process root.
+    @MainActor
+    func test_deallocatesAfterCallerReleasesReference() async throws {
+        weak var weakManager: DefaultTOTPExpirationManager?
+
+        do {
+            let manager = DefaultTOTPExpirationManager(
+                timeProvider: MockTimeProvider(.currentTime),
+                onExpiration: { _ in },
+            )
+            weakManager = manager
+        }
+
+        // Let any in-flight work settle so deinit (if it could fire) would have.
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        XCTAssertNil(
+            weakManager,
+            """
+            DefaultTOTPExpirationManager should deallocate after the caller \
+            releases its reference; a retain cycle in the Timer's block \
+            prevents deinit from running.
+            """,
+        )
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

Closes #2698

## 📔 Objective

`DefaultTOTPExpirationManager.init` schedules a repeating `Timer` whose block captures `self` strongly. The cycle (`Manager → updateTimer → Timer → block → self`) prevents `deinit` from running, which means `cleanup()` (the method that invalidates the Timer) is never called. Every instance ever constructed stays alive for the process lifetime.

`VaultGroupProcessor.deinit` already calls `cleanup()` on `groupTotpExpirationManager` as a workaround for this exact issue, suggesting prior awareness. The workaround is missing for `searchTotpExpirationManager`, and stops the timer without releasing the manager instance itself — symptom, not cause.

Full bug analysis, impact, and rationale for choosing this fix over a structural refactor are in #2698.

### Fix

Add `[weak self]` to the Timer block:

```diff
- block: { _ in
-     self.checkForExpirations()
- }
+ block: { [weak self] _ in
+     self?.checkForExpirations()
+ }
```

Non-breaking, no caller migration. With the cycle broken, `deinit` runs normally and `cleanup()` invalidates the Timer automatically. The existing `VaultGroupProcessor` workaround becomes defensive rather than load-bearing.

### Regression test

Added `TOTPExpirationManagerLeakTests.test_deallocatesAfterCallerReleasesReference`. Uses a weak reference to assert the manager deallocates after its only strong reference is dropped — `leaks(1)`-based audits don't catch this class of bug because the Timer is held by the main RunLoop, keeping the cycle reachable from a process root. The weak-reference approach catches it cleanly.

Test fails on `main` with `XCTAssertNil failed: "BitwardenShared.DefaultTOTPExpirationManager"`; passes with the fix.

## 📸 Screenshots

n/a — no UI changes.
