### PR TITLE
[PM-39381] feat: Add license number copy action to Driver's License more-options menu

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 "Bitwarden" = "Bitwarden";
 "Cancel" = "Cancel";
 "Copy" = "Copy";
+"CopyLicenseNumber" = "Copy license number";
 "CopyPassportNumber" = "Copy passport number";
 "CopyPassword" = "Copy password";
 "CopyUsername" = "Copy username";

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -482,8 +482,17 @@ extension Alert {
                 })
             }
         case .driversLicense:
-            // TODO: PM-32807
-            break
+            if let licenseNumber = context.cipherView.driversLicense?.licenseNumber {
+                alertActions.append(AlertAction(title: Localizations.copyLicenseNumber, style: .default) { _, _ in
+                    await action(.copy(
+                        toast: Localizations.licenseNumber,
+                        value: licenseNumber,
+                        requiresMasterPasswordReprompt: true,
+                        logEvent: nil,
+                        cipherId: context.cipherView.id,
+                    ))
+                })
+            }
         case .passport:
             if let passportNumber = context.cipherView.passport?.passportNumber {
                 alertActions.append(AlertAction(title: Localizations.copyPassportNumber, style: .default) { _, _ in

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -379,6 +379,65 @@ class AlertVaultTests: BitwardenTestCase { // swiftlint:disable:this type_body_l
     }
 
     /// `static moreOptions(canCopyTotp:cipherView:hasMasterPassword:id:showEdit:action:)` returns
+    /// the appropriate options for `.driversLicense` type
+    @MainActor
+    func test_moreOptions_driversLicense() async throws {
+        var capturedAction: MoreOptionsAction?
+        let action: (MoreOptionsAction) -> Void = { action in
+            capturedAction = action
+        }
+        let cipher = CipherView.fixture(
+            driversLicense: .fixture(),
+            edit: false,
+            id: "123",
+            name: "Test Cipher",
+            type: .driversLicense,
+            viewPassword: true,
+        )
+        let alert = Alert.moreOptions(
+            context: MoreOptionsAlertContext(
+                canArchive: false,
+                canCopyTotp: false,
+                canUnarchive: false,
+                cipherView: cipher,
+                id: cipher.id!,
+                showEdit: true,
+            ),
+            action: action,
+        )
+        XCTAssertEqual(alert.title, cipher.name)
+        XCTAssertEqual(alert.preferredStyle, .actionSheet)
+        XCTAssertEqual(alert.alertActions.count, 4)
+
+        try await alert.tapAction(byIndex: 0, withTitle: Localizations.view)
+        XCTAssertEqual(capturedAction, .view(id: "123"))
+        capturedAction = nil
+
+        try await alert.tapAction(byIndex: 1, withTitle: Localizations.edit)
+        XCTAssertEqual(
+            capturedAction,
+            .edit(cipherView: cipher),
+        )
+        capturedAction = nil
+
+        try await alert.tapAction(byIndex: 2, withTitle: Localizations.copyLicenseNumber)
+        XCTAssertEqual(
+            capturedAction,
+            .copy(
+                toast: Localizations.licenseNumber,
+                value: "D1234567",
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: "123",
+            ),
+        )
+        capturedAction = nil
+
+        try await alert.tapAction(byIndex: 3, withTitle: Localizations.cancel)
+        XCTAssertNil(capturedAction)
+    }
+
+    /// `static moreOptions(canCopyTotp:cipherView:hasMasterPassword:id:showEdit:action:)` returns
     /// the appropriate options for `.passport` type
     @MainActor
     func test_moreOptions_passport() async throws {

--- a/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
+++ b/BitwardenShared/UI/Vault/PreviewContent/BitwardenSdk+VaultFixtures.swift
@@ -261,6 +261,7 @@ extension CipherView {
         collectionIds: [String] = [],
         creationDate: DateTime = Date(year: 2023, month: 11, day: 5, hour: 9, minute: 41),
         deletedDate: Date? = nil,
+        driversLicense: DriversLicenseView? = nil,
         edit: Bool = true,
         favorite: Bool = false,
         fields: [FieldView]? = nil,
@@ -299,7 +300,7 @@ extension CipherView {
             secureNote: secureNote,
             sshKey: sshKey,
             bankAccount: bankAccount,
-            driversLicense: nil, // TODO: PM-32807
+            driversLicense: driversLicense,
             passport: passport,
             favorite: favorite,
             reprompt: reprompt,
@@ -928,6 +929,36 @@ extension Passport {
             issuingAuthority: issuingAuthority,
             issueDate: issueDate,
             expirationDate: expirationDate,
+        )
+    }
+}
+
+extension BitwardenSdk.DriversLicenseView {
+    static func fixture(
+        firstName: String? = nil,
+        middleName: String? = nil,
+        lastName: String? = nil,
+        dateOfBirth: String? = nil,
+        licenseNumber: String? = "D1234567",
+        issuingCountry: String? = nil,
+        issuingState: String? = nil,
+        issueDate: String? = nil,
+        expirationDate: String? = nil,
+        issuingAuthority: String? = nil,
+        licenseClass: String? = nil,
+    ) -> BitwardenSdk.DriversLicenseView {
+        BitwardenSdk.DriversLicenseView(
+            firstName: firstName,
+            middleName: middleName,
+            lastName: lastName,
+            dateOfBirth: dateOfBirth,
+            licenseNumber: licenseNumber,
+            issuingCountry: issuingCountry,
+            issuingState: issuingState,
+            issueDate: issueDate,
+            expirationDate: expirationDate,
+            issuingAuthority: issuingAuthority,
+            licenseClass: licenseClass,
         )
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39381

## 📔 Objective

Add a "Copy license number" quick-copy action to the Driver's License vault item more-options (⋯) menu. The license number is copied to the clipboard with master-password reprompt gating.

## 📸 Screenshots

<img width="365" src="https://github.com/user-attachments/assets/5340ece9-dd84-47c7-9121-65902292d3c1" />
