### PR TITLE
[PM-38944] fix: Hide storage cost row when user has no additional storage

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanState.swift
@@ -142,6 +142,11 @@ struct PremiumPlanState: Equatable {
         !discount.isEmpty
     }
 
+    /// Whether the storage cost row should be shown.
+    var showStorageCost: Bool {
+        (subscription?.storageCost ?? 0) > 0
+    }
+
     /// The storage cost label (e.g. "$4.00" or "$0.00").
     var storageCostLabel: String {
         guard let subscription else { return "" }

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanStateTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 // MARK: - PremiumPlanStateTests
 
-struct PremiumPlanStateTests {
+struct PremiumPlanStateTests { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     /// A date used for testing: April 2, 2026 at 12:00 UTC.
@@ -256,6 +256,31 @@ struct PremiumPlanStateTests {
         var state = PremiumPlanState()
         state.subscription = .fixture(discount: 0)
         #expect(!state.showDiscount)
+    }
+
+    // MARK: Tests - showStorageCost
+
+    /// `showStorageCost` is true when storage cost is positive.
+    @Test
+    func showStorageCost_true() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(storageCost: 4)
+        #expect(state.showStorageCost)
+    }
+
+    /// `showStorageCost` is false when storage cost is zero.
+    @Test
+    func showStorageCost_false() {
+        var state = PremiumPlanState()
+        state.subscription = .fixture(storageCost: 0)
+        #expect(!state.showStorageCost)
+    }
+
+    /// `showStorageCost` is false when subscription is nil.
+    @Test
+    func showStorageCost_nil() {
+        let state = PremiumPlanState()
+        #expect(!state.showStorageCost)
     }
 
     // MARK: Tests - storageCostLabel

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView+SnapshotTests.swift
@@ -33,6 +33,46 @@ class PremiumPlanViewSnapshotTests: BitwardenTestCase {
 
     // MARK: Snapshots
 
+    /// Check the snapshot for the active state with additional storage.
+    @MainActor
+    func disabletest_snapshot_activeWithStorage() {
+        processor.state.planStatus = .active
+        processor.state.subscription = PremiumSubscription(
+            cadence: .annually,
+            cancelAt: nil,
+            canceled: nil,
+            discount: 0,
+            estimatedTax: 4.55,
+            gracePeriod: nil,
+            nextCharge: Date(timeIntervalSince1970: 1_775_304_000),
+            seatsCost: 19.8,
+            status: .active,
+            storageCost: 4,
+            suspension: nil,
+        )
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+    }
+
+    /// Check the snapshot for the active state with no additional storage.
+    @MainActor
+    func disabletest_snapshot_activeNoStorage() {
+        processor.state.planStatus = .active
+        processor.state.subscription = PremiumSubscription(
+            cadence: .annually,
+            cancelAt: nil,
+            canceled: nil,
+            discount: 0,
+            estimatedTax: 4.55,
+            gracePeriod: nil,
+            nextCharge: Date(timeIntervalSince1970: 1_775_304_000),
+            seatsCost: 19.8,
+            status: .active,
+            storageCost: 0,
+            suspension: nil,
+        )
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+    }
+
     /// Check the snapshot for the active state.
     @MainActor
     func disabletest_snapshot_active() {

--- a/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
+++ b/BitwardenShared/UI/Billing/PremiumPlan/PremiumPlanView.swift
@@ -48,11 +48,13 @@ struct PremiumPlanView: View {
             value: store.state.billingAmount,
             valueColor: Color(asset: SharedAsset.Colors.textPrimary),
         )
-        billingRow(
-            label: Localizations.storageCost,
-            value: store.state.storageCostLabel,
-            valueColor: Color(asset: SharedAsset.Colors.textPrimary),
-        )
+        if store.state.showStorageCost {
+            billingRow(
+                label: Localizations.storageCost,
+                value: store.state.storageCostLabel,
+                valueColor: Color(asset: SharedAsset.Colors.textPrimary),
+            )
+        }
         if store.state.showDiscount {
             billingRow(
                 label: Localizations.discount,
@@ -255,6 +257,20 @@ private extension PremiumSubscription {
         suspension: nil,
     )
 
+    static let previewActiveNoStorage = PremiumSubscription(
+        cadence: .annually,
+        cancelAt: nil,
+        canceled: nil,
+        discount: 0,
+        estimatedTax: 4.55,
+        gracePeriod: nil,
+        nextCharge: Date().addingTimeInterval(60 * 60 * 24 * 30),
+        seatsCost: 19.8,
+        status: .active,
+        storageCost: 0,
+        suspension: nil,
+    )
+
     static let previewUpdatePayment = PremiumSubscription(
         cadence: .annually,
         cancelAt: Date().addingTimeInterval(60 * 60 * 24 * 14),
@@ -353,6 +369,21 @@ private extension PremiumSubscription {
                     state: PremiumPlanState(
                         planStatus: .pendingCancellation,
                         subscription: .previewPendingCancellation,
+                    ),
+                ),
+            ),
+        )
+    }
+}
+
+#Preview("Active - No Storage") {
+    NavigationView {
+        PremiumPlanView(
+            store: Store(
+                processor: StateProcessor(
+                    state: PremiumPlanState(
+                        planStatus: .active,
+                        subscription: .previewActiveNoStorage,
                     ),
                 ),
             ),


### PR DESCRIPTION
## 🎟️ Tracking

[PM-38944](https://bitwarden.atlassian.net/browse/PM-38944) — Storage line item is displayed when a user doesn't have additional storage

Also resolves [PM-38945](https://bitwarden.atlassian.net/browse/PM-38945) — Storage line item is displayed when there is additional storage at zero cost (same root cause and fix).

## 📔 Objective

The storage cost line item in the Premium plan view was always rendered, displaying "$0.00" for users without additional storage. This matched neither web nor Android behavior, where the row is hidden when `additionalStorage` is absent from the API response.

Adds a `showStorageCost` computed property to `PremiumPlanState` following the existing `showDiscount` pattern, and gates the storage `billingRow` on it. The property returns `true` only when `storageCost > 0`. Since the server sends `additionalStorage: null` for both "no storage purchased" and "zero-cost storage" scenarios, this single check covers both PM-38944 and PM-38945.

## 📸 Screenshots

| No additional storage | With additional storage ($4.00) |
|---|---|
| <img width="314" alt="Plan view without storage cost row" src="https://github.com/user-attachments/assets/18391642-e195-4fe4-ab77-48896824f3b3" /> | <img width="314" alt="Plan view with storage cost row showing $4.00" src="https://github.com/user-attachments/assets/194882c5-c475-482f-b3e0-10288a203f6b" /> |

[PM-38944]: https://bitwarden.atlassian.net/browse/PM-38944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-38945]: https://bitwarden.atlassian.net/browse/PM-38945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ