### PR TITLE
[PM-38444] feat: Use FillAssist cached rules to guide DOM field targeting in Action Extension

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -571,6 +571,8 @@
 "RequestAdminApproval" = "Request admin approval";
 "ApproveWithMasterPassword" = "Approve with master password";
 "TurnOffUsingPublicDevice" = "Turn off using a public device";
+"TurnOnFillAssist" = "Turn on fill assist";
+"TurnOnFillAssistDescriptionLong" = "Fill Assist improves autofill accuracy on supported sites by using site-specific rules.";
 "RememberThisDevice" = "Remember this device";
 "Passkey" = "Passkey";
 "Passkeys" = "Passkeys";

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
@@ -107,10 +107,9 @@ class DefaultFillAssistRepository: FillAssistRepository {
     /// Runs the full sync pipeline if sync conditions are met
     ///
     private func performSync() async throws {
-        // 1. Feature flag guard.
-        guard await configService.getFeatureFlag(.fillAssistTargetingRules) else { return }
+        guard await configService.getFeatureFlag(.fillAssistTargetingRules),
+              try await stateService.getFillAssistEnabled() else { return }
 
-        // 2. Time-interval guard — skip if last fetch was less than fillAssistUpdateInterval ago.
         let sourceUrl = environmentService.fillAssistRulesURL
         let userId = try await stateService.getActiveAccountId()
         let lastFetch = appSettingsStore.fillAssistLastFetchTimestamp(userId: userId)
@@ -118,32 +117,26 @@ class DefaultFillAssistRepository: FillAssistRepository {
             return
         }
 
-        // 3. Fetch manifest.
         let manifest = try await fillAssistAPIService.getManifest()
 
-        // 4. Resolve the non-deprecated entry for the current forms version.
         guard let entry = manifest.maps["forms"]?[Constants.FillAssist.formsVersion],
               !entry.deprecated
         else { return }
 
-        // 5. If cid and source URL are unchanged, update timestamp and skip download.
         let cached = appSettingsStore.fillAssistCachedData(userId: userId)
         if cached?.cid == entry.cid, cached?.sourceUrl == sourceUrl.absoluteString {
             appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
             return
         }
 
-        // 6. Download forms file.
         let formsMap = try await fillAssistAPIService.getFormsMap(filename: entry.filename)
 
-        // 7. Validate schema major version; update timestamp and skip if unsupported.
         let schemaMajor = formsMap.schemaVersion.split(separator: ".").first.map(String.init) ?? ""
         guard schemaMajor == Constants.FillAssist.expectedSchemaMajor else {
             appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
             return
         }
 
-        // 8. Parse, cache, and update timestamp.
         let rules = buildRules(from: formsMap)
         let data = FillAssistCachedData(cid: entry.cid, rules: rules, sourceUrl: sourceUrl.absoluteString)
         appSettingsStore.setFillAssistCachedData(data, userId: userId)

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
@@ -31,6 +31,7 @@ struct FillAssistRepositoryTests {
         fillAssistAPIService = MockFillAssistAPIService()
         stateService = MockStateService()
         stateService.activeAccount = .fixture()
+        stateService.fillAssistEnabledByUserId["1"] = true
         timeProvider = MockTimeProvider(.currentTime)
 
         subject = DefaultFillAssistRepository(
@@ -349,5 +350,37 @@ private extension FillAssistRepositoryTests {
             ],
             schemaVersion: "1.0.0",
         )
+    }
+
+    // MARK: Tests - user toggle guard
+
+    /// `syncRules()` makes no network calls when the feature flag is on but the user toggle is off.
+    @Test
+    func syncRules_userToggleOff_skipsSync() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.fillAssistEnabledByUserId["1"] = false
+
+        await subject.syncRules()
+
+        #expect(!fillAssistAPIService.getManifestCalled)
+    }
+
+    /// `syncRules()` proceeds past the user-toggle guard and fetches the manifest when both
+    /// feature flag and user toggle are on.
+    @Test
+    func syncRules_userToggleOn_fetchesManifest() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.fillAssistEnabledByUserId["1"] = true
+        fillAssistAPIService.getManifestReturnValue = makeManifest(cid: "sha256:abc")
+        // Pre-cache matching cid so sync stops at the "no changes" short-circuit.
+        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
+            cid: "sha256:abc",
+            rules: [:],
+            sourceUrl: environmentService.fillAssistRulesURL.absoluteString,
+        )
+
+        await subject.syncRules()
+
+        #expect(fillAssistAPIService.getManifestCalled)
     }
 }

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -219,6 +219,13 @@ protocol StateService: AnyObject, BillingStateService {
     ///
     func getEvents(userId: String?) async throws -> [EventData]
 
+    /// Gets whether the Fill Assist feature is enabled for the specified user.
+    ///
+    /// - Parameter userId: The user ID, or `nil` for the active account.
+    /// - Returns: Whether Fill Assist is enabled.
+    ///
+    func getFillAssistEnabled(userId: String?) async throws -> Bool
+
     /// Gets the data for the flight recorder.
     ///
     /// - Returns: The flight recorder data.
@@ -622,6 +629,14 @@ protocol StateService: AnyObject, BillingStateService {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setEvents(_ events: [EventData], userId: String?) async throws
+
+    /// Sets whether the Fill Assist feature is enabled for the specified user.
+    ///
+    /// - Parameters:
+    ///   - fillAssistEnabled: Whether Fill Assist is enabled.
+    ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
+    ///
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws
 
     /// Sets the force password reset reason for an account.
     ///
@@ -1049,6 +1064,14 @@ extension StateService {
         try await getEnvironmentURLs(userId: nil)
     }
 
+    /// Gets whether Fill Assist is enabled for the active account.
+    ///
+    /// - Returns: Whether Fill Assist is enabled.
+    ///
+    func getFillAssistEnabled() async throws -> Bool {
+        try await getFillAssistEnabled(userId: nil)
+    }
+
     /// Gets whether a sync has been done successfully after login for the current user.
     /// This is particular useful to trigger logic that needs to be executed right after login in
     /// and after the first successful sync.
@@ -1303,6 +1326,14 @@ extension StateService {
     ///
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool) async throws {
         try await setDisableAutoTotpCopy(disableAutoTotpCopy, userId: nil)
+    }
+
+    /// Sets whether Fill Assist is enabled for the active account.
+    ///
+    /// - Parameter fillAssistEnabled: Whether Fill Assist is enabled.
+    ///
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool) async throws {
+        try await setFillAssistEnabled(fillAssistEnabled, userId: nil)
     }
 
     /// Sets the force password reset reason for the active account.
@@ -1760,6 +1791,11 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
         return appSettingsStore.events(userId: userId)
     }
 
+    func getFillAssistEnabled(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.fillAssistEnabled(userId: userId)
+    }
+
     func getFlightRecorderData() async -> FlightRecorderData? {
         appSettingsStore.flightRecorderData
     }
@@ -2114,6 +2150,11 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
     func setEvents(_ events: [EventData], userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setEvents(events, userId: userId)
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setFillAssistEnabled(fillAssistEnabled, userId: userId)
     }
 
     func setFlightRecorderData(_ data: FlightRecorderData?) async {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -764,6 +764,15 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 
+    /// `getFillAssistEnabled()` returns the Fill Assist enabled value for the active account.
+    func test_getFillAssistEnabled() async throws {
+        await subject.addAccount(.fixture())
+        appSettingsStore.fillAssistEnabledByUserId["1"] = true
+
+        let value = try await subject.getFillAssistEnabled()
+        XCTAssertTrue(value)
+    }
+
     /// `getDisableAutoTotpCopy()` returns the disable auto-copy TOTP value for the active account.
     func test_getDisableAutoTotpCopy() async throws {
         await subject.addAccount(.fixture())
@@ -2095,6 +2104,17 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.setDefaultUriMatchType(.regularExpression, userId: "1")
         XCTAssertEqual(appSettingsStore.defaultUriMatchTypeByUserId["1"], .regularExpression)
+    }
+
+    /// `setFillAssistEnabled(_:userId:)` sets the Fill Assist enabled value for a user.
+    func test_setFillAssistEnabled() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        try await subject.setFillAssistEnabled(true, userId: "1")
+        XCTAssertEqual(appSettingsStore.fillAssistEnabledByUserId["1"], true)
+
+        try await subject.setFillAssistEnabled(false, userId: "1")
+        XCTAssertEqual(appSettingsStore.fillAssistEnabledByUserId["1"], false)
     }
 
     /// `setDisableAutoTotpCopy(_:userId:)` sets the disable auto-copy TOTP value for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -193,6 +193,12 @@ protocol AppSettingsStore: AnyObject {
     ///
     func fillAssistCachedData(userId: String) -> FillAssistCachedData?
 
+    /// Gets whether the Fill Assist feature is enabled for the user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the Fill Assist enabled value.
+    ///
+    func fillAssistEnabled(userId: String) -> Bool
+
     /// Gets the timestamp of the last successful fill-assist manifest check for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the timestamp.
@@ -453,6 +459,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the cached data.
     ///
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String)
+
+    /// Sets whether the Fill Assist feature is enabled for the user ID.
+    ///
+    /// - Parameters:
+    ///   - fillAssistEnabled: The value to set, or `nil` to clear.
+    ///   - userId: The user ID associated with the Fill Assist enabled value.
+    ///
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String)
 
     /// Sets the timestamp of the last successful fill-assist manifest check for the user ID.
     ///
@@ -824,6 +838,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case encryptedUserKey(userId: String)
         case events(userId: String)
         case fillAssistCachedData(userId: String)
+        case fillAssistEnabled(userId: String)
         case fillAssistLastFetchTimestamp(userId: String)
         case flightRecorderData
         case hasPerformedSyncAfterLogin(userId: String)
@@ -914,6 +929,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "events_\(userId)"
             case let .fillAssistCachedData(userId):
                 "fillAssistCachedData_\(userId)"
+            case let .fillAssistEnabled(userId):
+                "fillAssistEnabled_\(userId)"
             case let .fillAssistLastFetchTimestamp(userId):
                 "fillAssistLastFetchTimestamp_\(userId)"
             case .flightRecorderData:
@@ -1169,6 +1186,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         fetch(for: .fillAssistCachedData(userId: userId))
     }
 
+    func fillAssistEnabled(userId: String) -> Bool {
+        fetch(for: .fillAssistEnabled(userId: userId))
+    }
+
     func fillAssistLastFetchTimestamp(userId: String) -> Date? {
         fetch(for: .fillAssistLastFetchTimestamp(userId: userId))
     }
@@ -1309,6 +1330,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
 
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String) {
         store(data, for: .fillAssistCachedData(userId: userId))
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String) {
+        store(fillAssistEnabled, for: .fillAssistEnabled(userId: userId))
     }
 
     func setFillAssistLastFetchTimestamp(_ timestamp: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -512,6 +512,23 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNotNil(userDefaults.object(forKey: "bwPreferencesStorage:fillAssistLastFetchTimestamp_2"))
     }
 
+    /// `fillAssistEnabled(userId:)` returns `false` when no value has been set.
+    func test_fillAssistEnabled_isInitiallyFalse() {
+        XCTAssertFalse(subject.fillAssistEnabled(userId: "-1"))
+    }
+
+    /// `fillAssistEnabled(userId:)` and `setFillAssistEnabled(_:userId:)` get and set the value
+    /// per user and persist under the expected UserDefaults key.
+    func test_fillAssistEnabled_withValue() {
+        subject.setFillAssistEnabled(true, userId: "1")
+        subject.setFillAssistEnabled(false, userId: "2")
+
+        XCTAssertTrue(subject.fillAssistEnabled(userId: "1"))
+        XCTAssertFalse(subject.fillAssistEnabled(userId: "2"))
+        XCTAssertNotNil(userDefaults.object(forKey: "bwPreferencesStorage:fillAssistEnabled_1"))
+        XCTAssertNotNil(userDefaults.object(forKey: "bwPreferencesStorage:fillAssistEnabled_2"))
+    }
+
     /// `overrideDebugFeatureFlag(name:value:)` and `debugFeatureFlag(name:)` work as expected with correct values.
     func test_featureFlags() {
         let featureFlags: [FeatureFlag] = [.testFeatureFlag]

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -49,6 +49,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var eventsByUserId = [String: [EventData]]()
     var featureFlags = [String: Bool]()
     var fillAssistCachedDataByUserId = [String: FillAssistCachedData]()
+    var fillAssistEnabledByUserId = [String: Bool]()
     var fillAssistLastFetchTimestampByUserId = [String: Date]()
     var hasPerformedSyncAfterLogin = [String: Bool]()
     var lastActiveTime = [String: Date]()
@@ -153,6 +154,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func fillAssistCachedData(userId: String) -> FillAssistCachedData? {
         fillAssistCachedDataByUserId[userId]
+    }
+
+    func fillAssistEnabled(userId: String) -> Bool {
+        fillAssistEnabledByUserId[userId] ?? false
     }
 
     func fillAssistLastFetchTimestamp(userId: String) -> Date? {
@@ -306,6 +311,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String) {
         fillAssistCachedDataByUserId[userId] = data
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String) {
+        fillAssistEnabledByUserId[userId] = fillAssistEnabled
     }
 
     func setFillAssistLastFetchTimestamp(_ timestamp: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -45,6 +45,8 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     var didAccountSwitchInExtensionResult: Result<Bool, Error> = .success(false)
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
+    var fillAssistEnabledByUserId = [String: Bool]()
+    var getFillAssistEnabledError: Error?
     var doesActiveAccountHavePremiumResult: Bool = true
     var doesActiveAccountHavePremiumPersonallyCalled = false // swiftlint:disable:this identifier_name
     var doesActiveAccountHavePremiumPersonallyResult: Bool = true // swiftlint:disable:this identifier_name
@@ -311,6 +313,14 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
         try eventsResult.get()
         let userId = try unwrapUserId(userId)
         return events[userId] ?? []
+    }
+
+    func getFillAssistEnabled(userId: String?) async throws -> Bool {
+        if let getFillAssistEnabledError {
+            throw getFillAssistEnabledError
+        }
+        let userId = try unwrapUserId(userId)
+        return fillAssistEnabledByUserId[userId] ?? false
     }
 
     func getFlightRecorderData() async -> FlightRecorderData? {
@@ -644,6 +654,11 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     func setEvents(_ events: [EventData], userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         self.events[userId] = events
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        fillAssistEnabledByUserId[userId] = fillAssistEnabled
     }
 
     func setFlightRecorderData(_ data: FlightRecorderData?) async {

--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -23,6 +23,9 @@ extension ExternalLinksConstants {
     /// A link to the auto fill help page.
     static let autofillHelp = URL(string: "https://bitwarden.com/help/auto-fill-ios/#keyboard-auto-fill")!
 
+    /// A link to Bitwarden's help page for the Fill Assist feature.
+    static let fillAssistHelp = URL(string: "https://bitwarden.com/help/fill-assist/")!
+
     /// A link to Bitwarden's help page for learning more about the account fingerprint phrase.
     static let fingerprintPhrase = URL(string: "https://bitwarden.com/help/fingerprint-phrase/")!
 

--- a/BitwardenShared/UI/Platform/Application/TestHelpers/MockAppExtensionDelegate.swift
+++ b/BitwardenShared/UI/Platform/Application/TestHelpers/MockAppExtensionDelegate.swift
@@ -5,7 +5,7 @@ class MockAppExtensionDelegate: AppExtensionDelegate {
     var canAutofill = true
     var didCancelCalled = false
     var didCompleteAuthCalled = false
-    var didCompleteAutofillRequestFields: [(String, String)]?
+    var didCompleteAutofillRequestFields: [(selector: String, value: String)]?
     var didCompleteAutofillRequestPassword: String?
     var didCompleteAutofillRequestUsername: String?
     var isInAppExtension = false

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
@@ -23,6 +23,9 @@ enum AutoFillAction: Equatable {
     /// The copy TOTP automatically toggle value changed.
     case toggleCopyTOTPToggle(Bool)
 
+    /// The Fill Assist toggle value changed.
+    case toggleFillAssist(Bool)
+
     /// A toast was shown or hidden.
     case toastShown(Toast?)
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -12,6 +12,7 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
         & HasAutofillCredentialService
         & HasConfigService
         & HasErrorReporter
+        & HasFillAssistRepository
         & HasSettingsRepository
         & HasStateService
         & HasTimeProvider
@@ -72,6 +73,11 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
             state.url = ExternalLinksConstants.autofillHelp
         case .passwordAutoFillTapped:
             coordinator.navigate(to: .passwordAutoFill, context: self)
+        case let .toggleFillAssist(isOn):
+            state.isFillAssistEnabled = isOn
+            Task {
+                await updateFillAssistEnabled(isOn)
+            }
         case let .toggleCopyTOTPToggle(isOn):
             state.isCopyTOTPToggleOn = isOn
             Task {
@@ -132,8 +138,10 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     private func fetchSettingValues() async {
         state.defaultUriMatchType = await services.settingsRepository.getDefaultUriMatchType()
         state.shouldShowPasswordAutofill = await !services.autofillCredentialService.isAutofillCredentialsEnabled()
+        state.isFillAssistFeatureFlagEnabled = await services.configService.getFeatureFlag(.fillAssistTargetingRules)
         do {
             state.isCopyTOTPToggleOn = try await !services.settingsRepository.getDisableAutoTotpCopy()
+            state.isFillAssistEnabled = try await services.stateService.getFillAssistEnabled()
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             services.errorReporter.log(error: error)
@@ -204,6 +212,29 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             services.errorReporter.log(error: error)
+        }
+    }
+
+    /// Updates the Fill Assist enabled preference and triggers a rules sync if enabled.
+    ///
+    /// - Parameter fillAssistEnabled: Whether Fill Assist should be enabled.
+    ///
+    @MainActor
+    private func updateFillAssistEnabled(_ fillAssistEnabled: Bool) async {
+        // Guard against stale tasks: rapid toggling fires multiple concurrent tasks; bail out if
+        // the state has already moved past this task's intended value.
+        guard state.isFillAssistEnabled == fillAssistEnabled else { return }
+        do {
+            try await services.stateService.setFillAssistEnabled(fillAssistEnabled)
+            guard state.isFillAssistEnabled == fillAssistEnabled else { return }
+            if fillAssistEnabled {
+                await services.fillAssistRepository.syncRules()
+            }
+        } catch {
+            services.errorReporter.log(error: error)
+            guard state.isFillAssistEnabled == fillAssistEnabled else { return }
+            state.isFillAssistEnabled = !fillAssistEnabled
+            await coordinator.showErrorAlert(error: error)
         }
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
@@ -15,6 +15,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
     var configService: MockConfigService!
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
     var errorReporter: MockErrorReporter!
+    var fillAssistRepository: MockFillAssistRepository!
     var settingsRepository: MockSettingsRepository!
     var stateService: MockStateService!
     var subject: AutoFillProcessor!
@@ -29,8 +30,10 @@ class AutoFillProcessorTests: BitwardenTestCase {
         configService = MockConfigService()
         coordinator = MockCoordinator<SettingsRoute, SettingsEvent>()
         errorReporter = MockErrorReporter()
+        fillAssistRepository = MockFillAssistRepository()
         settingsRepository = MockSettingsRepository()
         stateService = MockStateService()
+        stateService.activeAccount = .fixture()
 
         subject = AutoFillProcessor(
             coordinator: coordinator.asAnyCoordinator(),
@@ -39,6 +42,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
                 autofillCredentialService: autofillCredentialService,
                 configService: configService,
                 errorReporter: errorReporter,
+                fillAssistRepository: fillAssistRepository,
                 settingsRepository: settingsRepository,
                 stateService: stateService,
             ),
@@ -54,6 +58,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
         configService = nil
         coordinator = nil
         errorReporter = nil
+        fillAssistRepository = nil
         settingsRepository = nil
         stateService = nil
         subject = nil
@@ -77,6 +82,8 @@ class AutoFillProcessorTests: BitwardenTestCase {
     /// error occurs.
     @MainActor
     func test_perform_dismissSetUpAutofillActionCard_error() async {
+        stateService.activeAccount = nil
+
         await subject.perform(.dismissSetUpAutofillActionCard)
 
         XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
@@ -89,18 +96,36 @@ class AutoFillProcessorTests: BitwardenTestCase {
         autofillCredentialService.isAutofillCredentialsEnabled = false
         settingsRepository.getDefaultUriMatchTypeResult = .exact
         settingsRepository.getDisableAutoTotpCopyResult = .success(false)
+        stateService.fillAssistEnabledByUserId["1"] = false
         await subject.perform(.fetchSettingValues)
         XCTAssertEqual(subject.state.defaultUriMatchType, .exact)
         XCTAssertTrue(subject.state.isCopyTOTPToggleOn)
         XCTAssertTrue(subject.state.shouldShowPasswordAutofill)
+        XCTAssertFalse(subject.state.isFillAssistEnabled)
 
         autofillCredentialService.isAutofillCredentialsEnabled = true
         settingsRepository.getDefaultUriMatchTypeResult = .regularExpression
         settingsRepository.getDisableAutoTotpCopyResult = .success(true)
+        stateService.fillAssistEnabledByUserId["1"] = true
         await subject.perform(.fetchSettingValues)
         XCTAssertEqual(subject.state.defaultUriMatchType, .regularExpression)
         XCTAssertFalse(subject.state.isCopyTOTPToggleOn)
         XCTAssertFalse(subject.state.shouldShowPasswordAutofill)
+        XCTAssertTrue(subject.state.isFillAssistEnabled)
+    }
+
+    /// `perform(_:)` with `.fetchSettingValues` loads fill assist feature flag state.
+    @MainActor
+    func test_perform_fetchSettingValues_fillAssistFeatureFlag() async {
+        settingsRepository.getDisableAutoTotpCopyResult = .success(false)
+
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        await subject.perform(.fetchSettingValues)
+        XCTAssertTrue(subject.state.isFillAssistFeatureFlagEnabled)
+
+        configService.featureFlagsBool[.fillAssistTargetingRules] = false
+        await subject.perform(.fetchSettingValues)
+        XCTAssertFalse(subject.state.isFillAssistFeatureFlagEnabled)
     }
 
     /// `perform(_:)` with `.fetchSettingValues` logs an error and shows an alert if fetching the values fails.
@@ -187,6 +212,8 @@ class AutoFillProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.streamSettingsBadge` logs an error if streaming the settings badge state fails.
     @MainActor
     func test_perform_streamSettingsBadge_error() async {
+        stateService.activeAccount = nil
+
         await subject.perform(.streamSettingsBadge)
 
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
@@ -233,6 +260,31 @@ class AutoFillProcessorTests: BitwardenTestCase {
 
         subject.receive(.toastShown(nil))
         XCTAssertNil(subject.state.toast)
+    }
+
+    /// `.receive(_:)` with `.toggleFillAssist(true)` persists the value and triggers a rules sync.
+    @MainActor
+    func test_receive_toggleFillAssist_on() {
+        subject.state.isFillAssistEnabled = false
+        subject.receive(.toggleFillAssist(true))
+
+        XCTAssertTrue(subject.state.isFillAssistEnabled)
+        waitFor(stateService.fillAssistEnabledByUserId["1"] == true)
+        XCTAssertEqual(stateService.fillAssistEnabledByUserId["1"], true)
+        waitFor(fillAssistRepository.syncRulesCalled)
+        XCTAssertTrue(fillAssistRepository.syncRulesCalled)
+    }
+
+    /// `.receive(_:)` with `.toggleFillAssist(false)` persists the value and does NOT sync rules.
+    @MainActor
+    func test_receive_toggleFillAssist_off() {
+        subject.state.isFillAssistEnabled = true
+        subject.receive(.toggleFillAssist(false))
+
+        XCTAssertFalse(subject.state.isFillAssistEnabled)
+        waitFor(stateService.fillAssistEnabledByUserId["1"] == false)
+        XCTAssertEqual(stateService.fillAssistEnabledByUserId["1"], false)
+        XCTAssertFalse(fillAssistRepository.syncRulesCalled)
     }
 
     /// `.receive(_:)` with  `.toggleCopyTOTPToggle` updates the state.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
@@ -18,6 +18,12 @@ struct AutoFillState {
     /// Whether or not the copy TOTP automatically toggle is on.
     var isCopyTOTPToggleOn: Bool = false
 
+    /// Whether the Fill Assist toggle is on.
+    var isFillAssistEnabled: Bool = false
+
+    /// Whether the Fill Assist feature flag is enabled.
+    var isFillAssistFeatureFlagEnabled: Bool = false
+
     /// Whether to show the password autofill row.
     var shouldShowPasswordAutofill: Bool = false
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -85,6 +85,30 @@ struct AutoFillView: View {
     /// The additional options section.
     private var additionalOptionsSection: some View {
         SectionView(Localizations.additionalOptions, contentSpacing: 8) {
+            if store.state.isFillAssistFeatureFlagEnabled {
+                BitwardenToggle(
+                    footer: Localizations.turnOnFillAssistDescriptionLong,
+                    isOn: store.binding(
+                        get: \.isFillAssistEnabled,
+                        send: AutoFillAction.toggleFillAssist,
+                    ),
+                    accessibilityIdentifier: "FillAssistSwitch",
+                ) {
+                    HStack(spacing: 8) {
+                        Text(Localizations.turnOnFillAssist)
+                        Button {
+                            openURL(ExternalLinksConstants.fillAssistHelp)
+                        } label: {
+                            SharedAsset.Icons.questionCircle16.swiftUIImage
+                                .scaledFrame(width: 16, height: 16)
+                                .accessibilityLabel(Localizations.learnMore)
+                        }
+                        .buttonStyle(.fieldLabelIcon)
+                    }
+                }
+                .contentBlock()
+            }
+
             BitwardenToggle(
                 Localizations.copyTotpAutomatically,
                 footer: Localizations.copyTotpAutomaticallyDescription,

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -78,6 +78,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasEventService
         & HasExportCXFCiphersRepository
         & HasExportVaultService
+        & HasFillAssistRepository
         & HasFlightRecorder
         & HasLanguageStateService
         & HasNotificationCenterService

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -110,19 +110,16 @@ class AutofillHelper {
         guard await services.configService.getFeatureFlag(.fillAssistTargetingRules) else { return [] }
         guard let uri,
               let url = URL(string: uri),
-              let host = url.host else { return [] }
-        let lookupHost = DomainName.parseBaseDomain(url: url) ?? host
+              let lookupHost = url.domain else { return [] }
         guard let rules = await services.fillAssistRepository.fillAssistRules(for: lookupHost) else { return [] }
 
         var result: [(String, String)] = []
 
-        if let attrs = rules.fields["username"]?.first,
-           let selector = attrs.id ?? attrs.name {
+        if let selector = rules.fields["username"]?.lazy.compactMap({ $0.id ?? $0.name }).first {
             result.append((selector, username))
         }
 
-        if let attrs = rules.fields["password"]?.first,
-           let selector = attrs.id ?? attrs.name {
+        if let selector = rules.fields["password"]?.lazy.compactMap({ $0.id ?? $0.name }).first {
             result.append((selector, password))
         }
 

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -111,7 +111,7 @@ class AutofillHelper {
         guard let uri,
               let url = URL(string: uri),
               let lookupHost = url.domain else { return [] }
-        guard let rules = await services.fillAssistRepository.fillAssistRules(for: lookupHost) else { return [] }
+        guard let rules = await services.fillAssistRepository.rules(for: lookupHost) else { return [] }
 
         var result: [(String, String)] = []
 

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -15,6 +15,7 @@ class AutofillHelper {
         & HasEventService
         & HasFillAssistRepository
         & HasPasteboardService
+        & HasStateService
         & HasVaultRepository
 
     // MARK: Properties
@@ -107,11 +108,12 @@ class AutofillHelper {
     /// - Returns: An array of `(selector, value)` tuples, or an empty array if unavailable.
     ///
     private func fillAssistFields(for uri: String?, username: String, password: String) async -> [(String, String)] {
-        guard await services.configService.getFeatureFlag(.fillAssistTargetingRules) else { return [] }
-        guard let uri,
+        guard await services.configService.getFeatureFlag(.fillAssistTargetingRules),
+              await (try? services.stateService.getFillAssistEnabled()) == true,
+              let uri,
               let url = URL(string: uri),
-              let lookupHost = url.domain else { return [] }
-        guard let rules = await services.fillAssistRepository.rules(for: lookupHost) else { return [] }
+              let lookupHost = url.domain,
+              let rules = await services.fillAssistRepository.rules(for: lookupHost) else { return [] }
 
         var result: [(String, String)] = []
 

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -109,8 +109,10 @@ class AutofillHelper {
     private func fillAssistFields(for uri: String?, username: String, password: String) async -> [(String, String)] {
         guard await services.configService.getFeatureFlag(.fillAssistTargetingRules) else { return [] }
         guard let uri,
-              let host = URL(string: uri)?.host else { return [] }
-        guard let rules = await services.fillAssistRepository.fillAssistRules(for: host) else { return [] }
+              let url = URL(string: uri),
+              let host = url.host else { return [] }
+        let lookupHost = DomainName.parseBaseDomain(url: url) ?? host
+        guard let rules = await services.fillAssistRepository.fillAssistRules(for: lookupHost) else { return [] }
 
         var result: [(String, String)] = []
 

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -1,6 +1,7 @@
 import BitwardenKit
 import BitwardenResources
 @preconcurrency import BitwardenSdk
+import Foundation
 
 /// A helper class to handle when a cipher is selected for autofill.
 ///
@@ -9,8 +10,10 @@ class AutofillHelper {
     // MARK: Types
 
     typealias Services = HasAuthRepository
+        & HasConfigService
         & HasErrorReporter
         & HasEventService
+        & HasFillAssistRepository
         & HasPasteboardService
         & HasVaultRepository
 
@@ -94,6 +97,36 @@ class AutofillHelper {
         }
     }
 
+    /// Builds FillAssist-derived `(selector, value)` tuples for username and password fields when
+    /// the `fillAssistTargetingRules` feature flag is enabled and cached rules exist for the host.
+    ///
+    /// - Parameters:
+    ///   - uri: The URI string of the current page.
+    ///   - username: The username value to fill.
+    ///   - password: The password value to fill.
+    /// - Returns: An array of `(selector, value)` tuples, or an empty array if unavailable.
+    ///
+    private func fillAssistFields(for uri: String?, username: String, password: String) async -> [(String, String)] {
+        guard await services.configService.getFeatureFlag(.fillAssistTargetingRules) else { return [] }
+        guard let uri,
+              let host = URL(string: uri)?.host else { return [] }
+        guard let rules = await services.fillAssistRepository.fillAssistRules(for: host) else { return [] }
+
+        var result: [(String, String)] = []
+
+        if let attrs = rules.fields["username"]?.first,
+           let selector = attrs.id ?? attrs.name {
+            result.append((selector, username))
+        }
+
+        if let attrs = rules.fields["password"]?.first,
+           let selector = attrs.id ?? attrs.name {
+            result.append((selector, password))
+        }
+
+        return result
+    }
+
     /// Handles autofill for a cipher after the master password reprompt has been confirmed, if it's
     /// required by the cipher.
     ///
@@ -126,10 +159,20 @@ class AutofillHelper {
 
             await copyTotpIfNeeded(cipherView: cipherView)
 
-            let fields: [(String, String)]? = cipherView.fields?.compactMap { field in
+            let cipherFields: [(String, String)] = cipherView.fields?.compactMap { field in
                 guard let name = field.name, let value = field.value else { return nil }
                 return (name, value)
-            }
+            } ?? []
+
+            let assistFields = await fillAssistFields(
+                for: appExtensionDelegate?.uri,
+                username: username,
+                password: password,
+            )
+
+            let combinedFields: [(String, String)]? = assistFields.isEmpty && cipherFields.isEmpty
+                ? nil
+                : assistFields + cipherFields
 
             await services.eventService.collect(
                 eventType: .cipherClientAutofilled,
@@ -139,7 +182,7 @@ class AutofillHelper {
             appExtensionDelegate?.completeAutofillRequest(
                 username: username,
                 password: password,
-                fields: fields,
+                fields: combinedFields,
             )
         } catch {
             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -115,11 +115,11 @@ class AutofillHelper {
 
         var result: [(String, String)] = []
 
-        if let selector = rules.fields["username"]?.lazy.compactMap({ $0.id ?? $0.name }).first {
+        if let selector = rules.fields["username"]?.compactMap({ $0.id ?? $0.name }).first {
             result.append((selector, username))
         }
 
-        if let selector = rules.fields["password"]?.lazy.compactMap({ $0.id ?? $0.name }).first {
+        if let selector = rules.fields["password"]?.compactMap({ $0.id ?? $0.name }).first {
             result.append((selector, password))
         }
 
@@ -169,9 +169,7 @@ class AutofillHelper {
                 password: password,
             )
 
-            let combinedFields: [(String, String)]? = assistFields.isEmpty && cipherFields.isEmpty
-                ? nil
-                : assistFields + cipherFields
+            let combinedFields = (assistFields + cipherFields).nilIfEmpty
 
             await services.eventService.collect(
                 eventType: .cipherClientAutofilled,

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -526,10 +526,10 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         XCTAssertEqual(fillAssistRepository.fillAssistRulesReceivedHostname, "example.com")
         let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
-        XCTAssertEqual(fields[0].0, "login-email")
-        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
-        XCTAssertEqual(fields[1].0, "login-pwd")
-        XCTAssertEqual(fields[1].1, "PASSWORD")
+        XCTAssertEqual(fields[0].selector, "login-email")
+        XCTAssertEqual(fields[0].value, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].selector, "login-pwd")
+        XCTAssertEqual(fields[1].value, "PASSWORD")
     }
 
     /// `handleCipherForAutofill` falls back to the `name` attribute when `id` is nil.
@@ -546,10 +546,10 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
         let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
-        XCTAssertEqual(fields[0].0, "email")
-        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
-        XCTAssertEqual(fields[1].0, "pass")
-        XCTAssertEqual(fields[1].1, "PASSWORD")
+        XCTAssertEqual(fields[0].selector, "email")
+        XCTAssertEqual(fields[0].value, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].selector, "pass")
+        XCTAssertEqual(fields[1].value, "PASSWORD")
     }
 
     /// `handleCipherForAutofill` does not call `fillAssistRepository` when the URI is nil.
@@ -582,12 +582,12 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
         XCTAssertEqual(fields.count, 3)
-        XCTAssertEqual(fields[0].0, "login-email")
-        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
-        XCTAssertEqual(fields[1].0, "login-pwd")
-        XCTAssertEqual(fields[1].1, "PASSWORD")
-        XCTAssertEqual(fields[2].0, "custom")
-        XCTAssertEqual(fields[2].1, "val")
+        XCTAssertEqual(fields[0].selector, "login-email")
+        XCTAssertEqual(fields[0].value, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].selector, "login-pwd")
+        XCTAssertEqual(fields[1].value, "PASSWORD")
+        XCTAssertEqual(fields[2].selector, "custom")
+        XCTAssertEqual(fields[2].value, "val")
     }
 
     /// `handleCipherForAutofill` strips the subdomain when looking up FillAssist rules so that a
@@ -608,9 +608,62 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         // Rules should be looked up under the registered domain, not the full host.
         XCTAssertEqual(fillAssistRepository.fillAssistRulesReceivedHostname, "example.com")
         let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
-        XCTAssertEqual(fields[0].0, "login-email")
-        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
-        XCTAssertEqual(fields[1].0, "login-pwd")
-        XCTAssertEqual(fields[1].1, "PASSWORD")
+        XCTAssertEqual(fields[0].selector, "login-email")
+        XCTAssertEqual(fields[0].value, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].selector, "login-pwd")
+        XCTAssertEqual(fields[1].value, "PASSWORD")
+    }
+
+    /// `handleCipherForAutofill` appends only a username selector when rules have no password entry.
+    func test_handleCipherForAutofill_fillAssist_usernameOnlyRule() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
+        XCTAssertEqual(fields.count, 1)
+        XCTAssertEqual(fields[0].selector, "login-email")
+        XCTAssertEqual(fields[0].value, "user@bitwarden.com")
+    }
+
+    /// `handleCipherForAutofill` appends only a password selector when rules have no username entry.
+    func test_handleCipherForAutofill_fillAssist_passwordOnlyRule() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
+        XCTAssertEqual(fields.count, 1)
+        XCTAssertEqual(fields[0].selector, "login-pwd")
+        XCTAssertEqual(fields[0].value, "PASSWORD")
+    }
+
+    /// `handleCipherForAutofill` produces no FillAssist fields when rules only contain
+    /// keys other than "username" and "password".
+    func test_handleCipherForAutofill_fillAssist_unknownFieldKeys_noFields() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "email": [.init(id: "email-field", name: nil, role: nil, tagName: nil, type: nil)],
+            "newPassword": [.init(id: "pass-field", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -589,4 +589,28 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(fields[2].0, "custom")
         XCTAssertEqual(fields[2].1, "val")
     }
+
+    /// `handleCipherForAutofill` strips the subdomain when looking up FillAssist rules so that a
+    /// URI like `https://www.example.com` matches rules stored under `example.com`.
+    func test_handleCipherForAutofill_fillAssist_stripsSubdomain() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        appExtensionDelegate.uri = "https://www.example.com/login"
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        // Rules should be looked up under the registered domain, not the full host.
+        XCTAssertEqual(fillAssistRepository.fillAssistRulesReceivedHostname, "example.com")
+        let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
+        XCTAssertEqual(fields[0].0, "login-email")
+        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].0, "login-pwd")
+        XCTAssertEqual(fields[1].1, "PASSWORD")
+    }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -19,6 +19,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     var errorReporter: MockErrorReporter!
     var fillAssistRepository: MockFillAssistRepository!
     var pasteboardService: MockPasteboardService!
+    var stateService: MockStateService!
     var subject: AutofillHelper!
     var vaultRepository: MockVaultRepository!
 
@@ -35,6 +36,9 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         errorReporter = MockErrorReporter()
         fillAssistRepository = MockFillAssistRepository()
         pasteboardService = MockPasteboardService()
+        stateService = MockStateService()
+        stateService.activeAccount = .fixture()
+        stateService.fillAssistEnabledByUserId["1"] = true
         vaultRepository = MockVaultRepository()
 
         subject = AutofillHelper(
@@ -46,6 +50,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 errorReporter: errorReporter,
                 fillAssistRepository: fillAssistRepository,
                 pasteboardService: pasteboardService,
+                stateService: stateService,
                 vaultRepository: vaultRepository,
             ),
         )
@@ -61,6 +66,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         errorReporter = nil
         fillAssistRepository = nil
         pasteboardService = nil
+        stateService = nil
         subject = nil
         vaultRepository = nil
     }
@@ -664,6 +670,44 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
+
+    /// `handleCipherForAutofill` does not use FillAssist when the user toggle is off,
+    /// even if the feature flag is on and rules are cached.
+    func test_handleCipherForAutofill_fillAssist_userToggleOff() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.fillAssistEnabledByUserId["1"] = false
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertFalse(fillAssistRepository.rulesCalled)
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
+
+    /// `handleCipherForAutofill` does not use Fill Assist when `getFillAssistEnabled` throws,
+    /// treating it the same as the toggle being off.
+    func test_handleCipherForAutofill_fillAssist_getFillAssistEnabledThrows() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.getFillAssistEnabledError = BitwardenTestError.example
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertFalse(fillAssistRepository.rulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -483,7 +483,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `handleCipherForAutofill` does not call `fillAssistRepository` when the feature flag is off.
     func test_handleCipherForAutofill_fillAssist_flagOff() async {
         configService.featureFlagsBool[.fillAssistTargetingRules] = false
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(
             fields: ["username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)]],
         )
         vaultRepository.fetchCipherResult = .success(.fixture(
@@ -492,7 +492,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
-        XCTAssertFalse(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertFalse(fillAssistRepository.rulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 
@@ -500,21 +500,21 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// exist for the host.
     func test_handleCipherForAutofill_fillAssist_noRulesForHost() async {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = nil
+        fillAssistRepository.rulesReturnValue = nil
         vaultRepository.fetchCipherResult = .success(.fixture(
             login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
         ))
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
-        XCTAssertTrue(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertTrue(fillAssistRepository.rulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 
     /// `handleCipherForAutofill` prepends FillAssist id-based selectors before cipher custom fields.
     func test_handleCipherForAutofill_fillAssist_rulesFound_idSelector() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
             "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
         ])
@@ -524,7 +524,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
-        XCTAssertEqual(fillAssistRepository.fillAssistRulesReceivedHostname, "example.com")
+        XCTAssertEqual(fillAssistRepository.rulesReceivedHostname, "example.com")
         let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
         XCTAssertEqual(fields[0].selector, "login-email")
         XCTAssertEqual(fields[0].value, "user@bitwarden.com")
@@ -535,7 +535,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `handleCipherForAutofill` falls back to the `name` attribute when `id` is nil.
     func test_handleCipherForAutofill_fillAssist_rulesFound_nameFallback() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "username": [.init(id: nil, name: "email", role: nil, tagName: nil, type: nil)],
             "password": [.init(id: nil, name: "pass", role: nil, tagName: nil, type: nil)],
         ])
@@ -562,14 +562,14 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
-        XCTAssertFalse(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertFalse(fillAssistRepository.rulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 
     /// `handleCipherForAutofill` prepends FillAssist selectors before cipher custom fields.
     func test_handleCipherForAutofill_fillAssist_prependsBeforeCipherFields() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
             "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
         ])
@@ -595,7 +595,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_handleCipherForAutofill_fillAssist_stripsSubdomain() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
         appExtensionDelegate.uri = "https://www.example.com/login"
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
             "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
         ])
@@ -606,7 +606,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
         // Rules should be looked up under the registered domain, not the full host.
-        XCTAssertEqual(fillAssistRepository.fillAssistRulesReceivedHostname, "example.com")
+        XCTAssertEqual(fillAssistRepository.rulesReceivedHostname, "example.com")
         let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
         XCTAssertEqual(fields[0].selector, "login-email")
         XCTAssertEqual(fields[0].value, "user@bitwarden.com")
@@ -617,7 +617,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `handleCipherForAutofill` appends only a username selector when rules have no password entry.
     func test_handleCipherForAutofill_fillAssist_usernameOnlyRule() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
         ])
         vaultRepository.fetchCipherResult = .success(.fixture(
@@ -635,7 +635,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// `handleCipherForAutofill` appends only a password selector when rules have no username entry.
     func test_handleCipherForAutofill_fillAssist_passwordOnlyRule() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
         ])
         vaultRepository.fetchCipherResult = .success(.fixture(
@@ -654,7 +654,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     /// keys other than "username" and "password".
     func test_handleCipherForAutofill_fillAssist_unknownFieldKeys_noFields() async {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "email": [.init(id: "email-field", name: nil, role: nil, tagName: nil, type: nil)],
             "newPassword": [.init(id: "pass-field", name: nil, role: nil, tagName: nil, type: nil)],
         ])

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -6,14 +6,18 @@ import TestHelpers
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
+@MainActor
 class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var appExtensionDelegate: MockAppExtensionDelegate!
     var authRepository: MockAuthRepository!
+    var configService: MockConfigService!
     var coordinator: MockCoordinator<VaultRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
+    var fillAssistRepository: MockFillAssistRepository!
     var pasteboardService: MockPasteboardService!
     var subject: AutofillHelper!
     var vaultRepository: MockVaultRepository!
@@ -24,9 +28,12 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         super.setUp()
 
         appExtensionDelegate = MockAppExtensionDelegate()
+        appExtensionDelegate.uri = "https://example.com/login"
         authRepository = MockAuthRepository()
+        configService = MockConfigService()
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
+        fillAssistRepository = MockFillAssistRepository()
         pasteboardService = MockPasteboardService()
         vaultRepository = MockVaultRepository()
 
@@ -35,20 +42,24 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
                 authRepository: authRepository,
+                configService: configService,
                 errorReporter: errorReporter,
+                fillAssistRepository: fillAssistRepository,
                 pasteboardService: pasteboardService,
                 vaultRepository: vaultRepository,
             ),
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
+    override func tearDown() async throws {
+        try await super.tearDown()
 
         appExtensionDelegate = nil
         authRepository = nil
+        configService = nil
         coordinator = nil
         errorReporter = nil
+        fillAssistRepository = nil
         pasteboardService = nil
         subject = nil
         vaultRepository = nil
@@ -465,5 +476,117 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         await subject.handleCipherForAutofill(cipherListView: cipher) { _ in }
 
         XCTAssertNil(pasteboardService.copiedString)
+    }
+
+    // MARK: Tests - FillAssist
+
+    /// `handleCipherForAutofill` does not call `fillAssistRepository` when the feature flag is off.
+    func test_handleCipherForAutofill_fillAssist_flagOff() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = false
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(
+            fields: ["username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)]],
+        )
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertFalse(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
+
+    /// `handleCipherForAutofill` calls `completeAutofillRequest` with `nil` fields when no rules
+    /// exist for the host.
+    func test_handleCipherForAutofill_fillAssist_noRulesForHost() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = nil
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertTrue(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
+
+    /// `handleCipherForAutofill` prepends FillAssist id-based selectors before cipher custom fields.
+    func test_handleCipherForAutofill_fillAssist_rulesFound_idSelector() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertEqual(fillAssistRepository.fillAssistRulesReceivedHostname, "example.com")
+        let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
+        XCTAssertEqual(fields[0].0, "login-email")
+        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].0, "login-pwd")
+        XCTAssertEqual(fields[1].1, "PASSWORD")
+    }
+
+    /// `handleCipherForAutofill` falls back to the `name` attribute when `id` is nil.
+    func test_handleCipherForAutofill_fillAssist_rulesFound_nameFallback() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: nil, name: "email", role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: nil, name: "pass", role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
+        XCTAssertEqual(fields[0].0, "email")
+        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].0, "pass")
+        XCTAssertEqual(fields[1].1, "PASSWORD")
+    }
+
+    /// `handleCipherForAutofill` does not call `fillAssistRepository` when the URI is nil.
+    func test_handleCipherForAutofill_fillAssist_nilUri() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        appExtensionDelegate.uri = nil
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertFalse(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
+
+    /// `handleCipherForAutofill` prepends FillAssist selectors before cipher custom fields.
+    func test_handleCipherForAutofill_fillAssist_prependsBeforeCipherFields() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            fields: [.fixture(name: "custom", value: "val")],
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        let fields = try XCTUnwrap(appExtensionDelegate.didCompleteAutofillRequestFields)
+        XCTAssertEqual(fields.count, 3)
+        XCTAssertEqual(fields[0].0, "login-email")
+        XCTAssertEqual(fields[0].1, "user@bitwarden.com")
+        XCTAssertEqual(fields[1].0, "login-pwd")
+        XCTAssertEqual(fields[1].1, "PASSWORD")
+        XCTAssertEqual(fields[2].0, "custom")
+        XCTAssertEqual(fields[2].1, "val")
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -24,6 +24,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
         & HasEventService
         & HasFido2CredentialStore
         & HasFido2UserInterfaceHelper
+        & HasFillAssistRepository
         & HasPasteboardService
         & HasPolicyService
         & HasSearchProcessorMediatorFactory

--- a/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultCoordinator.swift
@@ -91,6 +91,7 @@ final class VaultCoordinator: Coordinator, HasStackNavigator { // swiftlint:disa
         & HasFlightRecorder
         & HasFido2CredentialStore
         & HasFido2UserInterfaceHelper
+        & HasFillAssistRepository
         & HasLocalAuthService
         & HasNotificationService
         & HasReviewPromptService


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38444

## 📔 Objective

When the Action Extension autofills credentials, use FillAssist cached rules to prepend CSS-selector-derived field targets (`id`/`name` attributes) for username and password in the fill script. This improves targeting accuracy on sites where standard DOM heuristics fail to identify the correct fields.

Also fixes the host lookup to use the registered domain (eTLD+1) rather than the raw `URL.host`, so rules stored under `datacamp.com` are found correctly when the page URL contains a subdomain like `www.datacamp.com`.