### PR TITLE
[PM-27235] feat: Support v2 encryption on JIT password signups

### DIFF
--- a/BitwardenShared/Core/Auth/Extensions/BitwardenSdk+Auth.swift
+++ b/BitwardenShared/Core/Auth/Extensions/BitwardenSdk+Auth.swift
@@ -37,3 +37,13 @@ extension BitwardenSdk.MasterPasswordUnlockData {
         )
     }
 }
+
+extension MasterPasswordUnlockResponseModel {
+    init(unlockData: BitwardenSdk.MasterPasswordUnlockData) {
+        self.init(
+            kdf: KdfConfig(kdf: unlockData.kdf),
+            masterKeyEncryptedUserKey: unlockData.masterKeyWrappedUserKey,
+            salt: unlockData.salt,
+        )
+    }
+}

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -878,7 +878,38 @@ extension DefaultAuthRepository: AuthRepository {
             requestUserKey = passwordResult.newKey
             requestKeys = nil
             cryptographicState = accountKeys.cryptographicState
+        } else if await configService.getFeatureFlag(.accountEncryptionV2JITPassword) {
+            // V2 JIT password path: SDK handles all server-side API calls internally.
+            let organizationKeys = try await organizationAPIService.getOrganizationKeys(
+                organizationId: organizationId,
+            )
+            let request = JitMasterPasswordRegistrationRequest(
+                orgId: organizationId,
+                orgPublicKey: organizationKeys.publicKey,
+                organizationSsoIdentifier: organizationIdentifier,
+                userId: account.profile.userId,
+                salt: email,
+                masterPassword: password,
+                masterPasswordHint: masterPasswordHint.nilIfEmpty,
+                resetPasswordEnroll: resetPasswordAutoEnroll,
+            )
+            let response = try await clientService.auth().registration().postKeysForJitPasswordRegistration(
+                request: request,
+            )
+            try await stateService.setAccountEncryptionKeys(
+                AccountEncryptionKeys(
+                    cryptographicState: response.accountCryptographicState,
+                    encryptedUserKey: response.masterPasswordUnlock.masterKeyWrappedUserKey,
+                ),
+            )
+            try await stateService.setAccountMasterPasswordUnlock(
+                MasterPasswordUnlockResponseModel(unlockData: response.masterPasswordUnlock),
+            )
+            try await stateService.setUserHasMasterPassword(true)
+            try await unlockVault(method: .decryptedKey(decryptedUserKey: response.userKey))
+            return
         } else {
+            // V1 JIT password path
             let keys = try await clientService.auth().makeRegisterKeys(
                 email: email,
                 password: password,

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1,6 +1,7 @@
 import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import SwiftUI
 import TestHelpers
 import XCTest
@@ -19,6 +20,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     var changeKdfService: MockChangeKdfService!
     var client: MockHTTPClient!
     var clientCertificateService: MockClientCertificateService!
+    var clientRegistration: MockRegistrationClientProtocol!
     var clientService: MockClientService!
     var configService: MockConfigService!
     var environmentService: MockEnvironmentService!
@@ -103,6 +105,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         biometricsRepository = MockBiometricsRepository()
         changeKdfService = MockChangeKdfService()
         clientCertificateService = MockClientCertificateService()
+        clientRegistration = MockRegistrationClientProtocol()
         configService = MockConfigService()
         environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
@@ -124,7 +127,10 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             encryptedUserKey: "encryptedUserKey",
             keys: RsaKeyPair(public: "public", private: "private"),
         )
+        clientService.mockAuth.registrationReturnValue = clientRegistration
+        clientRegistration.postKeysForJitPasswordRegistrationReturnValue = .fixture()
         clientService.mockAuth.validatePinReturnValue = false
+        configService.featureFlagsBool[.accountEncryptionV2JITPassword] = true
         userSessionStateService.getVaultTimeoutReturnValue = .fifteenMinutes
         userSessionStateService.getUnsuccessfulUnlockAttemptsReturnValue = 0
 
@@ -163,6 +169,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         changeKdfService = nil
         client = nil
         clientCertificateService = nil
+        clientRegistration = nil
         clientService = nil
         configService = nil
         environmentService = nil
@@ -1457,9 +1464,97 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(value, .never)
     }
 
-    /// `setMasterPassword()` sets the user's master password, saves their encryption keys and
+    /// `setMasterPassword()` sets a JIT user's master password, saves their encryption keys and
     /// unlocks the vault.
-    func test_setMasterPassword() async throws { // swiftlint:disable:this function_body_length
+    func test_setMasterPassword_JIT() async throws {
+        let account = Account.fixture()
+        client.result = .httpSuccess(testData: .organizationKeys)
+        stateService.accountEncryptionKeys["1"] = nil
+        stateService.activeAccount = account
+
+        try await subject.setMasterPassword(
+            "NEW_PASSWORD",
+            masterPasswordHint: "HINT",
+            organizationId: "1234",
+            organizationIdentifier: "ORG_ID",
+            resetPasswordAutoEnroll: false,
+        )
+
+        XCTAssertEqual(
+            clientRegistration.postKeysForJitPasswordRegistrationReceivedRequest,
+            JitMasterPasswordRegistrationRequest(
+                orgId: "1234",
+                orgPublicKey: "MIIBIjAN...2QIDAQAB",
+                organizationSsoIdentifier: "ORG_ID",
+                userId: "1",
+                salt: "user@bitwarden.com",
+                masterPassword: "NEW_PASSWORD",
+                masterPasswordHint: "HINT",
+                resetPasswordEnroll: false,
+            ),
+        )
+
+        XCTAssertEqual(
+            stateService.accountEncryptionKeys["1"],
+            AccountEncryptionKeys(
+                cryptographicState: .fixtureV2(),
+                encryptedUserKey: "MASTER_KEY_WRAPPED_USER_KEY",
+            ),
+        )
+        XCTAssertEqual(stateService.userHasMasterPassword["1"], true)
+
+        XCTAssertEqual(
+            clientService.mockCrypto.initializeUserCryptoReceivedReq,
+            InitUserCryptoRequest(
+                userId: "1",
+                kdfParams: account.kdf.sdkKdf,
+                email: account.profile.email,
+                accountCryptographicState: .fixtureV2(),
+                method: .decryptedKey(decryptedUserKey: "USER_KEY"),
+                upgradeToken: nil,
+            ),
+        )
+
+        // The SDK handles server-side calls; only the org public key GET should be made.
+        let requests = client.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].url.absoluteString, "https://example.com/api/organizations/1234/public-key")
+        XCTAssertNil(clientService.mockAuth.makeRegisterKeysReceivedArguments?.email)
+    }
+
+    /// `setMasterPassword()` passes `resetPasswordEnroll: true` when enrollment is requested for a JIT user.
+    func test_setMasterPassword_JIT_resetPasswordEnroll() async throws {
+        let account = Account.fixture()
+        client.result = .httpSuccess(testData: .organizationKeys)
+        stateService.accountEncryptionKeys["1"] = nil
+        stateService.activeAccount = account
+
+        try await subject.setMasterPassword(
+            "NEW_PASSWORD",
+            masterPasswordHint: "",
+            organizationId: "1234",
+            organizationIdentifier: "ORG_ID",
+            resetPasswordAutoEnroll: true,
+        )
+
+        XCTAssertEqual(
+            clientRegistration.postKeysForJitPasswordRegistrationReceivedRequest?.resetPasswordEnroll,
+            true,
+        )
+        // Empty hint is converted to nil.
+        XCTAssertNil(
+            clientRegistration.postKeysForJitPasswordRegistrationReceivedRequest?.masterPasswordHint,
+        )
+
+        // SDK handles enrollment — no separate enrollment API call, only the org keys GET.
+        let requests = client.requests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertEqual(requests[0].url.absoluteString, "https://example.com/api/organizations/1234/public-key")
+    }
+
+    /// `setMasterPassword()` sets the user's master password using the JIT v1 path, saves their
+    /// encryption keys and unlocks the vault.
+    func test_setMasterPassword_JIT_v1() async throws { // swiftlint:disable:this function_body_length
         let account = Account.fixture(profile: .fixture(
             userDecryptionOptions: UserDecryptionOptions(
                 hasMasterPassword: true,
@@ -1469,6 +1564,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             ),
         ))
         client.result = .httpSuccess(testData: .emptyResponse)
+        configService.featureFlagsBool[.accountEncryptionV2JITPassword] = false
         // Account encryption keys don't exist until after a MP has been set for non-TDE users.
         stateService.accountEncryptionKeys["1"] = nil
         stateService.activeAccount = account
@@ -1524,8 +1620,8 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         )
     }
 
-    /// `setMasterPassword()` throws an error if one occurs.
-    func test_setMasterPassword_error() async {
+    /// `setMasterPassword()` throws an error if one occurs for a TDE user.
+    func test_setMasterPassword_TDE_error() async {
         clientService.mockCrypto.makeUpdatePasswordThrowableError = BitwardenTestError.example
         stateService.activeAccount = Account.fixtureWithTdeNoPassword()
         stateService.accountEncryptionKeys["1"] = AccountEncryptionKeys(
@@ -1544,9 +1640,9 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         }
     }
 
-    /// `setMasterPassword()` sets the user's master password, saves their encryption keys, enrolls
+    /// `setMasterPassword()` sets a TDE user's master password, saves their encryption keys, enrolls
     /// the user in password reset and unlocks the vault.
-    func test_setMasterPassword_resetPasswordEnrollment() async throws {
+    func test_setMasterPassword_TDE_resetPasswordEnrollment() async throws {
         client.results = [
             .httpSuccess(testData: .emptyResponse),
             .httpSuccess(testData: .organizationKeys),
@@ -1600,7 +1696,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         )
     }
 
-    /// `setMasterPassword()` sets the user's master password, saves their encryption keys and
+    /// `setMasterPassword()` sets a TDE user's master password, saves their encryption keys and
     /// unlocks the vault.
     func test_setMasterPassword_TDE() async throws {
         var account = Account.fixtureWithTDE()

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/BitwardenSdk+AuthFixtures.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/BitwardenSdk+AuthFixtures.swift
@@ -69,6 +69,24 @@ extension BitwardenSdk.GetAssertionResult {
     }
 }
 
+extension BitwardenSdk.JitMasterPasswordRegistrationResponse {
+    static func fixture(
+        accountCryptographicState: WrappedAccountCryptographicState = .fixtureV2(),
+        masterPasswordUnlock: BitwardenSdk.MasterPasswordUnlockData = MasterPasswordUnlockData(
+            kdf: .pbkdf2(iterations: 600_000),
+            masterKeyWrappedUserKey: "MASTER_KEY_WRAPPED_USER_KEY",
+            salt: "SALT",
+        ),
+        userKey: String = "USER_KEY",
+    ) -> BitwardenSdk.JitMasterPasswordRegistrationResponse {
+        .init(
+            accountCryptographicState: accountCryptographicState,
+            masterPasswordUnlock: masterPasswordUnlock,
+            userKey: userKey,
+        )
+    }
+}
+
 extension BitwardenSdk.MakeCredentialResult {
     static func fixture(
         authenticatorData: Data = Data(capacity: 37),

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -5,6 +5,11 @@ import Foundation
 
 /// An enum to represent a feature flag sent by the server
 extension FeatureFlag: @retroactive CaseIterable {
+    /// A feature flag to enable/disable V2 account encryption for JIT password registration.
+    static let accountEncryptionV2JITPassword = FeatureFlag(
+        rawValue: "enable-account-encryption-v2-jit-password-registration",
+    )
+
     /// Flag to enable/disable V2 password-based registration using the SDK registration client.
     static let accountEncryptionV2PasswordRegistration = FeatureFlag(rawValue: "pm-27278-v2-password-registration")
 
@@ -42,6 +47,7 @@ extension FeatureFlag: @retroactive CaseIterable {
 
     public static var allCases: [FeatureFlag] {
         [
+            .accountEncryptionV2JITPassword,
             .accountEncryptionV2PasswordRegistration,
             .cardScanner,
             .cipherKeyEncryption,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27235](https://bitwarden.atlassian.net/browse/PM-27235)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables support for v2 encryption on JIT password account registration. Most of the existing logic that was implemented in the app, including API requests, has been moved into the SDK (via the `postKeysForJitPasswordRegistration(request:)` function).

These changes are behind the `enable-account-encryption-v2-jit-password-registration` feature flag.

[PM-27235]: https://bitwarden.atlassian.net/browse/PM-27235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ