### PR TITLE
[PM-39088] chore: Fix Codecov config to ignore test files

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,3 +7,4 @@ ignore:
   - "GlobalTestHelpers-bwth/**"
   - "**/Mocks/**"
   - "**/*Mock*.swift"
+  - "**/*Tests.swift"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,10 +1,10 @@
 ignore:
   - "**/*Tests*/**"
   - "**/TestHelpers/**"
+  - "**/*Tests.swift"
   - "**/Fixtures/**"
   - "GlobalTestHelpers/**"
   - "GlobalTestHelpers-bwa/**"
   - "GlobalTestHelpers-bwth/**"
   - "**/Mocks/**"
   - "**/*Mock*.swift"
-  - "**/*Tests.swift"


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39088](https://bitwarden.atlassian.net/browse/PM-39088)

## 📔 Objective

Fixes Codecov config so matches any file whose name ends in Tests.swift regardless of which directory it sits in — covering +SnapshotTests.swift, +ViewInspectorTests.swift, BankAccountTypeTests.swift, etc.

[PM-39088]: https://bitwarden.atlassian.net/browse/PM-39088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ