### PR TITLE
[PM-38119] feat: Fix Send "Specific people" upgrade to premium flow

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -18,6 +18,7 @@ protocol PremiumUpgradeRoute {
     static func dismiss(_ action: DismissAction?) -> Self
 }
 
+extension SendItemRoute: PremiumUpgradeRoute {}
 extension VaultItemRoute: PremiumUpgradeRoute {}
 extension VaultRoute: PremiumUpgradeRoute {}
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -12,6 +12,8 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasBillingRepository
+        & HasBillingService
         & HasEnvironmentService
         & HasErrorReporter
         & HasPasteboardService
@@ -29,6 +31,13 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
 
     /// The `Coordinator` that handles navigation for this processor.
     let coordinator: AnyCoordinator<SendItemRoute, AuthAction>
+
+    /// The helper used to navigate to the premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
+    )
 
     /// The services required by this processor.
     let services: Services
@@ -425,7 +434,9 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     private func showSpecificPeoplePremiumRequiredAlert() {
         let alert = Alert.specificPeopleUnavailable { [weak self] in
             guard let self else { return }
-            state.url = services.environmentService.upgradeToPremiumURL
+            Task {
+                await self.premiumUpgradeHelper.navigateToPremiumUpgrade()
+            }
         }
         coordinator.showAlert(alert)
     }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -6,6 +6,7 @@ import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
 // MARK: - AddEditSendItemProcessorTests
 
@@ -16,6 +17,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
     var errorReporter: MockErrorReporter!
     var pasteboardService: MockPasteboardService!
     var policyService: MockPolicyService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var sendRepository: MockSendRepository!
     var reviewPromptService: MockReviewPromptService!
     var subject: AddEditSendItemProcessor!
@@ -31,6 +33,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         errorReporter = MockErrorReporter()
         pasteboardService = MockPasteboardService()
         policyService = MockPolicyService()
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         reviewPromptService = MockReviewPromptService()
         sendRepository = MockSendRepository()
         subject = AddEditSendItemProcessor(
@@ -44,6 +47,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
             ),
             state: AddEditSendItemState(),
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
@@ -52,6 +56,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         errorReporter = nil
         pasteboardService = nil
         policyService = nil
+        premiumUpgradeHelper = nil
         sendRepository = nil
         reviewPromptService = nil
         subject = nil
@@ -770,8 +775,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(alert.message, Localizations.sharingWithSpecificPeopleIsPremiumFeatureDescriptionLong)
     }
 
-    /// `receive(_:)` with `.accessTypeChanged` to specific people opens upgrade URL when user taps
-    /// "Upgrade to Premium" in the alert.
+    /// `receive(_:)` with `.accessTypeChanged` to specific people triggers the premium upgrade
+    /// helper when user taps "Upgrade to Premium" in the alert.
     @MainActor
     func test_receive_accessTypeChanged_specificPeople_nonPremium_upgradeAction() async throws {
         subject.state.hasPremium = false
@@ -780,8 +785,9 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         try await alert.tapAction(title: Localizations.upgradeToPremium)
+        try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
 
-        XCTAssertNotNil(subject.state.url)
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `receive(_:)` with `.addRecipientEmail` adds an empty email to the list and focuses it.

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
@@ -12,7 +12,8 @@ import SwiftUI
 final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcherDisplayable {
     // MARK: Types
 
-    typealias Module = FileSelectionModule
+    typealias Module = BillingModule
+        & FileSelectionModule
         & GeneratorModule
         & NavigatorBuilderModule
         & ProfileSwitcherModule
@@ -20,6 +21,8 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
 
     typealias Services = GeneratorCoordinator.Services
         & HasAuthRepository
+        & HasBillingRepository
+        & HasBillingService
         & HasConfigService
         & HasEnvironmentService
         & HasErrorAlertServices.ErrorAlertServices
@@ -101,6 +104,8 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
         case .generator:
             guard let delegate = context as? GeneratorCoordinatorDelegate else { return }
             showGenerator(delegate: delegate)
+        case .premiumUpgrade:
+            showPremiumUpgrade()
         case let .share(url):
             showShareSheet(for: [url])
         case let .view(sendView):
@@ -220,6 +225,15 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
         coordinator.navigate(to: .generator(staticType: .password))
         stackNavigator?.present(navigationController)
         generatorCoordinator = coordinator
+    }
+
+    /// Shows the premium upgrade screen.
+    ///
+    private func showPremiumUpgrade() {
+        let navigationController = module.makeNavigationController()
+        let coordinator = module.makeBillingCoordinator(stackNavigator: navigationController)
+        coordinator.navigate(to: .premiumUpgrade)
+        stackNavigator?.present(navigationController)
     }
 
     /// Presents the system share sheet for the specified items.

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
@@ -62,6 +62,9 @@ public enum SendItemRoute: Equatable, Hashable {
     /// A route to the password generator screen.
     case generator
 
+    /// A route to the premium upgrade screen.
+    case premiumUpgrade
+
     /// A route to share the provided URL.
     ///
     /// - Parameter url: The `URL` to share.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38119

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fix the Send "Specific People" feature not triggering the in-app premium upgrade flow. When a non-premium user selected "Specific People" as the Send access type and tapped "Upgrade to Premium", the app was opening Safari with the web upgrade URL instead of presenting the in-app purchase flow.

The fix wires up the `PremiumUpgradeHelper` pattern (same as Vault archive/attachments) into `SendItemCoordinator` and `AddEditSendItemProcessor`, so the in-app upgrade sheet is shown when available, with the web URL as fallback.


## 📸 Screenshots

https://github.com/user-attachments/assets/628f63f9-2b54-40eb-8597-410bacba7a82
