### PR TITLE
[PM-37998] feat: Update Cancel Premium confirmation dialog to match new design

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1060,7 +1060,6 @@
 "EstimatedTax" = "Estimated tax";
 "ManagePlan" = "Manage plan";
 "CancelPremium" = "Cancel Premium";
-"CancelNow" = "Cancel now";
 "YourNextChargeIsForXDueOnY" = "Your next charge is for **%1$@**, due on **%2$@**.";
 "WeCouldNotProcessYourPaymentUpdateYourPaymentMethodDescriptionLong" = "We could not process your payment. Update your payment method before your subscription ends on **%1$@**.";
 "YourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription was canceled on **%1$@**. Resubscribe to continue using premium features.";
@@ -1089,7 +1088,8 @@
 "YouNowHaveAccessToAdvancedSecurityDescriptionLong" = "You now have access to advanced security features. Learn more about what's included with Premium.";
 "YouNowHaveAccessToAllAdvancedSecurityFeatures" = "You now have access to all advanced security features.";
 "YoullGoToStripeSecureCheckoutToCompleteYourPurchase" = "You´ll go to Stripe´s secure checkout to complete your purchase.";
-"YoullContinueToHavePremiumAccessUntilX" = "You'll continue to have Premium access until %1$@.";
+"ContinueToStripe" = "Continue to Stripe?";
+"YoullBeTakenToStripeToManageYourSubscriptionCancellation" = "You'll be taken to stripe to manage your subscription cancellation.";
 "UserIDCopiedToTheClipboard" = "User ID copied to the clipboard";
 "UserID" = "User ID";
 "CopyUserID" = "Copy user ID";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1089,7 +1089,7 @@
 "YouNowHaveAccessToAllAdvancedSecurityFeatures" = "You now have access to all advanced security features.";
 "YoullGoToStripeSecureCheckoutToCompleteYourPurchase" = "You´ll go to Stripe´s secure checkout to complete your purchase.";
 "ContinueToStripe" = "Continue to Stripe?";
-"YoullBeTakenToStripeToManageYourSubscriptionCancellation" = "You'll be taken to stripe to manage your subscription cancellation.";
+"YoullBeTakenToStripeToManageYourSubscriptionCancellation" = "You'll be taken to Stripe to manage your subscription cancellation.";
 "UserIDCopiedToTheClipboard" = "User ID copied to the clipboard";
 "UserID" = "User ID";
 "CopyUserID" = "Copy user ID";

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
@@ -96,14 +96,14 @@ final class PremiumPlanProcessor: StateProcessor<
     private func showCancelConfirmation() {
         coordinator.showAlert(
             Alert(
-                title: Localizations.cancelPremium,
-                message: Localizations.youllContinueToHavePremiumAccessUntilX(state.nextChargeDate),
+                title: Localizations.continueToStripe,
+                message: Localizations.youllBeTakenToStripeToManageYourSubscriptionCancellation,
                 alertActions: [
-                    AlertAction(title: Localizations.cancelNow, style: .destructive) { [weak self] _ in
+                    AlertAction(title: Localizations.cancel, style: .cancel),
+                    AlertAction(title: Localizations.continue, style: .default) { [weak self] _ in
                         guard let self else { return }
                         await openPortalUrl()
                     },
-                    AlertAction(title: Localizations.close, style: .cancel),
                 ],
             ),
         )

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
@@ -112,10 +112,10 @@ struct PremiumPlanProcessorTests {
         subject.receive(.cancelPremiumTapped)
 
         #expect(coordinator.alertShown.count == 1)
-        #expect(coordinator.alertShown.first?.title == Localizations.cancelPremium)
+        #expect(coordinator.alertShown.first?.title == Localizations.continueToStripe)
         #expect(coordinator.alertShown.first?.alertActions.count == 2)
-        #expect(coordinator.alertShown.first?.alertActions.first?.title == Localizations.cancelNow)
-        #expect(coordinator.alertShown.first?.alertActions.last?.title == Localizations.close)
+        #expect(coordinator.alertShown.first?.alertActions.first?.title == Localizations.cancel)
+        #expect(coordinator.alertShown.first?.alertActions.last?.title == Localizations.continue)
     }
 
     /// `receive(_:)` with `.cancelPremiumTapped`, after confirming, fetches portal URL and sets state.
@@ -125,7 +125,7 @@ struct PremiumPlanProcessorTests {
         billingService.getPortalUrlReturnValue = portalURL
         subject.receive(.cancelPremiumTapped)
 
-        let confirmAction = try #require(coordinator.alertShown.first?.alertActions.first)
+        let confirmAction = try #require(coordinator.alertShown.first?.alertActions.last)
         await confirmAction.handler?(confirmAction, [])
 
         #expect(billingService.getPortalUrlCallsCount == 1)
@@ -138,7 +138,7 @@ struct PremiumPlanProcessorTests {
         billingService.getPortalUrlThrowableError = BitwardenTestError.example
         subject.receive(.cancelPremiumTapped)
 
-        let confirmAction = try #require(coordinator.alertShown.first?.alertActions.first)
+        let confirmAction = try #require(coordinator.alertShown.first?.alertActions.last)
         await confirmAction.handler?(confirmAction, [])
 
         #expect(errorReporter.errors.first as? BitwardenTestError == .example)

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
@@ -125,8 +125,7 @@ struct PremiumPlanProcessorTests {
         billingService.getPortalUrlReturnValue = portalURL
         subject.receive(.cancelPremiumTapped)
 
-        let confirmAction = try #require(coordinator.alertShown.first?.alertActions.last)
-        await confirmAction.handler?(confirmAction, [])
+        try await coordinator.alertShown.first?.tapAction(title: Localizations.continue)
 
         #expect(billingService.getPortalUrlCallsCount == 1)
         #expect(subject.state.urlToOpen == portalURL)
@@ -138,8 +137,7 @@ struct PremiumPlanProcessorTests {
         billingService.getPortalUrlThrowableError = BitwardenTestError.example
         subject.receive(.cancelPremiumTapped)
 
-        let confirmAction = try #require(coordinator.alertShown.first?.alertActions.last)
-        await confirmAction.handler?(confirmAction, [])
+        try await coordinator.alertShown.first?.tapAction(title: Localizations.continue)
 
         #expect(errorReporter.errors.first as? BitwardenTestError == .example)
         #expect(coordinator.errorAlertsShown.count == 1)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37998

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Updates the "Cancel Premium" confirmation alert to match the approved Figma design.
The alert now shows "Continue to Stripe?" as the title, with a message explaining
the user will be taken to Stripe to manage their subscription cancellation. Button
labels updated from "Cancel Now" / "Close" to "Cancel" / "Continue".

Unused localization strings (CancelNow, YoullContinueToHavePremiumAccessUntilX)
removed from en.lproj.

## 📸 Screenshots

<img width="300" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-26 at 15 12 55" src="https://github.com/user-attachments/assets/dcf0f8f8-ddca-4368-848c-e7d79b787b16" />
