### PR TITLE
[PM-38861] chore: Disable save password credential iOS 26 API on the extension

### DIFF
--- a/BitwardenAutoFillExtension/Application/Support/Info.plist
+++ b/BitwardenAutoFillExtension/Application/Support/Info.plist
@@ -119,8 +119,6 @@
 				</array>
 				<key>SupportsCredentialExchange</key>
 				<true/>
-				<key>SupportsSavePasswordCredentials</key>
-				<true/>
 			</dict>
 			<key>ASCredentialProviderExtensionShowsConfigurationUI</key>
 			<true/>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38861](https://bitwarden.atlassian.net/browse/PM-38861)

## 📔 Objective

Disables iOS 26 save password credential form the extension given #2762 can't be merged yet.


[PM-38861]: https://bitwarden.atlassian.net/browse/PM-38861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ