### PR TITLE
[PM-38790] Fixes TestHarness target dependency

### DIFF
--- a/project-bwth.yml
+++ b/project-bwth.yml
@@ -76,6 +76,7 @@ targets:
       - target: TestHarnessShared
       - target: BitwardenKit/BitwardenKit
       - target: BitwardenKit/BitwardenResources
+      - target: BitwardenKit/Networking
     postCompileScripts:
       - script: |
           if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38790](https://bitwarden.atlassian.net/browse/PM-38790)

## 📔 Objective

Fixes TestHarness target dependency to include Networking as it was throwing a SIGABRT on devices.


[PM-38790]: https://bitwarden.atlassian.net/browse/PM-38790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ