### PR TITLE
[QA-2027] Add accessibilityIdentifier to Landing App settings button

### DIFF
--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -160,6 +160,7 @@ struct LandingView: View {
             } label: {
                 Label(Localizations.appSettings, image: SharedAsset.Icons.cog16.swiftUIImage)
             }
+            .accessibilityIdentifier("AppSettingsButton")
             .buttonStyle(.bitwardenBorderless)
             .frame(maxWidth: .infinity, alignment: .center)
         }


### PR DESCRIPTION
## 🎟️ Tracking

[QA-2027](https://bitwarden.atlassian.net/browse/QA-2027)

## 📔 Objective

Adds a stable `accessibilityIdentifier("AppSettingsButton")` to the pre-login Landing screen's "App settings" button, so test automation can locate it by a stable ID instead of the localized label text. Matches the `CreateAccountButton` precedent on the same screen. No logic or UI change.

[QA-2027]: https://bitwarden.atlassian.net/browse/QA-2027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ