### PR TITLE
llm: Extend iOS alphabetization rules to properties and parameters

### DIFF
--- a/.claude/skills/implementing-ios-code/SKILL.md
+++ b/.claude/skills/implementing-ios-code/SKILL.md
@@ -27,6 +27,7 @@ Implement from the bottom up:
 
 **Data Models** (if needed)
 - Request/Response types in `Core/<Domain>/Models/Request/` and `Response/`
+  - Alphabetize stored properties and initializer parameters (parameters with default values go last). When you add one to an existing type, insert it at its alphabetical position and update the synthesized initializer and every call site to match — don't append.
 - Enum types in `Core/<Domain>/Models/Enum/`
   - Keep cases alphabetical. When you add a case to an existing enum, insert it at its alphabetical position in **every `switch` over that enum** (across all layers) rather than appending it — match the surrounding order.
 

--- a/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
+++ b/.claude/skills/reviewing-changes/reference/ios-style-patterns.md
@@ -19,9 +19,11 @@ Bitwarden-specific style rules enforced by tooling. Do not flag issues that Swif
 
 Source: [contributing.bitwarden.com — Swift style: Alphabetization](https://contributing.bitwarden.com/contributing/code-style/swift#alphabetization).
 
+- [ ] Members within a `// MARK:` section are alphabetized — stored properties, computed properties, methods, and static members share one alphabetical order within their section.
+- [ ] Function and initializer parameters are alphabetized. These go last instead, in this conventional order: parameters with default values, variadic parameters, then trailing-closure parameters. When adding a parameter to an existing signature, insert it at its alphabetical position and update the synthesized initializer (if any) and every call site to match.
 - [ ] Enum cases are alphabetized — unless the raw type encodes ordering (e.g., `Int` raw values that line up with server error codes or persisted indices). Document the carve-out inline if you take it.
 - [ ] Tests within a test file are alphabetized by function name. Within a group of tests for the same function, error-case tests are commonly placed at the end of the group rather than strictly alphabetized.
-- [ ] Static members and computed properties within a section are alphabetized.
+- [ ] UI objects (views, view modifiers) follow visual layout order rather than alphabetical order — do not flag them.
 
 Protocol conformance ordering is **not** an enforced project rule; don't flag it during review even if a reviewer expresses a personal preference.
 


### PR DESCRIPTION
## 🎟️ Tracking

#2756

## 📔 Objective

Extends the alphabetization conventions in the `reviewing-changes` and `implementing-ios-code` skills, which previously only covered enum cases, tests, and static/computed members. Per the [Swift style guide](https://contributing.bitwarden.com/contributing/code-style/swift#alphabetization), all `// MARK:`-section members and function/initializer parameters are alphabetized (default-value, variadic, and trailing-closure parameters last).

This came out of #2756, where stored properties and an initializer parameter were appended rather than slotted in alphabetically. Documenting the rule so future work follows it.