### PR TITLE
[PM-38515] feat: Add expand/collapse section headers to Password Manager vault

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -160,6 +160,14 @@ protocol StateService: AnyObject, BillingStateService {
     ///
     func getClearClipboardValue(userId: String?) async throws -> ClearClipboardValue
 
+    /// Gets the IDs of the collapsed vault list sections for the user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the collapsed vault list section IDs. Defaults
+    ///   to the active account if `nil`.
+    /// - Returns: The IDs of the vault list sections that are currently collapsed.
+    ///
+    func getCollapsedVaultListSectionIds(userId: String?) async throws -> [String]
+
     /// Gets the connect to watch value for an account.
     ///
     /// - Parameter userId: The user ID associated with the connect to watch value. Defaults to the active
@@ -566,6 +574,15 @@ protocol StateService: AnyObject, BillingStateService {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws
+
+    /// Sets the IDs of the collapsed vault list sections for the user ID.
+    ///
+    /// - Parameters:
+    ///   - ids: The IDs of the vault list sections that are currently collapsed.
+    ///   - userId: The user ID associated with the collapsed vault list section IDs. Defaults to the
+    ///     active account if `nil`.
+    ///
+    func setCollapsedVaultListSectionIds(_ ids: [String], userId: String?) async throws
 
     /// Sets the connect to watch value for an account.
     ///
@@ -977,6 +994,14 @@ extension StateService {
         try await getClearClipboardValue(userId: nil)
     }
 
+    /// Gets the IDs of the collapsed vault list sections for the active account.
+    ///
+    /// - Returns: The IDs of the vault list sections that are currently collapsed.
+    ///
+    func getCollapsedVaultListSectionIds() async throws -> [String] {
+        try await getCollapsedVaultListSectionIds(userId: nil)
+    }
+
     /// Gets the connect to watch value for the active account.
     ///
     /// - Returns: Whether to connect to the watch app.
@@ -1239,6 +1264,14 @@ extension StateService {
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?) async throws {
         try await setClearClipboardValue(clearClipboardValue, userId: nil)
+    }
+
+    /// Sets the IDs of the collapsed vault list sections for the active account.
+    ///
+    /// - Parameter ids: The IDs of the vault list sections that are currently collapsed.
+    ///
+    func setCollapsedVaultListSectionIds(_ ids: [String]) async throws {
+        try await setCollapsedVaultListSectionIds(ids, userId: nil)
     }
 
     /// Sets the connect to watch value for the active account.
@@ -1670,6 +1703,11 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
         return appSettingsStore.clearClipboardValue(userId: userId)
     }
 
+    func getCollapsedVaultListSectionIds(userId: String?) async throws -> [String] {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.collapsedVaultListSectionIds(userId: userId)
+    }
+
     func getConnectToWatch(userId: String?) async throws -> Bool {
         let userId = try userId ?? getActiveAccountUserId()
         return appSettingsStore.connectToWatch(userId: userId)
@@ -2027,6 +2065,11 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setClearClipboardValue(clearClipboardValue, userId: userId)
+    }
+
+    func setCollapsedVaultListSectionIds(_ ids: [String], userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setCollapsedVaultListSectionIds(ids, userId: userId)
     }
 
     func setConnectToWatch(_ connectToWatch: Bool, userId: String?) async throws {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -681,6 +681,23 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(value, .twoMinutes)
     }
 
+    /// `getCollapsedVaultListSectionIds()` returns the collapsed vault list section IDs for the
+    /// active account.
+    func test_getCollapsedVaultListSectionIds() async throws {
+        await subject.addAccount(.fixture())
+        appSettingsStore.collapsedVaultListSectionIdsByUserId["1"] = ["1", "2"]
+        let value = try await subject.getCollapsedVaultListSectionIds()
+        XCTAssertEqual(value, ["1", "2"])
+    }
+
+    /// `getCollapsedVaultListSectionIds()` returns an empty array if the active account doesn't have
+    /// a value set.
+    func test_getCollapsedVaultListSectionIds_notSet() async throws {
+        await subject.addAccount(.fixture())
+        let value = try await subject.getCollapsedVaultListSectionIds()
+        XCTAssertEqual(value, [])
+    }
+
     /// `getConnectToWatch()` returns the connect to watch value for the active account.
     func test_getConnectToWatch() async throws {
         await subject.addAccount(.fixture())
@@ -1967,6 +1984,15 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.setClearClipboardValue(.thirtySeconds)
         XCTAssertEqual(appSettingsStore.clearClipboardValues["1"], .thirtySeconds)
+    }
+
+    /// `setCollapsedVaultListSectionIds(_:)` sets the collapsed vault list section IDs for the
+    /// active account.
+    func test_setCollapsedVaultListSectionIds() async throws {
+        await subject.addAccount(.fixture())
+
+        try await subject.setCollapsedVaultListSectionIds(["1", "2"])
+        XCTAssertEqual(appSettingsStore.collapsedVaultListSectionIdsByUserId["1"], ["1", "2"])
     }
 
     /// `setConnectToWatch(_:userId:)` sets the connect to watch value for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -137,6 +137,13 @@ protocol AppSettingsStore: AnyObject {
     ///
     func clearClipboardValue(userId: String) -> ClearClipboardValue
 
+    /// Gets the IDs of the collapsed vault list sections for a user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the collapsed vault list section IDs.
+    /// - Returns: The IDs of the vault list sections that are currently collapsed.
+    ///
+    func collapsedVaultListSectionIds(userId: String) -> [String]
+
     /// Gets the connect to watch setting for the user.
     ///
     /// - Parameter userId: The user ID associated with the connect to watch value.
@@ -368,6 +375,14 @@ protocol AppSettingsStore: AnyObject {
     /// - Returns: The time after which the clipboard should be cleared.
     ///
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String)
+
+    /// Sets the IDs of the collapsed vault list sections for a user ID.
+    ///
+    /// - Parameters:
+    ///   - ids: The IDs of the vault list sections that are currently collapsed.
+    ///   - userId: The user ID associated with the collapsed vault list section IDs.
+    ///
+    func setCollapsedVaultListSectionIds(_ ids: [String], userId: String)
 
     /// Sets the connect to watch setting for the user.
     ///
@@ -769,6 +784,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case archiveOnboardingShown
         case biometricAuthEnabled(userId: String)
         case clearClipboardValue(userId: String)
+        case collapsedVaultListSectionIds(userId: String)
         case connectToWatch(userId: String)
         case debugFeatureFlag(name: String)
         case defaultUriMatch(userId: String)
@@ -846,6 +862,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "biometricUnlock_\(userId)"
             case let .clearClipboardValue(userId):
                 "clearClipboard_\(userId)"
+            case let .collapsedVaultListSectionIds(userId):
+                "collapsedVaultListSectionIds_\(userId)"
             case let .connectToWatch(userId):
                 "shouldConnectToWatch_\(userId)"
             case let .debugFeatureFlag(name):
@@ -1079,6 +1097,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         return .never
     }
 
+    func collapsedVaultListSectionIds(userId: String) -> [String] {
+        fetch(for: .collapsedVaultListSectionIds(userId: userId)) ?? []
+    }
+
     func connectToWatch(userId: String) -> Bool {
         fetch(for: .connectToWatch(userId: userId))
     }
@@ -1211,6 +1233,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String) {
         store(clearClipboardValue?.rawValue, for: .clearClipboardValue(userId: userId))
+    }
+
+    func setCollapsedVaultListSectionIds(_ ids: [String], userId: String) {
+        store(ids, for: .collapsedVaultListSectionIds(userId: userId))
     }
 
     func setConnectToWatch(_ connectToWatch: Bool, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -327,6 +327,30 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(userDefaults.integer(forKey: "bwPreferencesStorage:clearClipboard_2"), -1)
     }
 
+    /// `collapsedVaultListSectionIds(userId:)` returns an empty array if there isn't a previously
+    /// stored value.
+    func test_collapsedVaultListSectionIds_isInitiallyEmpty() {
+        XCTAssertEqual(subject.collapsedVaultListSectionIds(userId: "0"), [])
+    }
+
+    /// `collapsedVaultListSectionIds(userId:)` can be used to get the collapsed vault list section
+    /// IDs for a user.
+    func test_collapsedVaultListSectionIds_withValue() {
+        subject.setCollapsedVaultListSectionIds(["1", "2"], userId: "1")
+        subject.setCollapsedVaultListSectionIds(["3"], userId: "2")
+
+        XCTAssertEqual(subject.collapsedVaultListSectionIds(userId: "1"), ["1", "2"])
+        XCTAssertEqual(subject.collapsedVaultListSectionIds(userId: "2"), ["3"])
+        XCTAssertEqual(
+            userDefaults.string(forKey: "bwPreferencesStorage:collapsedVaultListSectionIds_1"),
+            #"["1","2"]"#,
+        )
+        XCTAssertEqual(
+            userDefaults.string(forKey: "bwPreferencesStorage:collapsedVaultListSectionIds_2"),
+            #"["3"]"#,
+        )
+    }
+
     /// `connectToWatch(userId:)` returns false if there isn't a previously stored value.
     func test_connectToWatch_isInitiallyFalse() {
         XCTAssertFalse(subject.connectToWatch(userId: "0"))

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -40,6 +40,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     var biometricAuthenticationEnabled = [String: Bool?]()
     var clearClipboardValues = [String: ClearClipboardValue]()
+    var collapsedVaultListSectionIdsByUserId = [String: [String]]()
     var connectToWatchByUserId = [String: Bool]()
     var defaultUriMatchTypeByUserId = [String: BitwardenShared.UriMatchType]()
     var disableAutoTotpCopyByUserId = [String: Bool]()
@@ -114,6 +115,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func clearClipboardValue(userId: String) -> ClearClipboardValue {
         clearClipboardValues[userId] ?? .never
+    }
+
+    func collapsedVaultListSectionIds(userId: String) -> [String] {
+        collapsedVaultListSectionIdsByUserId[userId] ?? []
     }
 
     func connectToWatch(userId: String) -> Bool {
@@ -255,6 +260,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setClearClipboardValue(_ clearClipboardValue: ClearClipboardValue?, userId: String) {
         clearClipboardValues[userId] = clearClipboardValue
+    }
+
+    func setCollapsedVaultListSectionIds(_ ids: [String], userId: String) {
+        collapsedVaultListSectionIdsByUserId[userId] = ids
     }
 
     func setConnectToWatch(_ connectToWatch: Bool, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -36,6 +36,7 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     var capturedUserId: String?
     var clearClipboardValues = [String: ClearClipboardValue]()
     var clearClipboardResult: Result<Void, Error> = .success(())
+    var collapsedVaultListSectionIds = [String: [String]]()
     var connectToWatchByUserId = [String: Bool]()
     var connectToWatchResult: Result<Void, Error> = .success(())
     var connectToWatchSubject = CurrentValueSubject<(String?, Bool), Never>((nil, false))
@@ -261,6 +262,11 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
         try clearClipboardResult.get()
         let userId = try unwrapUserId(userId)
         return clearClipboardValues[userId] ?? .never
+    }
+
+    func getCollapsedVaultListSectionIds(userId: String?) async throws -> [String] {
+        let userId = try unwrapUserId(userId)
+        return collapsedVaultListSectionIds[userId] ?? []
     }
 
     func getConnectToWatch(userId: String?) async throws -> Bool {
@@ -595,6 +601,11 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
         try clearClipboardResult.get()
         let userId = try unwrapUserId(userId)
         clearClipboardValues[userId] = clearClipboardValue
+    }
+
+    func setCollapsedVaultListSectionIds(_ ids: [String], userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        collapsedVaultListSectionIds[userId] = ids
     }
 
     func setConnectToWatch(_ connectToWatch: Bool, userId: String?) async throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
@@ -48,6 +48,14 @@ enum VaultListAction: Equatable {
     /// The selected vault filter for search changed.
     case searchVaultFilterChanged(VaultFilterType)
 
+    /// A vault list section header was tapped to expand or collapse the section.
+    ///
+    /// - Parameters:
+    ///   - sectionId: The ID of the section that was expanded or collapsed.
+    ///   - isExpanded: Whether the section is now expanded.
+    ///
+    case sectionExpandToggled(sectionId: String, isExpanded: Bool)
+
     /// The user tapped the get started button on the import logins action card.
     case showImportLogins
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -178,6 +178,8 @@ final class VaultListProcessor: StateProcessor<
             state.searchText = newValue
         case let .searchVaultFilterChanged(newValue):
             state.searchVaultFilterType = newValue
+        case let .sectionExpandToggled(sectionId, isExpanded):
+            setSectionExpanded(sectionId: sectionId, isExpanded: isExpanded)
         case .showImportLogins:
             coordinator.navigate(to: .importLogins)
         case let .toastShown(newValue):
@@ -238,7 +240,8 @@ extension VaultListProcessor {
 
         state.shouldShowArchiveOnboardingActionCard = await services.stateService.shouldDoArchiveOnboarding()
 
-        state.shouldShowUpgradedToPremiumActionCard = await services.billingService.shouldShowUpgradedToPremiumActionCard()
+        state.shouldShowUpgradedToPremiumActionCard = await services.billingService
+            .shouldShowUpgradedToPremiumActionCard()
 
         let isBannerDismissed = await services.stateService.isPremiumUpgradeBannerDismissed()
         guard !isBannerDismissed else {
@@ -656,9 +659,36 @@ extension VaultListProcessor {
         }
     }
 
+    /// Persists the expanded / collapsed state of a vault list section.
+    ///
+    /// The in-memory state is updated synchronously so the header animates immediately, then the
+    /// collapsed section IDs are persisted to disk so the preference survives app launches.
+    ///
+    /// - Parameters:
+    ///   - sectionId: The ID of the section that was expanded or collapsed.
+    ///   - isExpanded: Whether the section is now expanded.
+    ///
+    private func setSectionExpanded(sectionId: String, isExpanded: Bool) {
+        if isExpanded {
+            state.collapsedSectionIds.remove(sectionId)
+        } else {
+            state.collapsedSectionIds.insert(sectionId)
+        }
+        let collapsedSectionIds = Array(state.collapsedSectionIds)
+        Task {
+            do {
+                try await services.stateService.setCollapsedVaultListSectionIds(collapsedSectionIds)
+            } catch {
+                services.errorReporter.log(error: error)
+            }
+        }
+    }
+
     /// Streams the user's vault list.
     private func streamVaultList() async {
         do {
+            let collapsedSectionIds = await (try? services.stateService.getCollapsedVaultListSectionIds()) ?? []
+            state.collapsedSectionIds = Set(collapsedSectionIds)
             for try await vaultList in try await services.vaultRepository
                 .vaultListPublisher(
                     filter: VaultListFilter(

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -1304,6 +1304,32 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(errorReporter.errors.last as? BitwardenTestError, .example)
     }
 
+    /// `perform(_:)` with `.streamVaultList` loads the persisted collapsed section IDs into the
+    /// state.
+    @MainActor
+    func test_perform_streamVaultList_loadsCollapsedSectionIds() throws {
+        stateService.activeAccount = .fixture()
+        stateService.collapsedVaultListSectionIds["1"] = ["1", "2"]
+        vaultRepository.vaultListSubject.send(VaultListData(
+            sections: [
+                VaultListSection(
+                    id: "1",
+                    items: [VaultListItem.fixture()],
+                    name: "Name",
+                ),
+            ],
+        ))
+
+        let task = Task {
+            await subject.perform(.streamVaultList)
+        }
+
+        waitFor(!subject.state.collapsedSectionIds.isEmpty)
+        task.cancel()
+
+        XCTAssertEqual(subject.state.collapsedSectionIds, ["1", "2"])
+    }
+
     /// `perform(_:)` with `.streamVaultList` updates the state's vault list whenever it changes.
     @MainActor
     func test_perform_streamVaultList_needsSync_emptyData() throws {
@@ -2198,6 +2224,33 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
                 searchVaultFilterType: .organization(organization),
             ),
         )
+    }
+
+    /// `receive(_:)` with `.sectionExpandToggled` collapsing a section adds its ID to the state's
+    /// collapsed section IDs and persists the updated set.
+    @MainActor
+    func test_receive_sectionExpandToggled_collapse() {
+        stateService.activeAccount = .fixture()
+
+        subject.receive(.sectionExpandToggled(sectionId: "1", isExpanded: false))
+
+        XCTAssertEqual(subject.state.collapsedSectionIds, ["1"])
+        waitFor(stateService.collapsedVaultListSectionIds["1"] != nil)
+        XCTAssertEqual(stateService.collapsedVaultListSectionIds["1"], ["1"])
+    }
+
+    /// `receive(_:)` with `.sectionExpandToggled` expanding a section removes its ID from the
+    /// state's collapsed section IDs and persists the updated set.
+    @MainActor
+    func test_receive_sectionExpandToggled_expand() {
+        stateService.activeAccount = .fixture()
+        subject.state.collapsedSectionIds = ["1", "2"]
+
+        subject.receive(.sectionExpandToggled(sectionId: "1", isExpanded: true))
+
+        XCTAssertEqual(subject.state.collapsedSectionIds, ["2"])
+        waitFor(stateService.collapsedVaultListSectionIds["1"] != nil)
+        XCTAssertEqual(stateService.collapsedVaultListSectionIds["1"], ["2"])
     }
 
     /// `receive(_:)` with `showImportLogins(:)` has the coordinator navigate to the import logins

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
@@ -12,6 +12,10 @@ struct VaultListState: Equatable {
     /// Whether the vault filter can be shown.
     var canShowVaultFilter = true
 
+    /// The IDs of the vault list sections that are currently collapsed. Sections whose ID is not in
+    /// this set are expanded.
+    var collapsedSectionIds: Set<String> = []
+
     /// The state for the flight recorder toast banner displayed in the item list.
     var flightRecorderToastBanner = FlightRecorderToastBannerState()
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -302,8 +302,14 @@ private struct SearchableVaultListView: View { // swiftlint:disable:this type_bo
 
             vaultFilterRow
 
-            ForEach(sections) { section in
-                VaultListSectionView(section: section) { item in
+            ForEach(sections.filter { !$0.items.isEmpty }) { section in
+                VaultListSectionView(
+                    section: section,
+                    isExpanded: store.binding(
+                        get: { !$0.collapsedSectionIds.contains(section.id) },
+                        send: { .sectionExpandToggled(sectionId: section.id, isExpanded: $0) },
+                    ),
+                ) { item in
                     Button {
                         store.send(.itemPressed(item: item))
                     } label: {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -302,7 +302,7 @@ private struct SearchableVaultListView: View { // swiftlint:disable:this type_bo
 
             vaultFilterRow
 
-            ForEach(sections.filter { !$0.items.isEmpty }) { section in
+            ForEach(sections) { section in
                 VaultListSectionView(
                     section: section,
                     isExpanded: store.binding(

--- a/BitwardenShared/UI/Vault/Views/VaultListSectionView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListSectionView+SnapshotTests.swift
@@ -1,0 +1,44 @@
+// swiftlint:disable:this file_name
+import BitwardenResources
+import SnapshotTesting
+import SwiftUI
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+class VaultListSectionViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let section = VaultListSection(
+        id: "1",
+        items: [VaultListItem.fixture()],
+        name: "Name",
+    )
+
+    // MARK: Snapshots
+
+    /// The expandable section renders correctly when expanded.
+    @MainActor
+    func disabletest_snapshot_expanded() {
+        let subject = VaultListSectionView(section: section, isExpanded: .constant(true)) { item in
+            Text(item.id)
+        }
+        assertSnapshots(
+            of: subject,
+            as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 2)],
+        )
+    }
+
+    /// The expandable section renders correctly when collapsed.
+    @MainActor
+    func disabletest_snapshot_collapsed() {
+        let subject = VaultListSectionView(section: section, isExpanded: .constant(false)) { item in
+            Text(item.id)
+        }
+        assertSnapshots(
+            of: subject,
+            as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 2)],
+        )
+    }
+}

--- a/BitwardenShared/UI/Vault/Views/VaultListSectionView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListSectionView+ViewInspectorTests.swift
@@ -1,0 +1,71 @@
+// swiftlint:disable:this file_name
+import BitwardenKit
+import BitwardenResources
+import SwiftUI
+import ViewInspector
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+class VaultListSectionViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    let section = VaultListSection(
+        id: "1",
+        items: [VaultListItem.fixture()],
+        name: "Name",
+    )
+
+    // MARK: Tests
+
+    /// When an `isExpanded` binding is provided, the section renders a collapsible header with the
+    /// section-scoped accessibility identifier.
+    @MainActor
+    func test_isExpanded_rendersExpandableHeader() throws {
+        let subject = VaultListSectionView(section: section, isExpanded: .constant(true)) { item in
+            Text(item.id)
+        }
+
+        XCTAssertNoThrow(
+            try subject.inspect().find(viewWithAccessibilityIdentifier: "SectionExpandButton_1"),
+        )
+    }
+
+    /// When no `isExpanded` binding is provided, the section renders a static header without the
+    /// collapsible expand button.
+    @MainActor
+    func test_isExpanded_nil_rendersStaticHeader() throws {
+        let subject = VaultListSectionView(section: section) { item in
+            Text(item.id)
+        }
+
+        XCTAssertThrowsError(
+            try subject.inspect().find(viewWithAccessibilityIdentifier: "SectionExpandButton_1"),
+        )
+    }
+
+    /// When the `isExpanded` binding is `true`, the section's items are rendered.
+    @MainActor
+    func test_isExpanded_true_showsItems() throws {
+        let item = VaultListItem.fixture()
+        let section = VaultListSection(id: "1", items: [item], name: "Name")
+        let subject = VaultListSectionView(section: section, isExpanded: .constant(true)) { item in
+            Text(item.id)
+        }
+
+        XCTAssertNoThrow(try subject.inspect().find(text: item.id))
+    }
+
+    /// When the `isExpanded` binding is `false`, the section's items are hidden.
+    @MainActor
+    func test_isExpanded_false_hidesItems() throws {
+        let item = VaultListItem.fixture()
+        let section = VaultListSection(id: "1", items: [item], name: "Name")
+        let subject = VaultListSectionView(section: section, isExpanded: .constant(false)) { item in
+            Text(item.id)
+        }
+
+        XCTAssertThrowsError(try subject.inspect().find(text: item.id))
+    }
+}

--- a/BitwardenShared/UI/Vault/Views/VaultListSectionView.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListSectionView.swift
@@ -7,6 +7,11 @@ import SwiftUI
 struct VaultListSectionView<Content: View>: View {
     // MARK: Properties
 
+    /// An optional binding driving the section's expanded / collapsed state. When provided, the
+    /// section renders a collapsible `ExpandableHeaderView` whose state is driven by this binding;
+    /// when `nil`, the section renders a static, non-collapsible header.
+    let isExpanded: Binding<Bool>?
+
     /// The section to display.
     let section: VaultListSection
 
@@ -19,22 +24,40 @@ struct VaultListSectionView<Content: View>: View {
     // MARK: View
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 7) {
-            if showCount {
-                SectionHeaderView("\(section.name) (\(section.items.count))")
-                    .accessibilityLabel("\(section.name), \(Localizations.xItems(section.items.count))")
-            } else {
-                SectionHeaderView(section.name)
+        if let isExpanded {
+            ExpandableHeaderView(
+                title: section.name,
+                count: section.items.count,
+                buttonAccessibilityIdentifier: "SectionExpandButton_\(section.id)",
+                isExpanded: isExpanded,
+            ) {
+                itemsContent
             }
-
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(section.items) { item in
-                    itemContent(item)
+        } else {
+            VStack(alignment: .leading, spacing: 7) {
+                if showCount {
+                    SectionHeaderView("\(section.name) (\(section.items.count))")
+                        .accessibilityLabel("\(section.name), \(Localizations.xItems(section.items.count))")
+                } else {
+                    SectionHeaderView(section.name)
                 }
+
+                itemsContent
             }
-            .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
         }
+    }
+
+    // MARK: Private views
+
+    /// The list of item rows displayed within the section.
+    private var itemsContent: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            ForEach(section.items) { item in
+                itemContent(item)
+            }
+        }
+        .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 
     // MARK: Initializers
@@ -43,10 +66,18 @@ struct VaultListSectionView<Content: View>: View {
     /// - Parameters:
     ///   - section: The section with the values.
     ///   - showCount: Whether the items count should be shown.
+    ///   - isExpanded: An optional binding driving the section's expanded state. When provided, the
+    ///     section renders a collapsible `ExpandableHeaderView`; when `nil`, a static header is used.
     ///   - itemContent: The content for each item.
-    init(section: VaultListSection, showCount: Bool = true, itemContent: @escaping (VaultListItem) -> Content) {
+    init(
+        section: VaultListSection,
+        showCount: Bool = true,
+        isExpanded: Binding<Bool>? = nil,
+        itemContent: @escaping (VaultListItem) -> Content,
+    ) {
         self.section = section
         self.showCount = showCount
+        self.isExpanded = isExpanded
         self.itemContent = itemContent
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38515

## 📔 Objective

Password Manager vault list sections can now be expanded and collapsed by tapping their headers. Each section's collapsed state is persisted per account and restored across app launches.

## 📸 Screenshots

### Expanded

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/77ca7588-56a9-4436-b2e2-077e8675dcd8" /> | <img width="365" src="https://github.com/user-attachments/assets/883648f4-1c58-4658-a237-093cbe6dd5b0" /> | 

### Collapsed

| Figma | Actual |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/5c874f4c-7ad3-4254-bfff-000a9fdfd491" /> | <img width="365" src="https://github.com/user-attachments/assets/06ce0c39-179a-4a03-b16c-ce0ccb38d3c7" /> | 