### PR TITLE
[PM-37283] feat: Add Upgrade to Premium button to file send premium required alert

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -19,6 +19,7 @@ protocol PremiumUpgradeRoute {
 }
 
 extension SendItemRoute: PremiumUpgradeRoute {}
+extension SendRoute: PremiumUpgradeRoute {}
 extension VaultItemRoute: PremiumUpgradeRoute {}
 extension VaultRoute: PremiumUpgradeRoute {}
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinator.swift
@@ -17,7 +17,10 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
         & SendItemCoordinator.Module
         & SendItemModule
 
-    typealias Services = HasConfigService
+    typealias Services = HasBillingRepository
+        & HasBillingService
+        & HasConfigService
+        & HasEnvironmentService
         & HasErrorAlertServices.ErrorAlertServices
         & HasErrorReporter
         & HasPasteboardService
@@ -82,6 +85,8 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
             showGroup(type)
         case .list:
             showList()
+        case .premiumUpgrade:
+            showPremiumUpgrade()
         case let .share(url):
             showShareSheet(for: [url])
         case let .viewItem(sendView):
@@ -153,6 +158,15 @@ final class SendCoordinator: Coordinator, HasStackNavigator {
         let store = Store(processor: processor)
         let view = SendListView(store: store)
         stackNavigator?.replace(view)
+    }
+
+    /// Shows the premium upgrade screen.
+    ///
+    private func showPremiumUpgrade() {
+        let navigationController = module.makeNavigationController()
+        let coordinator = module.makeBillingCoordinator(stackNavigator: navigationController)
+        coordinator.navigate(to: .premiumUpgrade)
+        stackNavigator?.present(navigationController)
     }
 
     /// Presents the system share sheet for the specified items.

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
@@ -163,7 +163,7 @@ class SendCoordinatorTests: BitwardenTestCase {
         let action = try XCTUnwrap(stackNavigator.actions.last)
         XCTAssertEqual(action.type, .presented)
         XCTAssertTrue(action.view is UINavigationController)
-        XCTAssertTrue(module.billingCoordinator.isStarted)
+        XCTAssertEqual(module.billingCoordinator.routes, [.premiumUpgrade])
     }
 
     /// `navigate(to:)` with `.share` presents the share sheet.

--- a/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendCoordinatorTests.swift
@@ -155,6 +155,17 @@ class SendCoordinatorTests: BitwardenTestCase {
         XCTAssertTrue(action.view is BitwardenShared.SendListView)
     }
 
+    /// `navigate(to:)` with `.premiumUpgrade` presents the premium upgrade screen.
+    @MainActor
+    func test_navigateTo_premiumUpgrade() throws {
+        subject.navigate(to: .premiumUpgrade)
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .presented)
+        XCTAssertTrue(action.view is UINavigationController)
+        XCTAssertTrue(module.billingCoordinator.isStarted)
+    }
+
     /// `navigate(to:)` with `.share` presents the share sheet.
     @MainActor
     func test_navigateTo_share() throws {

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -26,7 +26,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     private let coordinator: AnyCoordinator<SendRoute, Void>
 
     /// The helper used to navigate to the premium upgrade flow.
-    private lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
         services: services,
         coordinator: coordinator,
         setURL: { [weak self] url in self?.state.infoUrl = url },

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -10,7 +10,10 @@ import Foundation
 final class SendListProcessor: StateProcessor<SendListState, SendListAction, SendListEffect> {
     // MARK: Types
 
-    typealias Services = HasConfigService
+    typealias Services = HasBillingRepository
+        & HasBillingService
+        & HasConfigService
+        & HasEnvironmentService
         & HasErrorReporter
         & HasPasteboardService
         & HasPolicyService
@@ -21,6 +24,13 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
 
     /// The `Coordinator` that handles navigation.
     private let coordinator: AnyCoordinator<SendRoute, Void>
+
+    /// The helper used to navigate to the premium upgrade flow.
+    private lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.infoUrl = url },
+    )
 
     /// The services required by this processor.
     private let services: Services
@@ -130,7 +140,10 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
             let hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
 
             guard hasPremium else {
-                coordinator.showAlert(.defaultAlert(title: Localizations.sendFilePremiumRequired))
+                coordinator.showAlert(.fileSendPremiumRequired { [weak self] in
+                    guard let self else { return }
+                    Task { await self.premiumUpgradeHelper.navigateToPremiumUpgrade() }
+                })
                 return
             }
         }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -6,6 +6,7 @@ import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
 // swiftlint:disable file_length
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -90,7 +90,8 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         sendRepository.doesActivateAccountHavePremiumResult = false
         await subject.perform(.addItemPressed(.file))
 
-        try await coordinator.alertShown.last?.tapAction(title: Localizations.upgradeToPremium)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.upgradeToPremium)
 
         try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
         XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -18,6 +18,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     var errorReporter: MockErrorReporter!
     var pasteboardService: MockPasteboardService!
     var policyService: MockPolicyService!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var sendRepository: MockSendRepository!
     var subject: SendListProcessor!
     var vaultRepository: MockVaultRepository!
@@ -29,6 +30,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         errorReporter = MockErrorReporter()
         pasteboardService = MockPasteboardService()
         policyService = MockPolicyService()
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         sendRepository = MockSendRepository()
         vaultRepository = MockVaultRepository()
 
@@ -43,6 +45,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             ),
             state: SendListState(),
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     override func tearDown() {
@@ -51,6 +54,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         coordinator = nil
         errorReporter = nil
         policyService = nil
+        premiumUpgradeHelper = nil
         sendRepository = nil
         subject = nil
         vaultRepository = nil
@@ -67,19 +71,29 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(coordinator.routes.last, .addItem(type: .file))
     }
 
-    /// `perform(_:)` with `.addItemPressed` shows an alert if attempting to add a file send and
-    /// the user doesn't have premium.
+    /// `perform(_:)` with `.addItemPressed` shows a premium required alert with an upgrade action
+    /// if attempting to add a file send and the user doesn't have premium.
     @MainActor
     func test_perform_addItemPressed_fileType_withoutPremium() async throws {
         sendRepository.doesActivateAccountHavePremiumResult = false
         subject.state.type = .file
         await subject.perform(.addItemPressed(.file))
 
-        XCTAssertEqual(
-            coordinator.alertShown,
-            [.defaultAlert(title: Localizations.sendFilePremiumRequired)],
-        )
+        XCTAssertEqual(coordinator.alertShown, [.fileSendPremiumRequired {}])
         XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+
+    /// `perform(_:)` with `.addItemPressed` tapping "Upgrade to Premium" in the premium required
+    /// alert triggers the premium upgrade flow.
+    @MainActor
+    func test_perform_addItemPressed_fileType_withoutPremium_upgradeAction() async throws {
+        sendRepository.doesActivateAccountHavePremiumResult = false
+        await subject.perform(.addItemPressed(.file))
+
+        try await coordinator.alertShown.last?.tapAction(title: Localizations.upgradeToPremium)
+
+        try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `perform(_:)` with `.addItemPressed` navigates to the `.addItem` route.

--- a/BitwardenShared/UI/Tools/Send/Send/SendRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendRoute.swift
@@ -28,6 +28,9 @@ public enum SendRoute: Equatable {
     /// A route to the send screen.
     case list
 
+    /// A route to the premium upgrade screen.
+    case premiumUpgrade
+
     /// A route to share the provided URL.
     ///
     /// - Parameter url: The `URL` to share.

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -389,10 +389,10 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
 
         let hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
         guard hasPremium else {
-            let alert = Alert.defaultAlert(
-                message: Localizations.sendFilePremiumRequired,
-            )
-            coordinator.showAlert(alert)
+            coordinator.showAlert(.fileSendPremiumRequired { [weak self] in
+                guard let self else { return }
+                Task { await self.premiumUpgradeHelper.navigateToPremiumUpgrade() }
+            })
             return false
         }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -336,7 +336,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject.state.type = .file
         await subject.perform(.savePressed)
 
-        try await coordinator.alertShown.last?.tapAction(title: Localizations.upgradeToPremium)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.upgradeToPremium)
 
         try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
         XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -309,7 +309,8 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         ])
     }
 
-    /// `perform(_:)` with `.savePressed` and no premium shows a validation alert.
+    /// `perform(_:)` with `.savePressed` and no premium shows a premium required alert with
+    /// an upgrade action.
     @MainActor
     func test_perform_savePressed_add_file_noPremium() async {
         sendRepository.doesActivateAccountHavePremiumResult = false
@@ -321,9 +322,24 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
         XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
         XCTAssertNil(sendRepository.addTextSendSendView)
-        XCTAssertEqual(coordinator.alertShown, [
-            Alert.defaultAlert(message: Localizations.sendFilePremiumRequired),
-        ])
+        XCTAssertEqual(coordinator.alertShown, [.fileSendPremiumRequired {}])
+    }
+
+    /// `perform(_:)` with `.savePressed` tapping "Upgrade to Premium" in the premium required
+    /// alert triggers the premium upgrade flow.
+    @MainActor
+    func test_perform_savePressed_add_file_noPremium_upgradeAction() async throws {
+        sendRepository.doesActivateAccountHavePremiumResult = false
+        subject.state.name = "Name"
+        subject.state.fileData = Data("example".utf8)
+        subject.state.fileName = "filename"
+        subject.state.type = .file
+        await subject.perform(.savePressed)
+
+        try await coordinator.alertShown.last?.tapAction(title: Localizations.upgradeToPremium)
+
+        try await waitForAsync { self.premiumUpgradeHelper.navigateToPremiumUpgradeCalled }
+        XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
     /// `perform(_:)` with `.savePressed` and an unverified email shows a validation alert.

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -57,6 +57,28 @@ extension Alert {
     /// Returns an alert for when the "Specific People" Send feature is unavailable due to
     /// lack of premium subscription.
     ///
+    /// Returns an alert notifying the user that a premium subscription is required to send files,
+    /// with an option to upgrade.
+    ///
+    /// - Parameters:
+    ///   - action: A closure to execute on upgrading to premium.
+    /// - Returns: The alert shown when a non-premium user tries to send a file.
+    static func fileSendPremiumRequired(
+        action: @escaping () -> Void,
+    ) -> Alert {
+        let preferredAction = AlertAction(title: Localizations.upgradeToPremium, style: .default) { _, _ in action() }
+        let alert = Alert(
+            title: Localizations.premiumSubscriptionRequired,
+            message: Localizations.sendFilePremiumRequired,
+            alertActions: [
+                preferredAction,
+                AlertAction(title: Localizations.cancel, style: .cancel),
+            ],
+        )
+        alert.preferredAction = preferredAction
+        return alert
+    }
+
     /// - Parameters:
     ///   - action: A closure to execute on upgrading to premium.
     /// - Returns: The alert when "Specific People" is unavailable.

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -54,9 +54,6 @@ extension Alert {
         return alert
     }
 
-    /// Returns an alert for when the "Specific People" Send feature is unavailable due to
-    /// lack of premium subscription.
-    ///
     /// Returns an alert notifying the user that a premium subscription is required to send files,
     /// with an option to upgrade.
     ///
@@ -79,6 +76,9 @@ extension Alert {
         return alert
     }
 
+    /// Returns an alert for when the "Specific People" Send feature is unavailable due to
+    /// lack of premium subscription.
+    ///
     /// - Parameters:
     ///   - action: A closure to execute on upgrading to premium.
     /// - Returns: The alert when "Specific People" is unavailable.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37283

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
When a non-premium user taps "File" in the Send creation flow, the prompt now shows both a "Cancel" button and an "Upgrade to Premium" button alongside the existing message, matching the pattern used elsewhere in the app. Previously only an "Okay" button was shown.

## 📸 Screenshots

https://github.com/user-attachments/assets/b40edb24-1e94-4844-a6c9-9e8489c3dd65

