### PR TITLE
[PM-37967] feat: Show premium canceled status in plan screen

### DIFF
--- a/BitwardenShared/Core/Billing/Models/Domain/PremiumSubscription.swift
+++ b/BitwardenShared/Core/Billing/Models/Domain/PremiumSubscription.swift
@@ -4,7 +4,7 @@ import Foundation
 
 /// A domain model representing the user's premium subscription details.
 ///
-struct PremiumSubscription: Equatable {
+public struct PremiumSubscription: Equatable, Hashable {
     // MARK: Properties
 
     /// The billing cadence (e.g. annually, monthly).

--- a/BitwardenShared/Core/Billing/Models/Enum/PlanCadenceType.swift
+++ b/BitwardenShared/Core/Billing/Models/Enum/PlanCadenceType.swift
@@ -4,7 +4,7 @@ import BitwardenResources
 
 /// The billing cadence for a subscription plan.
 ///
-enum PlanCadenceType: String, Codable, Equatable, Sendable {
+public enum PlanCadenceType: String, Codable, Equatable, Hashable, Sendable {
     /// An annual billing cadence.
     case annually
 

--- a/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequest.swift
+++ b/BitwardenShared/Core/Billing/Services/API/Requests/GetSubscriptionRequest.swift
@@ -1,5 +1,14 @@
 import Networking
 
+// MARK: - GetSubscriptionRequestError
+
+/// Errors thrown from validating a `GetSubscriptionRequest` response.
+///
+enum GetSubscriptionRequestError: Error {
+    /// The user has no subscription (free plan).
+    case noSubscription
+}
+
 // MARK: - GetSubscriptionRequest
 
 /// A networking request to get the user's subscription details.
@@ -14,4 +23,12 @@ struct GetSubscriptionRequest: Request {
 
     /// The URL path for this request.
     var path: String { "/account/billing/vnext/subscription" }
+
+    // MARK: Validation
+
+    func validate(_ response: HTTPResponse) throws {
+        if response.statusCode == 404 {
+            throw GetSubscriptionRequestError.noSubscription
+        }
+    }
 }

--- a/BitwardenShared/UI/Billing/BillingCoordinator.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinator.swift
@@ -59,8 +59,8 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
             }
         case .premiumUpgradeComplete:
             showPremiumUpgradeComplete()
-        case .premiumPlan:
-            showPremiumPlan(subscription: (context as? PremiumSubscriptionContext)?.subscription)
+        case let .premiumPlan(subscription):
+            showPremiumPlan(subscription: subscription)
         case .premiumUpgrade:
             showPremiumUpgrade()
         }

--- a/BitwardenShared/UI/Billing/BillingCoordinator.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinator.swift
@@ -60,7 +60,7 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
         case .premiumUpgradeComplete:
             showPremiumUpgradeComplete()
         case .premiumPlan:
-            showPremiumPlan()
+            showPremiumPlan(subscription: (context as? PremiumSubscriptionContext)?.subscription)
         case .premiumUpgrade:
             showPremiumUpgrade()
         }
@@ -79,7 +79,7 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
                 // Pop PremiumUpgradeView silently so back navigation from PremiumPlanView
                 // returns to Settings, not to the (now-irrelevant) upgrade screen.
                 self?.stackNavigator?.pop(animated: false)
-                self?.showPremiumPlan()
+                self?.showPremiumPlan(subscription: nil)
             }
         let processor = PremiumUpgradeCompleteProcessor(coordinator: asAnyCoordinator())
         let view = PremiumUpgradeCompleteView(store: Store(processor: processor))
@@ -88,11 +88,14 @@ class BillingCoordinator: Coordinator, HasStackNavigator {
 
     /// Shows the premium plan screen.
     ///
-    private func showPremiumPlan() {
+    /// - Parameter subscription: An already-fetched subscription; pass `nil` to let the plan screen fetch it.
+    ///
+    private func showPremiumPlan(subscription: PremiumSubscription?) {
+        let state = subscription.map(PremiumPlanState.init(subscription:)) ?? PremiumPlanState()
         let processor = PremiumPlanProcessor(
             coordinator: asAnyCoordinator(),
             services: services,
-            state: PremiumPlanState(),
+            state: state,
         )
         let view = PremiumPlanView(store: Store(processor: processor))
         let viewController = UIHostingController(rootView: view)

--- a/BitwardenShared/UI/Billing/BillingCoordinatorTests.swift
+++ b/BitwardenShared/UI/Billing/BillingCoordinatorTests.swift
@@ -120,7 +120,7 @@ struct BillingCoordinatorTests {
     /// `navigate(to:)` with `.premiumPlan` pushes the premium plan view.
     @Test
     func navigate_premiumPlan() throws {
-        subject.navigate(to: .premiumPlan)
+        subject.navigate(to: .premiumPlan(nil))
 
         #expect(stackNavigator.actions.count == 1)
         let action = try #require(stackNavigator.actions.last)

--- a/BitwardenShared/UI/Billing/BillingRoute.swift
+++ b/BitwardenShared/UI/Billing/BillingRoute.swift
@@ -7,7 +7,7 @@ enum BillingRoute: Equatable {
     case dismiss
 
     /// A route to the premium plan screen.
-    case premiumPlan
+    case premiumPlan(PremiumSubscription?)
 
     /// A route to the premium upgrade screen.
     case premiumUpgrade

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessor.swift
@@ -131,7 +131,12 @@ final class PremiumPlanProcessor: StateProcessor<
                 return
             }
 
-            let subscription = try await services.billingService.getSubscription()
+            let subscription: PremiumSubscription
+            if let existing = state.subscription {
+                subscription = existing
+            } else {
+                subscription = try await services.billingService.getSubscription()
+            }
             state.subscription = subscription
             state.planStatus = subscription.status
         } catch {

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
@@ -78,6 +78,35 @@ struct PremiumPlanProcessorTests {
         #expect(coordinator.routes.last == .dismiss)
     }
 
+    /// `perform(_:)` with `.appeared` skips `getSubscription()` when a subscription is pre-loaded in state.
+    @Test
+    func perform_appeared_skipsGetSubscription_whenPreloaded() async {
+        billingService.getPremiumPlanReturnValue = PremiumPlanResponseModel(
+            available: true,
+            legacyYear: nil,
+            name: "Premium",
+            seat: PlanPricingResponseModel(price: 12, provided: 1, stripePriceId: "seat"),
+            storage: PlanPricingResponseModel(price: 4.80, provided: 1, stripePriceId: "storage"),
+        )
+        let preloaded = PremiumSubscription.fixture(status: .canceled)
+        let subjectWithSubscription = PremiumPlanProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                billingService: billingService,
+                environmentService: environmentService,
+                errorReporter: errorReporter,
+            ),
+            state: PremiumPlanState(subscription: preloaded),
+        )
+
+        await subjectWithSubscription.perform(.appeared)
+
+        #expect(billingService.getPremiumPlanCallsCount == 1)
+        #expect(billingService.getSubscriptionCallsCount == 0)
+        #expect(subjectWithSubscription.state.planStatus == .canceled)
+        #expect(subjectWithSubscription.state.subscription == preloaded)
+    }
+
     /// `perform(_:)` with `.appeared` loads the subscription and updates state.
     @Test
     func perform_appeared_success() async {

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanProcessorTests.swift
@@ -89,22 +89,14 @@ struct PremiumPlanProcessorTests {
             storage: PlanPricingResponseModel(price: 4.80, provided: 1, stripePriceId: "storage"),
         )
         let preloaded = PremiumSubscription.fixture(status: .canceled)
-        let subjectWithSubscription = PremiumPlanProcessor(
-            coordinator: coordinator.asAnyCoordinator(),
-            services: ServiceContainer.withMocks(
-                billingService: billingService,
-                environmentService: environmentService,
-                errorReporter: errorReporter,
-            ),
-            state: PremiumPlanState(subscription: preloaded),
-        )
+        subject.state = PremiumPlanState(subscription: preloaded)
 
-        await subjectWithSubscription.perform(.appeared)
+        await subject.perform(.appeared)
 
         #expect(billingService.getPremiumPlanCallsCount == 1)
         #expect(billingService.getSubscriptionCallsCount == 0)
-        #expect(subjectWithSubscription.state.planStatus == .canceled)
-        #expect(subjectWithSubscription.state.subscription == preloaded)
+        #expect(subject.state.planStatus == .canceled)
+        #expect(subject.state.subscription == preloaded)
     }
 
     /// `perform(_:)` with `.appeared` loads the subscription and updates state.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -169,3 +169,16 @@ struct PremiumPlanState: Equatable {
         date.formatted(date: .long, time: .omitted)
     }
 }
+
+// MARK: - PremiumPlanState + Initialization
+
+extension PremiumPlanState {
+    /// Creates a `PremiumPlanState` pre-populated with a subscription, skipping the plan screen's
+    /// own `getSubscription()` fetch.
+    ///
+    /// - Parameter subscription: The already-fetched subscription.
+    ///
+    init(subscription: PremiumSubscription) {
+        self.init(planStatus: subscription.status, subscription: subscription)
+    }
+}

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
@@ -37,6 +37,16 @@ enum PremiumPlanStatus: Equatable {
         }
     }
 
+    /// Whether the status represents a subscription in a troubled state (e.g. canceled, past due).
+    var isTroubleState: Bool {
+        switch self {
+        case .canceled, .pastDue, .updatePayment:
+            true
+        case .active, .unknown:
+            false
+        }
+    }
+
     /// The localized label for this status.
     var label: String {
         switch self {

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
@@ -5,7 +5,7 @@ import BitwardenResources
 
 /// The status of the user's premium plan.
 ///
-enum PremiumPlanStatus: Equatable {
+public enum PremiumPlanStatus: Equatable, Hashable {
     /// The plan is active.
     case active
 

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatusTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatusTests.swift
@@ -33,6 +33,19 @@ struct PremiumPlanStatusTests {
         #expect(PremiumPlanStatus(subscriptionStatus: status) == expected)
     }
 
+    // MARK: Tests - isTroubleState
+
+    @Test(arguments: [
+        (PremiumPlanStatus.active, false),
+        (.canceled, true),
+        (.pastDue, true),
+        (.unknown, false),
+        (.updatePayment, true),
+    ] as [(PremiumPlanStatus, Bool)])
+    func isTroubleState(_ status: PremiumPlanStatus, expected: Bool) {
+        #expect(status.isTroubleState == expected)
+    }
+
     // MARK: Tests - label
 
     @Test(arguments: [

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsAction.swift
@@ -19,9 +19,6 @@ enum SettingsAction: Equatable {
     /// The other button was pressed.
     case otherPressed
 
-    /// The plan button was pressed.
-    case planPressed
-
     /// The vault button was pressed.
     case vaultPressed
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsEffect.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsEffect.swift
@@ -3,4 +3,7 @@
 enum SettingsEffect: Equatable {
     /// The view appeared so the initial data should be loaded.
     case appeared
+
+    /// The plan row was tapped.
+    case planPressed
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -96,6 +96,8 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             let isSelfHosted = await services.billingService.isSelfHosted()
             state.hasPremium = hasPremium
             state.showPlanRow = featureEnabled && !isSelfHosted
+        case .planPressed:
+            await navigateToPlan()
         }
     }
 
@@ -113,14 +115,31 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             coordinator.navigate(to: .dismiss)
         case .otherPressed:
             coordinator.navigate(to: .other)
-        case .planPressed:
-            if state.hasPremium {
+        case .vaultPressed:
+            coordinator.navigate(to: .vault)
+        }
+    }
+
+    // MARK: Private Methods
+
+    /// Navigates to the appropriate plan screen based on the user's premium and subscription status.
+    ///
+    private func navigateToPlan() async {
+        guard !state.hasPremium else {
+            coordinator.navigate(to: .premiumPlan)
+            return
+        }
+
+        do {
+            let subscription = try await services.billingService.getSubscription()
+            if subscription.status.isTroubleState {
                 coordinator.navigate(to: .premiumPlan)
             } else {
                 coordinator.navigate(to: .premiumUpgrade)
             }
-        case .vaultPressed:
-            coordinator.navigate(to: .vault)
+        } catch {
+            services.errorReporter.log(error: error)
+            coordinator.navigate(to: .premiumUpgrade)
         }
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -127,7 +127,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
     ///
     private func navigateToPlan() async {
         guard !state.hasPremium else {
-            coordinator.navigate(to: .premiumPlan)
+            coordinator.navigate(to: .premiumPlan(nil))
             return
         }
 
@@ -137,7 +137,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         do {
             let subscription = try await services.billingService.getSubscription()
             if subscription.status.isTroubleState {
-                coordinator.navigate(to: .premiumPlan, context: PremiumSubscriptionContext(subscription))
+                coordinator.navigate(to: .premiumPlan(subscription))
             } else {
                 coordinator.navigate(to: .premiumUpgrade)
             }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -141,9 +141,11 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             } else {
                 coordinator.navigate(to: .premiumUpgrade)
             }
+        } catch is GetSubscriptionRequestError {
+            coordinator.navigate(to: .premiumUpgrade)
         } catch {
             services.errorReporter.log(error: error)
-            coordinator.navigate(to: .premiumUpgrade)
+            await coordinator.showErrorAlert(error: error)
         }
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenResources
 
 // MARK: - SettingsProcessorDelegate
 
@@ -130,10 +131,13 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             return
         }
 
+        defer { coordinator.hideLoadingOverlay() }
+        coordinator.showLoadingOverlay(title: Localizations.loading)
+
         do {
             let subscription = try await services.billingService.getSubscription()
             if subscription.status.isTroubleState {
-                coordinator.navigate(to: .premiumPlan)
+                coordinator.navigate(to: .premiumPlan, context: PremiumSubscriptionContext(subscription))
             } else {
                 coordinator.navigate(to: .premiumUpgrade)
             }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -215,7 +215,7 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
-        XCTAssertTrue(errorReporter.errors.isEmpty)
+        XCTAssertFalse(errorReporter.errors.contains { $0 is GetSubscriptionRequestError })
     }
 
     /// `perform(.planPressed)` shows a loading overlay and shows an error alert
@@ -227,7 +227,7 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
+        XCTAssertEqual(coordinator.errorAlertsShown.count, 1)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
         XCTAssertTrue(errorReporter.errors.contains { $0 as? BitwardenTestError == .example })
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKitMocks
+import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
@@ -161,22 +162,59 @@ class SettingsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .other)
     }
 
-    /// Receiving `.planPressed` navigates to the premium upgrade screen for a free user.
+    /// `perform(.planPressed)` navigates to the premium plan screen for a premium user.
     @MainActor
-    func test_receive_planPressed_freeUser() {
-        subject.state.hasPremium = false
-        subject.receive(.planPressed)
-
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-    }
-
-    /// Receiving `.planPressed` navigates to the premium plan screen for a premium user.
-    @MainActor
-    func test_receive_planPressed_hasPremium() {
+    func test_perform_planPressed_hasPremium() async {
         subject.state.hasPremium = true
-        subject.receive(.planPressed)
+
+        await subject.perform(.planPressed)
 
         XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+    }
+
+    /// `perform(.planPressed)` navigates to the premium plan screen when the user has a canceled subscription.
+    @MainActor
+    func test_perform_planPressed_canceledSubscription() async {
+        subject.state.hasPremium = false
+        billingService.getSubscriptionReturnValue = .fixture(status: .canceled)
+
+        await subject.perform(.planPressed)
+
+        XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+    }
+
+    /// `perform(.planPressed)` navigates to the premium plan screen when the user has a past due subscription.
+    @MainActor
+    func test_perform_planPressed_pastDueSubscription() async {
+        subject.state.hasPremium = false
+        billingService.getSubscriptionReturnValue = .fixture(status: .pastDue)
+
+        await subject.perform(.planPressed)
+
+        XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+    }
+
+    /// `perform(.planPressed)` navigates to the premium upgrade screen and logs the error when the subscription fetch fails.
+    @MainActor
+    func test_perform_planPressed_freeUser_noSubscription() async {
+        subject.state.hasPremium = false
+        billingService.getSubscriptionThrowableError = BitwardenTestError.example
+
+        await subject.perform(.planPressed)
+
+        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+    }
+
+    /// `perform(.planPressed)` navigates to the premium upgrade screen when subscription status is active.
+    @MainActor
+    func test_perform_planPressed_activeSubscription() async {
+        subject.state.hasPremium = false
+        billingService.getSubscriptionReturnValue = .fixture(status: .active)
+
+        await subject.perform(.planPressed)
+
+        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
     }
 
     /// Receiving `.vaultPressed` navigates to the vault settings screen.

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -204,16 +204,30 @@ class SettingsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 
-    /// `perform(.planPressed)` shows a loading overlay, navigates to the premium upgrade screen,
-    /// and logs the error when the subscription fetch fails.
+    /// `perform(.planPressed)` shows a loading overlay and navigates to the premium upgrade screen
+    /// when the subscription fetch returns a 404 (free user with no subscription).
     @MainActor
     func test_perform_planPressed_freeUser_noSubscription() async {
+        subject.state.hasPremium = false
+        billingService.getSubscriptionThrowableError = GetSubscriptionRequestError.noSubscription
+
+        await subject.perform(.planPressed)
+
+        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
+        XCTAssertTrue(errorReporter.errors.isEmpty)
+    }
+
+    /// `perform(.planPressed)` shows a loading overlay and shows an error alert
+    /// when the subscription fetch fails with a non-404 error.
+    @MainActor
+    func test_perform_planPressed_freeUser_subscriptionFetchError() async {
         subject.state.hasPremium = false
         billingService.getSubscriptionThrowableError = BitwardenTestError.example
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertEqual(coordinator.alertShown.last, .networkResponseError(BitwardenTestError.example))
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
         XCTAssertTrue(errorReporter.errors.contains { $0 as? BitwardenTestError == .example })
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -1,4 +1,6 @@
+import BitwardenKit
 import BitwardenKitMocks
+import BitwardenResources
 import TestHelpers
 import XCTest
 
@@ -162,7 +164,8 @@ class SettingsProcessorTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .other)
     }
 
-    /// `perform(.planPressed)` navigates to the premium plan screen for a premium user.
+    /// `perform(.planPressed)` navigates to the premium plan screen for a premium user
+    /// without showing a loading overlay.
     @MainActor
     func test_perform_planPressed_hasPremium() async {
         subject.state.hasPremium = true
@@ -170,31 +173,41 @@ class SettingsProcessorTests: BitwardenTestCase {
         await subject.perform(.planPressed)
 
         XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
     }
 
-    /// `perform(.planPressed)` navigates to the premium plan screen when the user has a canceled subscription.
+    /// `perform(.planPressed)` shows a loading overlay and navigates to the premium plan screen
+    /// when the user has a canceled subscription, passing the subscription via context.
     @MainActor
     func test_perform_planPressed_canceledSubscription() async {
         subject.state.hasPremium = false
-        billingService.getSubscriptionReturnValue = .fixture(status: .canceled)
+        let subscription = PremiumSubscription.fixture(status: .canceled)
+        billingService.getSubscriptionReturnValue = subscription
 
         await subject.perform(.planPressed)
 
         XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+        XCTAssertEqual((coordinator.contexts.last as? PremiumSubscriptionContext)?.subscription, subscription)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 
-    /// `perform(.planPressed)` navigates to the premium plan screen when the user has a past due subscription.
+    /// `perform(.planPressed)` shows a loading overlay and navigates to the premium plan screen
+    /// when the user has a past due subscription, passing the subscription via context.
     @MainActor
     func test_perform_planPressed_pastDueSubscription() async {
         subject.state.hasPremium = false
-        billingService.getSubscriptionReturnValue = .fixture(status: .pastDue)
+        let subscription = PremiumSubscription.fixture(status: .pastDue)
+        billingService.getSubscriptionReturnValue = subscription
 
         await subject.perform(.planPressed)
 
         XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+        XCTAssertEqual((coordinator.contexts.last as? PremiumSubscriptionContext)?.subscription, subscription)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 
-    /// `perform(.planPressed)` navigates to the premium upgrade screen and logs the error when the subscription fetch fails.
+    /// `perform(.planPressed)` shows a loading overlay, navigates to the premium upgrade screen,
+    /// and logs the error when the subscription fetch fails.
     @MainActor
     func test_perform_planPressed_freeUser_noSubscription() async {
         subject.state.hasPremium = false
@@ -203,10 +216,12 @@ class SettingsProcessorTests: BitwardenTestCase {
         await subject.perform(.planPressed)
 
         XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
-        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
+        XCTAssertTrue(errorReporter.errors.contains { $0 as? BitwardenTestError == .example })
     }
 
-    /// `perform(.planPressed)` navigates to the premium upgrade screen when subscription status is active.
+    /// `perform(.planPressed)` shows a loading overlay and navigates to the premium upgrade screen
+    /// when subscription status is active.
     @MainActor
     func test_perform_planPressed_activeSubscription() async {
         subject.state.hasPremium = false
@@ -215,6 +230,7 @@ class SettingsProcessorTests: BitwardenTestCase {
         await subject.perform(.planPressed)
 
         XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 
     /// Receiving `.vaultPressed` navigates to the vault settings screen.

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -172,12 +172,12 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumPlan)
+        XCTAssertEqual(coordinator.routes.last, .premiumPlan(nil))
         XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
     }
 
     /// `perform(.planPressed)` shows a loading overlay and navigates to the premium plan screen
-    /// when the user has a canceled subscription, passing the subscription via context.
+    /// when the user has a canceled subscription.
     @MainActor
     func test_perform_planPressed_canceledSubscription() async {
         subject.state.hasPremium = false
@@ -186,13 +186,12 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumPlan)
-        XCTAssertEqual((coordinator.contexts.last as? PremiumSubscriptionContext)?.subscription, subscription)
+        XCTAssertEqual(coordinator.routes.last, .premiumPlan(subscription))
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 
     /// `perform(.planPressed)` shows a loading overlay and navigates to the premium plan screen
-    /// when the user has a past due subscription, passing the subscription via context.
+    /// when the user has a past due subscription.
     @MainActor
     func test_perform_planPressed_pastDueSubscription() async {
         subject.state.hasPremium = false
@@ -201,8 +200,7 @@ class SettingsProcessorTests: BitwardenTestCase {
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumPlan)
-        XCTAssertEqual((coordinator.contexts.last as? PremiumSubscriptionContext)?.subscription, subscription)
+        XCTAssertEqual(coordinator.routes.last, .premiumPlan(subscription))
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsView+ViewInspectorTests.swift
@@ -90,13 +90,15 @@ class SettingsViewTests: BitwardenTestCase {
         XCTAssertThrowsError(try subject.inspect().find(button: Localizations.plan))
     }
 
-    /// Tapping the plan button dispatches the `.planPressed` action.
+    /// Tapping the plan button performs the `.planPressed` effect.
     @MainActor
     func test_planButton_tap() throws {
         processor.state.showPlanRow = true
         let button = try subject.inspect().find(button: Localizations.plan)
         try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .planPressed)
+
+        waitFor { !self.processor.effects.isEmpty }
+        XCTAssertEqual(processor.effects.last, .planPressed)
     }
 
     /// Tapping the vault button dispatches the `.vaultPressed` action.

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsView.swift
@@ -130,7 +130,7 @@ struct SettingsView: View {
             Localizations.plan,
             icon: SharedAsset.Icons.card24,
         ) {
-            store.send(.planPressed)
+            Task { await store.perform(.planPressed) }
         } trailingContent: {
             chevron
         }

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -6,19 +6,6 @@ import SwiftUI
 
 // swiftlint:disable file_length
 
-// MARK: - PremiumSubscriptionContext
-
-/// A reference-type box used to pass a `PremiumSubscription` value via the coordinator context.
-///
-final class PremiumSubscriptionContext {
-    /// The subscription to pass.
-    let subscription: PremiumSubscription
-
-    init(_ subscription: PremiumSubscription) {
-        self.subscription = subscription
-    }
-}
-
 // MARK: - SettingsCoordinatorDelegate
 
 /// An object that is signaled when specific circumstances in the application flow have been encountered.
@@ -204,8 +191,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             showPasswordAutoFill(delegate: context as? PasswordAutoFillProcessorDelegate)
         case .pendingLoginRequests:
             showPendingLoginRequests()
-        case .premiumPlan:
-            showPremiumPlan(subscription: (context as? PremiumSubscriptionContext)?.subscription)
+        case let .premiumPlan(subscription):
+            showPremiumPlan(subscription: subscription)
         case .premiumUpgrade:
             showPremiumUpgrade()
         case let .selectLanguage(currentLanguage: currentLanguage):
@@ -491,7 +478,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
     private func showPremiumPlan(subscription: PremiumSubscription?) {
         guard let stackNavigator else { return }
         let coordinator = module.makeBillingCoordinator(stackNavigator: stackNavigator)
-        coordinator.navigate(to: .premiumPlan, context: subscription.map(PremiumSubscriptionContext.init))
+        coordinator.navigate(to: .premiumPlan(subscription))
     }
 
     /// Shows the premium upgrade screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -6,6 +6,19 @@ import SwiftUI
 
 // swiftlint:disable file_length
 
+// MARK: - PremiumSubscriptionContext
+
+/// A reference-type box used to pass a `PremiumSubscription` value via the coordinator context.
+///
+final class PremiumSubscriptionContext {
+    /// The subscription to pass.
+    let subscription: PremiumSubscription
+
+    init(_ subscription: PremiumSubscription) {
+        self.subscription = subscription
+    }
+}
+
 // MARK: - SettingsCoordinatorDelegate
 
 /// An object that is signaled when specific circumstances in the application flow have been encountered.
@@ -192,7 +205,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         case .pendingLoginRequests:
             showPendingLoginRequests()
         case .premiumPlan:
-            showPremiumPlan()
+            showPremiumPlan(subscription: (context as? PremiumSubscriptionContext)?.subscription)
         case .premiumUpgrade:
             showPremiumUpgrade()
         case let .selectLanguage(currentLanguage: currentLanguage):
@@ -473,10 +486,12 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
 
     /// Shows the premium plan screen.
     ///
-    private func showPremiumPlan() {
+    /// - Parameter subscription: An already-fetched subscription; pass `nil` to let the plan screen fetch it.
+    ///
+    private func showPremiumPlan(subscription: PremiumSubscription?) {
         guard let stackNavigator else { return }
         let coordinator = module.makeBillingCoordinator(stackNavigator: stackNavigator)
-        coordinator.navigate(to: .premiumPlan)
+        coordinator.navigate(to: .premiumPlan, context: subscription.map(PremiumSubscriptionContext.init))
     }
 
     /// Shows the premium upgrade screen.

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -350,9 +350,9 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// `navigate(to:)` with `.premiumPlan` shows the premium plan via the billing coordinator.
     @MainActor
     func test_navigateTo_premiumPlan() throws {
-        subject.navigate(to: .premiumPlan)
+        subject.navigate(to: .premiumPlan(nil))
 
-        XCTAssertEqual(module.billingCoordinator.routes, [.premiumPlan])
+        XCTAssertEqual(module.billingCoordinator.routes, [.premiumPlan(nil)])
     }
 
     /// `navigate(to:)` with `.premiumUpgrade` shows the premium upgrade via the billing coordinator.

--- a/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
@@ -69,7 +69,7 @@ public enum SettingsRoute: Equatable, Hashable {
     case pendingLoginRequests
 
     /// A route to the premium plan screen.
-    case premiumPlan
+    case premiumPlan(PremiumSubscription?)
 
     /// A route to the premium upgrade screen.
     case premiumUpgrade


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37967

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a premium user with a canceled, past-due, or payment-required subscription taps the Plan row in Settings, they are now navigated to the premium plan screen (which shows their subscription status) instead of the upgrade/checkout screen.

Previously, `hasPremium = false` for these users caused them to always land on the upgrade flow. The fix checks the subscription status via `getSubscription()` when `hasPremium` is false and uses the new `isTroubleState` property on `PremiumPlanStatus` to detect non-active subscriptions. A loading overlay is shown during the API call. The already-fetched subscription is threaded through to `PremiumPlanState` via `PremiumSubscriptionContext` so `PremiumPlanProcessor` can skip a redundant second fetch.

## 📸 Screenshots

https://github.com/user-attachments/assets/a80690e1-190d-4079-96e6-8540587f244c

