### PR TITLE
[PM-38183] feat: Add expired and pending cancellation premium plan states

### DIFF
--- a/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bitwarden.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "e3f69fd321d0c9fcdc16fb576a0cdd956675face",
-        "version" : "1.31.0"
+        "revision" : "f6506eaa86ed2e01cb0ae14a75035b7fdbf0918f",
+        "version" : "1.38.0"
       }
     },
     {

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1073,8 +1073,8 @@
 "ExternalLink" = "External link";
 "YourNextChargeIsForXDueOnY" = "Your next charge is for **%1$@**, due on **%2$@**.";
 "WeCouldNotProcessYourPaymentUpdateYourPaymentMethodDescriptionLong" = "We could not process your payment. Update your payment method before your subscription ends on **%1$@**.";
-"YourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription was canceled on **%1$@**. Resubscribe to continue using premium features.";
-"YourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription expired on **%1$@**. Resubscribe to continue using Premium features.";
+"YourSubscriptionWasCanceledOnXDescriptionLong" = "Your subscription was canceled on **%1$@**. Resubscribe to continue using Premium features.";
+"YourSubscriptionExpiredOnXDescriptionLong" = "Your subscription expired on **%1$@**. Resubscribe to continue using Premium features.";
 "YourSubscriptionIsScheduledToCancelOnXDescriptionLong" = "Your subscription is scheduled to cancel on **%1$@**. You can reinstate it anytime before then.";
 "PerMonth" = "/ month";
 "PerYear" = "/ year";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -674,6 +674,7 @@
 "BitwardenCannotResetALostOrForgottenMasterPassword" = "Bitwarden cannot reset a lost or forgotten master password.";
 "LearnAboutWaysToPreventAccountLockout" = "Learn about ways to prevent account lockout";
 "RestartRegistration" = "Restart registration";
+"Expired" = "Expired";
 "ExpiredLink" = "Expired link";
 "PleaseRestartRegistrationOrTryLoggingInYouMayAlreadyHaveAnAccount" = "Please restart registration or try logging in. You may already have an account.";
 "RemovePasskey" = "Remove passkey";
@@ -1072,6 +1073,7 @@
 "YourNextChargeIsForXDueOnY" = "Your next charge is for **%1$@**, due on **%2$@**.";
 "WeCouldNotProcessYourPaymentUpdateYourPaymentMethodDescriptionLong" = "We could not process your payment. Update your payment method before your subscription ends on **%1$@**.";
 "YourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription was canceled on **%1$@**. Resubscribe to continue using premium features.";
+"YourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription expired on **%1$@**. Resubscribe to continue using Premium features.";
 "PerMonth" = "/ month";
 "PerYear" = "/ year";
 "XAmountPerCadence" = "%1$@ %2$@";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1061,6 +1061,7 @@
 "Active" = "Active";
 "Canceled" = "Canceled";
 "PastDue" = "Past due";
+"PendingCancellation" = "Pending cancellation";
 "UpdatePayment" = "Update payment";
 "BillingAmount" = "Billing amount";
 "StorageCost" = "Storage cost";
@@ -1074,6 +1075,7 @@
 "WeCouldNotProcessYourPaymentUpdateYourPaymentMethodDescriptionLong" = "We could not process your payment. Update your payment method before your subscription ends on **%1$@**.";
 "YourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription was canceled on **%1$@**. Resubscribe to continue using premium features.";
 "YourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong" = "Your subscription expired on **%1$@**. Resubscribe to continue using Premium features.";
+"YourSubscriptionIsScheduledToCancelOnXDescriptionLong" = "Your subscription is scheduled to cancel on **%1$@**. You can reinstate it anytime before then.";
 "PerMonth" = "/ month";
 "PerYear" = "/ year";
 "XAmountPerCadence" = "%1$@ %2$@";

--- a/BitwardenShared/Core/Billing/Models/Domain/PremiumSubscription.swift
+++ b/BitwardenShared/Core/Billing/Models/Domain/PremiumSubscription.swift
@@ -73,7 +73,7 @@ struct PremiumSubscription: Equatable {
         gracePeriod = response.gracePeriod
         nextCharge = response.nextCharge
         self.seatsCost = seatsCost
-        status = PremiumPlanStatus(subscriptionStatus: response.status)
+        status = PremiumPlanStatus(subscriptionStatus: response.status, cancelAt: response.cancelAt)
         self.storageCost = storageCost
         suspension = response.suspension
     }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -56,11 +56,11 @@ struct PremiumPlanState: Equatable {
                 nextChargeDate,
             )
         case .canceled:
-            Localizations.yourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong(
+            Localizations.yourSubscriptionWasCanceledOnXDescriptionLong(
                 canceledDate,
             )
         case .expired:
-            Localizations.yourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong(
+            Localizations.yourSubscriptionExpiredOnXDescriptionLong(
                 expiredDate,
             )
         case .pastDue:

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -68,6 +68,10 @@ struct PremiumPlanState: Equatable {
                 subscription?.gracePeriod ?? 0,
                 subscriptionEndDate,
             )
+        case .pendingCancellation:
+            Localizations.yourSubscriptionIsScheduledToCancelOnXDescriptionLong(
+                pendingCancellationDate,
+            )
         case .unknown:
             Localizations.yourSubscriptionStatusIsUnknownVisitTheWebAppDescriptionLong
         case .updatePayment:
@@ -113,6 +117,12 @@ struct PremiumPlanState: Equatable {
         return formatDate(nextCharge)
     }
 
+    /// The date the subscription is scheduled to cancel, formatted for display.
+    var pendingCancellationDate: String {
+        guard let cancelAt = subscription?.cancelAt else { return "" }
+        return formatDate(cancelAt)
+    }
+
     /// Whether the billing details section should be shown.
     var showBillingDetails: Bool {
         planStatus != .canceled && planStatus != .expired && planStatus != .unknown
@@ -120,7 +130,10 @@ struct PremiumPlanState: Equatable {
 
     /// Whether the cancel premium button should be shown.
     var showCancelButton: Bool {
-        planStatus != .canceled && planStatus != .expired && planStatus != .unknown
+        planStatus != .canceled
+            && planStatus != .expired
+            && planStatus != .pendingCancellation
+            && planStatus != .unknown
     }
 
     /// Whether the discount row should be shown.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -59,6 +59,10 @@ struct PremiumPlanState: Equatable {
             Localizations.yourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong(
                 canceledDate,
             )
+        case .expired:
+            Localizations.yourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong(
+                expiredDate,
+            )
         case .pastDue:
             Localizations.youHaveAGracePeriodOfXDaysFromYourSubscriptionDescriptionLong(
                 subscription?.gracePeriod ?? 0,
@@ -85,6 +89,12 @@ struct PremiumPlanState: Equatable {
         return formatCurrency(subscription.estimatedTax)
     }
 
+    /// The date the subscription expired, formatted for display.
+    var expiredDate: String {
+        guard let suspension = subscription?.suspension else { return "" }
+        return formatDate(suspension)
+    }
+
     /// The next charge amount with currency code, formatted for display (e.g. "24.35 USD").
     var nextChargeAmount: String {
         guard let subscription, subscription.nextCharge != nil else { return "" }
@@ -105,12 +115,12 @@ struct PremiumPlanState: Equatable {
 
     /// Whether the billing details section should be shown.
     var showBillingDetails: Bool {
-        planStatus != .canceled && planStatus != .unknown
+        planStatus != .canceled && planStatus != .expired && planStatus != .unknown
     }
 
     /// Whether the cancel premium button should be shown.
     var showCancelButton: Bool {
-        planStatus != .canceled && planStatus != .unknown
+        planStatus != .canceled && planStatus != .expired && planStatus != .unknown
     }
 
     /// Whether the discount row should be shown.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -50,7 +50,7 @@ struct PremiumPlanStateTests {
     }
 
     /// `descriptionAccessibilityLabel` returns `descriptionText` with markdown stripped for non-active plan statuses.
-    @Test(arguments: [PremiumPlanStatus.canceled, .pastDue, .unknown, .updatePayment])
+    @Test(arguments: [PremiumPlanStatus.canceled, .expired, .pastDue, .unknown, .updatePayment])
     func descriptionAccessibilityLabel_nonActive(planStatus: PremiumPlanStatus) {
         var state = PremiumPlanState()
         state.planStatus = planStatus
@@ -94,6 +94,15 @@ struct PremiumPlanStateTests {
             .yourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong(
                 state.canceledDate,
             ))
+    }
+
+    /// `descriptionText` returns the correct text for the expired plan status.
+    @Test
+    func descriptionText_expired() {
+        var state = PremiumPlanState(planStatus: .expired)
+        state.subscription = .fixture(status: .expired, suspension: testDate)
+        let localization = Localizations.yourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong
+        #expect(state.descriptionText == localization(state.expiredDate))
     }
 
     /// `descriptionText` returns the correct text for the past due plan status.
@@ -194,6 +203,7 @@ struct PremiumPlanStateTests {
     @Test(arguments: [
         (PremiumPlanStatus.active, true),
         (PremiumPlanStatus.canceled, false),
+        (PremiumPlanStatus.expired, false),
         (PremiumPlanStatus.pastDue, true),
         (PremiumPlanStatus.unknown, false),
         (PremiumPlanStatus.updatePayment, true),
@@ -210,6 +220,7 @@ struct PremiumPlanStateTests {
     @Test(arguments: [
         (PremiumPlanStatus.active, true),
         (PremiumPlanStatus.canceled, false),
+        (PremiumPlanStatus.expired, false),
         (PremiumPlanStatus.pastDue, true),
         (PremiumPlanStatus.unknown, false),
         (PremiumPlanStatus.updatePayment, true),

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -50,7 +50,7 @@ struct PremiumPlanStateTests {
     }
 
     /// `descriptionAccessibilityLabel` returns `descriptionText` with markdown stripped for non-active plan statuses.
-    @Test(arguments: [PremiumPlanStatus.canceled, .expired, .pastDue, .unknown, .updatePayment])
+    @Test(arguments: [PremiumPlanStatus.canceled, .expired, .pastDue, .pendingCancellation, .unknown, .updatePayment])
     func descriptionAccessibilityLabel_nonActive(planStatus: PremiumPlanStatus) {
         var state = PremiumPlanState()
         state.planStatus = planStatus
@@ -103,6 +103,15 @@ struct PremiumPlanStateTests {
         state.subscription = .fixture(status: .expired, suspension: testDate)
         let localization = Localizations.yourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong
         #expect(state.descriptionText == localization(state.expiredDate))
+    }
+
+    /// `descriptionText` returns the correct text for the pending cancellation plan status.
+    @Test
+    func descriptionText_pendingCancellation() {
+        var state = PremiumPlanState(planStatus: .pendingCancellation)
+        state.subscription = .fixture(cancelAt: testDate, status: .pendingCancellation)
+        let localization = Localizations.yourSubscriptionIsScheduledToCancelOnXDescriptionLong
+        #expect(state.descriptionText == localization(state.pendingCancellationDate))
     }
 
     /// `descriptionText` returns the correct text for the past due plan status.
@@ -205,6 +214,7 @@ struct PremiumPlanStateTests {
         (PremiumPlanStatus.canceled, false),
         (PremiumPlanStatus.expired, false),
         (PremiumPlanStatus.pastDue, true),
+        (PremiumPlanStatus.pendingCancellation, true),
         (PremiumPlanStatus.unknown, false),
         (PremiumPlanStatus.updatePayment, true),
     ])
@@ -222,6 +232,7 @@ struct PremiumPlanStateTests {
         (PremiumPlanStatus.canceled, false),
         (PremiumPlanStatus.expired, false),
         (PremiumPlanStatus.pastDue, true),
+        (PremiumPlanStatus.pendingCancellation, false),
         (PremiumPlanStatus.unknown, false),
         (PremiumPlanStatus.updatePayment, true),
     ])

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -91,7 +91,7 @@ struct PremiumPlanStateTests {
         state.planStatus = .canceled
         state.subscription = .fixture(canceled: testDate, status: .canceled)
         #expect(state.descriptionText == Localizations
-            .yourSubscriptionWasCanceledOnXResubscribeToContinueUsingDescriptionLong(
+            .yourSubscriptionWasCanceledOnXDescriptionLong(
                 state.canceledDate,
             ))
     }
@@ -101,7 +101,7 @@ struct PremiumPlanStateTests {
     func descriptionText_expired() {
         var state = PremiumPlanState(planStatus: .expired)
         state.subscription = .fixture(status: .expired, suspension: testDate)
-        let localization = Localizations.yourSubscriptionExpiredOnXResubscribeToContinueUsingDescriptionLong
+        let localization = Localizations.yourSubscriptionExpiredOnXDescriptionLong
         #expect(state.descriptionText == localization(state.expiredDate))
     }
 

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
@@ -1,5 +1,6 @@
 import BitwardenKit
 import BitwardenResources
+import Foundation
 
 // MARK: - PremiumPlanStatus
 
@@ -18,6 +19,9 @@ enum PremiumPlanStatus: Equatable {
     /// The plan is past due.
     case pastDue
 
+    /// The plan is active but scheduled to cancel at a future date.
+    case pendingCancellation
+
     /// The plan has an unknown status not yet supported by the app.
     case unknown
 
@@ -35,6 +39,7 @@ enum PremiumPlanStatus: Equatable {
              .expired:
             .danger
         case .pastDue,
+             .pendingCancellation,
              .unknown,
              .updatePayment:
             .warning
@@ -52,6 +57,8 @@ enum PremiumPlanStatus: Equatable {
             Localizations.expired
         case .pastDue:
             Localizations.pastDue
+        case .pendingCancellation:
+            Localizations.pendingCancellation
         case .unknown:
             Localizations.unknownStatus
         case .updatePayment:
@@ -61,15 +68,17 @@ enum PremiumPlanStatus: Equatable {
 
     // MARK: Initialization
 
-    /// Initializes a `PremiumPlanStatus` from a `SubscriptionStatus`.
+    /// Initializes a `PremiumPlanStatus` from a `SubscriptionStatus` and optional cancellation date.
     ///
-    /// - Parameter subscriptionStatus: The subscription status from the API.
+    /// - Parameters:
+    ///   - subscriptionStatus: The subscription status from the API.
+    ///   - cancelAt: The scheduled cancellation date, if any.
     ///
-    init(subscriptionStatus: SubscriptionStatus) {
+    init(subscriptionStatus: SubscriptionStatus, cancelAt: Date? = nil) {
         switch subscriptionStatus {
         case .active,
              .trialing:
-            self = .active
+            self = cancelAt != nil ? .pendingCancellation : .active
         case .canceled,
              .paused:
             self = .canceled

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatus.swift
@@ -12,6 +12,9 @@ enum PremiumPlanStatus: Equatable {
     /// The plan has been canceled.
     case canceled
 
+    /// The plan has expired due to an incomplete payment.
+    case expired
+
     /// The plan is past due.
     case pastDue
 
@@ -28,7 +31,8 @@ enum PremiumPlanStatus: Equatable {
         switch self {
         case .active:
             .success
-        case .canceled:
+        case .canceled,
+             .expired:
             .danger
         case .pastDue,
              .unknown,
@@ -44,6 +48,8 @@ enum PremiumPlanStatus: Equatable {
             Localizations.active
         case .canceled:
             Localizations.canceled
+        case .expired:
+            Localizations.expired
         case .pastDue:
             Localizations.pastDue
         case .unknown:
@@ -65,9 +71,10 @@ enum PremiumPlanStatus: Equatable {
              .trialing:
             self = .active
         case .canceled,
-             .incompleteExpired,
              .paused:
             self = .canceled
+        case .incompleteExpired:
+            self = .expired
         case .incomplete,
              .unpaid:
             self = .updatePayment

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatusTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatusTests.swift
@@ -12,6 +12,7 @@ struct PremiumPlanStatusTests {
     @Test(arguments: [
         (PremiumPlanStatus.active, PillBadgeStyle.success),
         (.canceled, .danger),
+        (.expired, .danger),
         (.pastDue, .warning),
         (.unknown, .warning),
         (.updatePayment, .warning),
@@ -25,6 +26,7 @@ struct PremiumPlanStatusTests {
     @Test(arguments: [
         (SubscriptionStatus.active, PremiumPlanStatus.active),
         (.canceled, .canceled),
+        (.incompleteExpired, .expired),
         (.pastDue, .pastDue),
         (.unknown, .unknown),
         (.unpaid, .updatePayment),
@@ -38,6 +40,7 @@ struct PremiumPlanStatusTests {
     @Test(arguments: [
         (PremiumPlanStatus.active, Localizations.active),
         (.canceled, Localizations.canceled),
+        (.expired, Localizations.expired),
         (.pastDue, Localizations.pastDue),
         (.unknown, Localizations.unknownStatus),
         (.updatePayment, Localizations.updatePayment),

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatusTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStatusTests.swift
@@ -1,5 +1,6 @@
 import BitwardenKit
 import BitwardenResources
+import Foundation
 import Testing
 
 @testable import BitwardenShared
@@ -14,6 +15,7 @@ struct PremiumPlanStatusTests {
         (.canceled, .danger),
         (.expired, .danger),
         (.pastDue, .warning),
+        (.pendingCancellation, .warning),
         (.unknown, .warning),
         (.updatePayment, .warning),
     ] as [(PremiumPlanStatus, PillBadgeStyle)])
@@ -35,6 +37,12 @@ struct PremiumPlanStatusTests {
         #expect(PremiumPlanStatus(subscriptionStatus: status) == expected)
     }
 
+    @Test(arguments: [SubscriptionStatus.active, .trialing] as [SubscriptionStatus])
+    func init_mapsSubscriptionStatus_withCancelAt(_ status: SubscriptionStatus) {
+        let cancelAt = Date()
+        #expect(PremiumPlanStatus(subscriptionStatus: status, cancelAt: cancelAt) == .pendingCancellation)
+    }
+
     // MARK: Tests - label
 
     @Test(arguments: [
@@ -42,6 +50,7 @@ struct PremiumPlanStatusTests {
         (.canceled, Localizations.canceled),
         (.expired, Localizations.expired),
         (.pastDue, Localizations.pastDue),
+        (.pendingCancellation, Localizations.pendingCancellation),
         (.unknown, Localizations.unknownStatus),
         (.updatePayment, Localizations.updatePayment),
     ] as [(PremiumPlanStatus, String)])

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -241,6 +241,20 @@ private extension PremiumSubscription {
         suspension: Date().addingTimeInterval(60 * 60 * 24 * 30),
     )
 
+    static let previewPendingCancellation = PremiumSubscription(
+        cadence: .annually,
+        cancelAt: Date().addingTimeInterval(60 * 60 * 24 * 30),
+        canceled: nil,
+        discount: 2.10,
+        estimatedTax: 3.85,
+        gracePeriod: nil,
+        nextCharge: Date().addingTimeInterval(60 * 60 * 24 * 30),
+        seatsCost: 19.8,
+        status: .pendingCancellation,
+        storageCost: 8,
+        suspension: nil,
+    )
+
     static let previewUpdatePayment = PremiumSubscription(
         cadence: .annually,
         cancelAt: Date().addingTimeInterval(60 * 60 * 24 * 14),
@@ -324,6 +338,21 @@ private extension PremiumSubscription {
                     state: PremiumPlanState(
                         planStatus: .expired,
                         subscription: .previewExpired,
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+#Preview("Pending Cancellation") {
+    NavigationView {
+        PremiumPlanView(
+            store: Store(
+                processor: StateProcessor(
+                    state: PremiumPlanState(
+                        planStatus: .pendingCancellation,
+                        subscription: .previewPendingCancellation,
                     ),
                 ),
             ),

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -143,7 +143,7 @@ struct PremiumPlanView: View {
                     .padding(.horizontal, 16)
             }
 
-            if store.state.planStatus == .canceled {
+            if store.state.planStatus == .canceled || store.state.planStatus == .expired {
                 PremiumFeaturesList()
                     .padding(.horizontal, 16)
             }
@@ -211,6 +211,20 @@ private extension PremiumSubscription {
         status: .canceled,
         storageCost: 0,
         suspension: nil,
+    )
+
+    static let previewExpired = PremiumSubscription(
+        cadence: .annually,
+        cancelAt: nil,
+        canceled: nil,
+        discount: 0,
+        estimatedTax: 0,
+        gracePeriod: 1,
+        nextCharge: nil,
+        seatsCost: 19.8,
+        status: .expired,
+        storageCost: 0,
+        suspension: Date().addingTimeInterval(-60 * 60 * 24 * 9),
     )
 
     static let previewPastDue = PremiumSubscription(
@@ -295,6 +309,21 @@ private extension PremiumSubscription {
                     state: PremiumPlanState(
                         planStatus: .canceled,
                         subscription: .previewCanceled,
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+#Preview("Expired") {
+    NavigationView {
+        PremiumPlanView(
+            store: Store(
+                processor: StateProcessor(
+                    state: PremiumPlanState(
+                        planStatus: .expired,
+                        subscription: .previewExpired,
                     ),
                 ),
             ),


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-38183
https://bitwarden.atlassian.net/browse/PM-38184

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Add two new premium plan UI states:
- **Expired** (`incomplete_expired` Stripe status): danger badge, expiry date from `suspension` field, premium features list, no billing details
- **Pending Cancellation** (active/trialing with a future `cancelAt`): warning badge, scheduled cancellation date from `cancelAt`, full billing details, no cancel button

## 📸 Screenshots

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5bba14f1-046a-4f65-ae60-35362ab5e17d" />
<img width="360" alt="image" src="https://github.com/user-attachments/assets/1aab85db-4882-4740-94cb-7f3c7768f695" />
