### PR TITLE
[PM-37920] feat: Hide storage cost row when value is zero or absent

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -142,6 +142,11 @@ struct PremiumPlanState: Equatable {
         !discount.isEmpty
     }
 
+    /// Whether the storage cost row should be shown (only when cost is greater than zero).
+    var showStorageCost: Bool {
+        (subscription?.storageCost ?? 0) > 0
+    }
+
     /// The storage cost label (e.g. "$4.00" or "$0.00").
     var storageCostLabel: String {
         guard let subscription else { return "" }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 // MARK: - PremiumPlanStateTests
 
-struct PremiumPlanStateTests {
+struct PremiumPlanStateTests { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     /// A date used for testing: April 2, 2026 at 12:00 UTC.
@@ -256,6 +256,31 @@ struct PremiumPlanStateTests {
         var state = PremiumPlanState()
         state.subscription = .fixture(discount: 0)
         #expect(!state.showDiscount)
+    }
+
+    // MARK: Tests - showStorageCost
+
+    /// `showStorageCost` returns `true` when storage cost is greater than zero.
+    @Test
+    func showStorageCost_true() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(storageCost: 4)
+        #expect(state.showStorageCost)
+    }
+
+    /// `showStorageCost` returns `false` when storage cost is zero.
+    @Test
+    func showStorageCost_zero() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(storageCost: 0)
+        #expect(!state.showStorageCost)
+    }
+
+    /// `showStorageCost` returns `false` when subscription is nil.
+    @Test
+    func showStorageCost_nil() {
+        let state = PremiumPlanState()
+        #expect(!state.showStorageCost)
     }
 
     // MARK: Tests - storageCostLabel

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+ViewInspectorTests.swift
@@ -107,6 +107,23 @@ class PremiumPlanViewTests: BitwardenTestCase {
         XCTAssertNotNil(try subject.inspect().find(text: processor.state.estimatedTax))
     }
 
+    /// The storage cost row is hidden when storage cost is zero.
+    @MainActor
+    func test_storageCostRow_hidden_whenZero() throws {
+        processor.state.planStatus = .active
+        processor.state.subscription = .fixture(storageCost: 0)
+        XCTAssertThrowsError(try subject.inspect().find(text: Localizations.storageCost))
+    }
+
+    /// The storage cost row is visible when storage cost is greater than zero.
+    @MainActor
+    func test_storageCostRow_visible_whenNonZero() throws {
+        processor.state.planStatus = .active
+        processor.state.subscription = .fixture(storageCost: 4)
+        XCTAssertNotNil(try subject.inspect().find(text: Localizations.storageCost))
+        XCTAssertNotNil(try subject.inspect().find(text: processor.state.storageCostLabel))
+    }
+
     /// Tapping the manage plan button dispatches the `.managePlanTapped` effect.
     @MainActor
     func test_managePlanButton_tap() async throws {

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -48,11 +48,13 @@ struct PremiumPlanView: View {
             value: store.state.billingAmount,
             valueColor: Color(asset: SharedAsset.Colors.textPrimary),
         )
-        billingRow(
-            label: Localizations.storageCost,
-            value: store.state.storageCostLabel,
-            valueColor: Color(asset: SharedAsset.Colors.textPrimary),
-        )
+        if store.state.showStorageCost {
+            billingRow(
+                label: Localizations.storageCost,
+                value: store.state.storageCostLabel,
+                valueColor: Color(asset: SharedAsset.Colors.textPrimary),
+            )
+        }
         if store.state.showDiscount {
             billingRow(
                 label: Localizations.discount,


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37920

## 📔 Objective

Storage cost row was always rendered in the subscription cost breakdown, even when the amount was zero. This PR adds a `showStorageCost` computed property that returns `true` only when the storage cost is greater than zero, and conditionally renders the row accordingly — matching the web behaviour described in the ticket.

## 📸 Screenshots
| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/c8ccd406-aac3-49d4-a3a4-03487eb4bb27" /> | <img width="365" src="https://github.com/user-attachments/assets/ba2409ed-2159-4046-b55f-ea375d327698" /> | 
