### PR TITLE
chore: Include new item type data in cipher requests

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
@@ -64,11 +64,11 @@ struct CipherRequestModel: JSONRequestBody {
     /// The organization identifier for the cipher.
     let organizationID: String?
 
-    /// The password history for this cipher.
-    let passwordHistory: [CipherPasswordHistoryModel]?
-
     /// Passport data if the cipher is a passport.
     let passport: CipherPassportModel?
+
+    /// The password history for this cipher.
+    let passwordHistory: [CipherPasswordHistoryModel]?
 
     /// Whether the user needs to be re-prompted for their master password prior to autofilling the
     /// cipher's password.
@@ -114,8 +114,8 @@ extension CipherRequestModel {
             name: cipher.name,
             notes: cipher.notes,
             organizationID: cipher.organizationId,
-            passwordHistory: cipher.passwordHistory?.map(CipherPasswordHistoryModel.init),
             passport: cipher.passport.map(CipherPassportModel.init),
+            passwordHistory: cipher.passwordHistory?.map(CipherPasswordHistoryModel.init),
             reprompt: CipherRepromptType(type: cipher.reprompt),
             secureNote: cipher.secureNote.map(CipherSecureNoteModel.init),
             sshKey: cipher.sshKey.map(CipherSSHKeyModel.init),

--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
@@ -16,8 +16,14 @@ struct CipherRequestModel: JSONRequestBody {
     ///   attachment data.
     let attachments2: [String: AttachmentRequestModel]?
 
+    /// Bank account data if the cipher is a bank account.
+    let bankAccount: CipherBankAccountModel?
+
     /// Card data if the cipher is a card.
     let card: CipherCardModel?
+
+    /// Driver's license data if the cipher is a driver's license.
+    let driversLicense: CipherDriversLicenseModel?
 
     /// The ID of the user that encrypted the cipher. It should always represent a UserId.
     /// This is used to check that the user who encrypted the cipher is the same making the request.
@@ -61,6 +67,9 @@ struct CipherRequestModel: JSONRequestBody {
     /// The password history for this cipher.
     let passwordHistory: [CipherPasswordHistoryModel]?
 
+    /// Passport data if the cipher is a passport.
+    let passport: CipherPassportModel?
+
     /// Whether the user needs to be re-prompted for their master password prior to autofilling the
     /// cipher's password.
     let reprompt: CipherRepromptType
@@ -90,7 +99,9 @@ extension CipherRequestModel {
                 guard let id = attachment.id else { return }
                 result[id] = AttachmentRequestModel(attachment: attachment)
             },
+            bankAccount: cipher.bankAccount.map(CipherBankAccountModel.init),
             card: cipher.card.map(CipherCardModel.init),
+            driversLicense: cipher.driversLicense.map(CipherDriversLicenseModel.init),
             encryptedFor: encryptedFor,
             favorite: cipher.favorite,
             fields: cipher.fields?.map(CipherFieldModel.init),
@@ -104,6 +115,7 @@ extension CipherRequestModel {
             notes: cipher.notes,
             organizationID: cipher.organizationId,
             passwordHistory: cipher.passwordHistory?.map(CipherPasswordHistoryModel.init),
+            passport: cipher.passport.map(CipherPassportModel.init),
             reprompt: CipherRepromptType(type: cipher.reprompt),
             secureNote: cipher.secureNote.map(CipherSecureNoteModel.init),
             sshKey: cipher.sshKey.map(CipherSSHKeyModel.init),

--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModelTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModelTests.swift
@@ -1,13 +1,14 @@
 import BitwardenSdk
-import XCTest
+import Testing
 
 @testable import BitwardenShared
 
-class CipherRequestModelTests: BitwardenTestCase {
+struct CipherRequestModelTests {
     // MARK: Tests
 
     /// `init(cipher:)` maps the cipher's bank account data into the request model.
-    func test_init_bankAccount() {
+    @Test
+    func init_bankAccount() {
         let cipher = Cipher.fixture(
             bankAccount: .fixture(
                 accountNumber: "123456789",
@@ -26,27 +27,29 @@ class CipherRequestModelTests: BitwardenTestCase {
 
         let subject = CipherRequestModel(cipher: cipher)
 
-        XCTAssertEqual(subject.bankAccount?.accountNumber, "123456789")
-        XCTAssertEqual(subject.bankAccount?.accountType, "checking")
-        XCTAssertEqual(subject.bankAccount?.bankContactPhone, "555-0100")
-        XCTAssertEqual(subject.bankAccount?.bankName, "Bitwarden Bank")
-        XCTAssertEqual(subject.bankAccount?.branchNumber, "001")
-        XCTAssertEqual(subject.bankAccount?.iban, "GB33BUKB20201555555555")
-        XCTAssertEqual(subject.bankAccount?.nameOnAccount, "Test User")
-        XCTAssertEqual(subject.bankAccount?.pin, "4321")
-        XCTAssertEqual(subject.bankAccount?.routingNumber, "021000021")
-        XCTAssertEqual(subject.bankAccount?.swiftCode, "BUKBGB22")
+        #expect(subject.bankAccount?.accountNumber == "123456789")
+        #expect(subject.bankAccount?.accountType == "checking")
+        #expect(subject.bankAccount?.bankContactPhone == "555-0100")
+        #expect(subject.bankAccount?.bankName == "Bitwarden Bank")
+        #expect(subject.bankAccount?.branchNumber == "001")
+        #expect(subject.bankAccount?.iban == "GB33BUKB20201555555555")
+        #expect(subject.bankAccount?.nameOnAccount == "Test User")
+        #expect(subject.bankAccount?.pin == "4321")
+        #expect(subject.bankAccount?.routingNumber == "021000021")
+        #expect(subject.bankAccount?.swiftCode == "BUKBGB22")
     }
 
     /// `init(cipher:)` leaves the bank account data `nil` when the cipher has none.
-    func test_init_bankAccount_nil() {
+    @Test
+    func init_bankAccount_nil() {
         let subject = CipherRequestModel(cipher: .fixture(bankAccount: nil))
 
-        XCTAssertNil(subject.bankAccount)
+        #expect(subject.bankAccount == nil)
     }
 
     /// `init(cipher:)` maps the cipher's driver's license data into the request model.
-    func test_init_driversLicense() {
+    @Test
+    func init_driversLicense() {
         let cipher = Cipher.fixture(
             driversLicense: .fixture(
                 dateOfBirth: "1990-01-01",
@@ -66,28 +69,30 @@ class CipherRequestModelTests: BitwardenTestCase {
 
         let subject = CipherRequestModel(cipher: cipher)
 
-        XCTAssertEqual(subject.driversLicense?.dateOfBirth, "1990-01-01")
-        XCTAssertEqual(subject.driversLicense?.expirationDate, "2030-01-01")
-        XCTAssertEqual(subject.driversLicense?.firstName, "Test")
-        XCTAssertEqual(subject.driversLicense?.issueDate, "2020-01-01")
-        XCTAssertEqual(subject.driversLicense?.issuingAuthority, "DMV")
-        XCTAssertEqual(subject.driversLicense?.issuingCountry, "US")
-        XCTAssertEqual(subject.driversLicense?.issuingState, "CA")
-        XCTAssertEqual(subject.driversLicense?.lastName, "User")
-        XCTAssertEqual(subject.driversLicense?.licenseClass, "C")
-        XCTAssertEqual(subject.driversLicense?.licenseNumber, "D1234567")
-        XCTAssertEqual(subject.driversLicense?.middleName, "Q")
+        #expect(subject.driversLicense?.dateOfBirth == "1990-01-01")
+        #expect(subject.driversLicense?.expirationDate == "2030-01-01")
+        #expect(subject.driversLicense?.firstName == "Test")
+        #expect(subject.driversLicense?.issueDate == "2020-01-01")
+        #expect(subject.driversLicense?.issuingAuthority == "DMV")
+        #expect(subject.driversLicense?.issuingCountry == "US")
+        #expect(subject.driversLicense?.issuingState == "CA")
+        #expect(subject.driversLicense?.lastName == "User")
+        #expect(subject.driversLicense?.licenseClass == "C")
+        #expect(subject.driversLicense?.licenseNumber == "D1234567")
+        #expect(subject.driversLicense?.middleName == "Q")
     }
 
     /// `init(cipher:)` leaves the driver's license data `nil` when the cipher has none.
-    func test_init_driversLicense_nil() {
+    @Test
+    func init_driversLicense_nil() {
         let subject = CipherRequestModel(cipher: .fixture(driversLicense: nil))
 
-        XCTAssertNil(subject.driversLicense)
+        #expect(subject.driversLicense == nil)
     }
 
     /// `init(cipher:)` maps the cipher's passport data into the request model.
-    func test_init_passport() {
+    @Test
+    func init_passport() {
         let cipher = Cipher.fixture(
             passport: .fixture(
                 birthPlace: "Springfield",
@@ -109,25 +114,26 @@ class CipherRequestModelTests: BitwardenTestCase {
 
         let subject = CipherRequestModel(cipher: cipher)
 
-        XCTAssertEqual(subject.passport?.birthPlace, "Springfield")
-        XCTAssertEqual(subject.passport?.dateOfBirth, "1990-01-01")
-        XCTAssertEqual(subject.passport?.expirationDate, "2030-01-01")
-        XCTAssertEqual(subject.passport?.givenName, "Test")
-        XCTAssertEqual(subject.passport?.issueDate, "2020-01-01")
-        XCTAssertEqual(subject.passport?.issuingAuthority, "State Dept")
-        XCTAssertEqual(subject.passport?.issuingCountry, "US")
-        XCTAssertEqual(subject.passport?.nationalIdentificationNumber, "N1234567")
-        XCTAssertEqual(subject.passport?.nationality, "American")
-        XCTAssertEqual(subject.passport?.passportNumber, "P1234567")
-        XCTAssertEqual(subject.passport?.passportType, "P")
-        XCTAssertEqual(subject.passport?.sex, "X")
-        XCTAssertEqual(subject.passport?.surname, "User")
+        #expect(subject.passport?.birthPlace == "Springfield")
+        #expect(subject.passport?.dateOfBirth == "1990-01-01")
+        #expect(subject.passport?.expirationDate == "2030-01-01")
+        #expect(subject.passport?.givenName == "Test")
+        #expect(subject.passport?.issueDate == "2020-01-01")
+        #expect(subject.passport?.issuingAuthority == "State Dept")
+        #expect(subject.passport?.issuingCountry == "US")
+        #expect(subject.passport?.nationalIdentificationNumber == "N1234567")
+        #expect(subject.passport?.nationality == "American")
+        #expect(subject.passport?.passportNumber == "P1234567")
+        #expect(subject.passport?.passportType == "P")
+        #expect(subject.passport?.sex == "X")
+        #expect(subject.passport?.surname == "User")
     }
 
     /// `init(cipher:)` leaves the passport data `nil` when the cipher has none.
-    func test_init_passport_nil() {
+    @Test
+    func init_passport_nil() {
         let subject = CipherRequestModel(cipher: .fixture(passport: nil))
 
-        XCTAssertNil(subject.passport)
+        #expect(subject.passport == nil)
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModelTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModelTests.swift
@@ -1,0 +1,133 @@
+import BitwardenSdk
+import XCTest
+
+@testable import BitwardenShared
+
+class CipherRequestModelTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `init(cipher:)` maps the cipher's bank account data into the request model.
+    func test_init_bankAccount() {
+        let cipher = Cipher.fixture(
+            bankAccount: .fixture(
+                accountNumber: "123456789",
+                accountType: "checking",
+                bankContactPhone: "555-0100",
+                bankName: "Bitwarden Bank",
+                branchNumber: "001",
+                iban: "GB33BUKB20201555555555",
+                nameOnAccount: "Test User",
+                pin: "4321",
+                routingNumber: "021000021",
+                swiftCode: "BUKBGB22",
+            ),
+            type: .bankAccount,
+        )
+
+        let subject = CipherRequestModel(cipher: cipher)
+
+        XCTAssertEqual(subject.bankAccount?.accountNumber, "123456789")
+        XCTAssertEqual(subject.bankAccount?.accountType, "checking")
+        XCTAssertEqual(subject.bankAccount?.bankContactPhone, "555-0100")
+        XCTAssertEqual(subject.bankAccount?.bankName, "Bitwarden Bank")
+        XCTAssertEqual(subject.bankAccount?.branchNumber, "001")
+        XCTAssertEqual(subject.bankAccount?.iban, "GB33BUKB20201555555555")
+        XCTAssertEqual(subject.bankAccount?.nameOnAccount, "Test User")
+        XCTAssertEqual(subject.bankAccount?.pin, "4321")
+        XCTAssertEqual(subject.bankAccount?.routingNumber, "021000021")
+        XCTAssertEqual(subject.bankAccount?.swiftCode, "BUKBGB22")
+    }
+
+    /// `init(cipher:)` leaves the bank account data `nil` when the cipher has none.
+    func test_init_bankAccount_nil() {
+        let subject = CipherRequestModel(cipher: .fixture(bankAccount: nil))
+
+        XCTAssertNil(subject.bankAccount)
+    }
+
+    /// `init(cipher:)` maps the cipher's driver's license data into the request model.
+    func test_init_driversLicense() {
+        let cipher = Cipher.fixture(
+            driversLicense: .fixture(
+                dateOfBirth: "1990-01-01",
+                expirationDate: "2030-01-01",
+                firstName: "Test",
+                issueDate: "2020-01-01",
+                issuingAuthority: "DMV",
+                issuingCountry: "US",
+                issuingState: "CA",
+                lastName: "User",
+                licenseClass: "C",
+                licenseNumber: "D1234567",
+                middleName: "Q",
+            ),
+            type: .driversLicense,
+        )
+
+        let subject = CipherRequestModel(cipher: cipher)
+
+        XCTAssertEqual(subject.driversLicense?.dateOfBirth, "1990-01-01")
+        XCTAssertEqual(subject.driversLicense?.expirationDate, "2030-01-01")
+        XCTAssertEqual(subject.driversLicense?.firstName, "Test")
+        XCTAssertEqual(subject.driversLicense?.issueDate, "2020-01-01")
+        XCTAssertEqual(subject.driversLicense?.issuingAuthority, "DMV")
+        XCTAssertEqual(subject.driversLicense?.issuingCountry, "US")
+        XCTAssertEqual(subject.driversLicense?.issuingState, "CA")
+        XCTAssertEqual(subject.driversLicense?.lastName, "User")
+        XCTAssertEqual(subject.driversLicense?.licenseClass, "C")
+        XCTAssertEqual(subject.driversLicense?.licenseNumber, "D1234567")
+        XCTAssertEqual(subject.driversLicense?.middleName, "Q")
+    }
+
+    /// `init(cipher:)` leaves the driver's license data `nil` when the cipher has none.
+    func test_init_driversLicense_nil() {
+        let subject = CipherRequestModel(cipher: .fixture(driversLicense: nil))
+
+        XCTAssertNil(subject.driversLicense)
+    }
+
+    /// `init(cipher:)` maps the cipher's passport data into the request model.
+    func test_init_passport() {
+        let cipher = Cipher.fixture(
+            passport: .fixture(
+                birthPlace: "Springfield",
+                dateOfBirth: "1990-01-01",
+                expirationDate: "2030-01-01",
+                givenName: "Test",
+                issueDate: "2020-01-01",
+                issuingAuthority: "State Dept",
+                issuingCountry: "US",
+                nationalIdentificationNumber: "N1234567",
+                nationality: "American",
+                passportNumber: "P1234567",
+                passportType: "P",
+                sex: "X",
+                surname: "User",
+            ),
+            type: .passport,
+        )
+
+        let subject = CipherRequestModel(cipher: cipher)
+
+        XCTAssertEqual(subject.passport?.birthPlace, "Springfield")
+        XCTAssertEqual(subject.passport?.dateOfBirth, "1990-01-01")
+        XCTAssertEqual(subject.passport?.expirationDate, "2030-01-01")
+        XCTAssertEqual(subject.passport?.givenName, "Test")
+        XCTAssertEqual(subject.passport?.issueDate, "2020-01-01")
+        XCTAssertEqual(subject.passport?.issuingAuthority, "State Dept")
+        XCTAssertEqual(subject.passport?.issuingCountry, "US")
+        XCTAssertEqual(subject.passport?.nationalIdentificationNumber, "N1234567")
+        XCTAssertEqual(subject.passport?.nationality, "American")
+        XCTAssertEqual(subject.passport?.passportNumber, "P1234567")
+        XCTAssertEqual(subject.passport?.passportType, "P")
+        XCTAssertEqual(subject.passport?.sex, "X")
+        XCTAssertEqual(subject.passport?.surname, "User")
+    }
+
+    /// `init(cipher:)` leaves the passport data `nil` when the cipher has none.
+    func test_init_passport_nil() {
+        let subject = CipherRequestModel(cipher: .fixture(passport: nil))
+
+        XCTAssertNil(subject.passport)
+    }
+}

--- a/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
+++ b/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
@@ -29,10 +29,12 @@ extension Cipher {
     static func fixture(
         archivedDate: Date? = nil,
         attachments: [Attachment]? = nil,
+        bankAccount: BankAccount? = nil,
         card: Card? = nil,
         collectionIds: [String] = [],
         creationDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41),
         deletedDate: Date? = nil,
+        driversLicense: DriversLicense? = nil,
         edit: Bool = true,
         favorite: Bool = false,
         fields: [Field]? = nil,
@@ -46,6 +48,7 @@ extension Cipher {
         notes: String? = nil,
         organizationId: String? = nil,
         organizationUseTotp: Bool = false,
+        passport: Passport? = nil,
         passwordHistory: [PasswordHistory]? = nil,
         permissions: CipherPermissions? = nil,
         reprompt: BitwardenSdk.CipherRepromptType = .none,
@@ -69,9 +72,9 @@ extension Cipher {
             card: card,
             secureNote: secureNote,
             sshKey: sshKey,
-            bankAccount: nil, // TODO: PM-32809
-            driversLicense: nil, // TODO: PM-32807
-            passport: nil, // TODO: PM-32805
+            bankAccount: bankAccount,
+            driversLicense: driversLicense,
+            passport: passport,
             favorite: favorite,
             reprompt: reprompt,
             organizationUseTotp: organizationUseTotp,
@@ -189,6 +192,34 @@ extension CipherListView {
             archivedDate: archivedDate,
             copyableFields: copyableFields,
             localData: localData,
+        )
+    }
+}
+
+extension BankAccount {
+    static func fixture(
+        accountNumber: String? = nil,
+        accountType: String? = nil,
+        bankContactPhone: String? = nil,
+        bankName: String? = nil,
+        branchNumber: String? = nil,
+        iban: String? = nil,
+        nameOnAccount: String? = nil,
+        pin: String? = nil,
+        routingNumber: String? = nil,
+        swiftCode: String? = nil,
+    ) -> BankAccount {
+        BankAccount(
+            bankName: bankName,
+            nameOnAccount: nameOnAccount,
+            accountType: accountType,
+            accountNumber: accountNumber,
+            routingNumber: routingNumber,
+            branchNumber: branchNumber,
+            pin: pin,
+            swiftCode: swiftCode,
+            iban: iban,
+            bankContactPhone: bankContactPhone,
         )
     }
 }
@@ -488,6 +519,36 @@ extension CollectionView {
     }
 }
 
+extension DriversLicense {
+    static func fixture(
+        dateOfBirth: String? = nil,
+        expirationDate: String? = nil,
+        firstName: String? = nil,
+        issueDate: String? = nil,
+        issuingAuthority: String? = nil,
+        issuingCountry: String? = nil,
+        issuingState: String? = nil,
+        lastName: String? = nil,
+        licenseClass: String? = nil,
+        licenseNumber: String? = nil,
+        middleName: String? = nil,
+    ) -> DriversLicense {
+        DriversLicense(
+            firstName: firstName,
+            middleName: middleName,
+            lastName: lastName,
+            dateOfBirth: dateOfBirth,
+            licenseNumber: licenseNumber,
+            issuingCountry: issuingCountry,
+            issuingState: issuingState,
+            issueDate: issueDate,
+            expirationDate: expirationDate,
+            issuingAuthority: issuingAuthority,
+            licenseClass: licenseClass,
+        )
+    }
+}
+
 extension Fido2Credential {
     static func fixture(
         counter: String = "",
@@ -763,6 +824,40 @@ extension BitwardenSdk.SshKeyView {
         fingerprint: String = "fingerprint",
     ) -> SshKeyView {
         SshKeyView(privateKey: privateKey, publicKey: publicKey, fingerprint: fingerprint)
+    }
+}
+
+extension Passport {
+    static func fixture(
+        birthPlace: String? = nil,
+        dateOfBirth: String? = nil,
+        expirationDate: String? = nil,
+        givenName: String? = nil,
+        issueDate: String? = nil,
+        issuingAuthority: String? = nil,
+        issuingCountry: String? = nil,
+        nationalIdentificationNumber: String? = nil,
+        nationality: String? = nil,
+        passportNumber: String? = nil,
+        passportType: String? = nil,
+        sex: String? = nil,
+        surname: String? = nil,
+    ) -> Passport {
+        Passport(
+            surname: surname,
+            givenName: givenName,
+            dateOfBirth: dateOfBirth,
+            sex: sex,
+            birthPlace: birthPlace,
+            nationality: nationality,
+            issuingCountry: issuingCountry,
+            passportNumber: passportNumber,
+            passportType: passportType,
+            nationalIdentificationNumber: nationalIdentificationNumber,
+            issuingAuthority: issuingAuthority,
+            issueDate: issueDate,
+            expirationDate: expirationDate,
+        )
     }
 }
 


### PR DESCRIPTION
## Tracking

N/A - Internal tech-debt post SDK update.

## 📔 Objective

Completes the deferred wiring of the new item types — bank account, driver's license, and passport — into `CipherRequestModel` now that their SDK dependencies are in place. These types were already handled on the read path but were missing from the add/update request body, so their data wasn't persisted to the server. Maps all three (add and update share the same request path) and adds request-body regression tests.
