### PR TITLE
[PM-38428] ci: Fix codecov ignore patterns and exclude mock files

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,2 +1,8 @@
 ignore:
-  - "**/*Tests.*/**,**/TestHelpers/**,**/Fixtures/**,GlobalTestHelpers/**" # Tests
+  - "**/*Tests*/**"
+  - "**/TestHelpers/**"
+  - "**/Fixtures/**"
+  - "GlobalTestHelpers/**"
+  - "GlobalTestHelpers-bwa/**"
+  - "**/Mocks/**"
+  - "**/*Mock*.swift"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,5 +4,6 @@ ignore:
   - "**/Fixtures/**"
   - "GlobalTestHelpers/**"
   - "GlobalTestHelpers-bwa/**"
+  - "GlobalTestHelpers-bwth/**"
   - "**/Mocks/**"
   - "**/*Mock*.swift"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38428

## 📔 Objective

Codecov was treating the comma-separated glob list as a single pattern,
so none of the existing ignore entries (tests, fixtures, etc.) were being
applied. This PR:

- Splits the single comma-separated string into separate list entries so
  Codecov correctly parses each glob
- Adds patterns to exclude `Mocks/` directories and `Mock*.swift` files
  project-wide, preventing generated mocks from inflating missing-coverage
  counts
- Adds `GlobalTestHelpers-bwa/` which was absent from the original list