### PR TITLE
[PM-38178] ci: Increase test execution time allowance to 3 seconds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
               -resultBundlePath "$_TESTS_RESULT_BUNDLE_PATH" \
               -derivedDataPath build/DerivedData \
               -test-timeouts-enabled yes \
-              -maximum-test-execution-time-allowance 2 \
+              -maximum-test-execution-time-allowance 3 \
               -quiet
             kill "$PYEETD_PID"
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38178

## 📔 Objective

Following PM-36946 (which raised the per-test timeout from 1s to 2s), we are still
seeing occasional timeouts in CI due to system load from Swift Testing parallelization.
This bumps the `-maximum-test-execution-time-allowance` flag in `test.yml` from 2 to 3
seconds to give parallelized tests a bit more headroom.