### PR TITLE
[PM-38394] feat: Update settings plan row visibility

### DIFF
--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -25,6 +25,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         & HasConfigService
         & HasErrorReporter
         & HasStateService
+        & HasStorefrontService
         & HasVaultRepository
 
     // MARK: Private Properties
@@ -95,9 +96,11 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
                 .getFeatureFlag(.premiumUpgradePath, defaultValue: false)
             let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
             let isSelfHosted = await services.billingService.isSelfHosted()
+            let isUSStorefront = await services.storefrontService.isUSStorefront()
             state.hasPremium = hasPremium
-            state.showPlanRow = featureEnabled && !isSelfHosted
-            state.shouldShowUpgradedToPremiumActionCard = await services.billingService.shouldShowUpgradedToPremiumActionCard()
+            state.showPlanRow = featureEnabled && !isSelfHosted && isUSStorefront
+            state.shouldShowUpgradedToPremiumActionCard = await services.billingService
+                .shouldShowUpgradedToPremiumActionCard()
         case .dismissUpgradedToPremiumActionCard:
             state.shouldShowUpgradedToPremiumActionCard = false
             await services.billingService.setUpgradedToPremiumActionCardDismissed()

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -4,10 +4,12 @@ import BitwardenResources
 import TestHelpers
 import XCTest
 
+// swiftlint:disable file_length
+
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
-class SettingsProcessorTests: BitwardenTestCase {
+class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var billingService: MockBillingService!
@@ -17,6 +19,7 @@ class SettingsProcessorTests: BitwardenTestCase {
     var errorReporter: MockErrorReporter!
     var subject: SettingsProcessor!
     var stateService: MockStateService!
+    var storefrontService: MockStorefrontService!
     var vaultRepository: MockVaultRepository!
 
     // MARK: Setup & Teardown
@@ -32,6 +35,8 @@ class SettingsProcessorTests: BitwardenTestCase {
         delegate = MockSettingsProcessorDelegate()
         errorReporter = MockErrorReporter()
         stateService = MockStateService()
+        storefrontService = MockStorefrontService()
+        storefrontService.isUSStorefrontReturnValue = true
         vaultRepository = MockVaultRepository()
 
         setUpSubject()
@@ -47,6 +52,7 @@ class SettingsProcessorTests: BitwardenTestCase {
         errorReporter = nil
         subject = nil
         stateService = nil
+        storefrontService = nil
         vaultRepository = nil
     }
 
@@ -60,6 +66,7 @@ class SettingsProcessorTests: BitwardenTestCase {
                 configService: configService,
                 errorReporter: errorReporter,
                 stateService: stateService,
+                storefrontService: storefrontService,
                 vaultRepository: vaultRepository,
             ),
             state: SettingsState(presentationMode: presentationMode),
@@ -292,6 +299,17 @@ class SettingsProcessorTests: BitwardenTestCase {
         billingService.isSelfHostedReturnValue = true
         configService.featureFlagsBool[.premiumUpgradePath] = true
         vaultRepository.doesActiveAccountHavePremiumResult = true
+
+        await subject.perform(.appeared)
+
+        XCTAssertFalse(subject.state.showPlanRow)
+    }
+
+    /// `perform(.appeared)` hides the plan row when the storefront is not US.
+    @MainActor
+    func test_perform_appeared_hidesPlanRow_nonUSStorefront() async {
+        storefrontService.isUSStorefrontReturnValue = false
+        configService.featureFlagsBool[.premiumUpgradePath] = true
 
         await subject.perform(.appeared)
 

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -85,6 +85,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasPolicyService
         & HasSettingsRepository
         & HasStateService
+        & HasStorefrontService
         & HasSystemDevice
         & HasTimeProvider
         & HasTwoStepLoginService


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38394

## 📔 Objective

The settings plan row visibility was only checking the `premiumUpgradePath` feature flag and whether the user is self-hosted. This PR updates the logic to also require the user's App Store storefront to be US (`isUSStorefront`), matching the full set of conditions specified in the ticket:

- Not self-hosted
- Is US store
- Feature flag enabled