### PR TITLE
[PM-37886] refactor: Pass keyConnectorKeyWrappedUserKey through LoginUnlockMethod instead of persisting in state

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -267,10 +267,15 @@ protocol AuthRepository: AnyObject {
     /// Attempts to unlock the user's vault with the user's Key Connector key.
     ///
     /// - Parameters:
-    ///   - keyConnectorUrl: The URL to the Key Connector API.
+    ///   - keyConnectorKeyWrappedUserKey: The user key encrypted (wrapped) by the Key Connector key.
+    ///   - keyConnectorURL: The URL to the Key Connector API.
     ///   - orgIdentifier: The text identifier for the organization.
     ///
-    func unlockVaultWithKeyConnectorKey(keyConnectorURL: URL, orgIdentifier: String) async throws
+    func unlockVaultWithKeyConnectorKey(
+        keyConnectorKeyWrappedUserKey: String,
+        keyConnectorURL: URL,
+        orgIdentifier: String,
+    ) async throws
 
     /// Attempts to unlock the user's vault with the stored neverlock key.
     ///
@@ -1098,16 +1103,14 @@ extension DefaultAuthRepository: AuthRepository {
         ))
     }
 
-    func unlockVaultWithKeyConnectorKey(keyConnectorURL: URL, orgIdentifier: String) async throws {
-        let account = try await stateService.getActiveAccount()
-
-        let encryptionKeys = try await stateService.getAccountEncryptionKeys(userId: account.profile.userId)
-
-        guard let encryptedUserKey = encryptionKeys.encryptedUserKey else { throw StateServiceError.noEncUserKey }
-
+    func unlockVaultWithKeyConnectorKey(
+        keyConnectorKeyWrappedUserKey: String,
+        keyConnectorURL: URL,
+        orgIdentifier: String,
+    ) async throws {
         try await unlockVault(method: .keyConnectorUrl(
             url: keyConnectorURL.absoluteString,
-            keyConnectorKeyWrappedUserKey: encryptedUserKey,
+            keyConnectorKeyWrappedUserKey: keyConnectorKeyWrappedUserKey,
         ))
     }
 

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -2616,13 +2616,14 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         stateService.accountEncryptionKeys = [
             "1": AccountEncryptionKeys(
                 cryptographicState: .v1(privateKey: "private"),
-                encryptedUserKey: "user",
+                encryptedUserKey: nil,
             ),
         ]
         stateService.activeAccount = .fixture()
 
         await assertAsyncDoesNotThrow {
             try await subject.unlockVaultWithKeyConnectorKey(
+                keyConnectorKeyWrappedUserKey: "user",
                 keyConnectorURL: URL(string: "https://example.com")!,
                 orgIdentifier: "org-id",
             )
@@ -2644,18 +2645,15 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(stateService.manuallyLockedAccounts["1"], false)
     }
 
-    /// `unlockVaultWithKeyConnectorKey()` throws an error if the user is missing an encrypted user key.
-    func test_unlockVaultWithKeyConnectorKey_missingEncryptedUserKey() async {
+    /// `unlockVaultWithKeyConnectorKey()` throws an error if the account has no cryptographic state
+    /// (e.g. a new user who hasn't been migrated to key connector yet).
+    func test_unlockVaultWithKeyConnectorKey_noAccountCryptographicState() async {
         stateService.activeAccount = .fixture()
-        stateService.accountEncryptionKeys = [
-            "1": AccountEncryptionKeys(
-                cryptographicState: .v1(privateKey: "private"),
-                encryptedUserKey: nil,
-            ),
-        ]
+        stateService.getAccountEncryptionKeysError = StateServiceError.noAccountCryptographicState
 
-        await assertAsyncThrows(error: StateServiceError.noEncUserKey) {
+        await assertAsyncThrows(error: StateServiceError.noAccountCryptographicState) {
             try await subject.unlockVaultWithKeyConnectorKey(
+                keyConnectorKeyWrappedUserKey: "user",
                 keyConnectorURL: URL(string: "https://example.com")!,
                 orgIdentifier: "org-id",
             )
@@ -2666,6 +2664,7 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_unlockVaultWithKeyConnectorKey_noActiveAccount() async {
         await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
             try await subject.unlockVaultWithKeyConnectorKey(
+                keyConnectorKeyWrappedUserKey: "user",
                 keyConnectorURL: URL(string: "https://example.com")!,
                 orgIdentifier: "org-id",
             )

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -94,6 +94,7 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var unlockVaultWithDeviceKeyResult: Result<Void, Error> = .success(())
     var unlockVaultWithKeyConnectorKeyCalled = false
     var unlockVaultWithKeyConnectorKeyConnectorURL: URL? // swiftlint:disable:this identifier_name
+    var unlockVaultWithKeyConnectorKeyWrappedUserKey: String? // swiftlint:disable:this identifier_name
     var unlockVaultWithKeyConnectorOrgIdentifier: String?
     var unlockVaultWithKeyConnectorKeyResult: Result<Void, Error> = .success(())
 
@@ -387,9 +388,14 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
         try unlockVaultWithDeviceKeyResult.get()
     }
 
-    func unlockVaultWithKeyConnectorKey(keyConnectorURL: URL, orgIdentifier: String) async throws {
+    func unlockVaultWithKeyConnectorKey(
+        keyConnectorKeyWrappedUserKey: String,
+        keyConnectorURL: URL,
+        orgIdentifier: String,
+    ) async throws {
         unlockVaultWithKeyConnectorKeyCalled = true
         unlockVaultWithKeyConnectorKeyConnectorURL = keyConnectorURL
+        unlockVaultWithKeyConnectorKeyWrappedUserKey = keyConnectorKeyWrappedUserKey
         unlockVaultWithKeyConnectorOrgIdentifier = orgIdentifier
         try unlockVaultWithKeyConnectorKeyResult.get()
     }

--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -67,7 +67,7 @@ enum LoginUnlockMethod: Equatable {
     case masterPassword(Account)
 
     /// The user uses key connector to unlock the vault.
-    case keyConnector(keyConnectorURL: URL)
+    case keyConnector(keyConnectorKeyWrappedUserKey: String?, keyConnectorURL: URL)
 }
 
 // MARK: - AuthService
@@ -947,7 +947,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         }
 
         if let keyConnectorUrl = keyConnectorUrlForUnlock(response) {
-            return .keyConnector(keyConnectorURL: keyConnectorUrl)
+            return .keyConnector(keyConnectorKeyWrappedUserKey: response.key, keyConnectorURL: keyConnectorUrl)
         }
 
         return try await .masterPassword(stateService.getActiveAccount())

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -630,7 +630,10 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
 
         XCTAssertEqual(
             unlockMethod,
-            .keyConnector(keyConnectorURL: URL(string: "https://vault.bitwarden.com/key-connector")!),
+            .keyConnector(
+                keyConnectorKeyWrappedUserKey: "KEY",
+                keyConnectorURL: URL(string: "https://vault.bitwarden.com/key-connector")!,
+            ),
         )
         assertGetConfig()
     }
@@ -1051,7 +1054,10 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         )
         XCTAssertEqual(
             unlockMethod,
-            .keyConnector(keyConnectorURL: URL(string: "https://vault.bitwarden.com/key-connector")!),
+            .keyConnector(
+                keyConnectorKeyWrappedUserKey: "KEY",
+                keyConnectorURL: URL(string: "https://vault.bitwarden.com/key-connector")!,
+            ),
         )
         assertGetConfig()
     }

--- a/BitwardenShared/Core/Platform/Services/KeyConnectorService.swift
+++ b/BitwardenShared/Core/Platform/Services/KeyConnectorService.swift
@@ -137,7 +137,7 @@ extension DefaultKeyConnectorService: KeyConnectorService {
             try await stateService.setAccountEncryptionKeys(
                 AccountEncryptionKeys(
                     cryptographicState: .v1(privateKey: keyConnectorResponse.keys.private),
-                    encryptedUserKey: keyConnectorResponse.encryptedUserKey,
+                    encryptedUserKey: nil,
                 ),
             )
             return KeyConnectorConversionResult(
@@ -154,7 +154,7 @@ extension DefaultKeyConnectorService: KeyConnectorService {
         try await stateService.setAccountEncryptionKeys(
             AccountEncryptionKeys(
                 cryptographicState: result.accountCryptographicState,
-                encryptedUserKey: result.keyConnectorKeyWrappedUserKey,
+                encryptedUserKey: nil,
             ),
         )
 

--- a/BitwardenShared/Core/Platform/Services/KeyConnectorServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/KeyConnectorServiceTests.swift
@@ -8,8 +8,6 @@ import XCTest
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
-// swiftlint:disable file_length
-
 @MainActor
 class KeyConnectorServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
@@ -102,7 +100,7 @@ class KeyConnectorServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         )
         XCTAssertTrue(client.requests.isEmpty)
         XCTAssertNotNil(stateService.accountEncryptionKeys["1"]?.cryptographicState)
-        XCTAssertEqual(stateService.accountEncryptionKeys["1"]?.encryptedUserKey, "encryptedUserKey")
+        XCTAssertNil(stateService.accountEncryptionKeys["1"]?.encryptedUserKey)
     }
 
     /// `convertNewUserToKeyConnector()` throws if SDK registration fails.
@@ -144,7 +142,7 @@ class KeyConnectorServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
             stateService.accountEncryptionKeys["1"],
             AccountEncryptionKeys(
                 cryptographicState: .v1(privateKey: "private"),
-                encryptedUserKey: "encryptedUserKey",
+                encryptedUserKey: nil,
             ),
         )
     }

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -228,20 +228,21 @@ extension SingleSignOnProcessor: SingleSignOnFlowDelegate {
                         ),
                     )
                     coordinator.navigate(to: .dismiss)
-                case let .keyConnector(keyConnectorUrl):
-                    do {
-                        try await services.authRepository.unlockVaultWithKeyConnectorKey(
-                            keyConnectorURL: keyConnectorUrl,
-                            orgIdentifier: state.identifierText,
-                        )
-                        coordinator.hideLoadingOverlay()
-                        await coordinator.handleEvent(.didCompleteAuth)
-                    } catch StateServiceError.noAccountCryptographicState {
+                case let .keyConnector(keyConnectorKeyWrappedUserKey, keyConnectorUrl):
+                    guard let keyConnectorKeyWrappedUserKey else {
                         coordinator.hideLoadingOverlay()
                         coordinator.showAlert(Alert.keyConnectorConfirmation(keyConnectorUrl: keyConnectorUrl) {
                             await self.migrateUserKeyConnector(keyConnectorUrl: keyConnectorUrl)
                         })
+                        return
                     }
+                    try await services.authRepository.unlockVaultWithKeyConnectorKey(
+                        keyConnectorKeyWrappedUserKey: keyConnectorKeyWrappedUserKey,
+                        keyConnectorURL: keyConnectorUrl,
+                        orgIdentifier: state.identifierText,
+                    )
+                    coordinator.hideLoadingOverlay()
+                    await coordinator.handleEvent(.didCompleteAuth)
                 }
             } catch {
                 await self.handleError(error)

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
@@ -336,6 +336,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
     func test_singleSignOnCompleted_vaultUnlockedKeyConnector() {
         // Set up the mock data.
         authService.loginWithSingleSignOnResult = .success(.keyConnector(
+            keyConnectorKeyWrappedUserKey: "KEY",
             keyConnectorURL: URL(string: "https://example.com")!,
         ))
         coordinator.isLoadingOverlayShowing = true
@@ -347,6 +348,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
 
         // Verify the results.
         XCTAssertTrue(authRepository.unlockVaultWithKeyConnectorKeyCalled)
+        XCTAssertEqual(authRepository.unlockVaultWithKeyConnectorKeyWrappedUserKey, "KEY")
         XCTAssertEqual(authService.loginWithSingleSignOnCode, "super_cool_secret_code")
         XCTAssertEqual(stateService.rememberedOrgIdentifier, "BestOrganization")
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
@@ -354,26 +356,24 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(coordinator.routes, [])
     }
 
-    /// `singleSignOnCompleted(code:)` show confirm key connector dialog
-    /// if user has no private key and uses Key Connector.
+    /// `singleSignOnCompleted(code:)` shows the confirm key connector dialog directly
+    /// when the identity token response has no encrypted user key (new user not yet on key connector).
     @MainActor
-    func test_singleSignOnCompleted_vaultUnlockedKeyConnector_noPrivateKey() async throws {
+    func test_singleSignOnCompleted_vaultUnlockedKeyConnector_noEncryptedUserKey() async throws {
         // Set up the mock data.
         authService.loginWithSingleSignOnResult = .success(.keyConnector(
+            keyConnectorKeyWrappedUserKey: nil,
             keyConnectorURL: URL(string: "https://example.com")!,
         ))
         subject.state.identifierText = "BestOrganization"
-        authRepository.unlockVaultWithKeyConnectorKeyResult = .failure(StateServiceError.noAccountCryptographicState)
         coordinator.isLoadingOverlayShowing = true
 
         // Receive the completed code.
         subject.singleSignOnCompleted(code: "super_cool_secret_code")
-        try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
-        waitFor(!coordinator.alertShown.isEmpty)
-        authRepository.unlockVaultWithKeyConnectorKeyResult = .success(())
+        try await waitForAsync { !self.coordinator.alertShown.isEmpty }
 
-        // Verify the results.
-        XCTAssertTrue(authRepository.unlockVaultWithKeyConnectorKeyCalled)
+        // Verify the results — vault unlock is never attempted for a new user.
+        XCTAssertFalse(authRepository.unlockVaultWithKeyConnectorKeyCalled)
         XCTAssertEqual(authService.loginWithSingleSignOnCode, "super_cool_secret_code")
         XCTAssertEqual(stateService.rememberedOrgIdentifier, "BestOrganization")
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)
@@ -392,27 +392,26 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(coordinator.routes, [.dismiss])
     }
 
-    /// `singleSignOnCompleted(code:)` show confirm key connector dialog
-    /// if user has no private key and uses Key Connector.
+    /// `singleSignOnCompleted(code:)` shows the confirm key connector dialog and surfaces an error
+    /// when migration fails for a new user.
     @MainActor
-    func test_singleSignOnCompleted_vaultUnlockedKeyConnector_noPrivateKey_error() async throws {
+    func test_singleSignOnCompleted_vaultUnlockedKeyConnector_noEncryptedUserKey_error() async throws {
         // Set up the mock data.
         let error = BitwardenTestError.example
         authService.loginWithSingleSignOnResult = .success(.keyConnector(
+            keyConnectorKeyWrappedUserKey: nil,
             keyConnectorURL: URL(string: "https://example.com")!,
         ))
         subject.state.identifierText = "BestOrganization"
-        authRepository.unlockVaultWithKeyConnectorKeyResult = .failure(StateServiceError.noAccountCryptographicState)
+        authRepository.convertNewUserToKeyConnectorKeyResult = .failure(error)
         coordinator.isLoadingOverlayShowing = true
 
         // Receive the completed code.
         subject.singleSignOnCompleted(code: "super_cool_secret_code")
-        try await Task.sleep(nanoseconds: 100_000_000) // 0.1s
-        waitFor(!coordinator.alertShown.isEmpty)
-        authRepository.convertNewUserToKeyConnectorKeyResult = .failure(error)
+        try await waitForAsync { !self.coordinator.alertShown.isEmpty }
 
-        // Verify the results.
-        XCTAssertTrue(authRepository.unlockVaultWithKeyConnectorKeyCalled)
+        // Verify the results — vault unlock is never attempted for a new user.
+        XCTAssertFalse(authRepository.unlockVaultWithKeyConnectorKeyCalled)
         XCTAssertEqual(authService.loginWithSingleSignOnCode, "super_cool_secret_code")
         XCTAssertEqual(stateService.rememberedOrgIdentifier, "BestOrganization")
         XCTAssertFalse(coordinator.isLoadingOverlayShowing)

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -245,11 +245,15 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
                     ),
                 )
                 coordinator.navigate(to: .dismiss)
-            case let .keyConnector(keyConnectorUrl):
+            case let .keyConnector(keyConnectorKeyWrappedUserKey, keyConnectorUrl):
                 guard let orgIdentifier = state.orgIdentifier else {
                     throw TwoFactorAuthError.missingOrgIdentifier
                 }
+                guard let keyConnectorKeyWrappedUserKey else {
+                    throw StateServiceError.noEncUserKey
+                }
                 try await services.authRepository.unlockVaultWithKeyConnectorKey(
+                    keyConnectorKeyWrappedUserKey: keyConnectorKeyWrappedUserKey,
                     keyConnectorURL: keyConnectorUrl,
                     orgIdentifier: orgIdentifier,
                 )

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -454,6 +454,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
     @MainActor
     func test_perform_continueTapped_loginWithKeyConnectorKey_success() async {
         authService.loginWithTwoFactorCodeResult = .success(.keyConnector(
+            keyConnectorKeyWrappedUserKey: "KEY",
             keyConnectorURL: URL(string: "https://example.com")!,
         ))
         subject.state.verificationCode = "Test"
@@ -462,6 +463,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         await subject.perform(.continueTapped)
 
         XCTAssertTrue(authRepository.unlockVaultWithKeyConnectorKeyCalled)
+        XCTAssertEqual(authRepository.unlockVaultWithKeyConnectorKeyWrappedUserKey, "KEY")
         XCTAssertEqual(coordinator.events.last, .didCompleteAuth)
     }
 
@@ -470,6 +472,7 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
     @MainActor
     func test_perform_continueTapped_loginWithKeyConnectorKey_missingOrgIdentifier() async {
         authService.loginWithTwoFactorCodeResult = .success(.keyConnector(
+            keyConnectorKeyWrappedUserKey: "KEY",
             keyConnectorURL: URL(string: "https://example.com")!,
         ))
         subject.state.verificationCode = "Test"
@@ -480,6 +483,23 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertEqual(coordinator.errorAlertsShown.last as? TwoFactorAuthError, .missingOrgIdentifier)
         XCTAssertEqual(coordinator.routes, [])
         XCTAssertEqual(errorReporter.errors as? [TwoFactorAuthError], [.missingOrgIdentifier])
+    }
+
+    /// `perform(_:)` with `.continueTapped` throws `noEncUserKey` when the key connector wrapped
+    /// user key is missing (e.g. new user not yet migrated to key connector).
+    @MainActor
+    func test_perform_continueTapped_loginWithKeyConnectorKey_noEncryptedUserKey() async {
+        authService.loginWithTwoFactorCodeResult = .success(.keyConnector(
+            keyConnectorKeyWrappedUserKey: nil,
+            keyConnectorURL: URL(string: "https://example.com")!,
+        ))
+        subject.state.orgIdentifier = "org-id"
+        subject.state.verificationCode = "Test"
+
+        await subject.perform(.continueTapped)
+
+        XCTAssertFalse(authRepository.unlockVaultWithKeyConnectorKeyCalled)
+        XCTAssertEqual(coordinator.errorAlertsShown.last as? StateServiceError, .noEncUserKey)
     }
 
     /// `perform(_:)` with `.continueTapped` handles a two-factor error correctly.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-37886](https://bitwarden.atlassian.net/browse/PM-37886)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

When a user logs in with key connector, their `keyConnectorKeyWrappedUserKey` is being persisted to the device as `encryptedUserKey`. For key connector, once the user is logged in and the vault is unlocked, this key is no longer used. As such, it doesn't need to be persisted.

Additional context: https://github.com/bitwarden/ios/pull/2677#discussion_r3282105331

This updates the key connector flows to pass the `keyConnectorKeyWrappedUserKey` from the login response through `LoginUnlockMethod.keyConnector`, which can then be used to unlock the vault in `AuthRepository.unlockVaultWithKeyConnectorKey()`.

- `LoginUnlockMethod.keyConnector` now carries `encryptedUserKey: String?` populated from `response.key` in `AuthService.unlockMethod(for:)`, eliminating the need to read it back from state during unlock.
- `AuthRepository.unlockVaultWithKeyConnectorKey` accepts a non-optional `encryptedUserKey: String` parameter directly, removing the redundant `getAccountEncryptionKeys` state read.
- `KeyConnectorService.convertNewUserToKeyConnector` no longer persists `encryptedUserKey` to state (both v1 and v2 paths); the `cryptographicState` (private key) is still persisted as required for future operations.
- `SingleSignOnProcessor` now uses an explicit `guard let encryptedUserKey` to trigger the key connector migration dialog for new users, replacing the implicit `noAccountCryptographicState` error path.

[PM-37886]: https://bitwarden.atlassian.net/browse/PM-37886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ