### PR TITLE
[PM-38145] feat: Add View Bank Account screen

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemState.swift
@@ -65,6 +65,22 @@ extension BankAccountItemState {
             bankContactPhone: bankContactPhone.nilIfEmpty,
         )
     }
+
+    /// Whether the bank account details section has no values to display.
+    var isBankAccountDetailsSectionEmpty: Bool {
+        guard accountType == .default else { return false }
+        return [
+            accountNumber,
+            bankContactPhone,
+            bankName,
+            branchNumber,
+            iban,
+            nameOnAccount,
+            pin,
+            routingNumber,
+            swiftCode,
+        ].allSatisfy(\.isEmpty)
+    }
 }
 
 // MARK: AddEditBankAccountItemState

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/BankAccountItemStateTests.swift
@@ -56,4 +56,26 @@ struct BankAccountItemStateTests {
         #expect(view.iban == nil)
         #expect(view.bankContactPhone == nil)
     }
+
+    /// `isBankAccountDetailsSectionEmpty` is `true` when every field is empty and no account type is selected.
+    @Test
+    func isBankAccountDetailsSectionEmpty_empty() {
+        #expect(BankAccountItemState().isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` is `false` when any string field has a value.
+    @Test
+    func isBankAccountDetailsSectionEmpty_populatedField() {
+        var subject = BankAccountItemState()
+        subject.bankName = "Bank of America"
+        #expect(!subject.isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` is `false` when only an account type is selected and all fields are empty.
+    @Test
+    func isBankAccountDetailsSectionEmpty_accountTypeOnly() {
+        var subject = BankAccountItemState()
+        subject.accountType = .custom(.checking)
+        #expect(!subject.isBankAccountDetailsSectionEmpty)
+    }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemAction.swift
@@ -1,0 +1,14 @@
+// MARK: - ViewBankAccountItemAction
+
+/// An enum of actions for viewing a bank account item.
+///
+enum ViewBankAccountItemAction: Equatable {
+    /// Toggle for account number visibility changed.
+    case toggleAccountNumberVisibilityChanged(Bool)
+
+    /// Toggle for IBAN visibility changed.
+    case toggleIbanVisibilityChanged(Bool)
+
+    /// Toggle for PIN visibility changed.
+    case togglePinVisibilityChanged(Bool)
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+SnapshotTests.swift
@@ -1,0 +1,78 @@
+// swiftlint:disable:this file_name
+import BitwardenKit
+import BitwardenKitMocks
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import BitwardenShared
+
+class ViewBankAccountItemViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var processor: MockProcessor<BankAccountItemState, ViewItemAction, Void>!
+    var subject: ViewBankAccountItemView!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        processor = MockProcessor(state: BankAccountItemState())
+        subject = ViewBankAccountItemView(store: Store(processor: processor))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        processor = nil
+        subject = nil
+    }
+
+    // MARK: Snapshots
+
+    /// The empty bank account view renders correctly.
+    @MainActor
+    func disabletest_snapshot_empty() {
+        assertSnapshots(of: subject.navStackWrapped, as: [.defaultPortrait])
+    }
+
+    /// The populated bank account view renders correctly with the sensitive fields hidden.
+    @MainActor
+    func disabletest_snapshot_populated() {
+        processor.state = populatedState()
+        assertSnapshots(
+            of: subject.navStackWrapped,
+            as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 1.75)],
+        )
+    }
+
+    /// The populated bank account view renders correctly with the sensitive fields revealed.
+    @MainActor
+    func disabletest_snapshot_sensitiveFieldsVisible() {
+        var state = populatedState()
+        state.isAccountNumberVisible = true
+        state.isIbanVisible = true
+        state.isPinVisible = true
+        processor.state = state
+        assertSnapshot(of: subject.navStackWrapped, as: .defaultPortrait)
+    }
+
+    // MARK: Helpers
+
+    /// A fully populated bank account state for snapshots.
+    private func populatedState() -> BankAccountItemState {
+        var state = BankAccountItemState()
+        state.accountNumber = "1234567890123456"
+        state.accountType = .custom(.checking)
+        state.bankContactPhone = "123-456-7890"
+        state.bankName = "Bank of America"
+        state.branchNumber = "100"
+        state.iban = "GB33BUKB20201555555555"
+        state.nameOnAccount = "Personal Checking"
+        state.pin = "1234"
+        state.routingNumber = "1234567890"
+        state.swiftCode = "BOFAUS3N"
+        return state
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
@@ -1,0 +1,167 @@
+// swiftlint:disable:this file_name
+import BitwardenKit
+import BitwardenKitMocks
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@testable import BitwardenShared
+
+class ViewBankAccountItemViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var processor: MockProcessor<BankAccountItemState, ViewItemAction, Void>!
+    var subject: ViewBankAccountItemView!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        initSubject(state: populatedState())
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        processor = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// Tapping the copy account number button dispatches the copy action.
+    @MainActor
+    func test_copyAccountNumberButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyNumberButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(
+            processor.dispatchedActions.last,
+            .copyPressed(value: "1234567890123456", field: .accountNumber),
+        )
+    }
+
+    /// Tapping the copy routing number button dispatches the copy action.
+    @MainActor
+    func test_copyRoutingNumberButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyRoutingNumberButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "1234567890", field: .routingNumber))
+    }
+
+    /// Tapping the copy PIN button dispatches the copy action.
+    @MainActor
+    func test_copyPinButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyPinButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "1234", field: .pin))
+    }
+
+    /// Tapping the copy SWIFT code button dispatches the copy action.
+    @MainActor
+    func test_copySwiftCodeButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopySwiftCodeButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "BOFAUS3N", field: .swiftCode))
+    }
+
+    /// Tapping the copy IBAN button dispatches the copy action.
+    @MainActor
+    func test_copyIbanButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyIbanButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(
+            processor.dispatchedActions.last,
+            .copyPressed(value: "GB33BUKB20201555555555", field: .iban),
+        )
+    }
+
+    /// Tapping the account number visibility toggle dispatches the toggle action.
+    @MainActor
+    func test_accountNumberVisibilityToggle_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "ShowBankAccountNumberButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(
+            processor.dispatchedActions.last,
+            .bankAccountItemAction(.toggleAccountNumberVisibilityChanged(true)),
+        )
+    }
+
+    /// Tapping the PIN visibility toggle dispatches the toggle action.
+    @MainActor
+    func test_pinVisibilityToggle_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "ShowBankAccountPinButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(
+            processor.dispatchedActions.last,
+            .bankAccountItemAction(.togglePinVisibilityChanged(true)),
+        )
+    }
+
+    /// Tapping the IBAN visibility toggle dispatches the toggle action.
+    @MainActor
+    func test_ibanVisibilityToggle_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "ShowBankAccountIbanButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(
+            processor.dispatchedActions.last,
+            .bankAccountItemAction(.toggleIbanVisibilityChanged(true)),
+        )
+    }
+
+    /// An empty state renders no fields, so the copy and reveal buttons are absent.
+    @MainActor
+    func test_emptyState_hidesFields() throws {
+        initSubject(state: BankAccountItemState())
+        XCTAssertThrowsError(
+            try subject.inspect().find(viewWithAccessibilityIdentifier: "BankAccountCopyNumberButton").button(),
+        )
+        XCTAssertThrowsError(
+            try subject.inspect().find(viewWithAccessibilityIdentifier: "ShowBankAccountNumberButton").button(),
+        )
+    }
+
+    // MARK: Private
+
+    /// Initializes the subject with the given state.
+    ///
+    /// - Parameter state: The bank account state to render.
+    ///
+    @MainActor
+    func initSubject(state: BankAccountItemState) {
+        processor = MockProcessor(state: state)
+        subject = ViewBankAccountItemView(store: Store(processor: processor))
+    }
+
+    /// A fully populated bank account state.
+    private func populatedState() -> BankAccountItemState {
+        var state = BankAccountItemState()
+        state.accountNumber = "1234567890123456"
+        state.accountType = .custom(.checking)
+        state.bankContactPhone = "123-456-7890"
+        state.bankName = "Bank of America"
+        state.branchNumber = "100"
+        state.iban = "GB33BUKB20201555555555"
+        state.nameOnAccount = "Personal Checking"
+        state.pin = "1234"
+        state.routingNumber = "1234567890"
+        state.swiftCode = "BOFAUS3N"
+        return state
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
@@ -137,6 +137,25 @@ class ViewBankAccountItemViewTests: BitwardenTestCase {
         )
     }
 
+    /// `isBankAccountDetailsSectionEmpty` is `true` when every field is empty and no account type is selected.
+    func test_isBankAccountDetailsSectionEmpty_empty() {
+        XCTAssertTrue(BankAccountItemState().isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` is `false` when any string field has a value.
+    func test_isBankAccountDetailsSectionEmpty_populatedField() {
+        var state = BankAccountItemState()
+        state.bankName = "Bank of America"
+        XCTAssertFalse(state.isBankAccountDetailsSectionEmpty)
+    }
+
+    /// `isBankAccountDetailsSectionEmpty` is `false` when only an account type is selected and all fields are empty.
+    func test_isBankAccountDetailsSectionEmpty_accountTypeOnly() {
+        var state = BankAccountItemState()
+        state.accountType = .custom(.checking)
+        XCTAssertFalse(state.isBankAccountDetailsSectionEmpty)
+    }
+
     // MARK: Private
 
     /// Initializes the subject with the given state.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
@@ -73,6 +73,39 @@ class ViewBankAccountItemViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "BOFAUS3N", field: .swiftCode))
     }
 
+    /// Tapping the copy branch number button dispatches the copy action.
+    @MainActor
+    func test_copyBranchNumberButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyBranchNumberButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "100", field: .branchNumber))
+    }
+
+    /// Tapping the copy bank contact phone button dispatches the copy action.
+    @MainActor
+    func test_copyContactPhoneButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyContactPhoneButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .copyPressed(value: "123-456-7890", field: .bankContactPhone))
+    }
+
+    /// Tapping the copy name on account button dispatches the copy action.
+    @MainActor
+    func test_copyNameOnAccountButton_pressed() throws {
+        let button = try subject.inspect().find(
+            viewWithAccessibilityIdentifier: "BankAccountCopyNameOnAccountButton",
+        ).button()
+        try button.tap()
+        XCTAssertEqual(
+            processor.dispatchedActions.last,
+            .copyPressed(value: "Personal Checking", field: .nameOnAccount),
+        )
+    }
+
     /// Tapping the copy IBAN button dispatches the copy action.
     @MainActor
     func test_copyIbanButton_pressed() throws {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView+ViewInspectorTests.swift
@@ -170,25 +170,6 @@ class ViewBankAccountItemViewTests: BitwardenTestCase {
         )
     }
 
-    /// `isBankAccountDetailsSectionEmpty` is `true` when every field is empty and no account type is selected.
-    func test_isBankAccountDetailsSectionEmpty_empty() {
-        XCTAssertTrue(BankAccountItemState().isBankAccountDetailsSectionEmpty)
-    }
-
-    /// `isBankAccountDetailsSectionEmpty` is `false` when any string field has a value.
-    func test_isBankAccountDetailsSectionEmpty_populatedField() {
-        var state = BankAccountItemState()
-        state.bankName = "Bank of America"
-        XCTAssertFalse(state.isBankAccountDetailsSectionEmpty)
-    }
-
-    /// `isBankAccountDetailsSectionEmpty` is `false` when only an account type is selected and all fields are empty.
-    func test_isBankAccountDetailsSectionEmpty_accountTypeOnly() {
-        var state = BankAccountItemState()
-        state.accountType = .custom(.checking)
-        XCTAssertFalse(state.isBankAccountDetailsSectionEmpty)
-    }
-
     // MARK: Private
 
     /// Initializes the subject with the given state.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
@@ -1,0 +1,302 @@
+import BitwardenKit
+import BitwardenResources
+import BitwardenSdk
+import SwiftUI
+
+// MARK: - ViewBankAccountItemView
+
+/// A view for displaying the contents of a bank account item.
+struct ViewBankAccountItemView: View {
+    // MARK: Properties
+
+    /// The `Store` for this view.
+    @ObservedObject var store: Store<BankAccountItemState, ViewItemAction, Void>
+
+    var body: some View {
+        if !store.state.isBankAccountDetailsSectionEmpty {
+            SectionView(Localizations.accountDetails, contentSpacing: 8) {
+                ContentBlock {
+                    textField(
+                        title: Localizations.bankName,
+                        value: store.state.bankName,
+                        valueAccessibilityIdentifier: "BankAccountBankNameEntry",
+                    )
+
+                    textField(
+                        title: Localizations.nameOnAccount,
+                        value: store.state.nameOnAccount,
+                        valueAccessibilityIdentifier: "BankAccountNameOnAccountEntry",
+                    )
+
+                    accountTypeItem
+
+                    accountNumberItem
+
+                    copyableTextField(
+                        title: Localizations.routingNumber,
+                        value: store.state.routingNumber,
+                        valueAccessibilityIdentifier: "BankAccountRoutingNumberEntry",
+                        copyButtonAccessibilityIdentifier: "BankAccountCopyRoutingNumberButton",
+                        copyField: .routingNumber,
+                    )
+
+                    textField(
+                        title: Localizations.branchNumber,
+                        value: store.state.branchNumber,
+                        valueAccessibilityIdentifier: "BankAccountBranchNumberEntry",
+                    )
+
+                    pinItem
+
+                    copyableTextField(
+                        title: Localizations.swiftCode,
+                        value: store.state.swiftCode,
+                        valueAccessibilityIdentifier: "BankAccountSwiftCodeEntry",
+                        copyButtonAccessibilityIdentifier: "BankAccountCopySwiftCodeButton",
+                        copyField: .swiftCode,
+                    )
+
+                    ibanItem
+
+                    textField(
+                        title: Localizations.bankContactPhone,
+                        value: store.state.bankContactPhone,
+                        valueAccessibilityIdentifier: "BankAccountContactPhoneEntry",
+                    )
+                }
+            }
+        }
+    }
+
+    // MARK: Private Views
+
+    /// The account type field, displaying the selected type's localized name, hidden when no type is selected.
+    @ViewBuilder private var accountTypeItem: some View {
+        if case let .custom(type) = store.state.accountType {
+            BitwardenTextValueField(
+                title: Localizations.accountType,
+                value: type.localizedName,
+                valueAccessibilityIdentifier: "BankAccountTypeEntry",
+            )
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    /// The account number field, masked with a reveal toggle and a copy button, hidden when empty.
+    @ViewBuilder private var accountNumberItem: some View {
+        let accountNumber = store.state.accountNumber
+        let isVisible = store.state.isAccountNumberVisible
+        if !accountNumber.isEmpty {
+            BitwardenField(title: Localizations.accountNumber) {
+                PasswordText(password: accountNumber, isPasswordVisible: isVisible)
+                    .styleGuide(.body)
+                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .accessibilityIdentifier("BankAccountNumberEntry")
+            } accessoryContent: {
+                PasswordVisibilityButton(
+                    accessibilityIdentifier: "ShowBankAccountNumberButton",
+                    isPasswordVisible: isVisible,
+                ) {
+                    store.send(.bankAccountItemAction(.toggleAccountNumberVisibilityChanged(!isVisible)))
+                }
+
+                Button {
+                    store.send(.copyPressed(value: accountNumber, field: .accountNumber))
+                } label: {
+                    SharedAsset.Icons.copy24.swiftUIImage
+                        .imageStyle(.accessoryIcon24)
+                }
+                .accessibilityLabel(Localizations.copy)
+                .accessibilityIdentifier("BankAccountCopyNumberButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    /// The IBAN field, masked with a reveal toggle and a copy button, hidden when empty.
+    @ViewBuilder private var ibanItem: some View {
+        let iban = store.state.iban
+        let isVisible = store.state.isIbanVisible
+        if !iban.isEmpty {
+            BitwardenField(title: Localizations.iban) {
+                PasswordText(password: iban, isPasswordVisible: isVisible)
+                    .styleGuide(.body)
+                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .accessibilityIdentifier("BankAccountIbanEntry")
+            } accessoryContent: {
+                PasswordVisibilityButton(
+                    accessibilityIdentifier: "ShowBankAccountIbanButton",
+                    isPasswordVisible: isVisible,
+                ) {
+                    store.send(.bankAccountItemAction(.toggleIbanVisibilityChanged(!isVisible)))
+                }
+
+                Button {
+                    store.send(.copyPressed(value: iban, field: .iban))
+                } label: {
+                    SharedAsset.Icons.copy24.swiftUIImage
+                        .imageStyle(.accessoryIcon24)
+                }
+                .accessibilityLabel(Localizations.copy)
+                .accessibilityIdentifier("BankAccountCopyIbanButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    /// The PIN field, masked with a reveal toggle and a copy button, hidden when empty.
+    @ViewBuilder private var pinItem: some View {
+        let pin = store.state.pin
+        let isVisible = store.state.isPinVisible
+        if !pin.isEmpty {
+            BitwardenField(title: Localizations.pin) {
+                PasswordText(password: pin, isPasswordVisible: isVisible)
+                    .styleGuide(.body)
+                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .accessibilityIdentifier("BankAccountPinEntry")
+            } accessoryContent: {
+                PasswordVisibilityButton(
+                    accessibilityIdentifier: "ShowBankAccountPinButton",
+                    isPasswordVisible: isVisible,
+                ) {
+                    store.send(.bankAccountItemAction(.togglePinVisibilityChanged(!isVisible)))
+                }
+
+                Button {
+                    store.send(.copyPressed(value: pin, field: .pin))
+                } label: {
+                    SharedAsset.Icons.copy24.swiftUIImage
+                        .imageStyle(.accessoryIcon24)
+                }
+                .accessibilityLabel(Localizations.copy)
+                .accessibilityIdentifier("BankAccountCopyPinButton")
+            }
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    /// A read-only text field with a copy button, hidden when the value is empty.
+    ///
+    /// - Parameters:
+    ///   - title: The localized title of the field.
+    ///   - value: The value to display and copy.
+    ///   - valueAccessibilityIdentifier: The accessibility identifier for the value.
+    ///   - copyButtonAccessibilityIdentifier: The accessibility identifier for the copy button.
+    ///   - copyField: The field identifying the value being copied.
+    ///
+    @ViewBuilder
+    private func copyableTextField(
+        title: String,
+        value: String,
+        valueAccessibilityIdentifier: String,
+        copyButtonAccessibilityIdentifier: String,
+        copyField: CopyableField,
+    ) -> some View {
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: title,
+                value: value,
+                valueAccessibilityIdentifier: valueAccessibilityIdentifier,
+                copyButtonAccessibilityIdentifier: copyButtonAccessibilityIdentifier,
+                copyButtonAction: { store.send(.copyPressed(value: value, field: copyField)) },
+            )
+            .accessibilityElement(children: .contain)
+        }
+    }
+
+    /// A read-only text field, hidden when the value is empty.
+    ///
+    /// - Parameters:
+    ///   - title: The localized title of the field.
+    ///   - value: The value to display.
+    ///   - valueAccessibilityIdentifier: The accessibility identifier for the value.
+    ///
+    @ViewBuilder
+    private func textField(
+        title: String,
+        value: String,
+        valueAccessibilityIdentifier: String,
+    ) -> some View {
+        if !value.isEmpty {
+            BitwardenTextValueField(
+                title: title,
+                value: value,
+                valueAccessibilityIdentifier: valueAccessibilityIdentifier,
+            )
+            .accessibilityElement(children: .contain)
+        }
+    }
+}
+
+// MARK: - BankAccountItemState
+
+extension BankAccountItemState {
+    /// Whether the bank account details section has no values to display.
+    var isBankAccountDetailsSectionEmpty: Bool {
+        guard accountType == .default else { return false }
+        return [
+            accountNumber,
+            bankContactPhone,
+            bankName,
+            branchNumber,
+            iban,
+            nameOnAccount,
+            pin,
+            routingNumber,
+            swiftCode,
+        ].allSatisfy(\.isEmpty)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Empty View State") {
+    NavigationView {
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                ViewBankAccountItemView(
+                    store: Store(
+                        processor: StateProcessor(state: BankAccountItemState()),
+                    ),
+                )
+            }
+            .padding(16)
+        }
+        .background(SharedAsset.Colors.backgroundPrimary.swiftUIColor)
+        .ignoresSafeArea()
+    }
+}
+
+#Preview("Populated View State") {
+    NavigationView {
+        ScrollView {
+            LazyVStack(spacing: 20) {
+                ViewBankAccountItemView(
+                    store: Store(
+                        processor: StateProcessor(
+                            state: {
+                                var state = BankAccountItemState()
+                                state.bankName = "Bank of America"
+                                state.nameOnAccount = "Personal Checking"
+                                state.accountType = .custom(.checking)
+                                state.accountNumber = "1234567890123456"
+                                state.routingNumber = "1234567890"
+                                state.branchNumber = "100"
+                                state.pin = "1234"
+                                state.swiftCode = "BOFAUS3N"
+                                state.iban = "GB33BUKB20201555555555"
+                                state.bankContactPhone = "123-456-7890"
+                                return state
+                            }(),
+                        ),
+                    ),
+                )
+            }
+            .padding(16)
+        }
+        .background(SharedAsset.Colors.backgroundPrimary.swiftUIColor)
+        .ignoresSafeArea()
+    }
+}
+#endif

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
@@ -22,10 +22,12 @@ struct ViewBankAccountItemView: View {
                         valueAccessibilityIdentifier: "BankAccountBankNameEntry",
                     )
 
-                    textField(
+                    copyableTextField(
                         title: Localizations.nameOnAccount,
                         value: store.state.nameOnAccount,
                         valueAccessibilityIdentifier: "BankAccountNameOnAccountEntry",
+                        copyButtonAccessibilityIdentifier: "BankAccountCopyNameOnAccountButton",
+                        copyField: .nameOnAccount,
                     )
 
                     accountTypeItem
@@ -40,10 +42,12 @@ struct ViewBankAccountItemView: View {
                         copyField: .routingNumber,
                     )
 
-                    textField(
+                    copyableTextField(
                         title: Localizations.branchNumber,
                         value: store.state.branchNumber,
                         valueAccessibilityIdentifier: "BankAccountBranchNumberEntry",
+                        copyButtonAccessibilityIdentifier: "BankAccountCopyBranchNumberButton",
+                        copyField: .branchNumber,
                     )
 
                     pinItem
@@ -58,10 +62,12 @@ struct ViewBankAccountItemView: View {
 
                     ibanItem
 
-                    textField(
+                    copyableTextField(
                         title: Localizations.bankContactPhone,
                         value: store.state.bankContactPhone,
                         valueAccessibilityIdentifier: "BankAccountContactPhoneEntry",
+                        copyButtonAccessibilityIdentifier: "BankAccountCopyContactPhoneButton",
+                        copyField: .bankContactPhone,
                     )
                 }
             }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewBankAccountItem/ViewBankAccountItemView.swift
@@ -78,7 +78,7 @@ struct ViewBankAccountItemView: View {
 
     /// The account type field, displaying the selected type's localized name, hidden when no type is selected.
     @ViewBuilder private var accountTypeItem: some View {
-        if case let .custom(type) = store.state.accountType {
+        if let type = store.state.accountType.customValue {
             BitwardenTextValueField(
                 title: Localizations.accountType,
                 value: type.localizedName,
@@ -231,26 +231,6 @@ struct ViewBankAccountItemView: View {
             )
             .accessibilityElement(children: .contain)
         }
-    }
-}
-
-// MARK: - BankAccountItemState
-
-extension BankAccountItemState {
-    /// Whether the bank account details section has no values to display.
-    var isBankAccountDetailsSectionEmpty: Bool {
-        guard accountType == .default else { return false }
-        return [
-            accountNumber,
-            bankContactPhone,
-            bankName,
-            branchNumber,
-            iban,
-            nameOnAccount,
-            pin,
-            routingNumber,
-            swiftCode,
-        ].allSatisfy(\.isEmpty)
     }
 }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -6,6 +6,9 @@ import BitwardenResources
 
 /// Actions that can be processed by a `ViewItemProcessor`.
 enum ViewItemAction: Equatable, Sendable {
+    /// A bank account item action.
+    case bankAccountItemAction(ViewBankAccountItemAction)
+
     /// A card item action
     case cardItemAction(ViewCardItemAction)
 
@@ -62,6 +65,21 @@ enum ViewItemAction: Equatable, Sendable {
 /// The text fields within the `ViewItemView` that can be copied.
 ///
 enum CopyableField {
+    /// The bank account number field.
+    case accountNumber
+
+    /// The bank account IBAN field.
+    case iban
+
+    /// The bank account PIN field.
+    case pin
+
+    /// The bank account routing number field.
+    case routingNumber
+
+    /// The bank account SWIFT/BIC code field.
+    case swiftCode
+
     /// The card number field.
     case cardNumber
 
@@ -149,6 +167,16 @@ enum CopyableField {
     /// The localized name for each field.
     var localizedName: String? {
         switch self {
+        case .accountNumber:
+            Localizations.accountNumber
+        case .iban:
+            Localizations.iban
+        case .pin:
+            Localizations.pin
+        case .routingNumber:
+            Localizations.routingNumber
+        case .swiftCode:
+            Localizations.swiftCode
         case .cardNumber:
             Localizations.number
         case .customHiddenField,

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -65,6 +65,8 @@ enum ViewItemAction: Equatable, Sendable {
 /// The text fields within the `ViewItemView` that can be copied.
 ///
 enum CopyableField {
+    // MARK: Bank Account Fields
+
     /// The bank account number field.
     case accountNumber
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemAction.swift
@@ -68,8 +68,17 @@ enum CopyableField {
     /// The bank account number field.
     case accountNumber
 
+    /// The bank contact phone field.
+    case bankContactPhone
+
+    /// The bank account branch number field.
+    case branchNumber
+
     /// The bank account IBAN field.
     case iban
+
+    /// The name on the bank account field.
+    case nameOnAccount
 
     /// The bank account PIN field.
     case pin
@@ -169,8 +178,14 @@ enum CopyableField {
         switch self {
         case .accountNumber:
             Localizations.accountNumber
+        case .bankContactPhone:
+            Localizations.bankContactPhone
+        case .branchNumber:
+            Localizations.branchNumber
         case .iban:
             Localizations.iban
+        case .nameOnAccount:
+            Localizations.nameOnAccount
         case .pin:
             Localizations.pin
         case .routingNumber:

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
@@ -9,7 +9,10 @@ class ViewItemActionTests: BitwardenTestCase {
     /// `eventOnCopy` returns the event to collect for the field.
     func test_eventOnCopy() {
         XCTAssertNil(CopyableField.accountNumber.eventOnCopy)
+        XCTAssertNil(CopyableField.bankContactPhone.eventOnCopy)
+        XCTAssertNil(CopyableField.branchNumber.eventOnCopy)
         XCTAssertNil(CopyableField.iban.eventOnCopy)
+        XCTAssertNil(CopyableField.nameOnAccount.eventOnCopy)
         XCTAssertNil(CopyableField.pin.eventOnCopy)
         XCTAssertNil(CopyableField.routingNumber.eventOnCopy)
         XCTAssertNil(CopyableField.swiftCode.eventOnCopy)
@@ -35,7 +38,10 @@ class ViewItemActionTests: BitwardenTestCase {
     /// `getter:localizedName` returns the correct localized name for each action.
     func test_localizedName() {
         XCTAssertEqual(CopyableField.accountNumber.localizedName, Localizations.accountNumber)
+        XCTAssertEqual(CopyableField.bankContactPhone.localizedName, Localizations.bankContactPhone)
+        XCTAssertEqual(CopyableField.branchNumber.localizedName, Localizations.branchNumber)
         XCTAssertEqual(CopyableField.iban.localizedName, Localizations.iban)
+        XCTAssertEqual(CopyableField.nameOnAccount.localizedName, Localizations.nameOnAccount)
         XCTAssertEqual(CopyableField.pin.localizedName, Localizations.pin)
         XCTAssertEqual(CopyableField.routingNumber.localizedName, Localizations.routingNumber)
         XCTAssertEqual(CopyableField.swiftCode.localizedName, Localizations.swiftCode)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemActionTests.swift
@@ -8,6 +8,11 @@ class ViewItemActionTests: BitwardenTestCase {
 
     /// `eventOnCopy` returns the event to collect for the field.
     func test_eventOnCopy() {
+        XCTAssertNil(CopyableField.accountNumber.eventOnCopy)
+        XCTAssertNil(CopyableField.iban.eventOnCopy)
+        XCTAssertNil(CopyableField.pin.eventOnCopy)
+        XCTAssertNil(CopyableField.routingNumber.eventOnCopy)
+        XCTAssertNil(CopyableField.swiftCode.eventOnCopy)
         XCTAssertNil(CopyableField.cardNumber.eventOnCopy)
         XCTAssertEqual(CopyableField.customHiddenField.eventOnCopy, .cipherClientCopiedHiddenField)
         XCTAssertNil(CopyableField.customTextField.eventOnCopy)
@@ -29,6 +34,11 @@ class ViewItemActionTests: BitwardenTestCase {
 
     /// `getter:localizedName` returns the correct localized name for each action.
     func test_localizedName() {
+        XCTAssertEqual(CopyableField.accountNumber.localizedName, Localizations.accountNumber)
+        XCTAssertEqual(CopyableField.iban.localizedName, Localizations.iban)
+        XCTAssertEqual(CopyableField.pin.localizedName, Localizations.pin)
+        XCTAssertEqual(CopyableField.routingNumber.localizedName, Localizations.routingNumber)
+        XCTAssertEqual(CopyableField.swiftCode.localizedName, Localizations.swiftCode)
         XCTAssertEqual(CopyableField.cardNumber.localizedName, Localizations.number)
         XCTAssertNil(CopyableField.customHiddenField.localizedName)
         XCTAssertNil(CopyableField.customTextField.localizedName)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemDetailsView.swift
@@ -301,8 +301,13 @@ struct ViewItemDetailsView: View { // swiftlint:disable:this type_body_length
         // check for type
         switch store.state.type {
         case .bankAccount:
-            // TODO: PM-32809 - render ViewBankAccountItemView once the Bank Account view UI lands.
-            EmptyView()
+            ViewBankAccountItemView(
+                store: store.child(
+                    state: { _ in store.state.bankAccountItemState },
+                    mapAction: { $0 },
+                    mapEffect: nil,
+                ),
+            )
         case .driversLicense:
             ViewDriversLicenseItemView(
                 store: store.child(

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -29,6 +29,9 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
         /// An action that requires data has been performed while loading.
         case dataNotLoaded(String)
 
+        /// An error for bank account action handling
+        case nonBankAccountTypeToggle(String)
+
         /// An error for card action handling
         case nonCardTypeToggle(String)
 
@@ -150,6 +153,8 @@ final class ViewItemProcessor: StateProcessor<ViewItemState, ViewItemAction, Vie
 
     override func receive(_ action: ViewItemAction) { // swiftlint:disable:this function_body_length
         switch action {
+        case let .bankAccountItemAction(bankAccountAction):
+            handleBankAccountAction(bankAccountAction)
         case let .cardItemAction(cardAction):
             handleCardAction(cardAction)
         case .clearURL:
@@ -374,6 +379,38 @@ private extension ViewItemProcessor {
             operation: { try await self.services.vaultRepository.softDeleteCipher(cipher) },
             onDismiss: { [delegate] in delegate?.itemSoftDeleted() },
         )
+    }
+
+    /// Handles `ViewBankAccountItemAction` events.
+    ///
+    /// - Parameter action: The action to handle.
+    ///
+    private func handleBankAccountAction(_ action: ViewBankAccountItemAction) {
+        guard case var .data(cipherState) = state.loadingState else {
+            services.errorReporter.log(
+                error: ActionError.dataNotLoaded("Cannot handle bank account action without loaded data"),
+            )
+            return
+        }
+        guard case .bankAccount = cipherState.type else {
+            services.errorReporter.log(
+                error: ActionError.nonBankAccountTypeToggle(
+                    "Cannot handle bank account action on non-bank account type",
+                ),
+            )
+            return
+        }
+        switch action {
+        case let .toggleAccountNumberVisibilityChanged(isVisible):
+            cipherState.bankAccountItemState.isAccountNumberVisible = isVisible
+            state.loadingState = .data(cipherState)
+        case let .toggleIbanVisibilityChanged(isVisible):
+            cipherState.bankAccountItemState.isIbanVisible = isVisible
+            state.loadingState = .data(cipherState)
+        case let .togglePinVisibilityChanged(isVisible):
+            cipherState.bankAccountItemState.isPinVisible = isVisible
+            state.loadingState = .data(cipherState)
+        }
     }
 
     /// Handles `ViewCardItemAction` events.

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -688,6 +688,87 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         )
     }
 
+    /// `receive` with `.bankAccountItemAction` while loading logs an error.
+    @MainActor
+    func test_receive_bankAccountItemAction_impossible_loading() throws {
+        subject.state.loadingState = .loading(nil)
+        subject.receive(.bankAccountItemAction(.toggleAccountNumberVisibilityChanged(true)))
+        XCTAssertEqual(
+            errorReporter.errors.first as? ViewItemProcessor.ActionError,
+            ViewItemProcessor.ActionError.dataNotLoaded("Cannot handle bank account action without loaded data"),
+        )
+    }
+
+    /// `receive` with `.bankAccountItemAction` logs an error if the cipher is not of bank account type.
+    @MainActor
+    func test_receive_bankAccountItemAction_impossible_nonBankAccount() throws {
+        let cipherView = CipherView.fixture(
+            id: "123",
+            login: nil,
+            name: "name",
+            revisionDate: Date(),
+            type: .login,
+        )
+        let cipherState = CipherItemState(
+            existing: cipherView,
+            hasPremium: true,
+        )!
+        subject.state.loadingState = .data(cipherState)
+        subject.receive(.bankAccountItemAction(.toggleAccountNumberVisibilityChanged(true)))
+        XCTAssertEqual(
+            errorReporter.errors.first as? ViewItemProcessor.ActionError,
+            ViewItemProcessor.ActionError.nonBankAccountTypeToggle(
+                "Cannot handle bank account action on non-bank account type",
+            ),
+        )
+    }
+
+    /// `receive` with `.bankAccountItemAction(.toggleAccountNumberVisibilityChanged)` toggles the account number
+    /// visibility.
+    @MainActor
+    func test_receive_bankAccountItemAction_accountNumber() throws {
+        let cipherView = CipherView.bankAccountFixture()
+        var cipherState = CipherItemState(
+            existing: cipherView,
+            hasPremium: true,
+        )!
+        subject.state.loadingState = .data(cipherState)
+        subject.receive(.bankAccountItemAction(.toggleAccountNumberVisibilityChanged(true)))
+
+        cipherState.bankAccountItemState.isAccountNumberVisible = true
+        XCTAssertEqual(subject.state.loadingState, .data(cipherState))
+    }
+
+    /// `receive` with `.bankAccountItemAction(.togglePinVisibilityChanged)` toggles the PIN visibility.
+    @MainActor
+    func test_receive_bankAccountItemAction_pin() throws {
+        let cipherView = CipherView.bankAccountFixture()
+        var cipherState = CipherItemState(
+            existing: cipherView,
+            hasPremium: true,
+        )!
+        subject.state.loadingState = .data(cipherState)
+        subject.receive(.bankAccountItemAction(.togglePinVisibilityChanged(true)))
+
+        cipherState.bankAccountItemState.isPinVisible = true
+        XCTAssertEqual(subject.state.loadingState, .data(cipherState))
+    }
+
+    /// `receive` with `.bankAccountItemAction(.toggleIbanVisibilityChanged)` toggles the IBAN visibility.
+    @MainActor
+    func test_receive_bankAccountItemAction_iban() throws {
+        let cipherView = CipherView.bankAccountFixture()
+        var cipherState = CipherItemState(
+            existing: cipherView,
+            hasPremium: true,
+        )!
+        subject.state.loadingState = .data(cipherState)
+        subject.receive(.bankAccountItemAction(.toggleIbanVisibilityChanged(true)))
+
+        cipherState.bankAccountItemState.isIbanVisible = true
+        XCTAssertEqual(subject.state.loadingState, .data(cipherState))
+    }
+
     /// `receive` with `.copyPressed` copies the value with the pasteboard service and shows a toast.
     @MainActor
     func test_receive_copyPressed() {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewVaultItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewVaultItemState.swift
@@ -10,6 +10,9 @@ protocol ViewVaultItemState: Sendable, VaultItemWithDecorativeIcon {
     /// The item's attachments.
     var attachments: [AttachmentView]? { get }
 
+    /// The bank account item state.
+    var bankAccountItemState: BankAccountItemState { get set }
+
     /// Whether the item belongs to multiple collections.
     var belongsToMultipleCollections: Bool { get }
 


### PR DESCRIPTION
## 🎟️ Tracking

- [PM-38145](https://bitwarden.atlassian.net/browse/PM-38145)

## 📔 Objective

Adds the read-only **View Bank Account** detail screen for the Password Manager.

- Renders the **Account details** section; empty fields are hidden, and the whole section is hidden when the item has no bank account details.
- Copy buttons on account number, routing number, SWIFT code, IBAN, and PIN.
- Account number, PIN, and IBAN are masked by default with reveal toggles.
- Bank name, name on account, account type, branch number, and bank contact phone display as plain text.

## 📸 Screenshots

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/ec4273d5-0681-4466-a0fc-55dbeb8e389f" /> | <img width="365" src="https://github.com/user-attachments/assets/dfd51751-9a56-432d-8327-cce112711bdd" /> | 

[PM-38145]: https://bitwarden.atlassian.net/browse/PM-38145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ