### PR TITLE
[PM-39514] Fix debounce task to not use .task(id:)

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Extensions/View+Task.swift
+++ b/BitwardenKit/UI/Platform/Application/Extensions/View+Task.swift
@@ -1,5 +1,43 @@
 import SwiftUI
 
+/// A `ViewModifier` that debounces an async action and restarts it when a tracked value changes,
+/// without using `.task(id:)` — which triggers a linker error at iOS 15 deployment target when
+/// built against the iOS 26 SDK because of a new `@isolated(any)` overload in SwiftUICore.
+private struct DebouncedTaskModifier<T: Equatable>: ViewModifier {
+    /// The value to observe for changes; triggers a task restart when it changes.
+    let id: T
+
+    /// The minimum quiet interval (in nanoseconds) that must elapse before the action fires.
+    let debounceIntervalInNS: UInt64
+
+    /// The async action to execute after the debounce interval elapses.
+    let action: @Sendable () async -> Void
+
+    /// The currently running debounced task, cancelled and replaced on each restart.
+    @SwiftUI.State private var currentTask: Task<Void, Never>?
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { restart() }
+            .onChange(of: id) { _ in restart() }
+            .onDisappear {
+                currentTask?.cancel()
+                currentTask = nil
+            }
+    }
+
+    private func restart() {
+        currentTask?.cancel()
+        let interval = debounceIntervalInNS
+        let work = action
+        currentTask = Task {
+            try? await Task.sleep(nanoseconds: interval)
+            guard !Task.isCancelled else { return }
+            await work()
+        }
+    }
+}
+
 public extension View {
     /// Adds a debounced task to perform before this view appears or when a specified
     /// value changes.
@@ -23,13 +61,7 @@ public extension View {
         debounceIntervalInNS: UInt64,
         _ action: @escaping @Sendable () async -> Void,
     ) -> some View where T: Equatable {
-        task(id: value) {
-            try? await Task.sleep(nanoseconds: debounceIntervalInNS)
-            guard !Task.isCancelled else {
-                return
-            }
-            await action()
-        }
+        modifier(DebouncedTaskModifier(id: value, debounceIntervalInNS: debounceIntervalInNS, action: action))
     }
 
     /// Adds a task to perform before this view appears or when a specified


### PR DESCRIPTION
## 🎟️ Tracking

[PM-39514](https://bitwarden.atlassian.net/browse/PM-39514)

## 📔 Objective

Fix debounce task to not use .task(id:) because of update to Xcode 26.5.

`debouncedTask` in `View+Task.swift` was still called `.task(id:)` internally. Even without @inlinable, the some View opaque return type descriptor for that function encodes _TaskModifier2 — the new @isolated(any) overload Swift 6.3.2 selects from the iOS 26 SDK. That type descriptor isn't present in the iOS 15 runtime, so the linker fails anywhere that calls debouncedTask/searchDebouncedTask, including ItemListView.swift in AuthenticatorShared. 

**Fix:** Replaced the internal `.task(id:)` call with a private `DebouncedTaskModifier` struct that uses @State private var currentTask + .onAppear / .onChange / .onDisappear — the same pattern applied to all the other views in this branch. The public debouncedTask and searchDebouncedTask signatures are unchanged, so all call sites are unaffected.



[PM-39514]: https://bitwarden.atlassian.net/browse/PM-39514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ