### PR TITLE
[PM-38147] feat: Convert premium checkout to ASWebAuthenticationSession

### DIFF
--- a/BitwardenShared/Core/Billing/Models/Enum/BillingError.swift
+++ b/BitwardenShared/Core/Billing/Models/Enum/BillingError.swift
@@ -10,7 +10,4 @@ enum BillingError: Error {
 
     /// The portal URL is invalid (e.g., not HTTPS).
     case invalidPortalUrl
-
-    /// Unable to open the checkout URL in the browser.
-    case unableToOpenCheckout
 }

--- a/BitwardenShared/Core/Billing/Services/BillingService.swift
+++ b/BitwardenShared/Core/Billing/Services/BillingService.swift
@@ -7,6 +7,9 @@ import Foundation
 /// A protocol for a service used to manage billing operations.
 ///
 protocol BillingService: AnyObject { // sourcery: AutoMockable
+    /// The callback URL scheme used by the Stripe checkout web authentication session.
+    var checkoutCallbackUrlScheme: String { get }
+
     /// Creates a checkout session for premium upgrade and returns the checkout URL.
     ///
     /// - Returns: A validated HTTPS URL for the checkout session.
@@ -62,6 +65,8 @@ class DefaultBillingService: BillingService {
 
     /// The API service used for billing requests.
     private let billingAPIService: BillingAPIService
+
+    let checkoutCallbackUrlScheme = "bitwarden"
 
     /// The service used to manage feature flags.
     private let configService: ConfigService

--- a/BitwardenShared/UI/Billing/BillingCoordinator.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinator.swift
@@ -21,9 +21,6 @@ class BillingCoordinator: NSObject, Coordinator, HasStackNavigator {
     /// Determines the close behavior of PremiumUpgradeComplete.
     private var isUpgradeAsModalRoot = false
 
-    /// The active web authentication session for the Stripe checkout flow.
-    private var webAuthSession: ASWebAuthenticationSession?
-
     /// Closure invoked after PremiumUpgradeComplete is dismissed.
     private var premiumUpgradeCompleteOnClose: (() -> Void)?
 
@@ -32,6 +29,9 @@ class BillingCoordinator: NSObject, Coordinator, HasStackNavigator {
 
     /// The stack navigator that is managed by this coordinator.
     private(set) weak var stackNavigator: StackNavigator?
+
+    /// The active web authentication session for the Stripe checkout flow.
+    private var webAuthSession: ASWebAuthenticationSession?
 
     // MARK: Initialization
 
@@ -137,18 +137,24 @@ extension BillingCoordinator: HasErrorAlertServices {
 // MARK: - PremiumUpgradeProcessorDelegate
 
 extension BillingCoordinator: PremiumUpgradeProcessorDelegate {
-    func performCheckoutWebAuthSession(url: URL) async -> CheckoutWebAuthSessionOutcome {
+    func performCheckoutWebAuthSession(url: URL) async -> Result<URL, Error> {
         await withCheckedContinuation { continuation in
             let session = ASWebAuthenticationSession(
                 url: url,
                 callbackURLScheme: services.billingService.checkoutCallbackUrlScheme,
-            ) { [weak self] callbackURL, _ in
+            ) { [weak self] callbackURL, error in
                 self?.webAuthSession = nil
-                let outcome: CheckoutWebAuthSessionOutcome = callbackURL
-                    .map { .completed(callbackURL: $0) } ?? .canceled
-                self?.resumeAfterDismissal(continuation: continuation, outcome: outcome)
+                let result: Result<URL, Error> = if let callbackURL {
+                    .success(callbackURL)
+                } else if let sessionError = error as? ASWebAuthenticationSessionError,
+                          sessionError.code == .canceledLogin {
+                    .failure(CancellationError())
+                } else {
+                    .failure(error ?? CancellationError())
+                }
+                self?.resumeAfterDismissal(continuation: continuation, outcome: result)
             }
-            session.prefersEphemeralWebBrowserSession = false
+            session.prefersEphemeralWebBrowserSession = true
             session.presentationContextProvider = self
             webAuthSession = session
             session.start()
@@ -158,8 +164,8 @@ extension BillingCoordinator: PremiumUpgradeProcessorDelegate {
     /// Resumes the continuation only after any active sheet dismissal animation completes,
     /// so callers can safely present new UI without UIKit dropping the presentation.
     private func resumeAfterDismissal(
-        continuation: CheckedContinuation<CheckoutWebAuthSessionOutcome, Never>,
-        outcome: CheckoutWebAuthSessionOutcome
+        continuation: CheckedContinuation<Result<URL, Error>, Never>,
+        outcome: Result<URL, Error>,
     ) {
         // Traverse from the window root to find the deepest non-dismissing VC —
         // its presentedViewController (the session sheet) is being dismissed.

--- a/BitwardenShared/UI/Billing/BillingCoordinator.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinator.swift
@@ -144,16 +144,37 @@ extension BillingCoordinator: PremiumUpgradeProcessorDelegate {
                 callbackURLScheme: services.billingService.checkoutCallbackUrlScheme,
             ) { [weak self] callbackURL, _ in
                 self?.webAuthSession = nil
-                if let callbackURL {
-                    continuation.resume(returning: .completed(callbackURL: callbackURL))
-                } else {
-                    continuation.resume(returning: .canceled)
-                }
+                let outcome: CheckoutWebAuthSessionOutcome = callbackURL
+                    .map { .completed(callbackURL: $0) } ?? .canceled
+                self?.resumeAfterDismissal(continuation: continuation, outcome: outcome)
             }
             session.prefersEphemeralWebBrowserSession = false
             session.presentationContextProvider = self
             webAuthSession = session
             session.start()
+        }
+    }
+
+    /// Resumes the continuation only after any active sheet dismissal animation completes,
+    /// so callers can safely present new UI without UIKit dropping the presentation.
+    private func resumeAfterDismissal(
+        continuation: CheckedContinuation<CheckoutWebAuthSessionOutcome, Never>,
+        outcome: CheckoutWebAuthSessionOutcome
+    ) {
+        // Traverse from the window root to find the deepest non-dismissing VC —
+        // its presentedViewController (the session sheet) is being dismissed.
+        var presentingVC = stackNavigator?.rootViewController?.view.window?.rootViewController
+        while let child = presentingVC?.presentedViewController, !child.isBeingDismissed {
+            presentingVC = child
+        }
+
+        if let dismissingVC = presentingVC?.presentedViewController,
+           let transitionCoordinator = dismissingVC.transitionCoordinator {
+            transitionCoordinator.animate(alongsideTransition: nil) { _ in
+                continuation.resume(returning: outcome)
+            }
+        } else {
+            continuation.resume(returning: outcome)
         }
     }
 }

--- a/BitwardenShared/UI/Billing/BillingCoordinator.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinator.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import BitwardenKit
 import BitwardenResources
 import SwiftUI
@@ -6,7 +7,7 @@ import SwiftUI
 
 /// A coordinator that manages navigation for billing-related views.
 ///
-class BillingCoordinator: Coordinator, HasStackNavigator {
+class BillingCoordinator: NSObject, Coordinator, HasStackNavigator {
     // MARK: Types
 
     typealias Services = HasBillingService
@@ -19,6 +20,9 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
     /// Whether PremiumUpgrade was opened as the root of a modal navController (vault/archive context).
     /// Determines the close behavior of PremiumUpgradeComplete.
     private var isUpgradeAsModalRoot = false
+
+    /// The active web authentication session for the Stripe checkout flow.
+    private var webAuthSession: ASWebAuthenticationSession?
 
     /// Closure invoked after PremiumUpgradeComplete is dismissed.
     private var premiumUpgradeCompleteOnClose: (() -> Void)?
@@ -109,6 +113,7 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
         state.showCancelButton = shouldReplaceStack
         let processor = PremiumUpgradeProcessor(
             coordinator: asAnyCoordinator(),
+            delegate: self,
             services: services,
             state: state,
         )
@@ -127,4 +132,36 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
 
 extension BillingCoordinator: HasErrorAlertServices {
     var errorAlertServices: ErrorAlertServices { services }
+}
+
+// MARK: - PremiumUpgradeProcessorDelegate
+
+extension BillingCoordinator: PremiumUpgradeProcessorDelegate {
+    func performCheckoutWebAuthSession(url: URL) async -> CheckoutWebAuthSessionOutcome {
+        await withCheckedContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: services.billingService.checkoutCallbackUrlScheme,
+            ) { [weak self] callbackURL, _ in
+                self?.webAuthSession = nil
+                if let callbackURL {
+                    continuation.resume(returning: .completed(callbackURL: callbackURL))
+                } else {
+                    continuation.resume(returning: .canceled)
+                }
+            }
+            session.prefersEphemeralWebBrowserSession = false
+            session.presentationContextProvider = self
+            webAuthSession = session
+            session.start()
+        }
+    }
+}
+
+// MARK: - ASWebAuthenticationPresentationContextProviding
+
+extension BillingCoordinator: ASWebAuthenticationPresentationContextProviding {
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        stackNavigator?.rootViewController?.view.window ?? UIWindow()
+    }
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeAction.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeAction.swift
@@ -6,15 +6,9 @@ enum PremiumUpgradeAction: Equatable {
     /// The cancel button was tapped.
     case cancelTapped
 
-    /// Clear the checkout URL after it has been opened.
-    case clearURL
-
     /// The self-hosted info banner dismiss button was tapped.
     case dismissBannerTapped
 
     /// The pricing error banner dismiss (X) button was tapped.
     case dismissPricingErrorBannerTapped
-
-    /// The checkout URL failed to open in the browser.
-    case urlOpenFailed
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
@@ -3,6 +3,32 @@ import BitwardenResources
 import Combine
 import Foundation
 
+// MARK: - CheckoutWebAuthSessionOutcome
+
+/// The result of a Stripe checkout web authentication session.
+///
+enum CheckoutWebAuthSessionOutcome {
+    /// The user dismissed the session without completing checkout.
+    case canceled
+
+    /// The session completed and Stripe returned a callback URL.
+    case completed(callbackURL: URL)
+}
+
+// MARK: - PremiumUpgradeProcessorDelegate
+
+/// A delegate for `PremiumUpgradeProcessor` to start a web authentication session for Stripe checkout.
+///
+@MainActor
+protocol PremiumUpgradeProcessorDelegate: AnyObject {
+    /// Starts an `ASWebAuthenticationSession` for the Stripe checkout and returns the outcome.
+    ///
+    /// - Parameter url: The Stripe checkout URL to open.
+    /// - Returns: `.completed(callbackURL:)` if Stripe redirected back, or `.canceled` if the user dismissed.
+    ///
+    func performCheckoutWebAuthSession(url: URL) async -> CheckoutWebAuthSessionOutcome
+}
+
 // MARK: - PremiumUpgradeProcessor
 
 /// The processor used to manage state and handle actions for the `PremiumUpgradeView`.
@@ -22,8 +48,8 @@ final class PremiumUpgradeProcessor: StateProcessor<
     /// The coordinator used to manage navigation.
     private let coordinator: AnyCoordinator<BillingRoute, Void>
 
-    /// The last checkout URL returned by the billing service, used to reopen Stripe if canceled.
-    private var lastCheckoutURL: URL?
+    /// A delegate used to start the Stripe web authentication session.
+    private weak var delegate: PremiumUpgradeProcessorDelegate?
 
     /// Cancellable for the premium checkout status subscription.
     private var premiumStatusChangedCancellable: AnyCancellable?
@@ -37,15 +63,18 @@ final class PremiumUpgradeProcessor: StateProcessor<
     ///
     /// - Parameters:
     ///   - coordinator: The coordinator used for navigation.
+    ///   - delegate: The delegate used to start the Stripe web authentication session.
     ///   - services: The services used by this processor.
     ///   - state: The initial state of the processor.
     ///
     init(
         coordinator: AnyCoordinator<BillingRoute, Void>,
+        delegate: PremiumUpgradeProcessorDelegate?,
         services: Services,
         state: PremiumUpgradeState,
     ) {
         self.coordinator = coordinator
+        self.delegate = delegate
         self.services = services
         super.init(state: state)
     }
@@ -71,16 +100,10 @@ final class PremiumUpgradeProcessor: StateProcessor<
         switch action {
         case .cancelTapped:
             coordinator.navigate(to: .dismiss)
-        case .clearURL:
-            state.checkoutURL = nil
         case .dismissBannerTapped:
             state.isBannerDismissed = true
         case .dismissPricingErrorBannerTapped:
             state.showPricingErrorBanner = false
-        case .urlOpenFailed:
-            Task {
-                await coordinator.showErrorAlert(error: BillingError.unableToOpenCheckout)
-            }
         }
     }
 
@@ -113,7 +136,7 @@ final class PremiumUpgradeProcessor: StateProcessor<
                 switch status {
                 case .canceled:
                     coordinator.showAlert(.paymentNotReceivedYet {
-                        self.state.checkoutURL = self.lastCheckoutURL
+                        await self.createCheckoutSession()
                     })
                 case .syncing:
                     coordinator.showLoadingOverlay(title: Localizations.confirmingYourUpgrade)
@@ -129,7 +152,7 @@ final class PremiumUpgradeProcessor: StateProcessor<
             }
     }
 
-    /// Creates a checkout session by calling the billing service.
+    /// Creates a checkout session, opens it via `ASWebAuthenticationSession`, and handles the result.
     ///
     private func createCheckoutSession() async {
         do {
@@ -138,9 +161,18 @@ final class PremiumUpgradeProcessor: StateProcessor<
             let url = try await services.billingService.createCheckoutSession()
             coordinator.hideLoadingOverlay()
             state.isLoading = false
-            lastCheckoutURL = url
             subscribeToPremiumCheckoutStatus()
-            state.checkoutURL = url
+            switch await delegate?.performCheckoutWebAuthSession(url: url) {
+            case .canceled, nil:
+                // Wait for the ASWebAuthenticationSession sheet to finish dismissing
+                // before presenting the alert, otherwise UIKit drops the presentation.
+                try? await Task.sleep(nanoseconds: 300_000_000)
+                coordinator.showAlert(.paymentNotReceivedYet {
+                    await self.createCheckoutSession()
+                })
+            case let .completed(callbackURL):
+                await handleCheckoutCallback(callbackURL)
+            }
         } catch {
             coordinator.hideLoadingOverlay()
             state.isLoading = false
@@ -148,6 +180,22 @@ final class PremiumUpgradeProcessor: StateProcessor<
             coordinator.showAlert(.secureCheckoutDidntLoad {
                 await self.createCheckoutSession()
             })
+        }
+    }
+
+    /// Routes the Stripe callback URL to the appropriate billing service method.
+    ///
+    private func handleCheckoutCallback(_ callbackURL: URL) async {
+        let components = URLComponents(url: callbackURL, resolvingAgainstBaseURL: false)
+        let result = components?.queryItems?.first(where: { item in
+            item.name == BitwardenDeepLinkConstants.PremiumCheckoutResultQuery.parameterName
+        })?.value
+
+        if callbackURL.host == BitwardenDeepLinkConstants.premiumCheckoutResultHost,
+           result == BitwardenDeepLinkConstants.PremiumCheckoutResultQuery.successValue {
+            await services.billingService.premiumStatusChanged()
+        } else {
+            services.billingService.premiumCheckoutCanceled()
         }
     }
 }

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
@@ -164,9 +164,6 @@ final class PremiumUpgradeProcessor: StateProcessor<
             subscribeToPremiumCheckoutStatus()
             switch await delegate?.performCheckoutWebAuthSession(url: url) {
             case .canceled, nil:
-                // Wait for the ASWebAuthenticationSession sheet to finish dismissing
-                // before presenting the alert, otherwise UIKit drops the presentation.
-                try? await Task.sleep(nanoseconds: 300_000_000)
                 coordinator.showAlert(.paymentNotReceivedYet {
                     await self.createCheckoutSession()
                 })

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessor.swift
@@ -3,30 +3,18 @@ import BitwardenResources
 import Combine
 import Foundation
 
-// MARK: - CheckoutWebAuthSessionOutcome
-
-/// The result of a Stripe checkout web authentication session.
-///
-enum CheckoutWebAuthSessionOutcome {
-    /// The user dismissed the session without completing checkout.
-    case canceled
-
-    /// The session completed and Stripe returned a callback URL.
-    case completed(callbackURL: URL)
-}
-
 // MARK: - PremiumUpgradeProcessorDelegate
 
 /// A delegate for `PremiumUpgradeProcessor` to start a web authentication session for Stripe checkout.
 ///
 @MainActor
-protocol PremiumUpgradeProcessorDelegate: AnyObject {
-    /// Starts an `ASWebAuthenticationSession` for the Stripe checkout and returns the outcome.
+protocol PremiumUpgradeProcessorDelegate: AnyObject { // sourcery: AutoMockable
+    /// Starts an `ASWebAuthenticationSession` for the Stripe checkout and returns the result.
     ///
     /// - Parameter url: The Stripe checkout URL to open.
-    /// - Returns: `.completed(callbackURL:)` if Stripe redirected back, or `.canceled` if the user dismissed.
+    /// - Returns: `.success(callbackURL)` if Stripe redirected back, or `.failure` if canceled or an error occurred.
     ///
-    func performCheckoutWebAuthSession(url: URL) async -> CheckoutWebAuthSessionOutcome
+    func performCheckoutWebAuthSession(url: URL) async -> Result<URL, Error>
 }
 
 // MARK: - PremiumUpgradeProcessor
@@ -163,12 +151,17 @@ final class PremiumUpgradeProcessor: StateProcessor<
             state.isLoading = false
             subscribeToPremiumCheckoutStatus()
             switch await delegate?.performCheckoutWebAuthSession(url: url) {
-            case .canceled, nil:
+            case let .success(callbackURL)?:
+                await handleCheckoutCallback(callbackURL)
+            case let .failure(error)? where !(error is CancellationError):
+                services.errorReporter.log(error: error)
                 coordinator.showAlert(.paymentNotReceivedYet {
                     await self.createCheckoutSession()
                 })
-            case let .completed(callbackURL):
-                await handleCheckoutCallback(callbackURL)
+            default:
+                coordinator.showAlert(.paymentNotReceivedYet {
+                    await self.createCheckoutSession()
+                })
             }
         } catch {
             coordinator.hideLoadingOverlay()

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
@@ -9,21 +9,6 @@ import Testing
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
-// MARK: - MockPremiumUpgradeProcessorDelegate
-
-@MainActor
-class MockPremiumUpgradeProcessorDelegate: PremiumUpgradeProcessorDelegate {
-    var performCheckoutWebAuthSessionCalled = false
-    var webAuthSessionCalledWithURL: URL?
-    var performCheckoutWebAuthSessionReturnValue: CheckoutWebAuthSessionOutcome = .canceled
-
-    func performCheckoutWebAuthSession(url: URL) async -> CheckoutWebAuthSessionOutcome {
-        performCheckoutWebAuthSessionCalled = true
-        webAuthSessionCalledWithURL = url
-        return performCheckoutWebAuthSessionReturnValue
-    }
-}
-
 // MARK: - PremiumUpgradeProcessorTests
 
 @MainActor
@@ -52,6 +37,7 @@ struct PremiumUpgradeProcessorTests {
             .eraseToAnyPublisher()
         coordinator = MockCoordinator<BillingRoute, Void>()
         delegate = MockPremiumUpgradeProcessorDelegate()
+        delegate.performCheckoutWebAuthSessionReturnValue = .failure(CancellationError())
         errorReporter = MockErrorReporter()
         let services = ServiceContainer.withMocks(
             billingService: billingService,
@@ -179,12 +165,12 @@ struct PremiumUpgradeProcessorTests {
         billingService.createCheckoutSessionReturnValue = checkoutURL
         billingService.premiumCheckoutStatusPublisherReturnValue = PassthroughSubject<PremiumCheckoutStatus, Never>()
             .eraseToAnyPublisher()
-        delegate.performCheckoutWebAuthSessionReturnValue = .completed(callbackURL: callbackURL)
+        delegate.performCheckoutWebAuthSessionReturnValue = .success(callbackURL)
 
         await subject.perform(.upgradeNowTapped)
 
         #expect(billingService.createCheckoutSessionCallsCount == 1)
-        #expect(delegate.webAuthSessionCalledWithURL == checkoutURL)
+        #expect(delegate.performCheckoutWebAuthSessionReceivedUrl == checkoutURL)
         #expect(billingService.premiumStatusChangedCalled)
         #expect(subject.state.isLoading == false)
     }
@@ -196,11 +182,11 @@ struct PremiumUpgradeProcessorTests {
         billingService.createCheckoutSessionReturnValue = checkoutURL
         billingService.premiumCheckoutStatusPublisherReturnValue = PassthroughSubject<PremiumCheckoutStatus, Never>()
             .eraseToAnyPublisher()
-        delegate.performCheckoutWebAuthSessionReturnValue = .canceled
+        delegate.performCheckoutWebAuthSessionReturnValue = .failure(CancellationError())
 
         await subject.perform(.upgradeNowTapped)
 
-        #expect(delegate.webAuthSessionCalledWithURL == checkoutURL)
+        #expect(delegate.performCheckoutWebAuthSessionReceivedUrl == checkoutURL)
         let alert = try #require(coordinator.alertShown.last)
         #expect(alert.title == Localizations.paymentNotReceivedYet)
     }
@@ -259,8 +245,8 @@ struct PremiumUpgradeProcessorTests {
         billingService.createCheckoutSessionReturnValue = expectedURL
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        delegate.performCheckoutWebAuthSessionReturnValue = .completed(
-            callbackURL: URL(string: "bitwarden://premium-checkout-result?result=success")!,
+        delegate.performCheckoutWebAuthSessionReturnValue = .success(
+            URL(string: "bitwarden://premium-checkout-result?result=success")!,
         )
 
         await subject.perform(.upgradeNowTapped)
@@ -280,8 +266,8 @@ struct PremiumUpgradeProcessorTests {
         billingService.createCheckoutSessionReturnValue = expectedURL
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
-        delegate.performCheckoutWebAuthSessionReturnValue = .completed(
-            callbackURL: URL(string: "bitwarden://premium-checkout-result?result=success")!,
+        delegate.performCheckoutWebAuthSessionReturnValue = .success(
+            URL(string: "bitwarden://premium-checkout-result?result=success")!,
         )
 
         await subject.perform(.upgradeNowTapped)

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeProcessorTests.swift
@@ -9,6 +9,21 @@ import Testing
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
+// MARK: - MockPremiumUpgradeProcessorDelegate
+
+@MainActor
+class MockPremiumUpgradeProcessorDelegate: PremiumUpgradeProcessorDelegate {
+    var performCheckoutWebAuthSessionCalled = false
+    var webAuthSessionCalledWithURL: URL?
+    var performCheckoutWebAuthSessionReturnValue: CheckoutWebAuthSessionOutcome = .canceled
+
+    func performCheckoutWebAuthSession(url: URL) async -> CheckoutWebAuthSessionOutcome {
+        performCheckoutWebAuthSessionCalled = true
+        webAuthSessionCalledWithURL = url
+        return performCheckoutWebAuthSessionReturnValue
+    }
+}
+
 // MARK: - PremiumUpgradeProcessorTests
 
 @MainActor
@@ -17,6 +32,7 @@ struct PremiumUpgradeProcessorTests {
 
     let billingService: MockBillingService
     let coordinator: MockCoordinator<BillingRoute, Void>
+    let delegate: MockPremiumUpgradeProcessorDelegate
     let errorReporter: MockErrorReporter
     let subject: PremiumUpgradeProcessor
 
@@ -35,6 +51,7 @@ struct PremiumUpgradeProcessorTests {
         billingService.premiumCheckoutStatusPublisherReturnValue = PassthroughSubject<PremiumCheckoutStatus, Never>()
             .eraseToAnyPublisher()
         coordinator = MockCoordinator<BillingRoute, Void>()
+        delegate = MockPremiumUpgradeProcessorDelegate()
         errorReporter = MockErrorReporter()
         let services = ServiceContainer.withMocks(
             billingService: billingService,
@@ -42,6 +59,7 @@ struct PremiumUpgradeProcessorTests {
         )
         subject = PremiumUpgradeProcessor(
             coordinator: coordinator.asAnyCoordinator(),
+            delegate: delegate,
             services: services,
             state: PremiumUpgradeState(),
         )
@@ -136,7 +154,6 @@ struct PremiumUpgradeProcessorTests {
         await subject.perform(.upgradeNowTapped)
 
         #expect(billingService.createCheckoutSessionCallsCount == 1)
-        #expect(subject.state.checkoutURL == nil)
         #expect(subject.state.isLoading == false)
         #expect(errorReporter.errors.first as? BitwardenTestError == .example)
         #expect(coordinator.alertShown.count == 1)
@@ -149,25 +166,43 @@ struct PremiumUpgradeProcessorTests {
 
         await subject.perform(.upgradeNowTapped)
 
-        #expect(subject.state.checkoutURL == nil)
         #expect(subject.state.isLoading == false)
         #expect(errorReporter.errors.first as? BillingError == .invalidCheckoutUrl)
         #expect(coordinator.alertShown.count == 1)
     }
 
-    /// `perform(_:)` with `.upgradeNowTapped` sets the checkout URL on success.
+    /// `perform(_:)` with `.upgradeNowTapped` calls `premiumStatusChanged` when the session returns a success URL.
     @Test
-    func perform_upgradeNowTapped_success() async throws {
-        let expectedURL = URL(string: "https://checkout.stripe.com/session")!
-        billingService.createCheckoutSessionReturnValue = expectedURL
+    func perform_upgradeNowTapped_checkoutSucceeded() async throws {
+        let checkoutURL = URL(string: "https://checkout.stripe.com/session")!
+        let callbackURL = URL(string: "bitwarden://premium-checkout-result?result=success")!
+        billingService.createCheckoutSessionReturnValue = checkoutURL
         billingService.premiumCheckoutStatusPublisherReturnValue = PassthroughSubject<PremiumCheckoutStatus, Never>()
             .eraseToAnyPublisher()
+        delegate.performCheckoutWebAuthSessionReturnValue = .completed(callbackURL: callbackURL)
 
         await subject.perform(.upgradeNowTapped)
 
         #expect(billingService.createCheckoutSessionCallsCount == 1)
-        #expect(subject.state.checkoutURL == expectedURL)
+        #expect(delegate.webAuthSessionCalledWithURL == checkoutURL)
+        #expect(billingService.premiumStatusChangedCalled)
         #expect(subject.state.isLoading == false)
+    }
+
+    /// `perform(_:)` with `.upgradeNowTapped` shows the retry alert when the user cancels the session.
+    @Test
+    func perform_upgradeNowTapped_checkoutCanceled() async throws {
+        let checkoutURL = URL(string: "https://checkout.stripe.com/session")!
+        billingService.createCheckoutSessionReturnValue = checkoutURL
+        billingService.premiumCheckoutStatusPublisherReturnValue = PassthroughSubject<PremiumCheckoutStatus, Never>()
+            .eraseToAnyPublisher()
+        delegate.performCheckoutWebAuthSessionReturnValue = .canceled
+
+        await subject.perform(.upgradeNowTapped)
+
+        #expect(delegate.webAuthSessionCalledWithURL == checkoutURL)
+        let alert = try #require(coordinator.alertShown.last)
+        #expect(alert.title == Localizations.paymentNotReceivedYet)
     }
 
     /// `receive(_:)` with `.cancelTapped` navigates to dismiss.
@@ -200,25 +235,6 @@ struct PremiumUpgradeProcessorTests {
         #expect(subject.state.showPricingErrorBanner == false)
     }
 
-    /// `receive(_:)` with `.clearURL` clears the checkout URL.
-    @Test
-    func receive_clearURL() {
-        subject.state.checkoutURL = URL(string: "https://example.com")
-
-        subject.receive(.clearURL)
-
-        #expect(subject.state.checkoutURL == nil)
-    }
-
-    /// `receive(_:)` with `.urlOpenFailed` shows an error alert.
-    @Test
-    func receive_urlOpenFailed() async throws {
-        subject.receive(.urlOpenFailed)
-
-        try await waitForAsync { coordinator.errorAlertsShown.count == 1 }
-        #expect(coordinator.errorAlertsShown.first as? BillingError == .unableToOpenCheckout)
-    }
-
     /// When the billing service emits `.syncing` after checkout, the processor shows the
     /// confirming-upgrade loading overlay on the upgrade screen.
     @Test
@@ -243,6 +259,9 @@ struct PremiumUpgradeProcessorTests {
         billingService.createCheckoutSessionReturnValue = expectedURL
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        delegate.performCheckoutWebAuthSessionReturnValue = .completed(
+            callbackURL: URL(string: "bitwarden://premium-checkout-result?result=success")!,
+        )
 
         await subject.perform(.upgradeNowTapped)
         statusSubject.send(.confirmed)
@@ -261,6 +280,9 @@ struct PremiumUpgradeProcessorTests {
         billingService.createCheckoutSessionReturnValue = expectedURL
         let statusSubject = PassthroughSubject<PremiumCheckoutStatus, Never>()
         billingService.premiumCheckoutStatusPublisherReturnValue = statusSubject.eraseToAnyPublisher()
+        delegate.performCheckoutWebAuthSessionReturnValue = .completed(
+            callbackURL: URL(string: "bitwarden://premium-checkout-result?result=success")!,
+        )
 
         await subject.perform(.upgradeNowTapped)
         let routeCountBefore = coordinator.routes.count

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeState.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeState.swift
@@ -7,9 +7,6 @@ import Foundation
 struct PremiumUpgradeState: Equatable {
     // MARK: Properties
 
-    /// The checkout URL to open when the user taps the upgrade button.
-    var checkoutURL: URL?
-
     /// Whether the self-hosted info banner has been dismissed.
     var isBannerDismissed = false
 

--- a/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgrade/PremiumUpgradeView.swift
@@ -9,9 +9,6 @@ import SwiftUI
 struct PremiumUpgradeView: View {
     // MARK: Properties
 
-    /// An object used to open URLs from this view.
-    @Environment(\.openURL) private var openURL
-
     /// The store that renders the view.
     @ObservedObject var store: Store<PremiumUpgradeState, PremiumUpgradeAction, PremiumUpgradeEffect>
 
@@ -24,15 +21,6 @@ struct PremiumUpgradeView: View {
                 cancelToolbarItem(hidden: !store.state.showCancelButton) {
                     store.send(.cancelTapped)
                 }
-            }
-            .onChange(of: store.state.checkoutURL) { url in
-                guard let url else { return }
-                openURL(url) { success in
-                    if !success {
-                        store.send(.urlOpenFailed)
-                    }
-                }
-                store.send(.clearURL)
             }
     }
 

--- a/BitwardenShared/UI/Platform/Application/AppProcessor.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessor.swift
@@ -105,10 +105,6 @@ public class AppProcessor {
     /// - Parameter url: The deep link URL to handle.
     ///
     public func openUrl(_ url: URL) async {
-        if await handlePremiumCheckoutResult(url: url) {
-            return
-        }
-
         var route = await getBitwardenUrlRoute(url: url)
         if route == nil {
             route = await getOtpAuthUrlRoute(url: url)
@@ -433,28 +429,6 @@ extension AppProcessor {
         } catch {
             services.errorReporter.log(error: error)
         }
-    }
-
-    /// Handles the premium checkout result deep link.
-    ///
-    /// - Parameter url: The URL to check.
-    /// - Returns: `true` if the URL was a premium checkout result and was handled.
-    ///
-    private func handlePremiumCheckoutResult(url: URL) async -> Bool {
-        guard url.scheme?.isBitwardenAppScheme == true,
-              url.host == BitwardenDeepLinkConstants.premiumCheckoutResultHost else {
-            return false
-        }
-        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
-        let result = components?.queryItems?.first(where: { item in
-            item.name == BitwardenDeepLinkConstants.PremiumCheckoutResultQuery.parameterName
-        })?.value
-        if result == BitwardenDeepLinkConstants.PremiumCheckoutResultQuery.successValue {
-            await services.billingService.premiumStatusChanged()
-        } else {
-            services.billingService.premiumCheckoutCanceled()
-        }
-        return true
     }
 
     /// Attempt to create an `AppRoute` from an "bitwarden://" url.

--- a/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Application/AppProcessorTests.swift
@@ -898,38 +898,6 @@ class AppProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(coordinator.routes, [])
     }
 
-    /// `openUrl(_:)` with a premium checkout success URL calls `billingService.premiumStatusChanged()`.
-    @MainActor
-    func test_openUrl_premiumCheckoutResult_success() async throws {
-        let url = try XCTUnwrap(URL(string: "bitwarden://premium-checkout-result?result=success"))
-
-        await subject.openUrl(url)
-
-        XCTAssertEqual(billingService.premiumStatusChangedCallsCount, 1)
-    }
-
-    /// `openUrl(_:)` with a premium checkout canceled URL calls `premiumCheckoutCanceled()`.
-    @MainActor
-    func test_openUrl_premiumCheckoutResult_canceled() async throws {
-        let url = try XCTUnwrap(URL(string: "bitwarden://premium-checkout-result?result=canceled"))
-
-        await subject.openUrl(url)
-
-        XCTAssertEqual(billingService.premiumCheckoutCanceledCallsCount, 1)
-        XCTAssertEqual(billingService.premiumStatusChangedCallsCount, 0)
-    }
-
-    /// `openUrl(_:)` with a non-premium-checkout URL is not handled by `handlePremiumCheckoutResult`.
-    @MainActor
-    func test_openUrl_premiumCheckoutResult_unrelatedUrl() async throws {
-        let url = try XCTUnwrap(URL(string: "bitwarden://other-path"))
-
-        await subject.openUrl(url)
-
-        XCTAssertEqual(billingService.premiumStatusChangedCallsCount, 0)
-        XCTAssertEqual(billingService.premiumCheckoutCanceledCallsCount, 0)
-    }
-
     /// `provideCredential(for:)` returns the credential with the specified identifier.
     func test_provideCredential() async throws {
         let credential = ASPasswordCredential(user: "user@bitwarden.com", password: "password123")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38147
https://bitwarden.atlassian.net/browse/PM-37994

## 📔 Objective

Replaces the browser-based Stripe checkout flow with `ASWebAuthenticationSession`, keeping the user in-app and giving the processor direct access to the callback URL.

Removes the `openURL` / `state.checkoutURL` indirection from the view, the `handlePremiumCheckoutResult` deep link handler from `AppProcessor`, and the `unableToOpenCheckout` error case — all now handled inline by the session delegate.

## 📸 Screenshots

https://github.com/user-attachments/assets/1afc63b8-f0b4-402a-9617-bc15e3791f94

