### PR TITLE
[PM-37960] test: Fix BillingAPIServiceTests timeout by using MockAccountTokenProvider

### DIFF
--- a/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
+++ b/BitwardenShared/Core/Billing/Services/API/BillingAPIServiceTests.swift
@@ -24,7 +24,10 @@ struct BillingAPIServiceTests {
         activeAccountStateProvider = MockActiveAccountStateProvider()
         client = MockHTTPClient()
         stateService = MockStateService()
+        let accountTokenProvider = MockAccountTokenProvider()
+        accountTokenProvider.getTokenReturnValue = "ACCESS_TOKEN"
         subject = APIService(
+            accountTokenProvider: accountTokenProvider,
             activeAccountStateProvider: activeAccountStateProvider,
             client: client,
             stateService: stateService,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37960

## 📔 Objective

`BillingAPIServiceTests.getPremiumPlan()` was intermittently exceeding the 2-second CI per-test timeout.

The root cause: `BillingAPIServiceTests` was constructing `APIService` without an explicit `accountTokenProvider`, causing the test to use `DefaultAccountTokenProvider` — a Swift actor. Obtaining a token requires context switches to and from that actor, and under CI load those hops can collectively exceed the timeout.

The fix mirrors the pattern in `ConfigAPIServiceTests`: pass a `MockAccountTokenProvider` with `getTokenReturnValue = "ACCESS_TOKEN"` pre-set. This returns synchronously with no actor overhead, making the tests reliably fast.