### PR TITLE
[PM-37719] fix: Fix VoiceOver announcing "Star Star" in upcoming charge description

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/String+Extensions.swift
+++ b/BitwardenKit/Core/Platform/Extensions/String+Extensions.swift
@@ -21,4 +21,26 @@ public extension String {
 
         return self
     }
+
+    /// Returns a copy of the string with common markdown formatting removed, suitable for VoiceOver labels.
+    ///
+    /// Strips bold (`**text**`, `__text__`), italic (`*text*`, `_text_`), strikethrough (`~~text~~`),
+    /// and inline links (`[text](url)` → `text`). Bold patterns are applied before italic to avoid
+    /// partial matches on double markers.
+    ///
+    func removingMarkdownForVoiceOver() -> String {
+        var text = self
+        let patterns = [
+            "\\*\\*(.*?)\\*\\*",
+            "__(.*?)__",
+            "\\*(.*?)\\*",
+            "_(.*?)_",
+            "~~(.*?)~~",
+            "\\[(.*?)\\]\\(.*?\\)",
+        ]
+        for pattern in patterns {
+            text = text.replacingOccurrences(of: pattern, with: "$1", options: .regularExpression)
+        }
+        return text
+    }
 }

--- a/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
@@ -1,72 +1,54 @@
 import BitwardenKit
-import Combine
-import XCTest
+import Testing
 
-class StringExtensionsTests: BitwardenTestCase {
-    // MARK: Tests
+// MARK: - StringExtensionsTests
 
-    /// `fixURLIfNeeded()` returns the same string when it can be directly converted to `URL`.
-    func test_fixURLIfNeeded_sameStringWhenCanConvertToURL() {
-        let string = "https://bitwarden.com"
-        XCTAssertEqual(string.fixURLIfNeeded(), "https://bitwarden.com")
-    }
+struct StringExtensionsTests {
+    // MARK: Tests - fixURLIfNeeded
 
-    /// `fixURLIfNeeded()` returns the same string prefixed with "http://" when it can't be
-    /// directly converted to `URL` and it's an IP address.
-    func test_fixURLIfNeeded_httpWhenIPAddress() {
-        let string = "192.168.0.1:8080"
-        XCTAssertEqual(string.fixURLIfNeeded(), "http://192.168.0.1:8080")
-    }
-
-    /// `fixURLIfNeeded()` returns the same string prefixed with "https://" when it can't be
-    /// directly converted to `URL` and it's not an IP address.
-    func test_fixURLIfNeeded_httpsWhenNotIPAddress() {
-        let string = "ht tp://broken.com"
-        XCTAssertEqual(string.fixURLIfNeeded(), "https://ht tp://broken.com")
+    /// `fixURLIfNeeded()` returns the correct URL string for valid URLs, IP addresses, and broken URLs.
+    @Test(arguments: zip(
+        [
+            "https://bitwarden.com",
+            "192.168.0.1:8080",
+            "ht tp://broken.com",
+        ],
+        [
+            "https://bitwarden.com",
+            "http://192.168.0.1:8080",
+            "https://ht tp://broken.com",
+        ]
+    ))
+    func fixURLIfNeeded(input: String, expected: String) {
+        #expect(input.fixURLIfNeeded() == expected)
     }
 
     // MARK: Tests - removingMarkdownForVoiceOver
 
-    /// `removingMarkdownForVoiceOver()` strips asterisk bold markers.
-    func test_removingMarkdownForVoiceOver_bold() {
-        XCTAssertEqual("Your charge is **$19.80**, due on **May 1**.".removingMarkdownForVoiceOver(),
-                        "Your charge is $19.80, due on May 1.")
-    }
-
-    /// `removingMarkdownForVoiceOver()` strips underscore bold markers.
-    func test_removingMarkdownForVoiceOver_underscoreBold() {
-        XCTAssertEqual("__Bold text__".removingMarkdownForVoiceOver(), "Bold text")
-    }
-
-    /// `removingMarkdownForVoiceOver()` strips asterisk italic markers.
-    func test_removingMarkdownForVoiceOver_italic() {
-        XCTAssertEqual("This is *important*.".removingMarkdownForVoiceOver(), "This is important.")
-    }
-
-    /// `removingMarkdownForVoiceOver()` strips underscore italic markers.
-    func test_removingMarkdownForVoiceOver_underscoreItalic() {
-        XCTAssertEqual("This is _important_.".removingMarkdownForVoiceOver(), "This is important.")
-    }
-
-    /// `removingMarkdownForVoiceOver()` strips strikethrough markers.
-    func test_removingMarkdownForVoiceOver_strikethrough() {
-        XCTAssertEqual("~~Old price~~ New price.".removingMarkdownForVoiceOver(), "Old price New price.")
-    }
-
-    /// `removingMarkdownForVoiceOver()` strips inline links, keeping the link text.
-    func test_removingMarkdownForVoiceOver_links() {
-        XCTAssertEqual("Visit [Bitwarden](https://bitwarden.com) now.".removingMarkdownForVoiceOver(),
-                        "Visit Bitwarden now.")
-    }
-
-    /// `removingMarkdownForVoiceOver()` does not partially strip bold markers as italic.
-    func test_removingMarkdownForVoiceOver_boldNotStrippedAsItalic() {
-        XCTAssertEqual("**Bold text**".removingMarkdownForVoiceOver(), "Bold text")
-    }
-
-    /// `removingMarkdownForVoiceOver()` returns the string unchanged when no markdown is present.
-    func test_removingMarkdownForVoiceOver_noMarkdown() {
-        let plain = "No markdown here."
-        XCTAssertEqual(plain.removingMarkdownForVoiceOver(), plain)
+    /// `removingMarkdownForVoiceOver()` strips markdown syntax while preserving readable text.
+    @Test(arguments: zip(
+        [
+            "Your charge is **$19.80**, due on **May 1**.",
+            "__Bold text__",
+            "This is *important*.",
+            "This is _important_.",
+            "~~Old price~~ New price.",
+            "Visit [Bitwarden](https://bitwarden.com) now.",
+            "**Bold text**",
+            "No markdown here.",
+        ],
+        [
+            "Your charge is $19.80, due on May 1.",
+            "Bold text",
+            "This is important.",
+            "This is important.",
+            "Old price New price.",
+            "Visit Bitwarden now.",
+            "Bold text",
+            "No markdown here.",
+        ]
+    ))
+    func removingMarkdownForVoiceOver(input: String, expected: String) {
+        #expect(input.removingMarkdownForVoiceOver() == expected)
     }
 }

--- a/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
@@ -24,4 +24,49 @@ class StringExtensionsTests: BitwardenTestCase {
         let string = "ht tp://broken.com"
         XCTAssertEqual(string.fixURLIfNeeded(), "https://ht tp://broken.com")
     }
+
+    // MARK: Tests - removingMarkdownForVoiceOver
+
+    /// `removingMarkdownForVoiceOver()` strips asterisk bold markers.
+    func test_removingMarkdownForVoiceOver_bold() {
+        XCTAssertEqual("Your charge is **$19.80**, due on **May 1**.".removingMarkdownForVoiceOver(),
+                        "Your charge is $19.80, due on May 1.")
+    }
+
+    /// `removingMarkdownForVoiceOver()` strips underscore bold markers.
+    func test_removingMarkdownForVoiceOver_underscoreBold() {
+        XCTAssertEqual("__Bold text__".removingMarkdownForVoiceOver(), "Bold text")
+    }
+
+    /// `removingMarkdownForVoiceOver()` strips asterisk italic markers.
+    func test_removingMarkdownForVoiceOver_italic() {
+        XCTAssertEqual("This is *important*.".removingMarkdownForVoiceOver(), "This is important.")
+    }
+
+    /// `removingMarkdownForVoiceOver()` strips underscore italic markers.
+    func test_removingMarkdownForVoiceOver_underscoreItalic() {
+        XCTAssertEqual("This is _important_.".removingMarkdownForVoiceOver(), "This is important.")
+    }
+
+    /// `removingMarkdownForVoiceOver()` strips strikethrough markers.
+    func test_removingMarkdownForVoiceOver_strikethrough() {
+        XCTAssertEqual("~~Old price~~ New price.".removingMarkdownForVoiceOver(), "Old price New price.")
+    }
+
+    /// `removingMarkdownForVoiceOver()` strips inline links, keeping the link text.
+    func test_removingMarkdownForVoiceOver_links() {
+        XCTAssertEqual("Visit [Bitwarden](https://bitwarden.com) now.".removingMarkdownForVoiceOver(),
+                        "Visit Bitwarden now.")
+    }
+
+    /// `removingMarkdownForVoiceOver()` does not partially strip bold markers as italic.
+    func test_removingMarkdownForVoiceOver_boldNotStrippedAsItalic() {
+        XCTAssertEqual("**Bold text**".removingMarkdownForVoiceOver(), "Bold text")
+    }
+
+    /// `removingMarkdownForVoiceOver()` returns the string unchanged when no markdown is present.
+    func test_removingMarkdownForVoiceOver_noMarkdown() {
+        let plain = "No markdown here."
+        XCTAssertEqual(plain.removingMarkdownForVoiceOver(), plain)
+    }
 }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -35,15 +35,16 @@ struct PremiumPlanState: Equatable {
         return formatDate(canceled)
     }
 
-    /// The accessibility label for the description text, using a screen-reader-friendly currency format.
+    /// The accessibility label for the description text, with markdown stripped for VoiceOver.
+    /// For the active status, uses a screen-reader-friendly currency format instead of `descriptionText`.
     var descriptionAccessibilityLabel: String {
         guard planStatus == .active else {
-            return descriptionText.replacingOccurrences(of: "**", with: "")
+            return descriptionText.removingMarkdownForVoiceOver()
         }
         return Localizations.yourNextChargeIsForXDueOnY(
             nextChargeAmountAccessibilityLabel,
             nextChargeDate,
-        ).replacingOccurrences(of: "**", with: "")
+        ).removingMarkdownForVoiceOver()
     }
 
     /// The description text for the current plan status.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -37,13 +37,13 @@ struct PremiumPlanState: Equatable {
 
     /// The accessibility label for the description text, using a screen-reader-friendly currency format.
     var descriptionAccessibilityLabel: String {
-        if planStatus == .active {
-            return Localizations.yourNextChargeIsForXDueOnY(
-                nextChargeAmountAccessibilityLabel,
-                nextChargeDate,
-            ).replacingOccurrences(of: "**", with: "")
+        guard planStatus == .active else {
+            return descriptionText.replacingOccurrences(of: "**", with: "")
         }
-        return descriptionText.replacingOccurrences(of: "**", with: "")
+        return Localizations.yourNextChargeIsForXDueOnY(
+            nextChargeAmountAccessibilityLabel,
+            nextChargeDate,
+        ).replacingOccurrences(of: "**", with: "")
     }
 
     /// The description text for the current plan status.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -37,11 +37,13 @@ struct PremiumPlanState: Equatable {
 
     /// The accessibility label for the description text, using a screen-reader-friendly currency format.
     var descriptionAccessibilityLabel: String {
-        guard planStatus == .active else { return descriptionText }
-        return Localizations.yourNextChargeIsForXDueOnY(
-            nextChargeAmountAccessibilityLabel,
-            nextChargeDate,
-        )
+        if planStatus == .active {
+            return Localizations.yourNextChargeIsForXDueOnY(
+                nextChargeAmountAccessibilityLabel,
+                nextChargeDate,
+            ).replacingOccurrences(of: "**", with: "")
+        }
+        return descriptionText.replacingOccurrences(of: "**", with: "")
     }
 
     /// The description text for the current plan status.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -46,6 +46,7 @@ struct PremiumPlanStateTests {
         let label = state.descriptionAccessibilityLabel
         #expect(label.contains("USD $"))
         #expect(label.contains(state.nextChargeDate))
+        #expect(!label.contains("**"))
     }
 
     /// `descriptionAccessibilityLabel` returns `descriptionText` unchanged for non-active plan statuses.
@@ -60,7 +61,8 @@ struct PremiumPlanStateTests {
             status: planStatus,
             suspension: testDate,
         )
-        #expect(state.descriptionAccessibilityLabel == state.descriptionText)
+        #expect(!state.descriptionAccessibilityLabel.contains("**"))
+        #expect(state.descriptionAccessibilityLabel == state.descriptionText.replacingOccurrences(of: "**", with: ""))
     }
 
     // MARK: Tests - descriptionText

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -49,7 +49,7 @@ struct PremiumPlanStateTests {
         #expect(!label.contains("**"))
     }
 
-    /// `descriptionAccessibilityLabel` returns `descriptionText` unchanged for non-active plan statuses.
+    /// `descriptionAccessibilityLabel` returns `descriptionText` with markdown stripped for non-active plan statuses.
     @Test(arguments: [PremiumPlanStatus.canceled, .pastDue, .unknown, .updatePayment])
     func descriptionAccessibilityLabel_nonActive(planStatus: PremiumPlanStatus) {
         var state = PremiumPlanState()
@@ -62,7 +62,7 @@ struct PremiumPlanStateTests {
             suspension: testDate,
         )
         #expect(!state.descriptionAccessibilityLabel.contains("**"))
-        #expect(state.descriptionAccessibilityLabel == state.descriptionText.replacingOccurrences(of: "**", with: ""))
+        #expect(state.descriptionAccessibilityLabel == state.descriptionText.removingMarkdownForVoiceOver())
     }
 
     // MARK: Tests - descriptionText


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37719

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix VoiceOver announcing "Star Star" before and after the dollar amount and date in the upcoming charge description. The localization strings use `**` markdown for bold formatting, which renders correctly via `Text(LocalizedStringKey(...))` but was passed verbatim to the accessibility label — causing VoiceOver to read the asterisks aloud.

Strip `**` from `descriptionAccessibilityLabel` for all plan statuses (active, canceled, updatePayment, etc.) so VoiceOver announces the text cleanly without markdown noise.
