### PR TITLE
[PM-38180] feat: Announce external link on Manage plan and Cancel Premium buttons

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1068,6 +1068,7 @@
 "Total" = "Total";
 "ManagePlan" = "Manage plan";
 "CancelPremium" = "Cancel Premium";
+"ExternalLink" = "External link";
 "YourNextChargeIsForXDueOnY" = "Your next charge is for **%1$@**, due on **%2$@**.";
 "WeCouldNotProcessYourPaymentUpdateYourPaymentMethodDescriptionLong" = "We could not process your payment. Update your payment method before your subscription ends on **%1$@**.";
 "YourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription was canceled on **%1$@**. Resubscribe to continue using premium features.";

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -84,6 +84,7 @@ struct PremiumPlanView: View {
             }
         }
         .buttonStyle(.secondary())
+        .accessibilityHint(Localizations.externalLink)
         .accessibilityIdentifier("CancelPremiumButton")
     }
 
@@ -127,6 +128,7 @@ struct PremiumPlanView: View {
             }
         }
         .buttonStyle(.primary())
+        .accessibilityHint(Localizations.externalLink)
         .accessibilityIdentifier("ManagePlanButton")
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38180
https://bitwarden.atlassian.net/browse/PM-38181

## 📔 Objective

Add `.accessibilityHint` announcing "External link" on the "Manage plan" and "Cancel Premium" buttons in the Premium Plan screen, so VoiceOver users are informed these buttons open an external browser link.
