### PR TITLE
[PM-39087] chore: Fix projects dependencies warnings

### DIFF
--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -145,6 +145,8 @@ targets:
     dependencies:
       - target: Authenticator
       - target: BitwardenKit/AuthenticatorBridgeKit
+      - target: BitwardenKit/BitwardenKitMocks
+      - target: BitwardenKit/BitwardenSdkMocks
       - target: BitwardenKit/TestHelpers
       - package: SnapshotTesting
     randomExecutionOrder: true

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -261,6 +261,8 @@ targets:
     dependencies:
       - target: BitwardenActionExtension
       - target: BitwardenShared
+      - target: BitwardenKit/BitwardenKitMocks
+      - target: BitwardenKit/BitwardenSdkMocks
       - target: BitwardenKit/TestHelpers
     randomExecutionOrder: true
 
@@ -296,6 +298,8 @@ targets:
     dependencies:
       - target: BitwardenAutoFillExtension
       - target: BitwardenShared
+      - target: BitwardenKit/BitwardenKitMocks
+      - target: BitwardenKit/BitwardenSdkMocks
       - target: BitwardenKit/TestHelpers
     randomExecutionOrder: true
 
@@ -348,6 +352,8 @@ targets:
     dependencies:
       - target: BitwardenShareExtension
       - target: BitwardenShared
+      - target: BitwardenKit/BitwardenKitMocks
+      - target: BitwardenKit/BitwardenSdkMocks
       - target: BitwardenKit/TestHelpers
     randomExecutionOrder: true
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39087](https://bitwarden.atlassian.net/browse/PM-39087)

## 📔 Objective

Fix project dependencies for warnings:

- 'BitwardenShareExtensionTests' is missing a dependency on 'BitwardenSdkMocks' because dependency scan of Swift module 'BitwardenShareExtensionTests' discovered a dependency on 'BitwardenSdkMocks' 
- 'BitwardenShareExtensionTests' is missing a dependency on 'BitwardenKitMocks' because dependency scan of Swift module 'BitwardenShareExtensionTests' discovered a dependency on 'BitwardenKitMocks'
-  'BitwardenAutoFillExtensionTests' is missing a dependency on 'BitwardenSdkMocks' because dependency scan of Swift module 'BitwardenAutoFillExtensionTests' discovered a dependency on 'BitwardenSdkMocks' 
- 'BitwardenAutoFillExtensionTests' is missing a dependency on 'BitwardenKitMocks' because dependency scan of Swift module 'BitwardenAutoFillExtensionTests' discovered a dependency on 'BitwardenKitMocks'
-  'BitwardenActionExtensionTests' is missing a dependency on 'BitwardenSdkMocks' because dependency scan of Swift module 'BitwardenActionExtensionTests' discovered a dependency on 'BitwardenSdkMocks'
-  'BitwardenActionExtensionTests' is missing a dependency on 'BitwardenKitMocks' because dependency scan of Swift module 'BitwardenActionExtensionTests' discovered a dependency on 'BitwardenKitMocks'
- 'AuthenticatorTests' is missing a dependency on 'BitwardenSdkMocks' because dependency scan of Swift module 'AuthenticatorTests' discovered a dependency on 'BitwardenSdkMocks' 
- 'AuthenticatorTests' is missing a dependency on 'BitwardenKitMocks' because dependency scan of Swift module 'AuthenticatorTests' discovered a dependency on 'BitwardenKitMocks'


[PM-39087]: https://bitwarden.atlassian.net/browse/PM-39087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ