### PR TITLE
[PM-39081] feat: Add fill-assist toggle to autofill settings

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -572,7 +572,7 @@
 "ApproveWithMasterPassword" = "Approve with master password";
 "TurnOffUsingPublicDevice" = "Turn off using a public device";
 "TurnOnFillAssist" = "Turn on fill assist";
-"TurnOnFillAssistDescriptionLong" = "Fill assist improves autofill accuracy on supported sites by using site specific rules.";
+"TurnOnFillAssistDescriptionLong" = "Fill Assist improves autofill accuracy on supported sites by using site-specific rules.";
 "RememberThisDevice" = "Remember this device";
 "Passkey" = "Passkey";
 "Passkeys" = "Passkeys";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -571,6 +571,8 @@
 "RequestAdminApproval" = "Request admin approval";
 "ApproveWithMasterPassword" = "Approve with master password";
 "TurnOffUsingPublicDevice" = "Turn off using a public device";
+"TurnOnFillAssist" = "Turn on fill assist";
+"TurnOnFillAssistDescriptionLong" = "Fill assist improves autofill accuracy on supported sites by using site specific rules.";
 "RememberThisDevice" = "Remember this device";
 "Passkey" = "Passkey";
 "Passkeys" = "Passkeys";

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
@@ -107,10 +107,9 @@ class DefaultFillAssistRepository: FillAssistRepository {
     /// Runs the full sync pipeline if sync conditions are met
     ///
     private func performSync() async throws {
-        // 1. Feature flag guard.
-        guard await configService.getFeatureFlag(.fillAssistTargetingRules) else { return }
+        guard await configService.getFeatureFlag(.fillAssistTargetingRules),
+              try await stateService.getFillAssistEnabled() else { return }
 
-        // 2. Time-interval guard — skip if last fetch was less than fillAssistUpdateInterval ago.
         let sourceUrl = environmentService.fillAssistRulesURL
         let userId = try await stateService.getActiveAccountId()
         let lastFetch = appSettingsStore.fillAssistLastFetchTimestamp(userId: userId)
@@ -118,7 +117,6 @@ class DefaultFillAssistRepository: FillAssistRepository {
             return
         }
 
-        // 3. Fetch manifest.
         let manifest = try await fillAssistAPIService.getManifest()
 
         // 4. Resolve the non-deprecated entry for the current forms version.
@@ -126,24 +124,20 @@ class DefaultFillAssistRepository: FillAssistRepository {
               !entry.deprecated
         else { return }
 
-        // 5. If cid and source URL are unchanged, update timestamp and skip download.
         let cached = appSettingsStore.fillAssistCachedData(userId: userId)
         if cached?.cid == entry.cid, cached?.sourceUrl == sourceUrl.absoluteString {
             appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
             return
         }
 
-        // 6. Download forms file.
         let formsMap = try await fillAssistAPIService.getFormsMap(filename: entry.filename)
 
-        // 7. Validate schema major version; update timestamp and skip if unsupported.
         let schemaMajor = formsMap.schemaVersion.split(separator: ".").first.map(String.init) ?? ""
         guard schemaMajor == Constants.FillAssist.expectedSchemaMajor else {
             appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
             return
         }
 
-        // 8. Parse, cache, and update timestamp.
         let rules = buildRules(from: formsMap)
         let data = FillAssistCachedData(cid: entry.cid, rules: rules, sourceUrl: sourceUrl.absoluteString)
         appSettingsStore.setFillAssistCachedData(data, userId: userId)

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
@@ -119,7 +119,6 @@ class DefaultFillAssistRepository: FillAssistRepository {
 
         let manifest = try await fillAssistAPIService.getManifest()
 
-        // 4. Resolve the non-deprecated entry for the current forms version.
         guard let entry = manifest.maps["forms"]?[Constants.FillAssist.formsVersion],
               !entry.deprecated
         else { return }

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
@@ -354,34 +354,33 @@ private extension FillAssistRepositoryTests {
 
     // MARK: Tests - user toggle guard
 
-    /// `syncFillAssistRules()` makes no network calls when the feature flag is on but the user
-    /// toggle is off.
-    func test_syncFillAssistRules_userToggleOff() async {
+    /// `syncRules()` makes no network calls when the feature flag is on but the user toggle is off.
+    @Test
+    func syncRules_userToggleOff_skipsSync() async {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
         stateService.fillAssistEnabledByUserId["1"] = false
 
-        await subject.syncFillAssistRules()
+        await subject.syncRules()
 
-        XCTAssertFalse(fillAssistAPIService.getManifestCalled)
+        #expect(!fillAssistAPIService.getManifestCalled)
     }
 
-    /// `syncFillAssistRules()` proceeds past the user-toggle guard and fetches the manifest when
-    /// both feature flag and user toggle are on.
-    func test_syncFillAssistRules_userToggleOn_proceeds() async throws {
+    /// `syncRules()` proceeds past the user-toggle guard and fetches the manifest when both
+    /// feature flag and user toggle are on.
+    @Test
+    func syncRules_userToggleOn_fetchesManifest() async throws {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
         stateService.fillAssistEnabledByUserId["1"] = true
-        let manifest = try makeManifest(cid: "sha256:abc")
-        fillAssistAPIService.getManifestReturnValue = manifest
-        // Pre-cache matching cid so sync stops at the "no changes" short-circuit,
-        // avoiding a nil getFormsMapReturnValue crash.
+        fillAssistAPIService.getManifestReturnValue = makeManifest(cid: "sha256:abc")
+        // Pre-cache matching cid so sync stops at the "no changes" short-circuit.
         appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
             cid: "sha256:abc",
             rules: [:],
             sourceUrl: environmentService.fillAssistRulesURL.absoluteString,
         )
 
-        await subject.syncFillAssistRules()
+        await subject.syncRules()
 
-        XCTAssertTrue(fillAssistAPIService.getManifestCalled)
+        #expect(fillAssistAPIService.getManifestCalled)
     }
 }

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
@@ -31,6 +31,7 @@ struct FillAssistRepositoryTests {
         fillAssistAPIService = MockFillAssistAPIService()
         stateService = MockStateService()
         stateService.activeAccount = .fixture()
+        stateService.fillAssistEnabledByUserId["1"] = true
         timeProvider = MockTimeProvider(.currentTime)
 
         subject = DefaultFillAssistRepository(
@@ -349,5 +350,38 @@ private extension FillAssistRepositoryTests {
             ],
             schemaVersion: "1.0.0",
         )
+    }
+
+    // MARK: Tests - user toggle guard
+
+    /// `syncFillAssistRules()` makes no network calls when the feature flag is on but the user
+    /// toggle is off.
+    func test_syncFillAssistRules_userToggleOff() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.fillAssistEnabledByUserId["1"] = false
+
+        await subject.syncFillAssistRules()
+
+        XCTAssertFalse(fillAssistAPIService.getManifestCalled)
+    }
+
+    /// `syncFillAssistRules()` proceeds past the user-toggle guard and fetches the manifest when
+    /// both feature flag and user toggle are on.
+    func test_syncFillAssistRules_userToggleOn_proceeds() async throws {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.fillAssistEnabledByUserId["1"] = true
+        let manifest = try makeManifest(cid: "sha256:abc")
+        fillAssistAPIService.getManifestReturnValue = manifest
+        // Pre-cache matching cid so sync stops at the "no changes" short-circuit,
+        // avoiding a nil getFormsMapReturnValue crash.
+        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
+            cid: "sha256:abc",
+            rules: [:],
+            sourceUrl: environmentService.fillAssistRulesURL.absoluteString,
+        )
+
+        await subject.syncFillAssistRules()
+
+        XCTAssertTrue(fillAssistAPIService.getManifestCalled)
     }
 }

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -219,10 +219,10 @@ protocol StateService: AnyObject, BillingStateService {
     ///
     func getEvents(userId: String?) async throws -> [EventData]
 
-    /// Gets whether the fill assist feature is enabled for the specified user.
+    /// Gets whether the Fill Assist feature is enabled for the specified user.
     ///
     /// - Parameter userId: The user ID, or `nil` for the active account.
-    /// - Returns: Whether fill assist is enabled.
+    /// - Returns: Whether Fill Assist is enabled.
     ///
     func getFillAssistEnabled(userId: String?) async throws -> Bool
 
@@ -630,10 +630,10 @@ protocol StateService: AnyObject, BillingStateService {
     ///
     func setEvents(_ events: [EventData], userId: String?) async throws
 
-    /// Sets whether the fill assist feature is enabled for the specified user.
+    /// Sets whether the Fill Assist feature is enabled for the specified user.
     ///
     /// - Parameters:
-    ///   - fillAssistEnabled: Whether fill assist is enabled.
+    ///   - fillAssistEnabled: Whether Fill Assist is enabled.
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws
@@ -1064,9 +1064,9 @@ extension StateService {
         try await getEnvironmentURLs(userId: nil)
     }
 
-    /// Gets whether fill assist is enabled for the active account.
+    /// Gets whether Fill Assist is enabled for the active account.
     ///
-    /// - Returns: Whether fill assist is enabled.
+    /// - Returns: Whether Fill Assist is enabled.
     ///
     func getFillAssistEnabled() async throws -> Bool {
         try await getFillAssistEnabled(userId: nil)
@@ -1328,9 +1328,9 @@ extension StateService {
         try await setDisableAutoTotpCopy(disableAutoTotpCopy, userId: nil)
     }
 
-    /// Sets whether fill assist is enabled for the active account.
+    /// Sets whether Fill Assist is enabled for the active account.
     ///
-    /// - Parameter fillAssistEnabled: Whether fill assist is enabled.
+    /// - Parameter fillAssistEnabled: Whether Fill Assist is enabled.
     ///
     func setFillAssistEnabled(_ fillAssistEnabled: Bool) async throws {
         try await setFillAssistEnabled(fillAssistEnabled, userId: nil)

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -219,6 +219,13 @@ protocol StateService: AnyObject, BillingStateService {
     ///
     func getEvents(userId: String?) async throws -> [EventData]
 
+    /// Gets whether the fill assist feature is enabled for the specified user.
+    ///
+    /// - Parameter userId: The user ID, or `nil` for the active account.
+    /// - Returns: Whether fill assist is enabled.
+    ///
+    func getFillAssistEnabled(userId: String?) async throws -> Bool
+
     /// Gets the data for the flight recorder.
     ///
     /// - Returns: The flight recorder data.
@@ -622,6 +629,14 @@ protocol StateService: AnyObject, BillingStateService {
     ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
     ///
     func setEvents(_ events: [EventData], userId: String?) async throws
+
+    /// Sets whether the fill assist feature is enabled for the specified user.
+    ///
+    /// - Parameters:
+    ///   - fillAssistEnabled: Whether fill assist is enabled.
+    ///   - userId: The user ID of the account. Defaults to the active account if `nil`.
+    ///
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws
 
     /// Sets the force password reset reason for an account.
     ///
@@ -1049,6 +1064,14 @@ extension StateService {
         try await getEnvironmentURLs(userId: nil)
     }
 
+    /// Gets whether fill assist is enabled for the active account.
+    ///
+    /// - Returns: Whether fill assist is enabled.
+    ///
+    func getFillAssistEnabled() async throws -> Bool {
+        try await getFillAssistEnabled(userId: nil)
+    }
+
     /// Gets whether a sync has been done successfully after login for the current user.
     /// This is particular useful to trigger logic that needs to be executed right after login in
     /// and after the first successful sync.
@@ -1303,6 +1326,14 @@ extension StateService {
     ///
     func setDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool) async throws {
         try await setDisableAutoTotpCopy(disableAutoTotpCopy, userId: nil)
+    }
+
+    /// Sets whether fill assist is enabled for the active account.
+    ///
+    /// - Parameter fillAssistEnabled: Whether fill assist is enabled.
+    ///
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool) async throws {
+        try await setFillAssistEnabled(fillAssistEnabled, userId: nil)
     }
 
     /// Sets the force password reset reason for the active account.
@@ -1760,6 +1791,11 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
         return appSettingsStore.events(userId: userId)
     }
 
+    func getFillAssistEnabled(userId: String?) async throws -> Bool {
+        let userId = try userId ?? getActiveAccountUserId()
+        return appSettingsStore.fillAssistEnabled(userId: userId)
+    }
+
     func getFlightRecorderData() async -> FlightRecorderData? {
         appSettingsStore.flightRecorderData
     }
@@ -2114,6 +2150,11 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
     func setEvents(_ events: [EventData], userId: String?) async throws {
         let userId = try userId ?? getActiveAccountUserId()
         appSettingsStore.setEvents(events, userId: userId)
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws {
+        let userId = try userId ?? getActiveAccountUserId()
+        appSettingsStore.setFillAssistEnabled(fillAssistEnabled, userId: userId)
     }
 
     func setFlightRecorderData(_ data: FlightRecorderData?) async {

--- a/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/StateServiceTests.swift
@@ -764,6 +764,15 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 
+    /// `getFillAssistEnabled()` returns the Fill Assist enabled value for the active account.
+    func test_getFillAssistEnabled() async throws {
+        await subject.addAccount(.fixture())
+        appSettingsStore.fillAssistEnabledByUserId["1"] = true
+
+        let value = try await subject.getFillAssistEnabled()
+        XCTAssertTrue(value)
+    }
+
     /// `getDisableAutoTotpCopy()` returns the disable auto-copy TOTP value for the active account.
     func test_getDisableAutoTotpCopy() async throws {
         await subject.addAccount(.fixture())
@@ -2095,6 +2104,17 @@ class StateServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body
 
         try await subject.setDefaultUriMatchType(.regularExpression, userId: "1")
         XCTAssertEqual(appSettingsStore.defaultUriMatchTypeByUserId["1"], .regularExpression)
+    }
+
+    /// `setFillAssistEnabled(_:userId:)` sets the Fill Assist enabled value for a user.
+    func test_setFillAssistEnabled() async throws {
+        await subject.addAccount(.fixture(profile: .fixture(userId: "1")))
+
+        try await subject.setFillAssistEnabled(true, userId: "1")
+        XCTAssertEqual(appSettingsStore.fillAssistEnabledByUserId["1"], true)
+
+        try await subject.setFillAssistEnabled(false, userId: "1")
+        XCTAssertEqual(appSettingsStore.fillAssistEnabledByUserId["1"], false)
     }
 
     /// `setDisableAutoTotpCopy(_:userId:)` sets the disable auto-copy TOTP value for a user.

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -193,6 +193,12 @@ protocol AppSettingsStore: AnyObject {
     ///
     func fillAssistCachedData(userId: String) -> FillAssistCachedData?
 
+    /// Gets whether the fill assist feature is enabled for the user ID.
+    ///
+    /// - Parameter userId: The user ID associated with the fill assist enabled value.
+    ///
+    func fillAssistEnabled(userId: String) -> Bool
+
     /// Gets the timestamp of the last successful fill-assist manifest check for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the timestamp.
@@ -453,6 +459,14 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the cached data.
     ///
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String)
+
+    /// Sets whether the fill assist feature is enabled for the user ID.
+    ///
+    /// - Parameters:
+    ///   - fillAssistEnabled: The value to set, or `nil` to clear.
+    ///   - userId: The user ID associated with the fill assist enabled value.
+    ///
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String)
 
     /// Sets the timestamp of the last successful fill-assist manifest check for the user ID.
     ///
@@ -824,6 +838,7 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case encryptedUserKey(userId: String)
         case events(userId: String)
         case fillAssistCachedData(userId: String)
+        case fillAssistEnabled(userId: String)
         case fillAssistLastFetchTimestamp(userId: String)
         case flightRecorderData
         case hasPerformedSyncAfterLogin(userId: String)
@@ -914,6 +929,8 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "events_\(userId)"
             case let .fillAssistCachedData(userId):
                 "fillAssistCachedData_\(userId)"
+            case let .fillAssistEnabled(userId):
+                "fillAssistEnabled_\(userId)"
             case let .fillAssistLastFetchTimestamp(userId):
                 "fillAssistLastFetchTimestamp_\(userId)"
             case .flightRecorderData:
@@ -1169,6 +1186,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         fetch(for: .fillAssistCachedData(userId: userId))
     }
 
+    func fillAssistEnabled(userId: String) -> Bool {
+        fetch(for: .fillAssistEnabled(userId: userId))
+    }
+
     func fillAssistLastFetchTimestamp(userId: String) -> Date? {
         fetch(for: .fillAssistLastFetchTimestamp(userId: userId))
     }
@@ -1309,6 +1330,10 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
 
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String) {
         store(data, for: .fillAssistCachedData(userId: userId))
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String) {
+        store(fillAssistEnabled, for: .fillAssistEnabled(userId: userId))
     }
 
     func setFillAssistLastFetchTimestamp(_ timestamp: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -193,9 +193,9 @@ protocol AppSettingsStore: AnyObject {
     ///
     func fillAssistCachedData(userId: String) -> FillAssistCachedData?
 
-    /// Gets whether the fill assist feature is enabled for the user ID.
+    /// Gets whether the Fill Assist feature is enabled for the user ID.
     ///
-    /// - Parameter userId: The user ID associated with the fill assist enabled value.
+    /// - Parameter userId: The user ID associated with the Fill Assist enabled value.
     ///
     func fillAssistEnabled(userId: String) -> Bool
 
@@ -460,11 +460,11 @@ protocol AppSettingsStore: AnyObject {
     ///
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String)
 
-    /// Sets whether the fill assist feature is enabled for the user ID.
+    /// Sets whether the Fill Assist feature is enabled for the user ID.
     ///
     /// - Parameters:
     ///   - fillAssistEnabled: The value to set, or `nil` to clear.
-    ///   - userId: The user ID associated with the fill assist enabled value.
+    ///   - userId: The user ID associated with the Fill Assist enabled value.
     ///
     func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String)
 

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -512,6 +512,23 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNotNil(userDefaults.object(forKey: "bwPreferencesStorage:fillAssistLastFetchTimestamp_2"))
     }
 
+    /// `fillAssistEnabled(userId:)` returns `false` when no value has been set.
+    func test_fillAssistEnabled_isInitiallyFalse() {
+        XCTAssertFalse(subject.fillAssistEnabled(userId: "-1"))
+    }
+
+    /// `fillAssistEnabled(userId:)` and `setFillAssistEnabled(_:userId:)` get and set the value
+    /// per user and persist under the expected UserDefaults key.
+    func test_fillAssistEnabled_withValue() {
+        subject.setFillAssistEnabled(true, userId: "1")
+        subject.setFillAssistEnabled(false, userId: "2")
+
+        XCTAssertTrue(subject.fillAssistEnabled(userId: "1"))
+        XCTAssertFalse(subject.fillAssistEnabled(userId: "2"))
+        XCTAssertNotNil(userDefaults.object(forKey: "bwPreferencesStorage:fillAssistEnabled_1"))
+        XCTAssertNotNil(userDefaults.object(forKey: "bwPreferencesStorage:fillAssistEnabled_2"))
+    }
+
     /// `overrideDebugFeatureFlag(name:value:)` and `debugFeatureFlag(name:)` work as expected with correct values.
     func test_featureFlags() {
         let featureFlags: [FeatureFlag] = [.testFeatureFlag]

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -49,6 +49,7 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var eventsByUserId = [String: [EventData]]()
     var featureFlags = [String: Bool]()
     var fillAssistCachedDataByUserId = [String: FillAssistCachedData]()
+    var fillAssistEnabledByUserId = [String: Bool]()
     var fillAssistLastFetchTimestampByUserId = [String: Date]()
     var hasPerformedSyncAfterLogin = [String: Bool]()
     var lastActiveTime = [String: Date]()
@@ -153,6 +154,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func fillAssistCachedData(userId: String) -> FillAssistCachedData? {
         fillAssistCachedDataByUserId[userId]
+    }
+
+    func fillAssistEnabled(userId: String) -> Bool {
+        fillAssistEnabledByUserId[userId] ?? false
     }
 
     func fillAssistLastFetchTimestamp(userId: String) -> Date? {
@@ -306,6 +311,10 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String) {
         fillAssistCachedDataByUserId[userId] = data
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String) {
+        fillAssistEnabledByUserId[userId] = fillAssistEnabled
     }
 
     func setFillAssistLastFetchTimestamp(_ timestamp: Date?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -46,6 +46,7 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
     var fillAssistEnabledByUserId = [String: Bool]()
+    var getFillAssistEnabledError: Error?
     var doesActiveAccountHavePremiumResult: Bool = true
     var doesActiveAccountHavePremiumPersonallyCalled = false // swiftlint:disable:this identifier_name
     var doesActiveAccountHavePremiumPersonallyResult: Bool = true // swiftlint:disable:this identifier_name
@@ -315,6 +316,9 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     }
 
     func getFillAssistEnabled(userId: String?) async throws -> Bool {
+        if let getFillAssistEnabledError {
+            throw getFillAssistEnabledError
+        }
         let userId = try unwrapUserId(userId)
         return fillAssistEnabledByUserId[userId] ?? false
     }

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -45,6 +45,7 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     var didAccountSwitchInExtensionResult: Result<Bool, Error> = .success(false)
     var disableAutoTotpCopyByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumCalled = false
+    var fillAssistEnabledByUserId = [String: Bool]()
     var doesActiveAccountHavePremiumResult: Bool = true
     var doesActiveAccountHavePremiumPersonallyCalled = false // swiftlint:disable:this identifier_name
     var doesActiveAccountHavePremiumPersonallyResult: Bool = true // swiftlint:disable:this identifier_name
@@ -311,6 +312,11 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
         try eventsResult.get()
         let userId = try unwrapUserId(userId)
         return events[userId] ?? []
+    }
+
+    func getFillAssistEnabled(userId: String?) async throws -> Bool {
+        let userId = try unwrapUserId(userId)
+        return fillAssistEnabledByUserId[userId] ?? false
     }
 
     func getFlightRecorderData() async -> FlightRecorderData? {
@@ -644,6 +650,11 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
     func setEvents(_ events: [EventData], userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         self.events[userId] = events
+    }
+
+    func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws {
+        let userId = try unwrapUserId(userId)
+        fillAssistEnabledByUserId[userId] = fillAssistEnabled
     }
 
     func setFlightRecorderData(_ data: FlightRecorderData?) async {

--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -23,7 +23,7 @@ extension ExternalLinksConstants {
     /// A link to the auto fill help page.
     static let autofillHelp = URL(string: "https://bitwarden.com/help/auto-fill-ios/#keyboard-auto-fill")!
 
-    /// A link to Bitwarden's help page for the fill assist feature.
+    /// A link to Bitwarden's help page for the Fill Assist feature.
     static let fillAssistHelp = URL(string: "https://bitwarden.com/help/fill-assist/")!
 
     /// A link to Bitwarden's help page for learning more about the account fingerprint phrase.

--- a/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/ExternalLinksConstants.swift
@@ -23,6 +23,9 @@ extension ExternalLinksConstants {
     /// A link to the auto fill help page.
     static let autofillHelp = URL(string: "https://bitwarden.com/help/auto-fill-ios/#keyboard-auto-fill")!
 
+    /// A link to Bitwarden's help page for the fill assist feature.
+    static let fillAssistHelp = URL(string: "https://bitwarden.com/help/fill-assist/")!
+
     /// A link to Bitwarden's help page for learning more about the account fingerprint phrase.
     static let fingerprintPhrase = URL(string: "https://bitwarden.com/help/fingerprint-phrase/")!
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
@@ -23,7 +23,7 @@ enum AutoFillAction: Equatable {
     /// The copy TOTP automatically toggle value changed.
     case toggleCopyTOTPToggle(Bool)
 
-    /// The fill assist toggle value changed.
+    /// The Fill Assist toggle value changed.
     case toggleFillAssist(Bool)
 
     /// A toast was shown or hidden.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillAction.swift
@@ -23,6 +23,9 @@ enum AutoFillAction: Equatable {
     /// The copy TOTP automatically toggle value changed.
     case toggleCopyTOTPToggle(Bool)
 
+    /// The fill assist toggle value changed.
+    case toggleFillAssist(Bool)
+
     /// A toast was shown or hidden.
     case toastShown(Toast?)
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -219,7 +219,7 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
         do {
             try await services.stateService.setFillAssistEnabled(fillAssistEnabled)
             if fillAssistEnabled {
-                await services.fillAssistRepository.syncFillAssistRules()
+                await services.fillAssistRepository.syncRules()
             }
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -220,8 +220,10 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     /// - Parameter fillAssistEnabled: Whether Fill Assist should be enabled.
     ///
     private func updateFillAssistEnabled(_ fillAssistEnabled: Bool) async {
+        guard state.isFillAssistEnabled == fillAssistEnabled else { return }
         do {
             try await services.stateService.setFillAssistEnabled(fillAssistEnabled)
+            guard state.isFillAssistEnabled == fillAssistEnabled else { return }
             if fillAssistEnabled {
                 await services.fillAssistRepository.syncRules()
             }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -219,7 +219,10 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     ///
     /// - Parameter fillAssistEnabled: Whether Fill Assist should be enabled.
     ///
+    @MainActor
     private func updateFillAssistEnabled(_ fillAssistEnabled: Bool) async {
+        // Guard against stale tasks: rapid toggling fires multiple concurrent tasks; bail out if
+        // the state has already moved past this task's intended value.
         guard state.isFillAssistEnabled == fillAssistEnabled else { return }
         do {
             try await services.stateService.setFillAssistEnabled(fillAssistEnabled)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -231,9 +231,10 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
                 await services.fillAssistRepository.syncRules()
             }
         } catch {
+            services.errorReporter.log(error: error)
+            guard state.isFillAssistEnabled == fillAssistEnabled else { return }
             state.isFillAssistEnabled = !fillAssistEnabled
             await coordinator.showErrorAlert(error: error)
-            services.errorReporter.log(error: error)
         }
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -12,6 +12,7 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
         & HasAutofillCredentialService
         & HasConfigService
         & HasErrorReporter
+        & HasFillAssistRepository
         & HasSettingsRepository
         & HasStateService
         & HasTimeProvider
@@ -72,6 +73,11 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
             state.url = ExternalLinksConstants.autofillHelp
         case .passwordAutoFillTapped:
             coordinator.navigate(to: .passwordAutoFill, context: self)
+        case let .toggleFillAssist(isOn):
+            state.isFillAssistEnabled = isOn
+            Task {
+                await updateFillAssistEnabled(isOn)
+            }
         case let .toggleCopyTOTPToggle(isOn):
             state.isCopyTOTPToggleOn = isOn
             Task {
@@ -132,8 +138,10 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     private func fetchSettingValues() async {
         state.defaultUriMatchType = await services.settingsRepository.getDefaultUriMatchType()
         state.shouldShowPasswordAutofill = await !services.autofillCredentialService.isAutofillCredentialsEnabled()
+        state.isFillAssistFeatureFlagEnabled = await services.configService.getFeatureFlag(.fillAssistTargetingRules)
         do {
             state.isCopyTOTPToggleOn = try await !services.settingsRepository.getDisableAutoTotpCopy()
+            state.isFillAssistEnabled = try await services.stateService.getFillAssistEnabled()
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             services.errorReporter.log(error: error)
@@ -201,6 +209,18 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
     private func updateDisableAutoTotpCopy(_ disableAutoTotpCopy: Bool) async {
         do {
             try await services.settingsRepository.updateDisableAutoTotpCopy(disableAutoTotpCopy)
+        } catch {
+            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+            services.errorReporter.log(error: error)
+        }
+    }
+
+    private func updateFillAssistEnabled(_ fillAssistEnabled: Bool) async {
+        do {
+            try await services.stateService.setFillAssistEnabled(fillAssistEnabled)
+            if fillAssistEnabled {
+                await services.fillAssistRepository.syncFillAssistRules()
+            }
         } catch {
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
             services.errorReporter.log(error: error)

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessor.swift
@@ -215,6 +215,10 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
         }
     }
 
+    /// Updates the Fill Assist enabled preference and triggers a rules sync if enabled.
+    ///
+    /// - Parameter fillAssistEnabled: Whether Fill Assist should be enabled.
+    ///
     private func updateFillAssistEnabled(_ fillAssistEnabled: Bool) async {
         do {
             try await services.stateService.setFillAssistEnabled(fillAssistEnabled)
@@ -222,7 +226,8 @@ final class AutoFillProcessor: StateProcessor<AutoFillState, AutoFillAction, Aut
                 await services.fillAssistRepository.syncRules()
             }
         } catch {
-            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+            state.isFillAssistEnabled = !fillAssistEnabled
+            await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
     }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
@@ -271,8 +271,8 @@ class AutoFillProcessorTests: BitwardenTestCase {
         XCTAssertTrue(subject.state.isFillAssistEnabled)
         waitFor(stateService.fillAssistEnabledByUserId["1"] == true)
         XCTAssertEqual(stateService.fillAssistEnabledByUserId["1"], true)
-        waitFor(fillAssistRepository.syncFillAssistRulesCalled)
-        XCTAssertTrue(fillAssistRepository.syncFillAssistRulesCalled)
+        waitFor(fillAssistRepository.syncRulesCalled)
+        XCTAssertTrue(fillAssistRepository.syncRulesCalled)
     }
 
     /// `.receive(_:)` with `.toggleFillAssist(false)` persists the value and does NOT sync rules.
@@ -284,7 +284,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.isFillAssistEnabled)
         waitFor(stateService.fillAssistEnabledByUserId["1"] == false)
         XCTAssertEqual(stateService.fillAssistEnabledByUserId["1"], false)
-        XCTAssertFalse(fillAssistRepository.syncFillAssistRulesCalled)
+        XCTAssertFalse(fillAssistRepository.syncRulesCalled)
     }
 
     /// `.receive(_:)` with  `.toggleCopyTOTPToggle` updates the state.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillProcessorTests.swift
@@ -15,6 +15,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
     var configService: MockConfigService!
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
     var errorReporter: MockErrorReporter!
+    var fillAssistRepository: MockFillAssistRepository!
     var settingsRepository: MockSettingsRepository!
     var stateService: MockStateService!
     var subject: AutoFillProcessor!
@@ -29,8 +30,10 @@ class AutoFillProcessorTests: BitwardenTestCase {
         configService = MockConfigService()
         coordinator = MockCoordinator<SettingsRoute, SettingsEvent>()
         errorReporter = MockErrorReporter()
+        fillAssistRepository = MockFillAssistRepository()
         settingsRepository = MockSettingsRepository()
         stateService = MockStateService()
+        stateService.activeAccount = .fixture()
 
         subject = AutoFillProcessor(
             coordinator: coordinator.asAnyCoordinator(),
@@ -39,6 +42,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
                 autofillCredentialService: autofillCredentialService,
                 configService: configService,
                 errorReporter: errorReporter,
+                fillAssistRepository: fillAssistRepository,
                 settingsRepository: settingsRepository,
                 stateService: stateService,
             ),
@@ -54,6 +58,7 @@ class AutoFillProcessorTests: BitwardenTestCase {
         configService = nil
         coordinator = nil
         errorReporter = nil
+        fillAssistRepository = nil
         settingsRepository = nil
         stateService = nil
         subject = nil
@@ -77,6 +82,8 @@ class AutoFillProcessorTests: BitwardenTestCase {
     /// error occurs.
     @MainActor
     func test_perform_dismissSetUpAutofillActionCard_error() async {
+        stateService.activeAccount = nil
+
         await subject.perform(.dismissSetUpAutofillActionCard)
 
         XCTAssertEqual(coordinator.alertShown, [.defaultAlert(title: Localizations.anErrorHasOccurred)])
@@ -89,18 +96,36 @@ class AutoFillProcessorTests: BitwardenTestCase {
         autofillCredentialService.isAutofillCredentialsEnabled = false
         settingsRepository.getDefaultUriMatchTypeResult = .exact
         settingsRepository.getDisableAutoTotpCopyResult = .success(false)
+        stateService.fillAssistEnabledByUserId["1"] = false
         await subject.perform(.fetchSettingValues)
         XCTAssertEqual(subject.state.defaultUriMatchType, .exact)
         XCTAssertTrue(subject.state.isCopyTOTPToggleOn)
         XCTAssertTrue(subject.state.shouldShowPasswordAutofill)
+        XCTAssertFalse(subject.state.isFillAssistEnabled)
 
         autofillCredentialService.isAutofillCredentialsEnabled = true
         settingsRepository.getDefaultUriMatchTypeResult = .regularExpression
         settingsRepository.getDisableAutoTotpCopyResult = .success(true)
+        stateService.fillAssistEnabledByUserId["1"] = true
         await subject.perform(.fetchSettingValues)
         XCTAssertEqual(subject.state.defaultUriMatchType, .regularExpression)
         XCTAssertFalse(subject.state.isCopyTOTPToggleOn)
         XCTAssertFalse(subject.state.shouldShowPasswordAutofill)
+        XCTAssertTrue(subject.state.isFillAssistEnabled)
+    }
+
+    /// `perform(_:)` with `.fetchSettingValues` loads fill assist feature flag state.
+    @MainActor
+    func test_perform_fetchSettingValues_fillAssistFeatureFlag() async {
+        settingsRepository.getDisableAutoTotpCopyResult = .success(false)
+
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        await subject.perform(.fetchSettingValues)
+        XCTAssertTrue(subject.state.isFillAssistFeatureFlagEnabled)
+
+        configService.featureFlagsBool[.fillAssistTargetingRules] = false
+        await subject.perform(.fetchSettingValues)
+        XCTAssertFalse(subject.state.isFillAssistFeatureFlagEnabled)
     }
 
     /// `perform(_:)` with `.fetchSettingValues` logs an error and shows an alert if fetching the values fails.
@@ -187,6 +212,8 @@ class AutoFillProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.streamSettingsBadge` logs an error if streaming the settings badge state fails.
     @MainActor
     func test_perform_streamSettingsBadge_error() async {
+        stateService.activeAccount = nil
+
         await subject.perform(.streamSettingsBadge)
 
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
@@ -233,6 +260,31 @@ class AutoFillProcessorTests: BitwardenTestCase {
 
         subject.receive(.toastShown(nil))
         XCTAssertNil(subject.state.toast)
+    }
+
+    /// `.receive(_:)` with `.toggleFillAssist(true)` persists the value and triggers a rules sync.
+    @MainActor
+    func test_receive_toggleFillAssist_on() {
+        subject.state.isFillAssistEnabled = false
+        subject.receive(.toggleFillAssist(true))
+
+        XCTAssertTrue(subject.state.isFillAssistEnabled)
+        waitFor(stateService.fillAssistEnabledByUserId["1"] == true)
+        XCTAssertEqual(stateService.fillAssistEnabledByUserId["1"], true)
+        waitFor(fillAssistRepository.syncFillAssistRulesCalled)
+        XCTAssertTrue(fillAssistRepository.syncFillAssistRulesCalled)
+    }
+
+    /// `.receive(_:)` with `.toggleFillAssist(false)` persists the value and does NOT sync rules.
+    @MainActor
+    func test_receive_toggleFillAssist_off() {
+        subject.state.isFillAssistEnabled = true
+        subject.receive(.toggleFillAssist(false))
+
+        XCTAssertFalse(subject.state.isFillAssistEnabled)
+        waitFor(stateService.fillAssistEnabledByUserId["1"] == false)
+        XCTAssertEqual(stateService.fillAssistEnabledByUserId["1"], false)
+        XCTAssertFalse(fillAssistRepository.syncFillAssistRulesCalled)
     }
 
     /// `.receive(_:)` with  `.toggleCopyTOTPToggle` updates the state.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
@@ -18,6 +18,12 @@ struct AutoFillState {
     /// Whether or not the copy TOTP automatically toggle is on.
     var isCopyTOTPToggleOn: Bool = false
 
+    /// Whether the fill assist toggle is on.
+    var isFillAssistEnabled: Bool = false
+
+    /// Whether the fill assist row should be shown (feature flag is on).
+    var isFillAssistFeatureFlagEnabled: Bool = false
+
     /// Whether to show the password autofill row.
     var shouldShowPasswordAutofill: Bool = false
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillState.swift
@@ -18,10 +18,10 @@ struct AutoFillState {
     /// Whether or not the copy TOTP automatically toggle is on.
     var isCopyTOTPToggleOn: Bool = false
 
-    /// Whether the fill assist toggle is on.
+    /// Whether the Fill Assist toggle is on.
     var isFillAssistEnabled: Bool = false
 
-    /// Whether the fill assist row should be shown (feature flag is on).
+    /// Whether the Fill Assist feature flag is enabled.
     var isFillAssistFeatureFlagEnabled: Bool = false
 
     /// Whether to show the password autofill row.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -85,6 +85,30 @@ struct AutoFillView: View {
     /// The additional options section.
     private var additionalOptionsSection: some View {
         SectionView(Localizations.additionalOptions, contentSpacing: 8) {
+            if store.state.isFillAssistFeatureFlagEnabled {
+                BitwardenToggle(
+                    footer: Localizations.turnOnFillAssistDescriptionLong,
+                    isOn: store.binding(
+                        get: \.isFillAssistEnabled,
+                        send: AutoFillAction.toggleFillAssist,
+                    ),
+                    accessibilityIdentifier: "FillAssistSwitch",
+                ) {
+                    HStack(spacing: 8) {
+                        Text(Localizations.turnOnFillAssist)
+                        Button {
+                            openURL(ExternalLinksConstants.fillAssistHelp)
+                        } label: {
+                            SharedAsset.Icons.questionCircle16.swiftUIImage
+                                .scaledFrame(width: 16, height: 16)
+                                .accessibilityLabel(Localizations.learnMore)
+                        }
+                        .buttonStyle(.fieldLabelIcon)
+                    }
+                }
+                .contentBlock()
+            }
+
             BitwardenToggle(
                 Localizations.copyTotpAutomatically,
                 footer: Localizations.copyTotpAutomaticallyDescription,

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -77,6 +77,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasErrorReporter
         & HasEventService
         & HasExportCXFCiphersRepository
+        & HasFillAssistRepository
         & HasExportVaultService
         & HasFlightRecorder
         & HasLanguageStateService

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -77,8 +77,8 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasErrorReporter
         & HasEventService
         & HasExportCXFCiphersRepository
-        & HasFillAssistRepository
         & HasExportVaultService
+        & HasFillAssistRepository
         & HasFlightRecorder
         & HasLanguageStateService
         & HasNotificationCenterService

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -15,6 +15,7 @@ class AutofillHelper {
         & HasEventService
         & HasFillAssistRepository
         & HasPasteboardService
+        & HasStateService
         & HasVaultRepository
 
     // MARK: Properties
@@ -107,7 +108,8 @@ class AutofillHelper {
     /// - Returns: An array of `(selector, value)` tuples, or an empty array if unavailable.
     ///
     private func fillAssistFields(for uri: String?, username: String, password: String) async -> [(String, String)] {
-        guard await services.configService.getFeatureFlag(.fillAssistTargetingRules) else { return [] }
+        guard await services.configService.getFeatureFlag(.fillAssistTargetingRules),
+              await (try? services.stateService.getFillAssistEnabled()) == true else { return [] }
         guard let uri,
               let url = URL(string: uri),
               let lookupHost = url.domain else { return [] }

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -112,8 +112,8 @@ class AutofillHelper {
               await (try? services.stateService.getFillAssistEnabled()) == true,
               let uri,
               let url = URL(string: uri),
-              let lookupHost = url.domain else { return [] }
-        guard let rules = await services.fillAssistRepository.rules(for: lookupHost) else { return [] }
+              let lookupHost = url.domain,
+              let rules = await services.fillAssistRepository.rules(for: lookupHost) else { return [] }
 
         var result: [(String, String)] = []
 

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -109,8 +109,8 @@ class AutofillHelper {
     ///
     private func fillAssistFields(for uri: String?, username: String, password: String) async -> [(String, String)] {
         guard await services.configService.getFeatureFlag(.fillAssistTargetingRules),
-              await (try? services.stateService.getFillAssistEnabled()) == true else { return [] }
-        guard let uri,
+              await (try? services.stateService.getFillAssistEnabled()) == true,
+              let uri,
               let url = URL(string: uri),
               let lookupHost = url.domain else { return [] }
         guard let rules = await services.fillAssistRepository.rules(for: lookupHost) else { return [] }

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -19,6 +19,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     var errorReporter: MockErrorReporter!
     var fillAssistRepository: MockFillAssistRepository!
     var pasteboardService: MockPasteboardService!
+    var stateService: MockStateService!
     var subject: AutofillHelper!
     var vaultRepository: MockVaultRepository!
 
@@ -35,6 +36,9 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         errorReporter = MockErrorReporter()
         fillAssistRepository = MockFillAssistRepository()
         pasteboardService = MockPasteboardService()
+        stateService = MockStateService()
+        stateService.activeAccount = .fixture()
+        stateService.fillAssistEnabledByUserId["1"] = true
         vaultRepository = MockVaultRepository()
 
         subject = AutofillHelper(
@@ -46,6 +50,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 errorReporter: errorReporter,
                 fillAssistRepository: fillAssistRepository,
                 pasteboardService: pasteboardService,
+                stateService: stateService,
                 vaultRepository: vaultRepository,
             ),
         )
@@ -61,6 +66,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         errorReporter = nil
         fillAssistRepository = nil
         pasteboardService = nil
+        stateService = nil
         subject = nil
         vaultRepository = nil
     }
@@ -664,6 +670,25 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
+
+    /// `handleCipherForAutofill` does not use FillAssist when the user toggle is off,
+    /// even if the feature flag is on and rules are cached.
+    func test_handleCipherForAutofill_fillAssist_userToggleOff() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.fillAssistEnabledByUserId["1"] = false
+        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertFalse(fillAssistRepository.fillAssistRulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -678,7 +678,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_handleCipherForAutofill_fillAssist_userToggleOff() async {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
         stateService.fillAssistEnabledByUserId["1"] = false
-        fillAssistRepository.fillAssistRulesReturnValue = FillAssistHostRules(fields: [
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
             "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
             "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
         ])
@@ -688,7 +688,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
 
         await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
 
-        XCTAssertFalse(fillAssistRepository.fillAssistRulesCalled)
+        XCTAssertFalse(fillAssistRepository.rulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -691,4 +691,23 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertFalse(fillAssistRepository.rulesCalled)
         XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
     }
+
+    /// `handleCipherForAutofill` does not use Fill Assist when `getFillAssistEnabled` throws,
+    /// treating it the same as the toggle being off.
+    func test_handleCipherForAutofill_fillAssist_getFillAssistEnabledThrows() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        stateService.getFillAssistEnabledError = BitwardenTestError.example
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+            "password": [.init(id: "login-pwd", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertFalse(fillAssistRepository.rulesCalled)
+        XCTAssertNil(appExtensionDelegate.didCompleteAutofillRequestFields)
+    }
 } // swiftlint:disable:this file_length


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39081

## 📔 Objective

Adds an opt-in (off by default) "Turn on fill assist" toggle to Settings → Autofill → Additional Options, hidden behind the `fillAssistTargetingRules` feature flag. When the user enables the toggle, a rules sync is triggered immediately and fill assist field targeting is activated for future autofills.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/4a614f36-04b0-41d8-8ad9-0c38a91802f2" /> | <img width="365" src="https://github.com/user-attachments/assets/2126b048-2786-4bd3-a1a5-19fd37b95fd9" /> |