### PR TITLE
[PM-39616] chore: Remove SupportsSavePasswordCredentials key until Xcode 26.5 is used

### DIFF
--- a/BitwardenAutoFillExtension/Application/Support/Info.plist
+++ b/BitwardenAutoFillExtension/Application/Support/Info.plist
@@ -119,8 +119,6 @@
 				</array>
 				<key>SupportsCredentialExchange</key>
 				<true/>
-				<key>SupportsSavePasswordCredentials</key>
-				<true/>
 			</dict>
 			<key>ASCredentialProviderExtensionShowsConfigurationUI</key>
 			<true/>


### PR DESCRIPTION
## 🎟️ Tracking

PM-39616

## 📔 Objective

Given Save password is not behaving correctly in iOS 26.5, remove the configuration key until Xcode 26.5 is used in CI.
