### PR TITLE
[PM-39759] ci: Increase test execution time allowance to 10 seconds

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -164,7 +164,7 @@ jobs:
             -resultBundlePath "$_TESTS_RESULT_BUNDLE_PATH" \
             -derivedDataPath build/DerivedData \
             -test-timeouts-enabled yes \
-            -maximum-test-execution-time-allowance 2 \
+            -maximum-test-execution-time-allowance 10 \
             -quiet
           kill "$PYEETD_PID"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -158,7 +158,7 @@ jobs:
               -resultBundlePath "$_TESTS_RESULT_BUNDLE_PATH" \
               -derivedDataPath build/DerivedData \
               -test-timeouts-enabled yes \
-              -maximum-test-execution-time-allowance 3 \
+              -maximum-test-execution-time-allowance 10 \
               -quiet
             kill "$PYEETD_PID"
 


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39759](https://bitwarden.atlassian.net/browse/PM-39759)

## 📔 Objective

It has been seen that 3 seconds is not enough as maximum test execution time allowance as we keep getting failures as "Test exceeded execution time allowance of 3 seconds" on some tests that should be passing.
So we're getting a little more flexible by increasing it to 10 seconds which should cover all or most cases in CI testing as discussed internally.


[PM-39759]: https://bitwarden.atlassian.net/browse/PM-39759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ