### PR TITLE
llm: Add alphabetical enum case ordering rule to iOS skill

### DIFF
--- a/.claude/skills/implementing-ios-code/SKILL.md
+++ b/.claude/skills/implementing-ios-code/SKILL.md
@@ -28,6 +28,7 @@ Implement from the bottom up:
 **Data Models** (if needed)
 - Request/Response types in `Core/<Domain>/Models/Request/` and `Response/`
 - Enum types in `Core/<Domain>/Models/Enum/`
+  - Keep cases alphabetical. When you add a case to an existing enum, insert it at its alphabetical position in **every `switch` over that enum** (across all layers) rather than appending it — match the surrounding order.
 
 **Persistence** (if needed)
 - Vault sync data → CoreData via `DataStore` (add entities to `Bitwarden.xcdatamodeld`)


### PR DESCRIPTION
## 🎟️ Tracking

#2730

## 📔 Objective

Codifies a convention in the `implementing-ios-code` skill: when adding a case to an existing enum, insert it at its alphabetical position in **every `switch` over that enum** (across all layers) rather than appending it — matching the surrounding order.

This came out of #2730, where the new `.passport` case was appended instead of slotted in alphabetically across three switch statements. Documenting the rule so future work follows it.