### PR TITLE
[PM-31718] fix: Guard against double-invoked ASCredentialIdentityStore completion handlers in AutoFill

### DIFF
--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -340,7 +340,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         authAPIService: AuthAPIService,
         clientService: ClientService,
         configService: ConfigService,
-        credentialIdentityStore: CredentialIdentityStore = ASCredentialIdentityStore.shared,
+        credentialIdentityStore: CredentialIdentityStore = SafeCredentialIdentityStore(),
         environmentService: EnvironmentService,
         errorReporter: ErrorReporter,
         keychainRepository: KeychainRepository,

--- a/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
+++ b/BitwardenShared/Core/Autofill/Services/AutofillCredentialService.swift
@@ -195,7 +195,7 @@ class DefaultAutofillCredentialService {
         fido2CredentialStore: Fido2CredentialStore,
         fido2UserInterfaceHelper: Fido2UserInterfaceHelper,
         flightRecorder: FlightRecorder,
-        identityStore: CredentialIdentityStore = ASCredentialIdentityStore.shared,
+        identityStore: CredentialIdentityStore = SafeCredentialIdentityStore(),
         notificationCenterService: NotificationCenterService,
         pasteboardService: PasteboardService,
         stateService: StateService,
@@ -813,7 +813,3 @@ extension CredentialIdentityStore {
         await state().isEnabled
     }
 }
-
-// MARK: - ASCredentialIdentityStore+CredentialIdentityStore
-
-extension ASCredentialIdentityStore: CredentialIdentityStore {}

--- a/BitwardenShared/Core/Autofill/Services/SafeCredentialIdentityStore.swift
+++ b/BitwardenShared/Core/Autofill/Services/SafeCredentialIdentityStore.swift
@@ -25,9 +25,8 @@ import AuthenticationServices
 ///   extension ASCredentialIdentityStore: CredentialIdentityStore {}
 ///   ```
 ///
-///   Then change the three call sites that default to `SafeCredentialIdentityStore()` back to
-///   `ASCredentialIdentityStore.shared` (`AuthService`, `ReviewPromptService`,
-///   `AutofillCredentialService`).
+///   Then change any call sites that default to `SafeCredentialIdentityStore()` back to
+///   `ASCredentialIdentityStore.shared`.
 @available(iOS, deprecated: 18.0, message: "Obsolete on iOS 18+; delete and restore the direct conformance (see note).")
 class SafeCredentialIdentityStore: CredentialIdentityStore {
     // MARK: Properties

--- a/BitwardenShared/Core/Autofill/Services/SafeCredentialIdentityStore.swift
+++ b/BitwardenShared/Core/Autofill/Services/SafeCredentialIdentityStore.swift
@@ -1,0 +1,134 @@
+import AuthenticationServices
+
+// MARK: - SafeCredentialIdentityStore
+
+/// A `CredentialIdentityStore` that wraps `ASCredentialIdentityStore` and guards against the
+/// system invoking a completion handler more than once.
+///
+/// Several `ASCredentialIdentityStore` completion-handler APIs can deliver their reply over XPC
+/// more than once (observed as a crash on iOS 15–17). The compiler-generated `async` bridge for
+/// those APIs resumes its continuation on every callback, and resuming a continuation more than
+/// once is a fatal error (`EXC_BREAKPOINT`). This wrapper calls the completion-handler variants
+/// directly and resumes the continuation at most once, ignoring any further callbacks.
+///
+/// Only the completion-handler-based APIs (`removeAllCredentialIdentities()` and
+/// `replaceCredentialIdentities(with:)`) can be guarded this way. The iOS 17+ APIs that take
+/// `[ASCredentialIdentity]` are `async`-only with no completion-handler variant, so they forward
+/// directly to the system's `async` methods.
+///
+/// - Note: The double-callback bug does not occur on iOS 18+. Once the minimum deployment target
+///   reaches iOS 18 (i.e. iOS 17 support is dropped), the `@available` annotation below will start
+///   emitting deprecation warnings at the call sites. At that point this entire type can be deleted
+///   and the conformance restored to the original one-liner:
+///
+///   ```swift
+///   extension ASCredentialIdentityStore: CredentialIdentityStore {}
+///   ```
+///
+///   Then change the three call sites that default to `SafeCredentialIdentityStore()` back to
+///   `ASCredentialIdentityStore.shared` (`AuthService`, `ReviewPromptService`,
+///   `AutofillCredentialService`).
+@available(iOS, deprecated: 18.0, message: "Obsolete on iOS 18+; delete and restore the direct conformance (see note).")
+class SafeCredentialIdentityStore: CredentialIdentityStore {
+    // MARK: Properties
+
+    /// The underlying system store that operations are forwarded to.
+    private let store: ASCredentialIdentityStore
+
+    // MARK: Initialization
+
+    /// Initialize a `SafeCredentialIdentityStore`.
+    ///
+    /// - Parameter store: The underlying system store. Defaults to `ASCredentialIdentityStore.shared`.
+    ///
+    init(store: ASCredentialIdentityStore = .shared) {
+        self.store = store
+    }
+
+    // MARK: Type Methods
+
+    /// Bridges an `ASCredentialIdentityStore` completion-handler API to `async`/`await`, resuming
+    /// the continuation at most once even if `operation`'s completion handler is invoked multiple
+    /// times.
+    ///
+    /// This is the safeguard against the iOS 15–17 crash where the system invokes a credential
+    /// identity store completion handler more than once, double-resuming the continuation. Any
+    /// callback after the first is ignored.
+    ///
+    /// - Parameter operation: Performs the store operation, invoking the supplied completion handler
+    ///     when it finishes. The completion handler may be safely called more than once; only the
+    ///     first invocation resumes the continuation, with the first reported error (if any).
+    ///
+    static func withSingleResumedContinuation(
+        _ operation: (@escaping @Sendable (Bool, Error?) -> Void) -> Void,
+    ) async throws {
+        let resumeGuard = SingleResumeGuard()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            operation { _, error in
+                guard resumeGuard.claimResume() else { return }
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+        }
+    }
+
+    // MARK: Methods
+
+    func removeAllCredentialIdentities() async throws {
+        try await Self.withSingleResumedContinuation { completion in
+            store.removeAllCredentialIdentities(completion)
+        }
+    }
+
+    @available(iOS 17.0, *)
+    func removeCredentialIdentities(_ credentialIdentities: [any ASCredentialIdentity]) async throws {
+        try await store.removeCredentialIdentities(credentialIdentities)
+    }
+
+    @available(iOS 17, *)
+    func replaceCredentialIdentities(_ newCredentialIdentities: [ASCredentialIdentity]) async throws {
+        try await store.replaceCredentialIdentities(newCredentialIdentities)
+    }
+
+    func replaceCredentialIdentities(with newCredentialIdentities: [ASPasswordCredentialIdentity]) async throws {
+        try await Self.withSingleResumedContinuation { completion in
+            store.replaceCredentialIdentities(with: newCredentialIdentities, completion: completion)
+        }
+    }
+
+    @available(iOS 17.0, *)
+    func saveCredentialIdentities(_ credentialIdentities: [any ASCredentialIdentity]) async throws {
+        try await store.saveCredentialIdentities(credentialIdentities)
+    }
+
+    func state() async -> ASCredentialIdentityStoreState {
+        await store.state()
+    }
+}
+
+// MARK: - SingleResumeGuard
+
+/// A thread-safe, one-shot flag used to ensure a continuation is resumed at most once when a
+/// completion handler may be invoked multiple times from concurrent threads.
+private final class SingleResumeGuard: @unchecked Sendable {
+    /// Whether the continuation has already been resumed.
+    private var hasResumed = false
+
+    /// Lock protecting `hasResumed` from concurrent completion-handler invocations.
+    private let lock = NSLock()
+
+    /// Atomically claims the right to resume the continuation.
+    ///
+    /// - Returns: `true` the first time it is called, `false` for every subsequent call.
+    ///
+    func claimResume() -> Bool {
+        lock.withLock {
+            guard !hasResumed else { return false }
+            hasResumed = true
+            return true
+        }
+    }
+}

--- a/BitwardenShared/Core/Autofill/Services/SafeCredentialIdentityStoreTests.swift
+++ b/BitwardenShared/Core/Autofill/Services/SafeCredentialIdentityStoreTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import BitwardenShared
+
+// MARK: - SafeCredentialIdentityStoreTests
+
+struct SafeCredentialIdentityStoreTests {
+    // MARK: Tests
+
+    /// `withSingleResumedContinuation(_:)` resumes normally when the completion handler is invoked
+    /// exactly once with a success result.
+    @Test
+    func withSingleResumedContinuation_singleSuccess_resumes() async throws {
+        try await SafeCredentialIdentityStore.withSingleResumedContinuation { completion in
+            completion(true, nil)
+        }
+    }
+
+    /// `withSingleResumedContinuation(_:)` resumes exactly once and does not crash when the
+    /// completion handler is invoked multiple times. This is the regression guard for the iOS 15–17
+    /// `ASCredentialIdentityStore` crash where the system delivers its reply more than once,
+    /// double-resuming the continuation.
+    @Test
+    func withSingleResumedContinuation_multipleSuccessCallbacks_resumesOnce() async throws {
+        try await SafeCredentialIdentityStore.withSingleResumedContinuation { completion in
+            completion(true, nil)
+            completion(true, nil)
+            completion(false, nil)
+        }
+    }
+
+    /// `withSingleResumedContinuation(_:)` does not crash when the completion handler is invoked
+    /// concurrently from multiple threads, resuming the continuation only once.
+    @Test
+    func withSingleResumedContinuation_concurrentCallbacks_resumesOnce() async throws {
+        try await SafeCredentialIdentityStore.withSingleResumedContinuation { completion in
+            DispatchQueue.concurrentPerform(iterations: 100) { _ in
+                completion(true, nil)
+            }
+        }
+    }
+
+    /// `withSingleResumedContinuation(_:)` propagates the error when the completion handler is
+    /// invoked with one.
+    @Test
+    func withSingleResumedContinuation_failure_throws() async {
+        await #expect(throws: BitwardenTestError.example) {
+            try await SafeCredentialIdentityStore.withSingleResumedContinuation { completion in
+                completion(false, BitwardenTestError.example)
+            }
+        }
+    }
+
+    /// `withSingleResumedContinuation(_:)` propagates the first reported error and ignores any
+    /// subsequent callbacks, including a later success callback.
+    @Test
+    func withSingleResumedContinuation_errorThenSuccess_throwsFirstError() async {
+        await #expect(throws: BitwardenTestError.example) {
+            try await SafeCredentialIdentityStore.withSingleResumedContinuation { completion in
+                completion(false, BitwardenTestError.example)
+                completion(true, nil)
+            }
+        }
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/ReviewPromptService.swift
+++ b/BitwardenShared/Core/Platform/Services/ReviewPromptService.swift
@@ -58,7 +58,7 @@ class DefaultReviewPromptService: ReviewPromptService {
     init(
         appInfoService: AppInfoService,
         appVersion: String,
-        identityStore: CredentialIdentityStore = ASCredentialIdentityStore.shared,
+        identityStore: CredentialIdentityStore = SafeCredentialIdentityStore(),
         stateService: StateService,
     ) {
         self.appInfoService = appInfoService


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-31718](https://bitwarden.atlassian.net/browse/PM-31718)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Attempts to fix a low-volume `EXC_BREAKPOINT` crash in the AutoFill credential provider seen on iOS 15, 16, and 17. The crash occurs on the `com.apple.NSXPCConnection.user.com.apple.SafariFoundation.CredentialProviderExtensionHelper` thread, in a compiler-generated async-bridging thunk inside `BitwardenShared` — specifically when updating the system credential identity store.

**Root cause:** We call `ASCredentialIdentityStore` APIs via their Swift `async` bridges. That bridge wraps a `CheckedContinuation` that must be resumed exactly once. On iOS 15–17, the system can invoke the underlying completion handler **more than once** over XPC (e.g. an interrupted/redelivered reply), and the second resume trips the fatal "continuation resumed more than once" trap. The completion-bridged APIs in play are `replaceCredentialIdentities(with:)` (iOS <17 path) and `removeAllCredentialIdentities()` (all OS versions — this is the iOS 17 crash path). It's a race, not a deterministic failure, which matches the low crash volume.

**Fix:** Introduces a `SafeCredentialIdentityStore` adapter conforming to `CredentialIdentityStore` that wraps `ASCredentialIdentityStore`. The completion-handler-based APIs now route through a single-resume continuation helper that resumes the continuation at most once and ignores any further callbacks. The iOS 17+ APIs that take `[ASCredentialIdentity]` are `async`-only (no completion variant to guard), so they forward unchanged.

Using a distinct adapter type, rather than redeclaring the async bridge on `ASCredentialIdentityStore`, keeps the inner calls bound to the concrete completion-handler variants, with no same-name async overload in scope to accidentally recurse into.

**Changes:**
- Add `SafeCredentialIdentityStore` (adapter) + `SingleResumeGuard` (NSLock-backed one-shot flag).
- Remove the empty `extension ASCredentialIdentityStore: CredentialIdentityStore {}`.
- Default the three call sites (`AuthService`, `ReviewPromptService`, `AutofillCredentialService`)
  to `SafeCredentialIdentityStore()` instead of `ASCredentialIdentityStore.shared`.
- Annotate the wrapper with `@available(iOS, deprecated: 18.0)` plus a removal note: the bug
  doesn't occur on iOS 18+, so once iOS 17 support is dropped the deprecation warning will flag
  the type for deletion and restoration of the one-line direct conformance.
- Add `SafeCredentialIdentityStoreTests` covering single, multiple synchronous, and concurrent
  (100×) callbacks, plus error and error-then-success cases.

No behavior change for the happy path (single callback → single resume); the guard only affects the duplicate-callback case that previously crashed.

[PM-31718]: https://bitwarden.atlassian.net/browse/PM-31718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ