### PR TITLE
[PM-37997] feat: Hide cancel premium button when plan status is update payment

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -110,7 +110,7 @@ struct PremiumPlanState: Equatable {
 
     /// Whether the cancel premium button should be shown.
     var showCancelButton: Bool {
-        planStatus != .canceled && planStatus != .unknown
+        planStatus != .canceled && planStatus != .unknown && planStatus != .updatePayment
     }
 
     /// Whether the discount row should be shown.

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -212,7 +212,7 @@ struct PremiumPlanStateTests {
         (PremiumPlanStatus.canceled, false),
         (PremiumPlanStatus.pastDue, true),
         (PremiumPlanStatus.unknown, false),
-        (PremiumPlanStatus.updatePayment, true),
+        (PremiumPlanStatus.updatePayment, false),
     ])
     func showCancelButton(planStatus: PremiumPlanStatus, expected: Bool) {
         var state = PremiumPlanState()


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37997

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Hide the "Cancel Premium" button on the Plan screen when the subscription status is `updatePayment`. Canceling isn't a meaningful action when the user first needs to update their payment method.
