### PR TITLE
[PM-37885] fix: Check camera permission before opening card scanner

### DIFF
--- a/BitwardenAutoFillExtension/CredentialProviderViewController.swift
+++ b/BitwardenAutoFillExtension/CredentialProviderViewController.swift
@@ -520,7 +520,8 @@ private final class KeyboardAnchorTextField: UITextField {
         )
     }
 
-    @objc private func keyboardWillHide() {
+    @objc
+    private func keyboardWillHide() {
         guard !isFirstResponder else { return }
         Logger.appExtension.debug("KeyboardAnchorTextField: keyboard will hide without anchor as FR — reclaiming")
         becomeFirstResponder()

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -936,6 +936,7 @@
 "SaveToBitwarden" = "Save to Bitwarden";
 "ScanCard" = "Scan card";
 "PositionYourCardInTheFrameToScanIt" = "Position your card in the frame to scan it";
+"EnableCameraPermissionInSettingsToScanYourCard" = "Enable camera access in Settings to scan your card.";
 "ScanComplete" = "Scan complete";
 "ScanTheQRCodeInYourSettings" = "Scan the QR code in your 2-step verification settings for any account.";
 "SecureYourAssetsWithBitwardenAuthenticator" = "Secure your accounts with Bitwarden Authenticator";

--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -381,7 +381,7 @@ extension BitwardenSdk.Cipher {
             bankAccount: nil, // TODO: PM-32809
             driversLicense: nil, // TODO: PM-32807
             passport: nil, // TODO: PM-32805
-            favorite:model.favorite,
+            favorite: model.favorite,
             reprompt: BitwardenSdk.CipherRepromptType(model.reprompt),
             organizationUseTotp: model.organizationUseTotp,
             edit: model.edit,
@@ -429,7 +429,7 @@ extension BitwardenSdk.Cipher {
             bankAccount: nil, // TODO: PM-32809
             driversLicense: nil, // TODO: PM-32807
             passport: nil, // TODO: PM-32805
-            favorite:originalCipher?.favorite ?? false,
+            favorite: originalCipher?.favorite ?? false,
             reprompt: BitwardenSdk.CipherRepromptType(model.reprompt),
             organizationUseTotp: model.organizationUseTotp,
             edit: originalCipher?.edit ?? true,

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemAction.swift
@@ -27,9 +27,6 @@ enum AddEditCardItemAction: Equatable, Sendable {
     /// The expiration year of the card changed.
     case expirationYearChanged(String)
 
-    /// The user tapped the Scan Card button.
-    case scanCardButtonTapped
-
     /// Toggle for code visibility changed.
     case toggleCodeVisibilityChanged(Bool)
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/AddEditCardItemView.swift
@@ -141,6 +141,11 @@ struct AddEditCardItemView: View {
             guard shouldFocus else { return }
             focusedField = .cardholderName
         }
+        .onChange(of: store.state.isCardScannerPresented) { isPresented in
+            if !isPresented {
+                preWarmedScanner = nil
+            }
+        }
     }
 
     // MARK: Private Views
@@ -149,9 +154,9 @@ struct AddEditCardItemView: View {
     /// and ``FeatureFlag.cardScanner`` enabled.
     @ViewBuilder private var scanCardButton: some View {
         if #available(iOS 16.0, *), DataScannerViewController.isSupported, store.state.cardScannerEnabled {
-            Button {
+            AsyncButton {
                 preWarmedScanner = CardScannerView.makeScanner()
-                store.send(.scanCardButtonTapped)
+                await store.perform(.scanCardButtonTapped)
             } label: {
                 Label(Localizations.scanCard, image: SharedAsset.Icons.camera16.swiftUIImage)
             }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemEffect.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemEffect.swift
@@ -28,6 +28,9 @@ enum AddEditItemEffect {
     /// The save button was pressed.
     case savePressed
 
+    /// The scan card button was tapped.
+    case scanCardButtonTapped
+
     /// The setup totp button was pressed.
     case setupTotpPressed
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -176,6 +176,8 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             await fetchCipherOptions()
         case .savePressed:
             await saveItem()
+        case .scanCardButtonTapped:
+            await openCardScanner()
         case .setupTotpPressed:
             await setupTotp()
         case .deletePressed:
@@ -517,8 +519,6 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             state.cardItemState.expirationMonth = month
         case let .expirationYearChanged(year):
             state.cardItemState.expirationYear = year
-        case .scanCardButtonTapped:
-            state.cardItemState.isCardScannerPresented = true
         case let .toggleCodeVisibilityChanged(isVisible):
             state.cardItemState.isCodeVisible = isVisible
             if isVisible {
@@ -946,6 +946,22 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
         let shouldDismissed = delegate?.itemUpdated() ?? true
         if shouldDismissed {
             coordinator.navigate(to: .dismiss())
+        }
+    }
+
+    /// Checks camera authorization and either opens the card scanner sheet or shows a
+    /// camera-permission-required alert with a link to iOS Settings.
+    ///
+    private func openCardScanner() async {
+        let status = await services.cameraService.checkStatusOrRequestCameraAuthorization()
+        guard status == .authorized else {
+            coordinator.showAlert(.cameraPermissionRequired { [weak self] in
+                self?.state.url = URL(string: UIApplication.openSettingsURLString)
+            })
+            return
+        }
+        await MainActor.run {
+            state.cardItemState.isCardScannerPresented = true
         }
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -1717,6 +1717,78 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertTrue(reviewPromptService.userActions.isEmpty)
     }
 
+    /// `perform(_:)` with `.scanCardButtonTapped` when camera access is authorized presents the
+    /// card scanner sheet.
+    @MainActor
+    func test_perform_scanCardButtonTapped_cameraAuthorizationAuthorized() async {
+        cameraService.cameraAuthorizationStatus = .authorized
+
+        await subject.perform(.scanCardButtonTapped)
+
+        XCTAssertTrue(subject.state.cardItemState.isCardScannerPresented)
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+    }
+
+    /// `perform(_:)` with `.scanCardButtonTapped` when camera access is denied shows the
+    /// camera-permission-required alert instead of opening the scanner.
+    @MainActor
+    func test_perform_scanCardButtonTapped_cameraAuthorizationDenied() async throws {
+        cameraService.cameraAuthorizationStatus = .denied
+
+        await subject.perform(.scanCardButtonTapped)
+
+        XCTAssertFalse(subject.state.cardItemState.isCardScannerPresented)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.camera)
+        XCTAssertEqual(alert.message, Localizations.enableCameraPermissionInSettingsToScanYourCard)
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.settings)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+    }
+
+    /// `perform(_:)` with `.scanCardButtonTapped` when camera access is restricted shows the
+    /// camera-permission-required alert instead of opening the scanner.
+    @MainActor
+    func test_perform_scanCardButtonTapped_cameraAuthorizationRestricted() async throws {
+        cameraService.cameraAuthorizationStatus = .restricted
+
+        await subject.perform(.scanCardButtonTapped)
+
+        XCTAssertFalse(subject.state.cardItemState.isCardScannerPresented)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.camera)
+        XCTAssertEqual(alert.message, Localizations.enableCameraPermissionInSettingsToScanYourCard)
+        XCTAssertEqual(alert.alertActions.count, 2)
+        XCTAssertEqual(alert.alertActions[0].title, Localizations.settings)
+        XCTAssertEqual(alert.alertActions[1].title, Localizations.cancel)
+    }
+
+    /// `perform(_:)` with `.scanCardButtonTapped` when camera access is not yet determined and
+    /// the user allows it presents the card scanner sheet.
+    @MainActor
+    func test_perform_scanCardButtonTapped_cameraAuthorizationNotDetermined_authorized() async {
+        cameraService.cameraAuthorizationStatus = .authorized
+
+        await subject.perform(.scanCardButtonTapped)
+
+        XCTAssertTrue(subject.state.cardItemState.isCardScannerPresented)
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+    }
+
+    /// `perform(_:)` with `.scanCardButtonTapped` when camera access is not yet determined and
+    /// the user denies it shows the camera-permission-required alert.
+    @MainActor
+    func test_perform_scanCardButtonTapped_cameraAuthorizationNotDetermined_denied() async throws {
+        cameraService.cameraAuthorizationStatus = .denied
+
+        await subject.perform(.scanCardButtonTapped)
+
+        XCTAssertFalse(subject.state.cardItemState.isCardScannerPresented)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.camera)
+        XCTAssertEqual(alert.message, Localizations.enableCameraPermissionInSettingsToScanYourCard)
+    }
+
     /// `perform(_:)` with `.setupTotpPressed` with camera authorization authorized navigates to the
     /// `.setupTotpCamera` route.
     @MainActor
@@ -2126,16 +2198,6 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         subject.receive(.cardFieldChanged(.cardScannerLinesUpdated(["4111111111111111", "JANE DOE", "12/28"])))
 
         XCTAssertEqual(subject.state.cardItemState.brand, .custom(.visa))
-    }
-
-    /// `receive(_:)` with `.cardFieldChanged(.scanCardButtonTapped)` presents the card scanner.
-    @MainActor
-    func test_receive_cardFieldChanged_scanCardButtonTapped() {
-        subject.state.cardItemState.isCardScannerPresented = false
-
-        subject.receive(.cardFieldChanged(.scanCardButtonTapped))
-
-        XCTAssertTrue(subject.state.cardItemState.isCardScannerPresented)
     }
 
     /// `receive(_:)` with `.cardFieldChanged(.cardScannerDismissed)` hides the card scanner and

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/Extensions/Alert+ScanError.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/Extensions/Alert+ScanError.swift
@@ -2,6 +2,25 @@ import BitwardenKit
 import BitwardenResources
 
 extension Alert {
+    /// An alert telling the user that camera access is required to scan a card,
+    /// with a "Settings" action to open the iOS app-settings page.
+    ///
+    /// - Parameter openSettings: Called when the user taps "Settings".
+    /// - Returns: The camera permission required alert.
+    ///
+    static func cameraPermissionRequired(openSettings: @escaping () -> Void) -> Alert {
+        Alert(
+            title: Localizations.camera,
+            message: Localizations.enableCameraPermissionInSettingsToScanYourCard,
+            alertActions: [
+                AlertAction(title: Localizations.settings, style: .default) { _, _ in
+                    openSettings()
+                },
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ],
+        )
+    }
+
     /// An alert notifying the user that the TOTP key scan was unsuccessful.
     ///
     /// - Returns: An alert notifying the user that the TOTP key scan was unsuccessful.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/Cipher+Update.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewLoginItem/Extensions/Cipher+Update.swift
@@ -45,7 +45,6 @@ extension Cipher {
         )
     }
 
-
     /// Returns a copy of the existing cipher with an updated folder ID.
     ///
     /// - Parameter folderId: The folder ID to update in the cipher.


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37885

## 📔 Objective

Fixes a bug where tapping "Scan card" on a fresh install (or when access has previously been denied) opened the scanner sheet before checking camera permissions.

**Fix:** Converts `scanCardButtonTapped` from a synchronous `AddEditCardItemAction` to an async `AddEditItemEffect` (matching the `setupTotpPressed` pattern). The new `openCardScanner()` helper calls `cameraService.checkStatusOrRequestCameraAuthorization()` **before** opening the sheet:
- `.authorized` → opens the card scanner sheet (no change to the happy path)
- `.denied` / `.restricted` → shows a "Camera" alert — _"Enable camera access in Settings to scan your card."_ — with a Settings deep-link and a Cancel option

## 📸 Screenshots

<img width="314" alt="Card scanner ask camera permission" src="https://github.com/user-attachments/assets/d7698f98-1dbd-4d1a-b5e5-8a0eacc355a6" />

