### PR TITLE
[PM-39279] chore: Remove unnecessary ErrorReportBuilderTests setup

### DIFF
--- a/BitwardenKit/Core/Platform/Utilities/ErrorReportBuilderTests.swift
+++ b/BitwardenKit/Core/Platform/Utilities/ErrorReportBuilderTests.swift
@@ -23,12 +23,7 @@ struct ErrorReportBuilderTests {
 
     // MARK: Setup
 
-    @MainActor
     init() {
-        UI.applyDefaultAppearances()
-        UI.animated = false
-        UI.sizeCategory = .large
-
         activeAccountStateProvider = MockActiveAccountStateProvider()
         appInfoService = MockAppInfoService()
         timeProvider = MockTimeProvider(.mockTime(Date(year: 2024, month: 11, day: 5, hour: 9, minute: 41, second: 0)))


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-39279](https://bitwarden.atlassian.net/browse/PM-39279)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes some unnecessary setup in `ErrorReportBuilderTests`.

Swift Testing makes it hard to see how long these tests take in the larger suite of tests, but sometimes I see these tests popping up with long test times (>1 second). I'm not sure how much of an effect this will have, but the tests seemed faster in the runs that I did without this setup. And there's no UI here, so there shouldn't be any downsides.


[PM-39279]: https://bitwarden.atlassian.net/browse/PM-39279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ