### PR TITLE
[PM-38978] [RC] fix: Hide Plan settings row for organization-only premium users

### DIFF
--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -44,6 +44,13 @@ protocol StateService: AnyObject, BillingStateService {
     ///
     func doesActiveAccountHavePremium() async -> Bool
 
+    /// Returns whether the active user account has premium personally (i.e. premium that the user
+    /// purchased themselves), as opposed to premium granted by an organization.
+    ///
+    /// - Returns: Whether the active account has premium personally.
+    ///
+    func doesActiveAccountHavePremiumPersonally() async -> Bool
+
     /// Gets the access token's expiration date for an account.
     ///
     /// - Parameter userId: The user ID associated with the access token expiration date.
@@ -1559,6 +1566,16 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
                 .fetchAllOrganizations(userId: account.profile.userId)
                 .filter { $0.enabled && $0.usersGetPremium }
             return !organizations.isEmpty
+        } catch {
+            errorReporter.log(error: error)
+            return false
+        }
+    }
+
+    func doesActiveAccountHavePremiumPersonally() async -> Bool {
+        do {
+            let account = try await getActiveAccount()
+            return account.profile.hasPremiumPersonally ?? false
         } catch {
             errorReporter.log(error: error)
             return false

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -299,6 +299,37 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 
+    /// `doesActiveAccountHavePremiumPersonally()` returns true when the user has premium personally.
+    func test_doesActiveAccountHavePremiumPersonally_personalTrue() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: true)))
+        let hasPremium = await subject.doesActiveAccountHavePremiumPersonally()
+        XCTAssertTrue(hasPremium)
+    }
+
+    /// `doesActiveAccountHavePremiumPersonally()` returns false when the user has no personal
+    /// premium, even when an organization grants premium.
+    func test_doesActiveAccountHavePremiumPersonally_personalFalse_organizationTrue() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: false)))
+        try await dataStore.replaceOrganizations([.fixture(usersGetPremium: true)], userId: "1")
+        let hasPremium = await subject.doesActiveAccountHavePremiumPersonally()
+        XCTAssertFalse(hasPremium)
+    }
+
+    /// `doesActiveAccountHavePremiumPersonally()` returns false when personal premium is nil.
+    func test_doesActiveAccountHavePremiumPersonally_personalNil() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(hasPremiumPersonally: nil)))
+        let hasPremium = await subject.doesActiveAccountHavePremiumPersonally()
+        XCTAssertFalse(hasPremium)
+    }
+
+    /// `doesActiveAccountHavePremiumPersonally()` with no accounts throws error internally which is
+    /// logged and returns `false` as default.
+    func test_doesActiveAccountHavePremiumPersonally_throwsNoAccountLogsErrorAndReturnsFalse() async throws {
+        let hasPremium = await subject.doesActiveAccountHavePremiumPersonally()
+        XCTAssertFalse(hasPremium)
+        XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
+    }
+
     /// `getAccessTokenExpirationDate(userId:)` gets the user's access token expiration date.
     func test_getAccessTokenExpirationDate() async throws {
         let date1 = Date(year: 2025, month: 1, day: 1)

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -45,6 +45,8 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
     var doesActiveAccountHavePremiumResult: Bool = true
+    var doesActiveAccountHavePremiumPersonallyCalled = false // swiftlint:disable:this identifier_name
+    var doesActiveAccountHavePremiumPersonallyResult: Bool = true // swiftlint:disable:this identifier_name
     var encryptedPinByUserId = [String: String]()
     var environmentURLs = [String: EnvironmentURLData]()
     var environmentURLsError: Error?
@@ -161,6 +163,11 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     func doesActiveAccountHavePremium() async -> Bool {
         doesActiveAccountHavePremiumCalled = true
         return doesActiveAccountHavePremiumResult
+    }
+
+    func doesActiveAccountHavePremiumPersonally() async -> Bool {
+        doesActiveAccountHavePremiumPersonallyCalled = true
+        return doesActiveAccountHavePremiumPersonallyResult
     }
 
     func getAccountEncryptionKeys(userId: String?) async throws -> AccountEncryptionKeys {

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -95,10 +95,14 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             let featureEnabled = await services.configService
                 .getFeatureFlag(.premiumUpgradePath, defaultValue: false)
             let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
+            let hasPremiumPersonally = await services.stateService.doesActiveAccountHavePremiumPersonally()
             let isSelfHosted = await services.billingService.isSelfHosted()
             let isUSStorefront = await services.storefrontService.isUSStorefront()
             state.hasPremium = hasPremium
-            state.showPlanRow = featureEnabled && !isSelfHosted && isUSStorefront
+            // Users whose premium comes only from their organization (not purchased personally)
+            // have no personal subscription to manage or upgrade, so the plan row is hidden for them.
+            let hasPremiumFromOrganizationOnly = hasPremium && !hasPremiumPersonally
+            state.showPlanRow = featureEnabled && !isSelfHosted && isUSStorefront && !hasPremiumFromOrganizationOnly
             state.shouldShowUpgradedToPremiumActionCard = await services.billingService
                 .shouldShowUpgradedToPremiumActionCard()
         case .dismissUpgradedToPremiumActionCard:

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -286,6 +286,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_appeared_showsPlanRow_freeUser() async {
         configService.featureFlagsBool[.premiumUpgradePath] = true
         vaultRepository.doesActiveAccountHavePremiumResult = false
+        stateService.doesActiveAccountHavePremiumPersonallyResult = false
 
         await subject.perform(.appeared)
 
@@ -316,15 +317,31 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertFalse(subject.state.showPlanRow)
     }
 
-    /// `perform(.appeared)` shows the plan row when the feature flag is enabled and the user has premium.
+    /// `perform(.appeared)` shows the plan row when the feature flag is enabled and the user has
+    /// premium personally.
     @MainActor
     func test_perform_appeared_showsPlanRow_hasPremium() async {
         configService.featureFlagsBool[.premiumUpgradePath] = true
         vaultRepository.doesActiveAccountHavePremiumResult = true
+        stateService.doesActiveAccountHavePremiumPersonallyResult = true
 
         await subject.perform(.appeared)
 
         XCTAssertTrue(subject.state.showPlanRow)
+        XCTAssertTrue(subject.state.hasPremium)
+    }
+
+    /// `perform(.appeared)` hides the plan row when the user's premium comes only from their
+    /// organization (they have no personal subscription to manage or upgrade).
+    @MainActor
+    func test_perform_appeared_hidesPlanRow_premiumFromOrganizationOnly() async {
+        configService.featureFlagsBool[.premiumUpgradePath] = true
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+        stateService.doesActiveAccountHavePremiumPersonallyResult = false
+
+        await subject.perform(.appeared)
+
+        XCTAssertFalse(subject.state.showPlanRow)
         XCTAssertTrue(subject.state.hasPremium)
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-38978](https://bitwarden.atlassian.net/browse/PM-38978)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

🍒 Cherry picked for RC from https://github.com/bitwarden/ios/pull/2783.

Users whose premium is granted only by their organization (e.g. an Enterprise plan) could tap **Settings → Plan** and hit an error. The Plan screen is for managing or upgrading a *personal* subscription, which these users don't have.

The root cause is that the Settings screen relied on `doesActiveAccountHavePremium()`, which returns `true` for premium obtained **either** personally **or** through an organization. `navigateToPlan()` then routed these users to `.premiumPlan(nil)` (the personal-subscription management screen) with no personal subscription to display.

This change adds `StateService.doesActiveAccountHavePremiumPersonally()` to distinguish personally-purchased premium from organization-granted premium, and updates `SettingsProcessor` to hide the Plan row when premium comes only from an organization (`hasPremium && !hasPremiumPersonally`).

Behavior after this change:
- **Organization-only premium:** Plan row hidden (no error path).
- **Personal premium:** Plan row shown → manage subscription (unchanged).
- **No premium (free):** Plan row shown → upgrade path (unchanged).

[PM-38978]: https://bitwarden.atlassian.net/browse/PM-38978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ