### PR TITLE
[PM-38174] fix: Remove excess bold from past due status description

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.stringsdict
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.stringsdict
@@ -193,7 +193,7 @@
 	<key>YouHaveAGracePeriodOfXDaysFromYourSubscriptionDescriptionLong</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>
-		<string>**%1$#@YouHaveAGracePeriodOfXDaysFromYourSubscriptionExpirationDate@** Please resolve the past due invoices by **%2$@**.</string>
+		<string>%1$#@YouHaveAGracePeriodOfXDaysFromYourSubscriptionExpirationDate@ Please resolve the past due invoices by **%2$@**.</string>
 		<key>YouHaveAGracePeriodOfXDaysFromYourSubscriptionExpirationDate</key>
 		<dict>
 			<key>NSStringFormatSpecTypeKey</key>


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38174

## 📔 Objective

The past due status description was wrapping the entire first sentence in bold markdown (`**...**`). Only the date should be bolded. Removed the `**` markers surrounding the plural substitution in the English stringsdict so only the date (`%2$@`) remains bold.

## 📸 Screenshots
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9f7ce044-b155-40ac-acbb-a9ab04dd1ee5" />
