### PR TITLE
[PM-39111] chore: Fix flaky tests on PublisherAsyncTests

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/PublisherAsyncTests.swift
+++ b/BitwardenKit/Core/Platform/Extensions/PublisherAsyncTests.swift
@@ -1,59 +1,33 @@
 import BitwardenKit
 import Combine
-import XCTest
+import Testing
 
-class PublisherAsyncTests: BitwardenTestCase {
-    // MARK: Properties
-
-    var cancellable: AnyCancellable?
-
-    // MARK: Setup & Teardown
-
-    override func tearDown() {
-        super.tearDown()
-
-        cancellable = nil
-    }
-
+struct PublisherAsyncTests {
     // MARK: Tests
 
     /// `asyncCompactMap(_:)` maps the output of a publisher, discarding any `nil` values.
-    func test_asyncCompactMap() {
+    @Test
+    func asyncCompactMap() async {
         var receivedValues = [Int]()
 
-        let expectation = expectation(description: #function)
         let sequence = [1, 2, 3, 4, 5]
-        cancellable = sequence
-            .publisher
-            .asyncCompactMap { $0 % 2 == 0 ? $0 : nil }
-            .collect()
-            .sink { values in
-                receivedValues = values
-                expectation.fulfill()
-            }
+        for await value in sequence.publisher.asyncCompactMap({ $0 % 2 == 0 ? $0 : nil }).values {
+            receivedValues.append(value)
+        }
 
-        waitForExpectations(timeout: 1)
-
-        XCTAssertEqual(receivedValues, [2, 4])
+        #expect(receivedValues == [2, 4])
     }
 
     /// `asyncMap(_:)` maps the output of a publisher.
-    func test_asyncMap() {
+    @Test
+    func asyncMap() async {
         var receivedValues = [Int]()
 
-        let expectation = expectation(description: #function)
         let sequence = [1, 2, 3, 4, 5]
-        cancellable = sequence
-            .publisher
-            .asyncMap { $0 * 2 }
-            .collect()
-            .sink { values in
-                receivedValues = values
-                expectation.fulfill()
-            }
+        for await value in sequence.publisher.asyncMap({ $0 * 2 }).values {
+            receivedValues.append(value)
+        }
 
-        waitForExpectations(timeout: 1)
-
-        XCTAssertEqual(receivedValues, [2, 4, 6, 8, 10])
+        #expect(receivedValues == [2, 4, 6, 8, 10])
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39111](https://bitwarden.atlassian.net/browse/PM-39111)

## 📔 Objective

Fix flaky tests on PublisherAsyncTests. Also converted them to Swift testing.

**Root cause**: The sink closure was called on the Swift cooperative thread pool (where Task { } inside each Future fulfills the promise), while XCTAssertEqual on line 57 read receivedValues on the main thread after waitForExpectations returned. There was no memory ordering guarantee between the background-thread write and the main-thread read — causing the intermittent [0, 4, 6, 8, 10] torn read.

**Fix**: Both tests are now async, using for await value in publisher.values. XCTest runs async test methods on the main actor, so the entire test body — the iteration, the append, and the assertion — runs in a single isolated context with no concurrent access. The AnyCancellable property, tearDown, and expectation scaffolding are no longer needed and were removed.


[PM-39111]: https://bitwarden.atlassian.net/browse/PM-39111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ