### PR TITLE
[PM-28349] feat: Support https:// redirects for SSO and Duo auth connectors

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/EnvironmentService.swift
+++ b/AuthenticatorShared/Core/Platform/Services/EnvironmentService.swift
@@ -78,13 +78,7 @@ extension DefaultEnvironmentService {
     }
 
     var region: RegionType {
-        if environmentURLs.baseURL == EnvironmentURLData.defaultUS.base {
-            .unitedStates
-        } else if environmentURLs.baseURL == EnvironmentURLData.defaultEU.base {
-            .europe
-        } else {
-            .selfHosted
-        }
+        environmentURLs.region
     }
 
     var sendShareURL: URL {

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
@@ -119,12 +119,15 @@ public extension EnvironmentURLData {
 
     /// Gets the region depending on the base url.
     var region: RegionType {
-        switch base {
-        case EnvironmentURLData.defaultUS.base:
+        if base == EnvironmentURLData.defaultUS.base {
             .unitedStates
-        case EnvironmentURLData.defaultEU.base:
+        } else if base == EnvironmentURLData.defaultEU.base {
             .europe
-        default:
+        } else if let base,
+                  let host = URLComponents(url: base, resolvingAgainstBaseURL: false)?.host,
+                  host == "bitwarden.pw" || host.hasSuffix(".bitwarden.pw") {
+            .internal
+        } else {
             .selfHosted
         }
     }

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
@@ -119,17 +119,7 @@ public extension EnvironmentURLData {
 
     /// Gets the region depending on the base url.
     var region: RegionType {
-        if base == EnvironmentURLData.defaultUS.base {
-            .unitedStates
-        } else if base == EnvironmentURLData.defaultEU.base {
-            .europe
-        } else if let base,
-                  let host = URLComponents(url: base, resolvingAgainstBaseURL: false)?.host,
-                  host == "bitwarden.pw" || host.hasSuffix(".bitwarden.pw") {
-            .internal
-        } else {
-            .selfHosted
-        }
+        RegionType(baseURL: base)
     }
 
     /// The base url for send sharing.

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
@@ -136,6 +136,17 @@ class EnvironmentURLDataTests: XCTestCase {
         XCTAssertTrue(subject.region == .selfHosted)
     }
 
+    /// `region` returns `.internal` if the base URL host is `bitwarden.pw` or any subdomain of it.
+    func test_region_internal() {
+        XCTAssertEqual(EnvironmentURLData(base: URL(string: "https://bitwarden.pw")!).region, .internal)
+        XCTAssertEqual(EnvironmentURLData(base: URL(string: "https://qa-team.sh.bitwarden.pw")!).region, .internal)
+    }
+
+    /// `region` does not treat a look-alike host ending in `bitwarden.pw` as `.internal`.
+    func test_region_internal_lookAlikeHostIsSelfHosted() {
+        XCTAssertEqual(EnvironmentURLData(base: URL(string: "https://notbitwarden.pw")!).region, .selfHosted)
+    }
+
     /// `sendShareURL` returns the send URL for the united states region.
     func test_sendShareURL_unitedStates() {
         let subject = EnvironmentURLData.defaultUS

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
@@ -136,17 +136,6 @@ class EnvironmentURLDataTests: XCTestCase {
         XCTAssertTrue(subject.region == .selfHosted)
     }
 
-    /// `region` returns `.internal` if the base URL host is `bitwarden.pw` or any subdomain of it.
-    func test_region_internal() {
-        XCTAssertEqual(EnvironmentURLData(base: URL(string: "https://bitwarden.pw")!).region, .internal)
-        XCTAssertEqual(EnvironmentURLData(base: URL(string: "https://qa-team.sh.bitwarden.pw")!).region, .internal)
-    }
-
-    /// `region` does not treat a look-alike host ending in `bitwarden.pw` as `.internal`.
-    func test_region_internal_lookAlikeHostIsSelfHosted() {
-        XCTAssertEqual(EnvironmentURLData(base: URL(string: "https://notbitwarden.pw")!).region, .selfHosted)
-    }
-
     /// `sendShareURL` returns the send URL for the united states region.
     func test_sendShareURL_unitedStates() {
         let subject = EnvironmentURLData.defaultUS

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
@@ -119,14 +119,16 @@ public extension EnvironmentURLs {
         // default that has fillAssistRulesUrl = nil, which would discard the server-config override.
         let fillAssistRulesUrl = environmentURLData.fillAssistRulesUrl
 
-        // Use the default URLs if the region matches US or EU.
+        // Use the default URLs if the region matches US or EU. Internal (`bitwarden.pw`) environments
+        // use their entered URLs, like self-hosted.
         let environmentURLData: EnvironmentURLData = switch environmentURLData.region {
         case .europe: .defaultEU
         case .unitedStates: .defaultUS
-        case .selfHosted: environmentURLData
+        case .internal, .selfHosted: environmentURLData
         }
 
-        if environmentURLData.region == .selfHosted, let base = environmentURLData.base {
+        if environmentURLData.region == .selfHosted || environmentURLData.region == .internal,
+           let base = environmentURLData.base {
             apiURL = base.appendingPathComponent("api")
             baseURL = base
             eventsURL = base.appendingPathComponent("events")

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
@@ -110,6 +110,11 @@ public struct EnvironmentURLs: Equatable {
 }
 
 public extension EnvironmentURLs {
+    /// Gets the region depending on the base url.
+    var region: RegionType {
+        RegionType(baseURL: baseURL)
+    }
+
     /// Initialize `EnvironmentURLs` from `EnvironmentURLData`.
     ///
     /// - Parameter environmentURLData: The environment URLs used to initialize `EnvironmentURLs`.

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests.swift
@@ -275,4 +275,20 @@ class EnvironmentURLsTests: BitwardenTestCase {
 
         XCTAssertEqual(subject.fillAssistRulesURL, customFillAssistURL)
     }
+
+    /// `region` resolves the base URL to the matching region.
+    func test_region() {
+        XCTAssertEqual(EnvironmentURLs(environmentURLData: .defaultUS).region, .unitedStates)
+        XCTAssertEqual(EnvironmentURLs(environmentURLData: .defaultEU).region, .europe)
+        XCTAssertEqual(
+            EnvironmentURLs(environmentURLData: EnvironmentURLData(base: URL(string: "https://bitwarden.pw")!)).region,
+            .internal,
+        )
+        XCTAssertEqual(
+            EnvironmentURLs(
+                environmentURLData: EnvironmentURLData(base: URL(string: "https://selfhosted.com")!),
+            ).region,
+            .selfHosted,
+        )
+    }
 }

--- a/BitwardenKit/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/RegionType.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 // MARK: - RegionType
 
 /// A region that the user can select when creating or signing into their account.
@@ -13,4 +15,26 @@ public enum RegionType: CaseIterable, Sendable {
 
     /// Bitwarden's internal/QA environment (any `bitwarden.pw` host). Not user-selectable.
     case `internal`
+}
+
+public extension RegionType {
+    /// Determines the region for a given environment base URL. This is the single source of truth
+    /// for mapping a base URL to a region; callers that hold an `EnvironmentURLData` or
+    /// `EnvironmentURLs` should use their `region` property rather than reimplementing this.
+    ///
+    /// - Parameter baseURL: The environment's base URL (i.e. `EnvironmentURLData.base`).
+    ///
+    init(baseURL: URL?) {
+        if baseURL == EnvironmentURLData.defaultUS.base {
+            self = .unitedStates
+        } else if baseURL == EnvironmentURLData.defaultEU.base {
+            self = .europe
+        } else if let baseURL,
+                  let host = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)?.host,
+                  host == "bitwarden.pw" || host.hasSuffix(".bitwarden.pw") {
+            self = .internal
+        } else {
+            self = .selfHosted
+        }
+    }
 }

--- a/BitwardenKit/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/RegionType.swift
@@ -10,4 +10,7 @@ public enum RegionType: CaseIterable, Sendable {
 
     /// A self-hosted instance.
     case selfHosted
+
+    /// Bitwarden's internal/QA environment (any `bitwarden.pw` host). Not user-selectable.
+    case `internal`
 }

--- a/BitwardenKit/Core/Platform/Models/Enum/RegionTypeTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/RegionTypeTests.swift
@@ -1,0 +1,23 @@
+import BitwardenKit
+import Foundation
+import Testing
+
+// MARK: - RegionTypeTests
+
+struct RegionTypeTests {
+    // MARK: Tests
+
+    /// `init(baseURL:)` resolves an environment base URL to the matching region.
+    @Test(arguments: [
+        (EnvironmentURLData.defaultUS.base, RegionType.unitedStates),
+        (EnvironmentURLData.defaultEU.base, RegionType.europe),
+        (URL(string: "https://bitwarden.pw"), RegionType.internal),
+        (URL(string: "https://qa-team.sh.bitwarden.pw"), RegionType.internal),
+        (URL(string: "https://notbitwarden.pw"), RegionType.selfHosted),
+        (URL(string: "https://selfhosted.com"), RegionType.selfHosted),
+        (nil, RegionType.selfHosted),
+    ])
+    func initBaseURL(baseURL: URL?, expectedRegion: RegionType) {
+        #expect(RegionType(baseURL: baseURL) == expectedRegion)
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModel.swift
@@ -21,6 +21,10 @@ struct IdentityTokenRequestModel {
     /// The type of authentication method used.
     let authenticationMethod: AuthenticationMethod
 
+    /// The URL scheme (`https` or `bitwarden`) the server should use when building auth connector
+    /// callback URLs for this client.
+    let deeplinkScheme: String
+
     /// The device's details.
     let deviceInfo: DeviceInfo
 
@@ -50,6 +54,7 @@ extension IdentityTokenRequestModel: FormURLEncodedRequestBody {
         queryItems.append(contentsOf: [
             URLQueryItem(name: "scope", value: "api offline_access"),
             URLQueryItem(name: "client_id", value: Constants.clientType),
+            URLQueryItem(name: "deeplinkScheme", value: deeplinkScheme),
 
             URLQueryItem(name: "deviceIdentifier", value: deviceInfo.identifier),
             URLQueryItem(name: "deviceName", value: deviceInfo.name),

--- a/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModelTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/IdentityTokenRequestModelTests.swift
@@ -20,6 +20,7 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
                 codeVerifier: "codeVerifier",
                 redirectUri: "redirectUri",
             ),
+            deeplinkScheme: "https",
             deviceInfo: .fixture(),
             loginRequestId: nil,
         )
@@ -29,6 +30,7 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
                 username: "ramen@delicious.com",
                 password: "password",
             ),
+            deeplinkScheme: "bitwarden",
             deviceInfo: .fixture(),
             loginRequestId: nil,
         )
@@ -47,10 +49,11 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
     func test_values_authorizationCode() {
         let valuesByKey = valuesByKey(subjectAuthorizationCode.values)
 
-        XCTAssertEqual(valuesByKey.count, 9)
+        XCTAssertEqual(valuesByKey.count, 10)
 
         XCTAssertEqual(valuesByKey["scope"], "api offline_access")
         XCTAssertEqual(valuesByKey["client_id"], "mobile")
+        XCTAssertEqual(valuesByKey["deeplinkScheme"], "https")
 
         XCTAssertEqual(valuesByKey["deviceIdentifier"], "1234")
         XCTAssertEqual(valuesByKey["deviceName"], "iPhone 14")
@@ -66,10 +69,11 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
     func test_values_password() {
         let valuesByKey = valuesByKey(subjectPassword.values)
 
-        XCTAssertEqual(valuesByKey.count, 8)
+        XCTAssertEqual(valuesByKey.count, 9)
 
         XCTAssertEqual(valuesByKey["scope"], "api offline_access")
         XCTAssertEqual(valuesByKey["client_id"], "mobile")
+        XCTAssertEqual(valuesByKey["deeplinkScheme"], "bitwarden")
 
         XCTAssertEqual(valuesByKey["deviceIdentifier"], "1234")
         XCTAssertEqual(valuesByKey["deviceName"], "iPhone 14")
@@ -87,6 +91,7 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
                 username: "user@example.com",
                 password: "password",
             ),
+            deeplinkScheme: "bitwarden",
             deviceInfo: .fixture(),
             loginRequestId: nil,
             twoFactorCode: "hi_im_a_lil_code",
@@ -107,6 +112,7 @@ class IdentityTokenRequestModelTests: BitwardenTestCase {
                 username: "user@example.com",
                 password: "password",
             ),
+            deeplinkScheme: "bitwarden",
             deviceInfo: .fixture(),
             loginRequestId: nil,
             newDeviceOtp: "onetimepass",

--- a/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/AuthAPIServiceTests.swift
@@ -63,6 +63,7 @@ class AuthAPIServiceTests: BitwardenTestCase {
         let response = try await subject.getIdentityToken(
             IdentityTokenRequestModel(
                 authenticationMethod: .password(username: "username", password: "password"),
+                deeplinkScheme: "https",
                 deviceInfo: .fixture(),
                 loginRequestId: nil,
             ),
@@ -86,6 +87,7 @@ class AuthAPIServiceTests: BitwardenTestCase {
             _ = try await subject.getIdentityToken(
                 IdentityTokenRequestModel(
                     authenticationMethod: .password(username: "username", password: "password"),
+                    deeplinkScheme: "https",
                     deviceInfo: .fixture(),
                     loginRequestId: nil,
                 ),

--- a/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Auth/Requests/IdentityTokenRequestTests.swift
@@ -23,6 +23,7 @@ class IdentityTokenRequestTests: BitwardenTestCase {
                     codeVerifier: "codeVerifier",
                     redirectUri: "redirectUri",
                 ),
+                deeplinkScheme: "https",
                 deviceInfo: .fixture(),
                 loginRequestId: nil,
             ),
@@ -31,6 +32,7 @@ class IdentityTokenRequestTests: BitwardenTestCase {
         subjectPassword = IdentityTokenRequest(
             requestModel: IdentityTokenRequestModel(
                 authenticationMethod: .password(username: "user@example.com", password: "password"),
+                deeplinkScheme: "https",
                 deviceInfo: .fixture(),
                 loginRequestId: nil,
             ),
@@ -51,7 +53,7 @@ class IdentityTokenRequestTests: BitwardenTestCase {
         let bodyData = try XCTUnwrap(subjectAuthorizationCode.body?.encode())
         XCTAssertEqual(
             String(data: bodyData, encoding: .utf8),
-            "scope=api%20offline%5Faccess&client%5Fid=mobile&deviceIdentifier=1234&" +
+            "scope=api%20offline%5Faccess&client%5Fid=mobile&deeplinkScheme=https&deviceIdentifier=1234&" +
                 "deviceName=iPhone%2014&deviceType=1&grant%5Ftype=authorization%5Fcode&code=code&" +
                 "code%5Fverifier=codeVerifier&redirect%5Furi=redirectUri",
         )
@@ -62,7 +64,7 @@ class IdentityTokenRequestTests: BitwardenTestCase {
         let bodyData = try XCTUnwrap(subjectPassword.body?.encode())
         XCTAssertEqual(
             String(data: bodyData, encoding: .utf8),
-            "scope=api%20offline%5Faccess&client%5Fid=mobile&deviceIdentifier=1234&" +
+            "scope=api%20offline%5Faccess&client%5Fid=mobile&deeplinkScheme=https&deviceIdentifier=1234&" +
                 "deviceName=iPhone%2014&deviceType=1&grant%5Ftype=password&" +
                 "username=user%40example%2Ecom&password=password",
         )

--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -55,6 +55,53 @@ enum AuthError: Error {
     case unableToResendNewDeviceOtp
 }
 
+// MARK: - AuthWebSessionCallback
+
+/// How an `ASWebAuthenticationSession` should match the redirect that ends an auth connector flow.
+///
+enum AuthWebSessionCallback: Equatable {
+    /// Matches a custom URL scheme redirect (e.g. `bitwarden://sso-callback`).
+    case customScheme(String)
+
+    /// Matches an HTTPS redirect (e.g. `https://vault.bitwarden.com/sso-callback`). Requires iOS 17.4+.
+    case https(host: String, path: String)
+}
+
+// MARK: - AuthWebSessionCallbackKind
+
+/// The auth connector flow that an `ASWebAuthenticationSession` is being created for. Determines the
+/// callback path and whether the HTTPS callback is eligible for Cloud users.
+///
+enum AuthWebSessionCallbackKind {
+    /// The Duo two-factor connector.
+    case duo
+
+    /// The single sign-on (SSO) connector.
+    case singleSignOn
+
+    /// The self-hosted WebAuthn connector.
+    case webAuthnSelfHosted
+
+    /// The callback path component, without a leading slash (e.g. `sso-callback`).
+    var callbackPath: String {
+        switch self {
+        case .duo: "duo-callback"
+        case .singleSignOn: "sso-callback"
+        case .webAuthnSelfHosted: "webauthn-callback"
+        }
+    }
+
+    /// Whether this connector supports the HTTPS callback for Cloud users. WebAuthn is excluded
+    /// because Cloud WebAuthn uses the native passkey API rather than a connector
+    /// callback URL; the self-hosted WebAuthn connector continues to use the custom scheme.
+    var supportsHttpsCallback: Bool {
+        switch self {
+        case .duo, .singleSignOn: true
+        case .webAuthnSelfHosted: false
+        }
+    }
+}
+
 // MARK: - LoginUnlockMethod
 
 /// An enumeration of vault unlock methods that can be used when a user is logging in.
@@ -224,11 +271,20 @@ protocol AuthService {
     ///
     func setPendingAdminLoginRequest(_ adminLoginRequest: PendingAdminLoginRequest?, userId: String?) async throws
 
-    /// Provides a web authentication session. In practice this is a passthrough
-    /// for `ASWebAuthenticationSession.init`.
+    /// Provides a web authentication session configured with the appropriate callback for the given
+    /// connector flow. The session matches an HTTPS redirect for Cloud users on iOS 17.4+ (SSO and
+    /// Duo only), otherwise the `bitwarden://` custom scheme.
+    ///
+    /// - Parameters:
+    ///   - url: The URL to load in the web authentication session.
+    ///   - callbackKind: The connector flow this session is for, which determines the callback.
+    ///   - completionHandler: Invoked with the callback URL or an error when the session completes.
+    /// - Returns: An unstarted, unconfigured `ASWebAuthenticationSession`. The caller is responsible
+    ///   for setting `prefersEphemeralWebBrowserSession`/`presentationContextProvider` and calling `start()`.
     ///
     func webAuthenticationSession(
         url: URL,
+        callbackKind: AuthWebSessionCallbackKind,
         completionHandler: @escaping ASWebAuthenticationSession.CompletionHandler,
     ) -> ASWebAuthenticationSession
 }
@@ -294,8 +350,10 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
     /// The request model to resend the email with the new device verification code.
     private var resendNewDeviceOtpModel: ResendNewDeviceOtpRequestModel?
 
-    /// The single sign on callback url for this application.
-    private var singleSignOnCallbackUrl: String { "\(callbackUrlScheme)://sso-callback" }
+    /// The single sign on callback url for this application. Resolves to an HTTPS URL for Cloud
+    /// users on iOS 17.4+, otherwise the `bitwarden://` custom scheme. Must stay in sync with
+    /// the callback the `ASWebAuthenticationSession` is configured to match.
+    private var singleSignOnCallbackUrl: String { callbackUrl(for: .singleSignOn) }
 
     /// The service used by the application to manage account state.
     private let stateService: StateService
@@ -780,16 +838,52 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
 
     func webAuthenticationSession(
         url: URL,
+        callbackKind: AuthWebSessionCallbackKind,
         completionHandler: @escaping ASWebAuthenticationSession.CompletionHandler,
     ) -> ASWebAuthenticationSession {
-        ASWebAuthenticationSession(
-            url: url,
-            callbackURLScheme: callbackUrlScheme,
-            completionHandler: completionHandler,
-        )
+        switch resolveCallback(for: callbackKind) {
+        case let .customScheme(scheme):
+            ASWebAuthenticationSession(
+                url: url,
+                callbackURLScheme: scheme,
+                completionHandler: completionHandler,
+            )
+        case let .https(host, path):
+            if #available(iOS 17.4, *) {
+                ASWebAuthenticationSession(
+                    url: url,
+                    callback: .https(host: host, path: path),
+                    completionHandler: completionHandler,
+                )
+            } else {
+                // `resolveCallback` only returns `.https` on iOS 17.4+, so this branch is
+                // unreachable; fall back to the custom scheme to remain exhaustive for the compiler.
+                ASWebAuthenticationSession(
+                    url: url,
+                    callbackURLScheme: callbackUrlScheme,
+                    completionHandler: completionHandler,
+                )
+            }
+        }
     }
 
     // MARK: Private Methods
+
+    /// The redirect URL string for a connector flow, matching the callback that
+    /// `webAuthenticationSession(url:callbackKind:completionHandler:)` is configured to intercept.
+    ///
+    /// - Parameter kind: The connector flow the redirect is for.
+    /// - Returns: e.g. `https://vault.bitwarden.com/sso-callback` for Cloud/iOS 17.4+, otherwise
+    ///   `bitwarden://sso-callback`.
+    ///
+    private func callbackUrl(for kind: AuthWebSessionCallbackKind) -> String {
+        switch resolveCallback(for: kind) {
+        case let .customScheme(scheme):
+            "\(scheme)://\(kind.callbackPath)"
+        case let .https(host, path):
+            "https://\(host)\(path)"
+        }
+    }
 
     /// Returns the Key Connector URL if it exists in the identity token response and if it can be
     /// used to fetch the user's Key Connector key.
@@ -951,6 +1045,23 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
         }
 
         return try await .masterPassword(stateService.getActiveAccount())
+    }
+
+    /// Resolves which callback an auth connector session should match, based on the connector flow,
+    /// the active environment region, and OS availability of the HTTPS callback API.
+    ///
+    /// - Parameter kind: The connector flow the session is for.
+    /// - Returns: An HTTPS callback for Cloud users on iOS 17.4+ (SSO and Duo only), otherwise the
+    ///   `bitwarden://` custom scheme.
+    ///
+    private func resolveCallback(for kind: AuthWebSessionCallbackKind) -> AuthWebSessionCallback {
+        guard kind.supportsHttpsCallback,
+              #available(iOS 17.4, *),
+              let host = environmentService.region.authCallbackHost
+        else {
+            return .customScheme(callbackUrlScheme)
+        }
+        return .https(host: host, path: "/\(kind.callbackPath)")
     }
 
     /// Saves the user's account information.

--- a/BitwardenShared/Core/Auth/Services/AuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthService.swift
@@ -372,6 +372,21 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
     /// complete the login process after the request is approved.
     private var loginWithDeviceData: AuthRequestResponse?
 
+    // MARK: Computed Properties
+
+    /// The deeplink scheme (`https` or `bitwarden`) the server should use when building auth
+    /// connector callback URLs for this client, based on the current environment and OS.
+    private var deeplinkScheme: String {
+        supportsHttpsAuthCallback ? "https" : callbackUrlScheme
+    }
+
+    /// Whether the current environment and OS support the HTTPS auth connector callback — Cloud
+    /// regions (those exposing an `authCallbackHost`) on iOS 17.4+.
+    private var supportsHttpsAuthCallback: Bool {
+        guard #available(iOS 17.4, *) else { return false }
+        return environmentService.region.authCallbackHost != nil
+    }
+
     // MARK: Initialization
 
     /// Creates a new `DefaultSingleSignOnService`.
@@ -946,6 +961,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
             // Form the token request.
             request = IdentityTokenRequestModel(
                 authenticationMethod: authenticationMethod,
+                deeplinkScheme: deeplinkScheme,
                 deviceInfo: DeviceInfo(
                     identifier: appID,
                     name: systemDevice.modelIdentifier,
@@ -1056,7 +1072,7 @@ class DefaultAuthService: AuthService { // swiftlint:disable:this type_body_leng
     ///
     private func resolveCallback(for kind: AuthWebSessionCallbackKind) -> AuthWebSessionCallback {
         guard kind.supportsHttpsCallback,
-              #available(iOS 17.4, *),
+              supportsHttpsAuthCallback,
               let host = environmentService.region.authCallbackHost
         else {
             return .customScheme(callbackUrlScheme)

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -395,6 +395,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
                 username: "email@example.com",
                 password: "accessCode",
             ),
+            deeplinkScheme: "bitwarden",
             deviceInfo: DeviceInfo(
                 identifier: "App ID",
                 name: "Model id",
@@ -438,6 +439,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         )
         let tokenRequest = IdentityTokenRequestModel(
             authenticationMethod: .password(username: "email@example.com", password: "hashed password"),
+            deeplinkScheme: "bitwarden",
             deviceInfo: DeviceInfo(
                 identifier: "App ID",
                 name: "Model id",
@@ -507,6 +509,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         )
         let tokenRequest = IdentityTokenRequestModel(
             authenticationMethod: .password(username: "email@example.com", password: "hashed password"),
+            deeplinkScheme: "bitwarden",
             deviceInfo: DeviceInfo(
                 identifier: "App ID",
                 name: "Model id",
@@ -637,6 +640,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
                 username: "email@example.com",
                 password: "hashed password",
             ),
+            deeplinkScheme: "bitwarden",
             deviceInfo: DeviceInfo(
                 identifier: "App ID",
                 name: "Model id",
@@ -772,6 +776,7 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
                 codeVerifier: "",
                 redirectUri: "bitwarden://sso-callback",
             ),
+            deeplinkScheme: "bitwarden",
             deviceInfo: DeviceInfo(
                 identifier: "App ID",
                 name: "Model id",

--- a/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/AuthServiceTests.swift
@@ -118,6 +118,21 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         XCTAssertEqual(client.requests.last?.url.absoluteString, "https://example.com/api/auth-requests/1")
     }
 
+    /// `AuthWebSessionCallbackKind.callbackPath` returns the expected path for each connector.
+    func test_authWebSessionCallbackKind_callbackPath() {
+        XCTAssertEqual(AuthWebSessionCallbackKind.singleSignOn.callbackPath, "sso-callback")
+        XCTAssertEqual(AuthWebSessionCallbackKind.duo.callbackPath, "duo-callback")
+        XCTAssertEqual(AuthWebSessionCallbackKind.webAuthnSelfHosted.callbackPath, "webauthn-callback")
+    }
+
+    /// `AuthWebSessionCallbackKind.supportsHttpsCallback` is true only for the SSO and Duo connectors;
+    /// WebAuthn always uses the `bitwarden://` custom scheme on iOS regardless of region or OS.
+    func test_authWebSessionCallbackKind_supportsHttpsCallback() {
+        XCTAssertTrue(AuthWebSessionCallbackKind.singleSignOn.supportsHttpsCallback)
+        XCTAssertTrue(AuthWebSessionCallbackKind.duo.supportsHttpsCallback)
+        XCTAssertFalse(AuthWebSessionCallbackKind.webAuthnSelfHosted.supportsHttpsCallback)
+    }
+
     /// `callbackUrlScheme` has the expected value.
     func test_callbackUrlScheme() {
         XCTAssertEqual(subject.callbackUrlScheme, "bitwarden")
@@ -199,6 +214,77 @@ class AuthServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         ]
         XCTAssertEqual(expectedUrlComponents?.url, result.0)
         XCTAssertEqual("PASSWORD", result.1)
+    }
+
+    /// `generateSingleSignOnUrl(from:)` uses the HTTPS callback at the region's apex host as the
+    /// `redirect_uri` for Cloud (US) users on iOS 17.4+, and the `bitwarden://` custom scheme on
+    /// earlier OS versions.
+    func test_generateSingleSignOnUrl_unitedStatesUsesHttpsCallback() async throws {
+        client.result = .httpSuccess(testData: .preValidateSingleSignOn)
+        clientService.mockGenerators.passwordReturnValue = "PASSWORD"
+        environmentService.region = .unitedStates
+
+        let result = try await subject.generateSingleSignOnUrl(from: "Org123")
+
+        let redirectUri = URLComponents(url: result.url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "redirect_uri" }?.value
+        if #available(iOS 17.4, *) {
+            XCTAssertEqual(redirectUri, "https://bitwarden.com/sso-callback")
+        } else {
+            XCTAssertEqual(redirectUri, "bitwarden://sso-callback")
+        }
+    }
+
+    /// `generateSingleSignOnUrl(from:)` uses the HTTPS callback at the region's apex host as the
+    /// `redirect_uri` for Cloud (EU) users on iOS 17.4+, and the `bitwarden://` custom scheme on
+    /// earlier OS versions.
+    func test_generateSingleSignOnUrl_europeUsesHttpsCallback() async throws {
+        client.result = .httpSuccess(testData: .preValidateSingleSignOn)
+        clientService.mockGenerators.passwordReturnValue = "PASSWORD"
+        environmentService.region = .europe
+
+        let result = try await subject.generateSingleSignOnUrl(from: "Org123")
+
+        let redirectUri = URLComponents(url: result.url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "redirect_uri" }?.value
+        if #available(iOS 17.4, *) {
+            XCTAssertEqual(redirectUri, "https://bitwarden.eu/sso-callback")
+        } else {
+            XCTAssertEqual(redirectUri, "bitwarden://sso-callback")
+        }
+    }
+
+    /// `generateSingleSignOnUrl(from:)` uses the HTTPS callback at the `bitwarden.pw` apex for
+    /// Internal (`bitwarden.pw`) environments on iOS 17.4+, and the `bitwarden://` custom scheme
+    /// on earlier OS versions.
+    func test_generateSingleSignOnUrl_internalUsesHttpsCallback() async throws {
+        client.result = .httpSuccess(testData: .preValidateSingleSignOn)
+        clientService.mockGenerators.passwordReturnValue = "PASSWORD"
+        environmentService.region = .internal
+
+        let result = try await subject.generateSingleSignOnUrl(from: "Org123")
+
+        let redirectUri = URLComponents(url: result.url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "redirect_uri" }?.value
+        if #available(iOS 17.4, *) {
+            XCTAssertEqual(redirectUri, "https://bitwarden.pw/sso-callback")
+        } else {
+            XCTAssertEqual(redirectUri, "bitwarden://sso-callback")
+        }
+    }
+
+    /// `generateSingleSignOnUrl(from:)` keeps the `bitwarden://` custom scheme `redirect_uri` for
+    /// self-hosted users regardless of OS version.
+    func test_generateSingleSignOnUrl_selfHostedUsesCustomScheme() async throws {
+        client.result = .httpSuccess(testData: .preValidateSingleSignOn)
+        clientService.mockGenerators.passwordReturnValue = "PASSWORD"
+        environmentService.region = .selfHosted
+
+        let result = try await subject.generateSingleSignOnUrl(from: "Org123")
+
+        let redirectUri = URLComponents(url: result.url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "redirect_uri" }?.value
+        XCTAssertEqual(redirectUri, "bitwarden://sso-callback")
     }
 
     /// `getPendingAdminLoginRequest(userId:)` returns the specific admin pending login request.

--- a/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
+++ b/BitwardenShared/Core/Auth/Services/TestHelpers/MockAuthService.swift
@@ -66,6 +66,8 @@ class MockAuthService: AuthService {
     var setPendingAdminLoginRequestResult: Result<Void, Error> = .success(())
 
     var webAuthenticationSession: ASWebAuthenticationSession?
+    var webAuthenticationSessionCallbackKind: AuthWebSessionCallbackKind?
+    var webAuthenticationSessionUrl: URL?
 
     func answerLoginRequest(_ request: BitwardenShared.LoginRequest, approve: Bool) async throws {
         answerLoginRequestRequest = request
@@ -179,8 +181,11 @@ class MockAuthService: AuthService {
 
     func webAuthenticationSession(
         url: URL,
+        callbackKind: AuthWebSessionCallbackKind,
         completionHandler: @escaping ASWebAuthenticationSession.CompletionHandler,
     ) -> ASWebAuthenticationSession {
+        webAuthenticationSessionCallbackKind = callbackKind
+        webAuthenticationSessionUrl = url
         let mockSession = MockWebAuthenticationSession(
             url: url,
             callbackURLScheme: callbackUrlScheme,

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
@@ -10,6 +10,17 @@ extension RegionType {
         allCases.filter(\.isUserSelectable)
     }
 
+    /// The region's apex domain, used as the host for the HTTPS auth-connector callback (Cloud
+    /// regions only), or `nil` for self-hosted (which uses the `bitwarden://` custom scheme).
+    var authCallbackHost: String? {
+        switch self {
+        case .europe: "bitwarden.eu"
+        case .internal: "bitwarden.pw"
+        case .selfHosted: nil
+        case .unitedStates: "bitwarden.com"
+        }
+    }
+
     /// The name for this region, localized.
     var localizedName: String {
         switch self {

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
@@ -5,10 +5,16 @@ import BitwardenResources
 
 /// A region that the user can select when creating or signing into their account.
 extension RegionType {
+    /// The regions the user can choose from in the region picker, in display order.
+    static var userSelectableCases: [RegionType] {
+        allCases.filter(\.isUserSelectable)
+    }
+
     /// The name for this region, localized.
     var localizedName: String {
         switch self {
         case .europe: Localizations.eu
+        case .internal: "Internal" // Internal only, hidden from the region picker and not user facing.
         case .selfHosted: Localizations.selfHosted
         case .unitedStates: Localizations.us
         }
@@ -18,7 +24,8 @@ extension RegionType {
     var baseURLDescription: String {
         switch self {
         case .europe: "bitwarden.eu"
-        case .selfHosted: Localizations.selfHosted
+        // `.internal` is not user facing, so it mirrors self-hosted's description.
+        case .internal, .selfHosted: Localizations.selfHosted
         case .unitedStates: "bitwarden.com"
         }
     }
@@ -30,7 +37,7 @@ extension RegionType {
             .defaultEU
         case .unitedStates:
             .defaultUS
-        case .selfHosted:
+        case .internal, .selfHosted:
             nil
         }
     }
@@ -39,8 +46,19 @@ extension RegionType {
     var errorReporterName: String {
         switch self {
         case .europe: "EU"
+        case .internal: "Internal"
         case .selfHosted: "Self-Hosted"
         case .unitedStates: "US"
+        }
+    }
+
+    /// Whether the user can choose this region in the region picker. Internal/QA regions (e.g.
+    /// `.internal`) are excluded — they're detected automatically from the configured URL, never
+    /// offered as a selectable option.
+    var isUserSelectable: Bool {
+        switch self {
+        case .europe, .selfHosted, .unitedStates: true
+        case .internal: false
         }
     }
 }

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionTypeTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionTypeTests.swift
@@ -7,6 +7,14 @@ import BitwardenResources
 class RegionTypeTests: BitwardenTestCase {
     // MARK: Tests
 
+    /// `authCallbackHost` returns the apex host for Cloud regions and `nil` for self-hosted.
+    func test_authCallbackHost() {
+        XCTAssertEqual(RegionType.europe.authCallbackHost, "bitwarden.eu")
+        XCTAssertEqual(RegionType.internal.authCallbackHost, "bitwarden.pw")
+        XCTAssertNil(RegionType.selfHosted.authCallbackHost)
+        XCTAssertEqual(RegionType.unitedStates.authCallbackHost, "bitwarden.com")
+    }
+
     /// `getter:localizedName` returns the correct values.
     func test_localizedName() {
         XCTAssertEqual(RegionType.europe.localizedName, Localizations.eu)

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionTypeTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionTypeTests.swift
@@ -10,6 +10,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:localizedName` returns the correct values.
     func test_localizedName() {
         XCTAssertEqual(RegionType.europe.localizedName, Localizations.eu)
+        XCTAssertEqual(RegionType.internal.localizedName, "Internal")
         XCTAssertEqual(RegionType.selfHosted.localizedName, Localizations.selfHosted)
         XCTAssertEqual(RegionType.unitedStates.localizedName, Localizations.us)
     }
@@ -17,6 +18,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:baseURLDescription` returns the correct values.
     func test_baseURLDescription() {
         XCTAssertEqual(RegionType.europe.baseURLDescription, "bitwarden.eu")
+        XCTAssertEqual(RegionType.internal.baseURLDescription, Localizations.selfHosted)
         XCTAssertEqual(RegionType.selfHosted.baseURLDescription, Localizations.selfHosted)
         XCTAssertEqual(RegionType.unitedStates.baseURLDescription, "bitwarden.com")
     }
@@ -24,6 +26,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:defaultURLs` returns the correct values.
     func test_defaultURLs() {
         XCTAssertEqual(RegionType.europe.defaultURLs?.api?.absoluteString, "https://api.bitwarden.eu")
+        XCTAssertNil(RegionType.internal.defaultURLs)
         XCTAssertNil(RegionType.selfHosted.defaultURLs)
         XCTAssertEqual(RegionType.unitedStates.defaultURLs?.api?.absoluteString, "https://api.bitwarden.com")
     }
@@ -31,7 +34,21 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:errorReporterName` returns the correct values.
     func test_errorReporterName() {
         XCTAssertEqual(RegionType.europe.errorReporterName, "EU")
+        XCTAssertEqual(RegionType.internal.errorReporterName, "Internal")
         XCTAssertEqual(RegionType.selfHosted.errorReporterName, "Self-Hosted")
         XCTAssertEqual(RegionType.unitedStates.errorReporterName, "US")
+    }
+
+    /// `getter:isUserSelectable` is true for the user-facing regions and false for internal.
+    func test_isUserSelectable() {
+        XCTAssertTrue(RegionType.europe.isUserSelectable)
+        XCTAssertFalse(RegionType.internal.isUserSelectable)
+        XCTAssertTrue(RegionType.selfHosted.isUserSelectable)
+        XCTAssertTrue(RegionType.unitedStates.isUserSelectable)
+    }
+
+    /// `userSelectableCases` returns the user-facing regions in display order, excluding internal.
+    func test_userSelectableCases() {
+        XCTAssertEqual(RegionType.userSelectableCases, [.unitedStates, .europe, .selfHosted])
     }
 }

--- a/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
@@ -164,16 +164,7 @@ extension DefaultEnvironmentService {
     }
 
     var region: RegionType {
-        if environmentURLs.baseURL == EnvironmentURLData.defaultUS.base {
-            .unitedStates
-        } else if environmentURLs.baseURL == EnvironmentURLData.defaultEU.base {
-            .europe
-        } else if let host = URLComponents(url: environmentURLs.baseURL, resolvingAgainstBaseURL: false)?.host,
-                  host == "bitwarden.pw" || host.hasSuffix(".bitwarden.pw") {
-            .internal
-        } else {
-            .selfHosted
-        }
+        environmentURLs.region
     }
 
     var sendShareURL: URL {

--- a/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentService.swift
@@ -168,6 +168,9 @@ extension DefaultEnvironmentService {
             .unitedStates
         } else if environmentURLs.baseURL == EnvironmentURLData.defaultEU.base {
             .europe
+        } else if let host = URLComponents(url: environmentURLs.baseURL, resolvingAgainstBaseURL: false)?.host,
+                  host == "bitwarden.pw" || host.hasSuffix(".bitwarden.pw") {
+            .internal
         } else {
             .selfHosted
         }

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -271,6 +271,15 @@ class EnvironmentServiceTests: XCTestCase {
         XCTAssertEqual(errorReporter.region?.isPreAuth, false)
     }
 
+    /// `region` resolves a `bitwarden.pw` environment (including subdomains) to `.internal`.
+    func test_region_internal() async {
+        await subject.setPreAuthURLs(urls: EnvironmentURLData(base: URL(string: "https://qa-team.sh.bitwarden.pw")!))
+
+        XCTAssertEqual(subject.region, .internal)
+        XCTAssertEqual(errorReporter.region?.region, "Internal")
+        XCTAssertEqual(errorReporter.region?.isPreAuth, true)
+    }
+
     /// `setPreAuthURLs(urls:)` sets the pre-auth URLs.
     func test_setPreAuthURLs() async {
         let urls = EnvironmentURLData(base: .example)

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -219,9 +219,8 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
             showSelfHostedView(delegate: context as? SelfHostedProcessorDelegate, currentRegion: region)
         case let .setMasterPassword(organizationIdentifier):
             showSetMasterPassword(organizationIdentifier: organizationIdentifier)
-        case let .singleSignOn(callbackUrlScheme, state, url):
+        case let .singleSignOn(state, url):
             showSingleSignOn(
-                callbackUrlScheme: callbackUrlScheme,
                 delegate: context as? SingleSignOnFlowDelegate,
                 state: state,
                 url: url,
@@ -373,9 +372,9 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         authURL url: URL,
         delegate: DuoAuthenticationFlowDelegate?,
     ) {
-        let session = ASWebAuthenticationSession(
+        let session = services.authService.webAuthenticationSession(
             url: url,
-            callbackURLScheme: services.authService.callbackUrlScheme,
+            callbackKind: .duo,
         ) { callbackURL, error in
             if let error {
                 delegate?.duoErrored(error: error)
@@ -691,21 +690,19 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
     /// Shows the single sign on screen.
     ///
     /// - Parameters:
-    ///   - callbackUrlScheme: The callback url scheme for this application.
     ///   - delegate: A `SingleSignOnFlowDelegate` object that is notified when the single sign on flow succeeds or
     ///     fails.
     ///   - state: The password that the response has to match.
     ///   - url: The URL for the single sign on web auth session.
     ///
     private func showSingleSignOn(
-        callbackUrlScheme: String,
         delegate: SingleSignOnFlowDelegate?,
         state: String,
         url: URL,
     ) {
-        let session = ASWebAuthenticationSession(
+        let session = services.authService.webAuthenticationSession(
             url: url,
-            callbackURLScheme: callbackUrlScheme,
+            callbackKind: .singleSignOn,
         ) { url, error in
             if let error {
                 delegate?.singleSignOnErrored(error: error)
@@ -914,6 +911,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         guard let delegate else { return }
         let session = services.authService.webAuthenticationSession(
             url: url,
+            callbackKind: .webAuthnSelfHosted,
         ) { callbackURL, error in
             if let error {
                 delegate.webAuthnErrored(error: error)

--- a/BitwardenShared/UI/Auth/AuthCoordinator.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinator.swift
@@ -652,7 +652,7 @@ final class AuthCoordinator: NSObject, // swiftlint:disable:this type_body_lengt
         let preAuthEnvironmentURLs = services.appSettingsStore.preAuthEnvironmentURLs ?? EnvironmentURLData()
         var state = SelfHostedState()
 
-        if currentRegion == .selfHosted {
+        if currentRegion == .selfHosted || currentRegion == .internal {
             state = SelfHostedState(
                 apiServerUrl: preAuthEnvironmentURLs.api?.sanitized.description ?? "",
                 iconsServerUrl: preAuthEnvironmentURLs.icons?.sanitized.description ?? "",

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -263,6 +263,38 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertTrue(didRun)
     }
 
+    /// `navigate(to:)` with `.duoAuthenticationFlow` starts a web auth session built for the Duo
+    /// connector and completes with the combined `code|state` token.
+    @MainActor
+    func test_navigate_duoAuthenticationFlow() throws {
+        let delegate = MockDuoAuthenticationFlowDelegate()
+
+        subject.navigate(to: .duoAuthenticationFlow(URL.example), context: delegate)
+
+        let mockSession = try XCTUnwrap(authService.webAuthenticationSession as? MockWebAuthenticationSession)
+        XCTAssertEqual(authService.webAuthenticationSessionCallbackKind, .duo)
+        XCTAssertEqual(authService.webAuthenticationSessionUrl, .example)
+        XCTAssertEqual(mockSession.initUrl, .example)
+        XCTAssertTrue(mockSession.startCalled)
+
+        mockSession.initCompletionHandler(URL(string: "bitwarden://?code=duo_code&state=duo_state"), nil)
+
+        XCTAssertEqual(delegate.didCompleteReceivedCode, "duo_code|duo_state")
+    }
+
+    /// `navigate(to:)` with `.duoAuthenticationFlow` surfaces errors from the web auth session.
+    @MainActor
+    func test_navigate_duoAuthenticationFlow_error() throws {
+        let delegate = MockDuoAuthenticationFlowDelegate()
+
+        subject.navigate(to: .duoAuthenticationFlow(URL.example), context: delegate)
+
+        let mockSession = try XCTUnwrap(authService.webAuthenticationSession as? MockWebAuthenticationSession)
+        mockSession.initCompletionHandler(nil, BitwardenTestError.example)
+
+        XCTAssertEqual(delegate.duoErroredReceivedError as? BitwardenTestError, BitwardenTestError.example)
+    }
+
     /// `navigate(to:)` with `.expiredLink` pushes the expired link view onto the stack navigator.
     @MainActor
     func test_navigate_expiredLink() throws {
@@ -540,6 +572,38 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
         let view = viewController.rootView
         let state = view.store.state
         XCTAssertEqual(state.orgIdentifier, "Bitwarden")
+    }
+
+    /// `navigate(to:)` with `.singleSignOn` starts a web auth session built for the SSO connector and
+    /// completes with the returned code when the callback's state matches.
+    @MainActor
+    func test_navigate_singleSignOn() throws {
+        let delegate = MockSingleSignOnFlowDelegate()
+
+        subject.navigate(to: .singleSignOn(state: "state", url: .example), context: delegate)
+
+        let mockSession = try XCTUnwrap(authService.webAuthenticationSession as? MockWebAuthenticationSession)
+        XCTAssertEqual(authService.webAuthenticationSessionCallbackKind, .singleSignOn)
+        XCTAssertEqual(authService.webAuthenticationSessionUrl, .example)
+        XCTAssertEqual(mockSession.initUrl, .example)
+        XCTAssertTrue(mockSession.startCalled)
+
+        mockSession.initCompletionHandler(URL(string: "bitwarden://sso-callback?state=state&code=super_code"), nil)
+
+        XCTAssertEqual(delegate.singleSignOnCompletedReceivedCode, "super_code")
+    }
+
+    /// `navigate(to:)` with `.singleSignOn` surfaces errors from the web auth session.
+    @MainActor
+    func test_navigate_singleSignOn_error() throws {
+        let delegate = MockSingleSignOnFlowDelegate()
+
+        subject.navigate(to: .singleSignOn(state: "state", url: .example), context: delegate)
+
+        let mockSession = try XCTUnwrap(authService.webAuthenticationSession as? MockWebAuthenticationSession)
+        mockSession.initCompletionHandler(nil, BitwardenTestError.example)
+
+        XCTAssertEqual(delegate.singleSignOnErroredReceivedError as? BitwardenTestError, BitwardenTestError.example)
     }
 
     /// `handleEvent()` with `.switchAccount` with an locked account navigates to vault unlock

--- a/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
+++ b/BitwardenShared/UI/Auth/AuthCoordinatorTests.swift
@@ -478,6 +478,28 @@ class AuthCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(action.embedInNavigationController, true)
     }
 
+    /// `navigate(to:)` with `.selfHosted` pre-fills the self-hosted view with the stored URLs when
+    /// the current region is internal, mirroring self-hosted behavior.
+    @MainActor
+    func test_navigate_selfHosted_prefillsURLsForInternalRegion() throws {
+        appSettingsStore.preAuthEnvironmentURLs = EnvironmentURLData(base: URL(string: "https://bitwarden.pw")!)
+        subject.navigate(to: .selfHosted(currentRegion: .internal))
+
+        let view = try XCTUnwrap(stackNavigator.actions.last?.view as? SelfHostedView)
+        XCTAssertEqual(view.store.state.serverUrl, "https://bitwarden.pw")
+    }
+
+    /// `navigate(to:)` with `.selfHosted` pre-fills the self-hosted view with the stored URLs when
+    /// the current region is self-hosted.
+    @MainActor
+    func test_navigate_selfHosted_prefillsURLsForSelfHostedRegion() throws {
+        appSettingsStore.preAuthEnvironmentURLs = EnvironmentURLData(base: URL(string: "https://example.com")!)
+        subject.navigate(to: .selfHosted(currentRegion: .selfHosted))
+
+        let view = try XCTUnwrap(stackNavigator.actions.last?.view as? SelfHostedView)
+        XCTAssertEqual(view.store.state.serverUrl, "https://example.com")
+    }
+
     /// `navigate(to:)` with `.removeMasterPassword` pushes the remove master password view onto the stack navigator.
     @MainActor
     func test_navigate_removeMasterPassword() throws {

--- a/BitwardenShared/UI/Auth/AuthRoute.swift
+++ b/BitwardenShared/UI/Auth/AuthRoute.swift
@@ -141,11 +141,10 @@ public enum AuthRoute: Equatable {
     /// A route to the single sign on WebAuth screen.
     ///
     /// - Parameters:
-    ///   - callbackUrlScheme: The callback url scheme for this application.
     ///   - state: The string that the result will have to match.
     ///   - url: The url to present to the web auth session.
     ///
-    case singleSignOn(callbackUrlScheme: String, state: String, url: URL)
+    case singleSignOn(state: String, url: URL)
 
     /// A route to the two-factor authentication screen.
     ///

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -8,7 +8,7 @@ import Foundation
 /// An object that is signaled when specific circumstances in the single sign on flow have been encountered.
 ///
 @MainActor
-protocol SingleSignOnFlowDelegate: AnyObject {
+protocol SingleSignOnFlowDelegate: AnyObject { // sourcery: AutoMockable
     /// Called when the single sign on flow has been completed successfully.
     ///
     /// - Parameter code: The code that was returned by the single sign on web auth process.
@@ -117,7 +117,6 @@ final class SingleSignOnProcessor: StateProcessor<SingleSignOnState, SingleSignO
             let result = try await services.authService.generateSingleSignOnUrl(from: state.identifierText)
             coordinator.navigate(
                 to: .singleSignOn(
-                    callbackUrlScheme: services.authService.callbackUrlScheme,
                     state: result.state,
                     url: result.url,
                 ),

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessorTests.swift
@@ -101,7 +101,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
         XCTAssertEqual(
             coordinator.routes.last,
-            .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example),
+            .singleSignOn(state: "state", url: .example),
         )
         XCTAssertEqual(subject.state.identifierText, "OrgId")
     }
@@ -119,7 +119,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertNotEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
         XCTAssertNotEqual(
             coordinator.routes.last,
-            .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example),
+            .singleSignOn(state: "state", url: .example),
         )
         XCTAssertEqual(subject.state.identifierText, "")
     }
@@ -139,7 +139,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertNotEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
         XCTAssertNotEqual(
             coordinator.routes.last,
-            .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example),
+            .singleSignOn(state: "state", url: .example),
         )
         XCTAssertEqual(subject.state.identifierText, "BestOrganization")
     }
@@ -162,7 +162,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         )
         XCTAssertEqual(
             coordinator.routes.last,
-            .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example),
+            .singleSignOn(state: "state", url: .example),
         )
         XCTAssertEqual(subject.state.identifierText, "OrgId")
     }
@@ -216,7 +216,7 @@ class SingleSignOnProcessorTests: BitwardenTestCase { // swiftlint:disable:this 
         XCTAssertEqual(coordinator.loadingOverlaysShown.last, LoadingOverlayState(title: Localizations.loggingIn))
         XCTAssertEqual(
             coordinator.routes.last,
-            .singleSignOn(callbackUrlScheme: "callback", state: "state", url: .example),
+            .singleSignOn(state: "state", url: .example),
         )
     }
 

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -285,7 +285,7 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
 /// An object that is signaled when specific circumstances in the web authentication on flow have been encountered.
 ///
 @MainActor
-protocol DuoAuthenticationFlowDelegate: AnyObject {
+protocol DuoAuthenticationFlowDelegate: AnyObject { // sourcery: AutoMockable
     /// Called when the web auth flow has been completed successfully.
     ///
     /// - Parameter code: The code that was returned by the single sign on web auth process.

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelper.swift
@@ -36,7 +36,7 @@ class RegionHelper {
     /// Builds an alert for region selection and navigates to the alert.
     ///
     func presentRegionSelectorAlert(title: String, currentRegion: RegionType?) async {
-        let actions = RegionType.allCases.map { region in
+        let actions = RegionType.userSelectableCases.map { region in
             AlertAction(title: region.baseURLDescription, style: .default) { _ in
                 if let urls = region.defaultURLs {
                     await self.delegate?.setRegion(region, urls)

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelper.swift
@@ -66,13 +66,7 @@ class RegionHelper {
             return
         }
 
-        if urls.base == EnvironmentURLData.defaultUS.base {
-            await delegate?.setRegion(.unitedStates, urls)
-        } else if urls.base == EnvironmentURLData.defaultEU.base {
-            await delegate?.setRegion(.europe, urls)
-        } else {
-            await delegate?.setRegion(.selfHosted, urls)
-        }
+        await delegate?.setRegion(urls.region, urls)
     }
 }
 

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
@@ -150,6 +150,17 @@ class RegionHelperTests: BitwardenTestCase {
         XCTAssertEqual(regionDelegate.setRegionType, .selfHosted)
         XCTAssertEqual(regionDelegate.setRegionUrls, EnvironmentURLData(base: URL(string: "https://selfhosted.com")))
     }
+
+    /// `loadRegion()` resolves a `bitwarden.pw` pre-auth environment (including subdomains) to
+    /// `.internal` rather than treating it as self-hosted.
+    func test_loadRegion_internal() async throws {
+        let urls = EnvironmentURLData(base: URL(string: "https://qa-team.sh.bitwarden.pw"))
+        stateService.preAuthEnvironmentURLs = urls
+        await subject.loadRegion()
+        XCTAssertTrue(regionDelegate.setRegionCalled)
+        XCTAssertEqual(regionDelegate.setRegionType, .internal)
+        XCTAssertEqual(regionDelegate.setRegionUrls, urls)
+    }
 }
 
 class MockRegionDelegate: RegionDelegate {

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
@@ -103,6 +103,18 @@ class RegionHelperTests: BitwardenTestCase {
         XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .unitedStates))
     }
 
+    /// `presentRegionSelectorAlert(title:currentRegion:)` offers exactly the user-selectable regions
+    /// (US, EU, self-hosted) plus cancel — the internal (`bitwarden.pw`) region is detected
+    /// automatically and must never appear in the picker.
+    @MainActor
+    func test_presentRegionSelectorAlert_excludesInternal() async throws {
+        await subject.presentRegionSelectorAlert(title: Localizations.creatingOn, currentRegion: .unitedStates)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        let actionTitles = alert.alertActions.map(\.title)
+        XCTAssertEqual(actionTitles, ["bitwarden.com", "bitwarden.eu", Localizations.selfHosted, Localizations.cancel])
+    }
+
     /// `loadRegion()` with pre auth region as nil default to us
     func test_loadRegion_nil() async throws {
         stateService.preAuthEnvironmentURLs = nil


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-28349](https://bitwarden.atlassian.net/browse/PM-28349)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Our mobile authentication connectors currently complete the `ASWebAuthenticationSession` flow at the end of the SSO and Duo flows using a custom `bitwarden://` URL scheme. This adds support for switching this to a HTTPS callback URL for **Cloud** users (US, EU, and Internal regions)

What changed:
- **Region-gated callback selection (no feature flag).** The callback descriptor is now resolved centrally in `AuthService` from `EnvironmentService.region`. Cloud regions use an `https://{apexHost}/{sso,duo}-callback` callback at the region's fixed apex host (US→`bitwarden.com`, EU→`bitwarden.eu`, Internal→`bitwarden.pw`); self-hosted continues to use `bitwarden://`.
- **New `RegionType.internal`** for Bitwarden's `bitwarden.pw` (QA/Internal) environments. It is hidden from the region picker and detected automatically by `bitwarden.pw` host suffix (`EnvironmentService.region` / `EnvironmentURLData.region`). The apex host comes from `RegionType.authCallbackHost`.
- **`ASWebAuthenticationSession.Callback.https(host:path:)`** is used to intercept the `https://` redirect for SSO and Duo. This API is iOS 17.4+, and the deployment target is iOS 15.0, so it is `@available`-gated: Cloud users on iOS < 17.4 transparently fall back to the existing `bitwarden://` callback.
- SSO's OAuth `redirect_uri` follows the same region/availability resolution so the value sent to the identity provider always matches the callback the app intercepts.
- Session construction for the SSO, Duo, and WebAuthn-self-hosted flows is consolidated behind a single `AuthService` factory (the coordinator retains presentation/start). The now-unused `callbackUrlScheme` parameter is removed from `AuthRoute.singleSignOn`.

Scope notes:
- **WebAuthn is intentionally excluded.** On iOS, Cloud WebAuthn 2FA already uses the native passkey API (`ASAuthorizationController`), not a connector callback URL; only the self-hosted connector uses `webauthn-callback`, and self-hosted remains on `bitwarden://`.



[PM-28349]: https://bitwarden.atlassian.net/browse/PM-28349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ