### PR TITLE
[PM-38861] [RC] chore: Disable save password credential iOS 26 API on the extension

### DIFF
--- a/BitwardenAutoFillExtension/Application/Support/Info.plist
+++ b/BitwardenAutoFillExtension/Application/Support/Info.plist
@@ -119,8 +119,6 @@
 				</array>
 				<key>SupportsCredentialExchange</key>
 				<true/>
-				<key>SupportsSavePasswordCredentials</key>
-				<true/>
 			</dict>
 			<key>ASCredentialProviderExtensionShowsConfigurationUI</key>
 			<true/>

--- a/BitwardenKit/Core/Platform/Services/ConfigServiceTests.swift
+++ b/BitwardenKit/Core/Platform/Services/ConfigServiceTests.swift
@@ -320,13 +320,15 @@ final class ConfigServiceTests: BitwardenTestCase { // swiftlint:disable:this ty
         configApiService.clientResult = .httpSuccess(testData: .validServerConfig)
         // Subscribe before getConfig so the background-task emission is not missed.
         var configUpdates = await subject.configPublisher().makeAsyncIterator()
+
+        // AsyncPublisher uses demand-based delivery (.max(1) per next() call). Consuming the
+        // initial nil here replenishes demand to 1 before the background fetch fires, so the
+        // subsequent MetaServerConfig emission is delivered rather than dropped.
+        _ = await configUpdates.next()
+
         let response = await subject.getConfig(forceRefresh: false, isPreAuth: true)
         XCTAssertNil(response)
 
-        // CurrentValueSubject emits nil on subscribe; skip it, then await the
-        // background fetch update via the thread-safe publisher instead of polling
-        // the mock's state across thread boundaries (which causes SEGV data races).
-        _ = await configUpdates.next()
         let wrappedMetaConfig = await configUpdates.next()
         let metaConfig = try XCTUnwrap(XCTUnwrap(wrappedMetaConfig))
         XCTAssertTrue(metaConfig.isPreAuth)


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38861](https://bitwarden.atlassian.net/browse/PM-38861)

## 📔 Objective

🍒 Cherry picked for RC from #2777.

Disables iOS 26 save password credential form the extension given #2762 can't be merged yet.


[PM-38861]: https://bitwarden.atlassian.net/browse/PM-38861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ