### PR TITLE
[PM-38808] Support optional encrypted Cipher.name

### DIFF
--- a/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
+++ b/BitwardenShared/Core/Vault/Extensions/BitwardenSdk+Vault.swift
@@ -132,7 +132,7 @@ extension CipherDetailsResponseModel {
             identity: cipher.identity.map(CipherIdentityModel.init),
             key: cipher.key,
             login: cipher.login.map(CipherLoginModel.init),
-            name: cipher.name,
+            name: cipher.name ?? "",
             notes: cipher.notes,
             organizationId: cipher.organizationId,
             organizationUseTotp: cipher.organizationUseTotp,

--- a/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
+++ b/BitwardenShared/Core/Vault/Models/Request/CipherRequestModel.swift
@@ -111,7 +111,7 @@ extension CipherRequestModel {
             lastKnownRevisionDate: cipher.revisionDate,
             login: cipher.login.map(CipherLoginModel.init),
             key: cipher.key,
-            name: cipher.name,
+            name: cipher.name ?? "",
             notes: cipher.notes,
             organizationID: cipher.organizationId,
             passport: cipher.passport.map(CipherPassportModel.init),


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38808

## 📔 Objective

The SDK is making the encrypted `Cipher.name` field optional (`String` → `String?`) as part of the blob encryption migration ([sdk-internal#1122](https://github.com/bitwarden/sdk-internal/pull/1122)) — blob-encrypted ciphers carry the name inside the sealed `data` blob rather than as a top-level field.

The SDK → network conversions `CipherRequestModel.init(cipher:)` and `CipherDetailsResponseModel.init(cipher:)` assign into non-optional `name` fields, so the now-nullable `name` no longer compiles. These fall back to an empty string when the name is absent.

The decrypted `CipherView` / `CipherListView` `name` fields are unchanged, so all UI is unaffected.

> ⚠️ `?? ""` emits a non-optional-operand warning until the bumped SDK lands — this PR is intended to merge alongside the SDK version bump.
