### PR TITLE
[PM-38411] tech-debt: Update deprecated argument in actions/create-github-app-token

### DIFF
--- a/.github/workflows/crowdin-pull.yml
+++ b/.github/workflows/crowdin-pull.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          client-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
           permission-contents: write      # for pushing branches
           permission-pull-requests: write # for creating pull requests

--- a/.github/workflows/sdlc-sdk-update.yml
+++ b/.github/workflows/sdlc-sdk-update.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: app-token
         with:
-          app-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
+          client-id: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-ID }}
           private-key: ${{ steps.get-kv-secrets.outputs.BW-GHAPP-KEY }}
           permission-pull-requests: write
           permission-actions: read


### PR DESCRIPTION
## 🎟️ Tracking

PM-38411

## 📔 Objective

Replacing deprecated argument of `actions/create-github-app-token`, `app-id` deprecated in favour of `client-id` in 3.1.0. 

https://github.com/actions/create-github-app-token/releases/tag/v3.1.0
