### PR TITLE
[PM-29571] chore: Reenable save password credentials in Info.plist

### DIFF
--- a/BitwardenAutoFillExtension/Application/Support/Info.plist
+++ b/BitwardenAutoFillExtension/Application/Support/Info.plist
@@ -119,6 +119,8 @@
 				</array>
 				<key>SupportsCredentialExchange</key>
 				<true/>
+				<key>SupportsSavePasswordCredentials</key>
+				<true/>
 			</dict>
 			<key>ASCredentialProviderExtensionShowsConfigurationUI</key>
 			<true/>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-29571](https://bitwarden.atlassian.net/browse/PM-29571)

## 📔 Objective

Re-enable save password credentials in the autofill extension.

[PM-29571]: https://bitwarden.atlassian.net/browse/PM-29571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ