### PR TITLE
[PM-27240] feat: Support v2 encryption on TDE signups

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/StringExtensionsTests.swift
@@ -17,7 +17,7 @@ struct StringExtensionsTests {
             "https://bitwarden.com",
             "http://192.168.0.1:8080",
             "https://ht tp://broken.com",
-        ]
+        ],
     ))
     func fixURLIfNeeded(input: String, expected: String) {
         #expect(input.fixURLIfNeeded() == expected)
@@ -46,7 +46,7 @@ struct StringExtensionsTests {
             "Visit Bitwarden now.",
             "Bold text",
             "No markdown here.",
-        ]
+        ],
     ))
     func removingMarkdownForVoiceOver(input: String, expected: String) {
         #expect(input.removingMarkdownForVoiceOver() == expected)

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -52,7 +52,12 @@ protocol AuthRepository: AnyObject {
     ///
     func convertNewUserToKeyConnector(keyConnectorURL: URL, orgIdentifier: String) async throws
 
-    /// Create new account for a JIT sso user .
+    /// Create new account for a JIT SSO user and unlocks the vault.
+    ///
+    /// - Parameters:
+    ///   - orgIdentifier: The text identifier for the organization.
+    ///   - rememberDevice: Whether to trust this device, storing a device key that can be used
+    ///     to unlock the vault on future logins without additional verification.
     ///
     func createNewSsoUser(orgIdentifier: String, rememberDevice: Bool) async throws
 
@@ -432,6 +437,9 @@ class DefaultAuthRepository {
     /// Helper to know about the app context.
     private let appContextHelper: AppContextHelper
 
+    /// The service used by the application to manage the app's ID.
+    private let appIDService: AppIDService
+
     /// The service used that handles some of the auth logic.
     private let authService: AuthService
 
@@ -496,6 +504,7 @@ class DefaultAuthRepository {
     /// - Parameters:
     ///   - accountAPIService: The services used by the application to make account related API requests.
     ///   - appContextHelper: The helper to know about the app context.
+    ///   - appIDService: The service used by the application to manage the app's ID.
     ///   - authService: The service used that handles some of the auth logic.
     ///   - biometricsRepository: The service to use system Biometrics for vault unlock.
     ///   - changeKdfService: The service used to change the user's KDF settings.
@@ -520,6 +529,7 @@ class DefaultAuthRepository {
     init(
         accountAPIService: AccountAPIService,
         appContextHelper: AppContextHelper,
+        appIDService: AppIDService,
         authService: AuthService,
         biometricsRepository: BiometricsRepository,
         changeKdfService: ChangeKdfService,
@@ -542,6 +552,7 @@ class DefaultAuthRepository {
     ) {
         self.accountAPIService = accountAPIService
         self.appContextHelper = appContextHelper
+        self.appIDService = appIDService
         self.authService = authService
         self.biometricsRepository = biometricsRepository
         self.changeKdfService = changeKdfService
@@ -639,45 +650,72 @@ extension DefaultAuthRepository: AuthRepository {
     }
 
     func createNewSsoUser(orgIdentifier: String, rememberDevice: Bool) async throws {
+        // swiftlint:disable:previous function_body_length
         let account = try await stateService.getActiveAccount()
         let enrollStatus = try await organizationAPIService.getOrganizationAutoEnrollStatus(identifier: orgIdentifier)
         let organizationKeys = try await organizationAPIService.getOrganizationKeys(organizationId: enrollStatus.id)
 
-        let registrationKeys = try await clientService.auth().makeRegisterTdeKeys(
-            email: account.profile.email,
-            orgPublicKey: organizationKeys.publicKey,
-            rememberDevice: rememberDevice,
-        )
+        guard await configService.getFeatureFlag(.accountEncryptionV2TDE) else {
+            let registrationKeys = try await clientService.auth().makeRegisterTdeKeys(
+                email: account.profile.email,
+                orgPublicKey: organizationKeys.publicKey,
+                rememberDevice: rememberDevice,
+            )
 
-        let setAccountKeysResponse = try await accountAPIService.setAccountKeys(
-            requestModel: KeysRequestModel(
-                encryptedPrivateKey: registrationKeys.privateKey,
-                publicKey: registrationKeys.publicKey,
-            ),
+            let setAccountKeysResponse = try await accountAPIService.setAccountKeys(
+                requestModel: KeysRequestModel(
+                    encryptedPrivateKey: registrationKeys.privateKey,
+                    publicKey: registrationKeys.publicKey,
+                ),
+            )
+
+            try await stateService.setAccountEncryptionKeys(
+                AccountEncryptionKeys(
+                    cryptographicState: .create(
+                        accountKeys: setAccountKeysResponse.accountKeys,
+                        privateKey: registrationKeys.privateKey,
+                    ),
+                    encryptedUserKey: nil,
+                ),
+            )
+
+            try await organizationUserAPIService.organizationUserResetPasswordEnrollment(
+                organizationId: enrollStatus.id,
+                requestModel: OrganizationUserResetPasswordEnrollmentRequestModel(
+                    masterPasswordHash: nil, resetPasswordKey: registrationKeys.adminReset,
+                ),
+                userId: account.profile.userId,
+            )
+
+            if rememberDevice,
+               let trustDeviceResponse = registrationKeys.deviceKey {
+                try await trustDeviceService.trustDeviceWithExistingKeys(keys: trustDeviceResponse)
+            }
+            return
+        }
+
+        let appId = await appIDService.getOrCreateAppID()
+        let request = TdeRegistrationRequest(
+            orgId: enrollStatus.id,
+            orgPublicKey: organizationKeys.publicKey,
+            userId: account.profile.userId,
+            deviceIdentifier: appId,
+            trustDevice: rememberDevice,
         )
+        let response = try await clientService.auth().registration().postKeysForTdeRegistration(request: request)
 
         try await stateService.setAccountEncryptionKeys(
             AccountEncryptionKeys(
-                cryptographicState: .create(
-                    accountKeys: setAccountKeysResponse.accountKeys,
-                    privateKey: registrationKeys.privateKey,
-                ),
+                cryptographicState: response.accountCryptographicState,
                 encryptedUserKey: nil,
             ),
         )
 
-        try await organizationUserAPIService.organizationUserResetPasswordEnrollment(
-            organizationId: enrollStatus.id,
-            requestModel: OrganizationUserResetPasswordEnrollmentRequestModel(
-                masterPasswordHash: nil, resetPasswordKey: registrationKeys.adminReset,
-            ),
-            userId: account.profile.userId,
-        )
-
-        if rememberDevice,
-           let trustDeviceResponse = registrationKeys.deviceKey {
-            try await trustDeviceService.trustDeviceWithExistingKeys(keys: trustDeviceResponse)
+        if rememberDevice {
+            try await keychainService.setDeviceKey(response.deviceKey, userId: account.profile.userId)
         }
+
+        try await unlockVault(method: .decryptedKey(decryptedUserKey: response.userKey))
     }
 
     func clearPins() async throws {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -1,6 +1,7 @@
 import BitwardenKit
 import BitwardenKitMocks
 import BitwardenSdk
+import BitwardenSdkMocks
 import SwiftUI
 import TestHelpers
 import XCTest
@@ -14,6 +15,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
     var accountAPIService: APIService!
     var appContextHelper: MockAppContextHelper!
+    var appIDSettingsStore: MockAppIDSettingsStore!
     var authService: MockAuthService!
     var biometricsRepository: MockBiometricsRepository!
     var changeKdfService: MockChangeKdfService!
@@ -96,6 +98,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         super.setUp()
 
         appContextHelper = MockAppContextHelper()
+        appIDSettingsStore = MockAppIDSettingsStore()
         client = MockHTTPClient()
         clientService = MockClientService()
         accountAPIService = APIService(client: client)
@@ -131,6 +134,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         subject = DefaultAuthRepository(
             accountAPIService: accountAPIService,
             appContextHelper: appContextHelper,
+            appIDService: AppIDService(appIDSettingsStore: appIDSettingsStore),
             authService: authService,
             biometricsRepository: biometricsRepository,
             changeKdfService: changeKdfService,
@@ -158,6 +162,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         accountAPIService = nil
         appContextHelper = nil
+        appIDSettingsStore = nil
         authService = nil
         biometricsRepository = nil
         changeKdfService = nil
@@ -247,7 +252,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `createNewSsoUser()` creates a new account for sso JIT user and trust device.
-    func test_createNewSsoUser_remember() async throws {
+    func test_createNewSsoUser_v1_remember() async throws {
         let registerTdeInput = RegisterTdeKeyResponse(
             privateKey: "privateKey",
             publicKey: "publicKey",
@@ -285,7 +290,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `createNewSsoUser()` creates a new account for sso JIT user and don't trust device.
-    func test_createNewSsoUser_notRemember() async throws {
+    func test_createNewSsoUser_v1_notRemember() async throws {
         let registerTdeInput = RegisterTdeKeyResponse(
             privateKey: "privateKey",
             publicKey: "publicKey",
@@ -321,7 +326,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     }
 
     /// `createNewSsoUser()` stores the accountKeys from the setAccountKeys response.
-    func test_createNewSsoUser_withAccountKeys() async throws {
+    func test_createNewSsoUser_v1_withAccountKeys() async throws {
         let registerTdeInput = RegisterTdeKeyResponse(
             privateKey: "privateKey",
             publicKey: "publicKey",
@@ -353,6 +358,116 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 encryptedUserKey: nil,
             ),
         )
+    }
+
+    /// `createNewSsoUser()` creates a new SSO JIT user account and trusts the device.
+    func test_createNewSsoUser_remember() async throws {
+        appIDSettingsStore.appID = "TEST_DEVICE_ID"
+        client.results = [
+            .httpSuccess(testData: .organizationAutoEnrollStatus),
+            .httpSuccess(testData: .organizationKeys),
+        ]
+        configService.featureFlagsBool[.accountEncryptionV2TDE] = true
+        stateService.activeAccount = Account.fixture()
+        let mockRegistrationClient = MockRegistrationClientProtocol()
+        mockRegistrationClient.postKeysForTdeRegistrationReturnValue = TdeRegistrationResponse(
+            accountCryptographicState: .fixtureV2(),
+            deviceKey: "DEVICE_KEY",
+            userKey: "USER_KEY",
+        )
+        clientService.mockAuth.registrationReturnValue = mockRegistrationClient
+
+        try await subject.createNewSsoUser(orgIdentifier: "Bitwarden", rememberDevice: true)
+
+        let request = try XCTUnwrap(mockRegistrationClient.postKeysForTdeRegistrationReceivedRequest)
+        XCTAssertEqual(request.orgId, "af0d946f-8a7c-41eb-af0e-4b2e4e9fb8f5")
+        XCTAssertEqual(request.orgPublicKey, "MIIBIjAN...2QIDAQAB")
+        XCTAssertEqual(request.userId, "1")
+        XCTAssertEqual(request.deviceIdentifier, "TEST_DEVICE_ID")
+        XCTAssertTrue(request.trustDevice)
+        XCTAssertEqual(
+            stateService.accountEncryptionKeys["1"],
+            AccountEncryptionKeys(
+                cryptographicState: .fixtureV2(),
+                encryptedUserKey: nil,
+            ),
+        )
+        XCTAssertEqual(keychainService.setDeviceKeyReceivedArguments?.value, "DEVICE_KEY")
+        XCTAssertEqual(keychainService.setDeviceKeyReceivedArguments?.userId, "1")
+        XCTAssertEqual(
+            clientService.mockCrypto.initializeUserCryptoReceivedReq,
+            InitUserCryptoRequest(
+                userId: "1",
+                kdfParams: Account.fixture().kdf.sdkKdf,
+                email: "user@bitwarden.com",
+                accountCryptographicState: .fixtureV2(),
+                method: .decryptedKey(decryptedUserKey: "USER_KEY"),
+                upgradeToken: nil,
+            ),
+        )
+    }
+
+    /// `createNewSsoUser()` creates a new SSO JIT user account without trusting the device.
+    func test_createNewSsoUser_notRemember() async throws {
+        appIDSettingsStore.appID = "TEST_DEVICE_ID"
+        client.results = [
+            .httpSuccess(testData: .organizationAutoEnrollStatus),
+            .httpSuccess(testData: .organizationKeys),
+        ]
+        configService.featureFlagsBool[.accountEncryptionV2TDE] = true
+        stateService.activeAccount = Account.fixture()
+        let mockRegistrationClient = MockRegistrationClientProtocol()
+        mockRegistrationClient.postKeysForTdeRegistrationReturnValue = TdeRegistrationResponse(
+            accountCryptographicState: .fixtureV2(),
+            deviceKey: "DEVICE_KEY",
+            userKey: "USER_KEY",
+        )
+        clientService.mockAuth.registrationReturnValue = mockRegistrationClient
+
+        try await subject.createNewSsoUser(orgIdentifier: "Bitwarden", rememberDevice: false)
+
+        let request = try XCTUnwrap(mockRegistrationClient.postKeysForTdeRegistrationReceivedRequest)
+        XCTAssertFalse(request.trustDevice)
+        XCTAssertEqual(
+            stateService.accountEncryptionKeys["1"],
+            AccountEncryptionKeys(
+                cryptographicState: .fixtureV2(),
+                encryptedUserKey: nil,
+            ),
+        )
+        XCTAssertFalse(keychainService.setDeviceKeyCalled)
+        XCTAssertEqual(
+            clientService.mockCrypto.initializeUserCryptoReceivedReq,
+            InitUserCryptoRequest(
+                userId: "1",
+                kdfParams: Account.fixture().kdf.sdkKdf,
+                email: "user@bitwarden.com",
+                accountCryptographicState: .fixtureV2(),
+                method: .decryptedKey(decryptedUserKey: "USER_KEY"),
+                upgradeToken: nil,
+            ),
+        )
+    }
+
+    /// `createNewSsoUser()` rethrows an error from the SDK registration call without storing any keys.
+    func test_createNewSsoUser_registrationError() async throws {
+        client.results = [
+            .httpSuccess(testData: .organizationAutoEnrollStatus),
+            .httpSuccess(testData: .organizationKeys),
+        ]
+        configService.featureFlagsBool[.accountEncryptionV2TDE] = true
+        stateService.activeAccount = Account.fixture()
+        let mockRegistrationClient = MockRegistrationClientProtocol()
+        mockRegistrationClient.postKeysForTdeRegistrationThrowableError = BitwardenTestError.example
+        clientService.mockAuth.registrationReturnValue = mockRegistrationClient
+
+        await assertAsyncThrows(error: BitwardenTestError.example) {
+            try await subject.createNewSsoUser(orgIdentifier: "Bitwarden", rememberDevice: true)
+        }
+
+        XCTAssertNil(stateService.accountEncryptionKeys["1"])
+        XCTAssertFalse(keychainService.setDeviceKeyCalled)
+        XCTAssertFalse(clientService.mockCrypto.initializeUserCryptoCalled)
     }
 
     /// `deleteAccount()` deletes the active account and removes it from the state.

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -8,6 +8,9 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// Flag to enable/disable V2 password-based registration using the SDK registration client.
     static let accountEncryptionV2PasswordRegistration = FeatureFlag(rawValue: "pm-27278-v2-password-registration")
 
+    /// A feature flag to enable/disable V2 account encryption for TDE.
+    static let accountEncryptionV2TDE = FeatureFlag(rawValue: "pm-27279-v2-registration-tde-jit")
+
     /// A feature flag to enable/disable scanning a card to autocomplete its details in add/edit cipher.
     static let cardScanner = FeatureFlag(rawValue: "pm-34171-card-scanner")
 
@@ -43,6 +46,7 @@ extension FeatureFlag: @retroactive CaseIterable {
     public static var allCases: [FeatureFlag] {
         [
             .accountEncryptionV2PasswordRegistration,
+            .accountEncryptionV2TDE,
             .cardScanner,
             .cipherKeyEncryption,
             .debugDisableSelfHostPremiumCheck,

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -829,6 +829,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
         let authRepository = DefaultAuthRepository(
             accountAPIService: apiService,
             appContextHelper: appContextHelper,
+            appIDService: appIDService,
             authService: authService,
             biometricsRepository: biometricsRepository,
             changeKdfService: changeKdfService,

--- a/BitwardenShared/UI/Auth/Login/LoginDecryptionOptions/LoginDecryptionOptionsProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/LoginDecryptionOptions/LoginDecryptionOptionsProcessor.swift
@@ -98,6 +98,9 @@ class LoginDecryptionOptionsProcessor: StateProcessor<
 
     /// Creates a new SSO user
     private func createNewSsoUser() async {
+        coordinator.showLoadingOverlay(title: Localizations.loading)
+        defer { coordinator.hideLoadingOverlay() }
+
         do {
             guard let orgIdentifier = state.orgIdentifier else { throw AuthError.missingData }
             try await services.authRepository.createNewSsoUser(
@@ -105,9 +108,10 @@ class LoginDecryptionOptionsProcessor: StateProcessor<
                 rememberDevice: state.isRememberDeviceToggleOn,
             )
 
+            coordinator.hideLoadingOverlay()
             await coordinator.handleEvent(.didCompleteAuth)
         } catch {
-            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+            await coordinator.showErrorAlert(error: error)
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-27240](https://bitwarden.atlassian.net/browse/PM-27240)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enables support for v2 encryption on TDE account registration. Most of the existing logic that was implemented in the app, including API requests, has been moved into the SDK (via the `postKeysForTdeRegistration(request:)` function).

These changes are behind the `pm-27279-v2-registration-tde-jit` feature flag.

[PM-27240]: https://bitwarden.atlassian.net/browse/PM-27240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ