### PR TITLE
[PM-38533] chore: Fix flaky tests

### DIFF
--- a/BitwardenKit/Core/Platform/Services/ConfigServiceTests.swift
+++ b/BitwardenKit/Core/Platform/Services/ConfigServiceTests.swift
@@ -318,16 +318,21 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// but in background returning nil to the caller as is the current available local config.
     func test_getConfig_noLocalPreAuth() async throws {
         configApiService.clientResult = .httpSuccess(testData: .validServerConfig)
+        // Subscribe before getConfig so the background-task emission is not missed.
+        var configUpdates = await subject.configPublisher().makeAsyncIterator()
         let response = await subject.getConfig(forceRefresh: false, isPreAuth: true)
         XCTAssertNil(response)
 
-        try await waitForAsync {
-            self.stateService.preAuthServerConfig != nil
-        }
-
-        XCTAssertEqual(stateService.preAuthServerConfig?.gitHash, "75238191")
+        // CurrentValueSubject emits nil on subscribe; skip it, then await the
+        // background fetch update via the thread-safe publisher instead of polling
+        // the mock's state across thread boundaries (which causes SEGV data races).
+        _ = await configUpdates.next()
+        let wrappedMetaConfig = await configUpdates.next()
+        let metaConfig = try XCTUnwrap(XCTUnwrap(wrappedMetaConfig))
+        XCTAssertTrue(metaConfig.isPreAuth)
+        XCTAssertEqual(metaConfig.serverConfig?.gitHash, "75238191")
         XCTAssertEqual(
-            stateService.preAuthServerConfig?.featureStates[FeatureFlag.testFeatureFlag.rawValue],
+            metaConfig.serverConfig?.featureStates[FeatureFlag.testFeatureFlag.rawValue],
             .bool(true),
         )
     }

--- a/BitwardenKit/Core/Platform/Services/TimeProviderTests.swift
+++ b/BitwardenKit/Core/Platform/Services/TimeProviderTests.swift
@@ -83,10 +83,16 @@ class TimeProviderTests: BitwardenTestCase {
     }
 
     /// `calculateTamperResistantElapsedTime(lastMonotonicTime:lastWallClockTime:divergenceThreshold:)` tests
-    /// divergence exactly at threshold boundary.
+    /// divergence just below threshold boundary does not trigger detection.
+    ///
+    /// A 4 s divergence (1 s below the 5 s threshold) is used rather than exactly 5 s because
+    /// the implementation reads the live monotonic and wall-clock clocks in separate statements;
+    /// the resulting sub-millisecond jitter between those reads can push an "exactly at threshold"
+    /// divergence fractionally over 5.0, causing `divergence > threshold` to flip true and making
+    /// the test fail intermittently. The `_divergenceOverThreshold` test covers the "just past" case.
     func test_calculateTamperResistantElapsedTime_divergenceAtThreshold() {
         let lastMonotonicTime = subject.monotonicTime - 150
-        let lastWallClockTime = subject.presentTime.addingTimeInterval(-155)
+        let lastWallClockTime = subject.presentTime.addingTimeInterval(-154)
 
         let result = subject.calculateTamperResistantElapsedTime(
             lastMonotonicTime: lastMonotonicTime,
@@ -95,7 +101,7 @@ class TimeProviderTests: BitwardenTestCase {
         )
 
         XCTAssertFalse(result.tamperingDetected)
-        XCTAssertEqual(result.divergence, 5, accuracy: 0.1)
+        XCTAssertEqual(result.divergence, 4, accuracy: 0.1)
     }
 
     /// `calculateTamperResistantElapsedTime(lastMonotonicTime:lastWallClockTime:divergenceThreshold:)` tests


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38533](https://bitwarden.atlassian.net/browse/PM-38533)

## 📔 Objective

Fixes `TimeProvider -> test_calculateTamperResistantElapsedTime_divergenceAtThreshold` test race condition.

The test was flaky because it tested the exact boundary (divergence == threshold == 5.0) using a live clock with four separate reads. Any sub-millisecond jitter between those reads could push the result to 5.0 + ε, which is strictly greater than 5.0, triggering tamperingDetected = true and failing XCTAssertFalse.

The fix changes the wall-clock offset from -155 to -154 so the divergence is ≈4 s — a full second below threshold, immune to timing noise — while the existing _divergenceOverThreshold test already covers the "just past 5 s" case.

Secondly the fix in `ConfigServiceTests` replaces the racy waitForAsync { stateService.preAuthServerConfig != nil } poll with an AsyncPublisher iterator subscribed before getConfig is called:

Before: waitForAsync read preAuthServerConfig on the main actor while the unstructured Task wrote it from the cooperative pool — a classic data race on a non-isolated class property that can corrupt the Optional<ServerConfig>'s storage and SEGV.

After: we consume the configPublisher() async sequence instead. CurrentValueSubject emits nil on subscribe (that's the _ = await configUpdates.next() skip), then the second next() suspends until the background task calls configSubject.send(...). The configSubject.send() in updateConfigFromServer is called after setPreAuthServerConfig completes, so the happens-before is maintained and the final assertions are safe. AsyncPublisher's continuation mechanism handles the cross-thread notification without any unguarded shared-memory access


[PM-38533]: https://bitwarden.atlassian.net/browse/PM-38533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ