### PR TITLE
[BRE] Updated codecov action to v7.0.0 to fix issue with key verification

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -215,7 +215,7 @@ jobs:
 
       - name: Upload to codecov.io
         id: upload-to-codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           files: coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -209,7 +209,7 @@ jobs:
 
       - name: Upload to codecov.io
         id: upload-to-codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         continue-on-error: true
         with:
           files: coverage.xml


### PR DESCRIPTION
## 🎟️ Tracking
[https://bitwarden.atlassian.net/browse/BRE-1995](https://bitwarden.atlassian.net/browse/BRE-1995)

## 📔 Objective
the `test-bwa.yml` workflow was throwing an [error](https://github.com/bitwarden/ios/actions/runs/27146541119/job/80129742927) when trying to upload to codecov. The issue seems to be related to disclaimer [here](https://github.com/codecov/codecov-action/releases/tag/v7.0.0):
> ⚠️ Due to migration issues with keybase, we are unable to update our keys under the codecovsecurity account. We have deleted the account and are using codecovsecops with the original gpg key

This PR bumps the codecov action to `v7.0.0` to fix this issue.