### PR TITLE
[PM-38420] ci: Update brew check behaviour in bootstrap.sh

### DIFF
--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -3,8 +3,8 @@
 set -euo pipefail
 
 if ! brew bundle check --no-upgrade --verbose; then
-    osascript -e 'display notification "Missing Brewfile dependencies." with title "Bootstrap failed" sound name "Submarine"'
-    exit 1
+    echo "❌ ❌ ❌ ❌ ❌ ❌"
+    echo
 fi
 
 mint bootstrap

--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
-brew bundle check # use --verbose to list missing dependencies
+if ! brew bundle check --no-upgrade --verbose; then
+    osascript -e 'display notification "Missing Brewfile dependencies." with title "Bootstrap failed" sound name "Submarine"'
+    exit 1
+fi
 
 mint bootstrap
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38420](https://bitwarden.atlassian.net/browse/PM-38420)

## 📔 Objective

1. `--no-upgrade` - Checks if dependencies are installed, without enforcing versions to be up-to-date
2. `--verbose` - When this check fails, it'll list the missing dependencies
3. Transition to a non blocking check - script will continue if check fails. 


[PM-38420]: https://bitwarden.atlassian.net/browse/PM-38420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ