### PR TITLE
[PM-32685] Send cherry-pick slack message to QA

### DIFF
--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Send slack notification
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
+          webhook: ${{ secrets.TEMP_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             channel: "#automations-test-channel"
             text: "*GitHub Action test message*: ${{ job.status }}\nBranch: ${{ github.ref_name }}\n${{ steps.pr.outputs.url }}"
-        env:
+        # env:
           # SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_URL: ${{ secrets.TEMP_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -1,0 +1,37 @@
+name: Send RC Merge Slack Notification
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - "**-rc[0-9]*"
+
+permissions:
+  contents: read
+  # id-token: write
+  pull-requests: read
+
+jobs:
+  send_notification:
+    name: Send Slack Notification
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Resolve merged PR
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          url=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq '.[0].html_url // empty')
+          echo "url=${url:-${{ github.event.head_commit.url }}}" >> "$GITHUB_OUTPUT"
+
+      - name: Send slack notification
+        uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
+        with:
+          webhook-type: incoming-webhook
+          payload: |
+            channel: "#automations-test-channel"
+            text: "*GitHub Action test message*: ${{ job.status }}\nBranch: ${{ github.ref_name }}\n${{ steps.pr.outputs.url }}"
+        env:
+          # SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.TEMP_SLACK_WEBHOOK_URL }}

--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   send_notification:
     name: Send Slack Notification
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Only run on pushes that carry new commits (or a manual dispatch);
     # skip bare branch-creation pushes that have no commits
     if: ${{ github.event_name != 'push' || github.event.head_commit != null }}

--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -7,13 +7,15 @@ on:
       - release/**/*
 
 permissions:
-  contents: read
   id-token: write
 
 jobs:
   send_notification:
     name: Send Slack Notification
     runs-on: ubuntu-22.04
+    # Only run on pushes that carry new commits (or a manual dispatch);
+    # skip bare branch-creation pushes that have no commits
+    if: ${{ github.event_name != 'push' || github.event.head_commit != null }}
     steps:
       - name: Log in to Azure
         uses: bitwarden/gh-actions/azure-login@main

--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -1,37 +1,49 @@
-name: Send RC Merge Slack Notification
+name: Send Slack Notification
 
 on:
   workflow_dispatch:
-  pull_request:
   push:
     branches:
-      - "**-rc[0-9]*"
+      - release/**/*
 
 permissions:
   contents: read
-  # id-token: write
-  pull-requests: read
+  id-token: write
 
 jobs:
   send_notification:
     name: Send Slack Notification
     runs-on: ubuntu-22.04
     steps:
-      - name: Resolve merged PR
-        id: pr
+      - name: Log in to Azure
+        uses: bitwarden/gh-actions/azure-login@main
+        with:
+          subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+          client_id: ${{ secrets.AZURE_CLIENT_ID }}
+
+      - name: Retrieve Slack secrets
+        id: retrieve-slack-secrets
+        uses: bitwarden/gh-actions/get-keyvault-secrets@main
+        with:
+          keyvault: gh-ios
+          secrets: "SLACK-WEBHOOK-TEAM-ENG-MOBILE"
+
+      - name: Log out from Azure
+        uses: bitwarden/gh-actions/azure-logout@main
+
+      - name: Build message
+        id: msg
         env:
-          GH_TOKEN: ${{ github.token }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          COMMIT_SHA: ${{ github.event.head_commit.id }}
         run: |
-          url=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-            --jq '.[0].html_url // empty')
-          echo "url=${url:-${{ github.event.head_commit.url }}}" >> "$GITHUB_OUTPUT"
+          echo "text=:cherry-pick: <${COMMIT_URL}|${COMMIT_SHA}> into *${GITHUB_REF_NAME}*\ncc <!subteam^S022CDR7W2Z> <@U06538MSPJP>" >> "$GITHUB_OUTPUT"
 
       - name: Send slack notification
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
         with:
-          webhook: ${{ secrets.TEMP_SLACK_WEBHOOK_URL }}
+          webhook: ${{ steps.retrieve-slack-secrets.outputs.SLACK-WEBHOOK-TEAM-ENG-MOBILE }}
           webhook-type: incoming-webhook
           payload: |
-            text: "*GitHub Action test message*: ${{ job.status }}\nBranch: ${{ github.ref_name }}\n${{ steps.pr.outputs.url }}"
-        # env:
-          # SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
+            text: "${{ steps.msg.outputs.text }}"

--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -32,7 +32,6 @@ jobs:
           webhook: ${{ secrets.TEMP_SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
-            channel: "#automations-test-channel"
             text: "*GitHub Action test message*: ${{ job.status }}\nBranch: ${{ github.ref_name }}\n${{ steps.pr.outputs.url }}"
         # env:
           # SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/send_slack_notification.yml
+++ b/.github/workflows/send_slack_notification.yml
@@ -2,6 +2,7 @@ name: Send RC Merge Slack Notification
 
 on:
   workflow_dispatch:
+  pull_request:
   push:
     branches:
       - "**-rc[0-9]*"


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-32685

## 📔 Objective

When changed are cherry-picked to a `release/` branch, a :cherry-pick: slack message pinging `@group-qa` is generated with a link to the commit
