### PR TITLE
[PM-37886] refactor: Remove unused key connector organization identifier parameter

### DIFF
--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -269,12 +269,10 @@ protocol AuthRepository: AnyObject {
     /// - Parameters:
     ///   - keyConnectorKeyWrappedUserKey: The user key encrypted (wrapped) by the Key Connector key.
     ///   - keyConnectorURL: The URL to the Key Connector API.
-    ///   - orgIdentifier: The text identifier for the organization.
     ///
     func unlockVaultWithKeyConnectorKey(
         keyConnectorKeyWrappedUserKey: String,
         keyConnectorURL: URL,
-        orgIdentifier: String,
     ) async throws
 
     /// Attempts to unlock the user's vault with the stored neverlock key.
@@ -1106,7 +1104,6 @@ extension DefaultAuthRepository: AuthRepository {
     func unlockVaultWithKeyConnectorKey(
         keyConnectorKeyWrappedUserKey: String,
         keyConnectorURL: URL,
-        orgIdentifier: String,
     ) async throws {
         try await unlockVault(method: .keyConnectorUrl(
             url: keyConnectorURL.absoluteString,

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -2625,7 +2625,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             try await subject.unlockVaultWithKeyConnectorKey(
                 keyConnectorKeyWrappedUserKey: "user",
                 keyConnectorURL: URL(string: "https://example.com")!,
-                orgIdentifier: "org-id",
             )
         }
 
@@ -2655,7 +2654,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             try await subject.unlockVaultWithKeyConnectorKey(
                 keyConnectorKeyWrappedUserKey: "user",
                 keyConnectorURL: URL(string: "https://example.com")!,
-                orgIdentifier: "org-id",
             )
         }
     }
@@ -2666,7 +2664,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             try await subject.unlockVaultWithKeyConnectorKey(
                 keyConnectorKeyWrappedUserKey: "user",
                 keyConnectorURL: URL(string: "https://example.com")!,
-                orgIdentifier: "org-id",
             )
         }
     }

--- a/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/TestHelpers/MockAuthRepository.swift
@@ -95,7 +95,6 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     var unlockVaultWithKeyConnectorKeyCalled = false
     var unlockVaultWithKeyConnectorKeyConnectorURL: URL? // swiftlint:disable:this identifier_name
     var unlockVaultWithKeyConnectorKeyWrappedUserKey: String? // swiftlint:disable:this identifier_name
-    var unlockVaultWithKeyConnectorOrgIdentifier: String?
     var unlockVaultWithKeyConnectorKeyResult: Result<Void, Error> = .success(())
 
     var convertNewUserToKeyConnectorKeyCalled = false
@@ -391,12 +390,10 @@ class MockAuthRepository: AuthRepository { // swiftlint:disable:this type_body_l
     func unlockVaultWithKeyConnectorKey(
         keyConnectorKeyWrappedUserKey: String,
         keyConnectorURL: URL,
-        orgIdentifier: String,
     ) async throws {
         unlockVaultWithKeyConnectorKeyCalled = true
         unlockVaultWithKeyConnectorKeyConnectorURL = keyConnectorURL
         unlockVaultWithKeyConnectorKeyWrappedUserKey = keyConnectorKeyWrappedUserKey
-        unlockVaultWithKeyConnectorOrgIdentifier = orgIdentifier
         try unlockVaultWithKeyConnectorKeyResult.get()
     }
 

--- a/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/SingleSignOn/SingleSignOnProcessor.swift
@@ -239,7 +239,6 @@ extension SingleSignOnProcessor: SingleSignOnFlowDelegate {
                     try await services.authRepository.unlockVaultWithKeyConnectorKey(
                         keyConnectorKeyWrappedUserKey: keyConnectorKeyWrappedUserKey,
                         keyConnectorURL: keyConnectorUrl,
-                        orgIdentifier: state.identifierText,
                     )
                     coordinator.hideLoadingOverlay()
                     await coordinator.handleEvent(.didCompleteAuth)

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessor.swift
@@ -4,13 +4,6 @@ import BitwardenResources
 import CryptoKit
 import Foundation
 
-/// Errors thrown by `TwoFactorAuthProcessor`.
-///
-enum TwoFactorAuthError: Error {
-    /// The organization's identifier is missing, but required for Key Connector unlock.
-    case missingOrgIdentifier
-}
-
 // MARK: - TwoFactorAuthProcessor
 
 /// The processor used to manage state and handle actions for the `TwoFactorAuthView`.
@@ -246,16 +239,12 @@ final class TwoFactorAuthProcessor: StateProcessor<TwoFactorAuthState, TwoFactor
                 )
                 coordinator.navigate(to: .dismiss)
             case let .keyConnector(keyConnectorKeyWrappedUserKey, keyConnectorUrl):
-                guard let orgIdentifier = state.orgIdentifier else {
-                    throw TwoFactorAuthError.missingOrgIdentifier
-                }
                 guard let keyConnectorKeyWrappedUserKey else {
                     throw StateServiceError.noEncUserKey
                 }
                 try await services.authRepository.unlockVaultWithKeyConnectorKey(
                     keyConnectorKeyWrappedUserKey: keyConnectorKeyWrappedUserKey,
                     keyConnectorURL: keyConnectorUrl,
-                    orgIdentifier: orgIdentifier,
                 )
                 await coordinator.handleEvent(.didCompleteAuth)
             }

--- a/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Login/TwoFactorAuth/TwoFactorAuthProcessorTests.swift
@@ -467,24 +467,6 @@ class TwoFactorAuthProcessorTests: BitwardenTestCase { // swiftlint:disable:this
         XCTAssertEqual(coordinator.events.last, .didCompleteAuth)
     }
 
-    /// `perform(_:)` with `.continueTapped` throws an error if the organization identifier is
-    /// missing for log in with Key Connector.
-    @MainActor
-    func test_perform_continueTapped_loginWithKeyConnectorKey_missingOrgIdentifier() async {
-        authService.loginWithTwoFactorCodeResult = .success(.keyConnector(
-            keyConnectorKeyWrappedUserKey: "KEY",
-            keyConnectorURL: URL(string: "https://example.com")!,
-        ))
-        subject.state.verificationCode = "Test"
-
-        await subject.perform(.continueTapped)
-
-        XCTAssertFalse(authRepository.unlockVaultWithKeyConnectorKeyCalled)
-        XCTAssertEqual(coordinator.errorAlertsShown.last as? TwoFactorAuthError, .missingOrgIdentifier)
-        XCTAssertEqual(coordinator.routes, [])
-        XCTAssertEqual(errorReporter.errors as? [TwoFactorAuthError], [.missingOrgIdentifier])
-    }
-
     /// `perform(_:)` with `.continueTapped` throws `noEncUserKey` when the key connector wrapped
     /// user key is missing (e.g. new user not yet migrated to key connector).
     @MainActor


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-37886](https://bitwarden.atlassian.net/browse/PM-37886)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Removes the unused `orgIdentifier` parameter from `AuthRepository.unlockVaultWithKeyConnectorKey()`. At one point, there was logic in this method to convert a user to key connector if needed (which required the org ID), but this was refactored out of this method in https://github.com/bitwarden/ios/pull/1529.

[PM-37886]: https://bitwarden.atlassian.net/browse/PM-37886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ