### PR TITLE
[PM-39851] feat: Encrypt Fill Assist cached data

### DIFF
--- a/BitwardenShared/Core/Auth/Services/KeychainRepository.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepository.swift
@@ -27,6 +27,9 @@ enum BitwardenKeychainItem: Equatable, KeychainItem {
     /// The keychain item for device key.
     case deviceKey(userId: String)
 
+    /// The keychain item for the Fill Assist encrypted rules encryption key.
+    case fillAssistEncryptionKey(userId: String)
+
     /// The keychain item for a user's last active boot epoch.
     ///
     /// The boot epoch is `wallTime − monotonicTime` and is used to detect the reboot-timing attack.
@@ -69,6 +72,7 @@ enum BitwardenKeychainItem: Equatable, KeychainItem {
              .clientCertificateIdentity,
              .deviceAuthKeyMetadata,
              .deviceKey,
+             .fillAssistEncryptionKey,
              .lastActiveBootEpoch,
              .lastActiveMonotonicTime,
              .lastActiveTime,
@@ -104,6 +108,7 @@ enum BitwardenKeychainItem: Equatable, KeychainItem {
         case .accessToken,
              .authenticatorVaultKey,
              .clientCertificateIdentity,
+             .fillAssistEncryptionKey,
              .localUserDataKeyStates,
              .refreshToken,
              .serverCommunicationConfig:
@@ -129,6 +134,8 @@ enum BitwardenKeychainItem: Equatable, KeychainItem {
             "deviceAuthKey_" + id
         case let .deviceAuthKeyMetadata(userId: id):
             "deviceAuthKeyMetadata_" + id
+        case let .fillAssistEncryptionKey(userId):
+            "fillAssistEncryptionKey_\(userId)"
         case let .lastActiveBootEpoch(userId):
             "lastActiveBootEpoch_\(userId)"
         case let .lastActiveMonotonicTime(userId):
@@ -359,6 +366,7 @@ extension DefaultKeychainRepository {
             .accessToken(userId: userId),
             .authenticatorVaultKey(userId: userId),
             .biometrics(userId: userId),
+            .fillAssistEncryptionKey(userId: userId),
             // Exclude `deviceKey` since it is used to log back into an account.
             // Also exclude `deviceAuthKey` and `deviceAuthKeyMetadata` since they are used to log back into an account.
             .lastActiveBootEpoch(userId: userId),

--- a/BitwardenShared/Core/Auth/Services/KeychainRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Services/KeychainRepositoryTests.swift
@@ -92,6 +92,7 @@ final class KeychainRepositoryTests: BitwardenTestCase { // swiftlint:disable:th
                 BitwardenKeychainItem.accessToken(userId: "1").unformattedKey,
                 BitwardenKeychainItem.authenticatorVaultKey(userId: "1").unformattedKey,
                 BitwardenKeychainItem.biometrics(userId: "1").unformattedKey,
+                BitwardenKeychainItem.fillAssistEncryptionKey(userId: "1").unformattedKey,
                 BitwardenKeychainItem.lastActiveBootEpoch(userId: "1").unformattedKey,
                 BitwardenKeychainItem.lastActiveMonotonicTime(userId: "1").unformattedKey,
                 BitwardenKeychainItem.lastActiveTime(userId: "1").unformattedKey,

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
@@ -46,6 +46,9 @@ class DefaultFillAssistDataStore: FillAssistDataStore {
     /// The Keychain repository for storing and retrieving the encryption key.
     private let keychainRepository: KeychainRepository
 
+    /// An optional directory override used in tests to avoid writing to the real app container.
+    private let overrideBaseURL: URL?
+
     // MARK: Initialization
 
     /// Creates a `DefaultFillAssistDataStore`.
@@ -53,13 +56,16 @@ class DefaultFillAssistDataStore: FillAssistDataStore {
     /// - Parameters:
     ///   - fileManager: The file manager to use for file I/O. Defaults to `.default`.
     ///   - keychainRepository: The Keychain repository for key storage.
+    ///   - overrideBaseURL: Base directory override for tests. Production callers omit this.
     ///
     init(
         fileManager: FileManager = .default,
         keychainRepository: KeychainRepository,
+        overrideBaseURL: URL? = nil,
     ) {
         self.fileManager = fileManager
         self.keychainRepository = keychainRepository
+        self.overrideBaseURL = overrideBaseURL
     }
 
     // MARK: FillAssistDataStore
@@ -94,30 +100,35 @@ class DefaultFillAssistDataStore: FillAssistDataStore {
         if fileManager.fileExists(atPath: fileURL.path) {
             try fileManager.removeItem(at: fileURL)
         }
-        try? await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
+        try await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
     }
 
     // MARK: Private
 
-    /// Returns the file URL for a user's encrypted rules file.
-    ///
     private func rulesFileURL(for userId: String) throws -> URL {
-        guard let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
-            throw FillAssistDataStoreError.missingApplicationSupportDirectory
+        if let base = overrideBaseURL {
+            return base.appendingPathComponent("\(userId).bin")
         }
-        return base
-            .appendingPathComponent("FillAssistRules", isDirectory: true)
-            .appendingPathComponent("\(userId).bin")
+        return try fileManager.fillAssistRulesURL(for: userId)
     }
 
     /// Returns the AES-256 encryption key for a user, creating and storing it if it does not exist.
     ///
+    /// Propagates any Keychain error (e.g. locked device) so callers can retry rather than
+    /// silently generating a new key and making existing encrypted data permanently unreadable.
+    ///
     private func encryptionKey(for userId: String) async throws -> SymmetricKey {
-        if let stored = try? await keychainRepository.getUserAuthKeyValue(
-            for: .fillAssistEncryptionKey(userId: userId)
-        ), let key = SymmetricKey(base64EncodedString: stored) {
-            return key
+        do {
+            let stored = try await keychainRepository.getUserAuthKeyValue(
+                for: .fillAssistEncryptionKey(userId: userId),
+            )
+            if let key = SymmetricKey(base64EncodedString: stored) {
+                return key
+            }
+        } catch KeychainServiceError.keyNotFound {
+            // Key genuinely absent — fall through to generate a new one.
         }
+        // stored == nil or key was not found: generate, persist, and return a fresh key.
         let key = SymmetricKey(size: .bits256)
         try await keychainRepository.setUserAuthKey(
             for: .fillAssistEncryptionKey(userId: userId),
@@ -131,7 +142,6 @@ class DefaultFillAssistDataStore: FillAssistDataStore {
 
 enum FillAssistDataStoreError: Error {
     case encryptionFailed
-    case missingApplicationSupportDirectory
 }
 
 // MARK: - SymmetricKey + Base64

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
@@ -97,8 +97,12 @@ actor DefaultFillAssistDataStore: FillAssistDataStore {
 
     func delete(userId: String) async throws {
         // Delete the Keychain key first so the data becomes permanently unreadable even if
-        // file removal fails below.
-        try await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
+        // file removal fails below. Treat a missing key as success — delete is idempotent.
+        do {
+            try await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
+        } catch KeychainServiceError.keyNotFound {
+            // Key already absent — nothing to delete.
+        }
         let fileURL = try rulesFileURL(for: userId)
         if fileManager.fileExists(atPath: fileURL.path) {
             try fileManager.removeItem(at: fileURL)

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
@@ -92,7 +92,7 @@ actor DefaultFillAssistDataStore: FillAssistDataStore {
         guard let combined = sealedBox.combined else {
             throw FillAssistDataStoreError.encryptionFailed
         }
-        try combined.write(to: fileURL, options: .completeFileProtectionUntilFirstUserAuthentication)
+        try combined.write(to: fileURL, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
     }
 
     func delete(userId: String) async throws {
@@ -122,9 +122,10 @@ actor DefaultFillAssistDataStore: FillAssistDataStore {
             let stored = try await keychainRepository.getUserAuthKeyValue(
                 for: .fillAssistEncryptionKey(userId: userId),
             )
-            if let key = SymmetricKey(base64EncodedString: stored) {
-                return key
+            guard let key = SymmetricKey(base64EncodedString: stored) else {
+                throw FillAssistDataStoreError.invalidKeyMaterial
             }
+            return key
         } catch KeychainServiceError.keyNotFound {
             // Key genuinely absent — fall through to generate a new one.
         }
@@ -142,6 +143,7 @@ actor DefaultFillAssistDataStore: FillAssistDataStore {
 
 enum FillAssistDataStoreError: Error {
     case encryptionFailed
+    case invalidKeyMaterial
 }
 
 // MARK: - SymmetricKey + Base64

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
@@ -1,0 +1,148 @@
+import BitwardenKit
+import CryptoKit
+import Foundation
+
+// MARK: - FillAssistDataStore
+
+/// A protocol for a store that persists fill-assist cached data encrypted on disk.
+///
+protocol FillAssistDataStore { // sourcery: AutoMockable
+    /// Loads the cached fill-assist data for a user.
+    ///
+    /// - Parameter userId: The user ID whose data to load.
+    /// - Returns: The cached `FillAssistCachedData`, or `nil` if none is stored.
+    ///
+    func load(userId: String) async throws -> FillAssistCachedData?
+
+    /// Saves fill-assist cached data for a user, encrypting it before writing to disk.
+    ///
+    /// - Parameters:
+    ///   - data: The `FillAssistCachedData` to persist.
+    ///   - userId: The user ID to associate the data with.
+    ///
+    func save(_ data: FillAssistCachedData, userId: String) async throws
+
+    /// Deletes the cached fill-assist data and encryption key for a user.
+    ///
+    /// - Parameter userId: The user ID whose data and key to delete.
+    ///
+    func delete(userId: String) async throws
+}
+
+// MARK: - DefaultFillAssistDataStore
+
+/// The default implementation of `FillAssistDataStore`.
+///
+/// Data is AES-GCM encrypted with a per-user 256-bit key stored in the Keychain,
+/// and written to `{applicationSupportDirectory}/FillAssistRules/{userId}.bin` with
+/// `.completeUntilFirstUserAuthentication` file protection.
+///
+class DefaultFillAssistDataStore: FillAssistDataStore {
+    // MARK: Properties
+
+    /// The file manager used for file I/O.
+    private let fileManager: FileManager
+
+    /// The Keychain repository for storing and retrieving the encryption key.
+    private let keychainRepository: KeychainRepository
+
+    // MARK: Initialization
+
+    /// Creates a `DefaultFillAssistDataStore`.
+    ///
+    /// - Parameters:
+    ///   - fileManager: The file manager to use for file I/O. Defaults to `.default`.
+    ///   - keychainRepository: The Keychain repository for key storage.
+    ///
+    init(
+        fileManager: FileManager = .default,
+        keychainRepository: KeychainRepository,
+    ) {
+        self.fileManager = fileManager
+        self.keychainRepository = keychainRepository
+    }
+
+    // MARK: FillAssistDataStore
+
+    func load(userId: String) async throws -> FillAssistCachedData? {
+        let fileURL = try rulesFileURL(for: userId)
+        guard fileManager.fileExists(atPath: fileURL.path) else { return nil }
+        let key = try await encryptionKey(for: userId)
+        let combined = try Data(contentsOf: fileURL)
+        let sealedBox = try AES.GCM.SealedBox(combined: combined)
+        let plaintext = try AES.GCM.open(sealedBox, using: key)
+        return try JSONDecoder().decode(FillAssistCachedData.self, from: plaintext)
+    }
+
+    func save(_ data: FillAssistCachedData, userId: String) async throws {
+        let fileURL = try rulesFileURL(for: userId)
+        try fileManager.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+        )
+        let key = try await encryptionKey(for: userId)
+        let plaintext = try JSONEncoder().encode(data)
+        let sealedBox = try AES.GCM.seal(plaintext, using: key)
+        guard let combined = sealedBox.combined else {
+            throw FillAssistDataStoreError.encryptionFailed
+        }
+        try combined.write(to: fileURL, options: .completeFileProtectionUntilFirstUserAuthentication)
+    }
+
+    func delete(userId: String) async throws {
+        let fileURL = try rulesFileURL(for: userId)
+        if fileManager.fileExists(atPath: fileURL.path) {
+            try fileManager.removeItem(at: fileURL)
+        }
+        try? await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
+    }
+
+    // MARK: Private
+
+    /// Returns the file URL for a user's encrypted rules file.
+    ///
+    private func rulesFileURL(for userId: String) throws -> URL {
+        guard let base = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else {
+            throw FillAssistDataStoreError.missingApplicationSupportDirectory
+        }
+        return base
+            .appendingPathComponent("FillAssistRules", isDirectory: true)
+            .appendingPathComponent("\(userId).bin")
+    }
+
+    /// Returns the AES-256 encryption key for a user, creating and storing it if it does not exist.
+    ///
+    private func encryptionKey(for userId: String) async throws -> SymmetricKey {
+        if let stored = try? await keychainRepository.getUserAuthKeyValue(
+            for: .fillAssistEncryptionKey(userId: userId)
+        ), let key = SymmetricKey(base64EncodedString: stored) {
+            return key
+        }
+        let key = SymmetricKey(size: .bits256)
+        try await keychainRepository.setUserAuthKey(
+            for: .fillAssistEncryptionKey(userId: userId),
+            value: key.base64EncodedString(),
+        )
+        return key
+    }
+}
+
+// MARK: - FillAssistDataStoreError
+
+enum FillAssistDataStoreError: Error {
+    case encryptionFailed
+    case missingApplicationSupportDirectory
+}
+
+// MARK: - SymmetricKey + Base64
+
+private extension SymmetricKey {
+    init?(base64EncodedString: String) {
+        guard let data = Data(base64Encoded: base64EncodedString) else { return nil }
+        self.init(data: data)
+    }
+
+    func base64EncodedString() -> String {
+        withUnsafeBytes { Data($0).base64EncodedString() }
+    }
+}

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
@@ -96,11 +96,13 @@ actor DefaultFillAssistDataStore: FillAssistDataStore {
     }
 
     func delete(userId: String) async throws {
+        // Delete the Keychain key first so the data becomes permanently unreadable even if
+        // file removal fails below.
+        try await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
         let fileURL = try rulesFileURL(for: userId)
         if fileManager.fileExists(atPath: fileURL.path) {
             try fileManager.removeItem(at: fileURL)
         }
-        try await keychainRepository.deleteUserAuthKey(for: .fillAssistEncryptionKey(userId: userId))
     }
 
     // MARK: Private
@@ -129,7 +131,7 @@ actor DefaultFillAssistDataStore: FillAssistDataStore {
         } catch KeychainServiceError.keyNotFound {
             // Key genuinely absent — fall through to generate a new one.
         }
-        // stored == nil or key was not found: generate, persist, and return a fresh key.
+        // Key was not found: generate, persist, and return a fresh key.
         let key = SymmetricKey(size: .bits256)
         try await keychainRepository.setUserAuthKey(
             for: .fillAssistEncryptionKey(userId: userId),

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStore.swift
@@ -34,10 +34,10 @@ protocol FillAssistDataStore { // sourcery: AutoMockable
 /// The default implementation of `FillAssistDataStore`.
 ///
 /// Data is AES-GCM encrypted with a per-user 256-bit key stored in the Keychain,
-/// and written to `{applicationSupportDirectory}/FillAssistRules/{userId}.bin` with
-/// `.completeUntilFirstUserAuthentication` file protection.
+/// and written to `{appGroupContainer}/FillAssistRules/{userId}.bin` with
+/// `.completeFileProtectionUntilFirstUserAuthentication` file protection.
 ///
-class DefaultFillAssistDataStore: FillAssistDataStore {
+actor DefaultFillAssistDataStore: FillAssistDataStore {
     // MARK: Properties
 
     /// The file manager used for file I/O.

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStoreTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStoreTests.swift
@@ -61,6 +61,7 @@ struct FillAssistDataStoreTests {
     /// `load(userId:)` returns `nil` when no file exists for the user.
     @Test
     func load_noFile_returnsNil() async throws {
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
         let result = try await subject.load(userId: "nonexistent")
         #expect(result == nil)
     }
@@ -116,6 +117,7 @@ struct FillAssistDataStoreTests {
     /// `delete(userId:)` succeeds even if no file exists.
     @Test
     func delete_noFile_succeeds() async throws {
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
         await #expect(throws: Never.self) {
             try await subject.delete(userId: "nonexistent")
         }

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStoreTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStoreTests.swift
@@ -1,0 +1,123 @@
+import BitwardenKit
+import BitwardenKitMocks
+import CryptoKit
+import Foundation
+import Testing
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - FillAssistDataStoreTests
+
+@MainActor
+struct FillAssistDataStoreTests {
+    // MARK: Properties
+
+    let keychainRepository: MockKeychainRepository
+    let subject: DefaultFillAssistDataStore
+    let tempDirectory: URL
+
+    // MARK: Initialization
+
+    init() throws {
+        keychainRepository = MockKeychainRepository()
+        // Simulate "key not found" so encryptionKey() generates a fresh key rather than
+        // returning nil from the uninitialised String! mock return value.
+        keychainRepository.getUserAuthKeyValueThrowableError = KeychainServiceError
+            .keyNotFound(BitwardenKeychainItem.fillAssistEncryptionKey(userId: "1"))
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+        subject = DefaultFillAssistDataStore(
+            keychainRepository: keychainRepository,
+            overrideBaseURL: tempDirectory,
+        )
+    }
+
+    // MARK: Tests - save and load round-trip
+
+    /// `save(_:userId:)` encrypts and writes data; `load(userId:)` decrypts and returns it.
+    @Test
+    func saveAndLoad_roundTrip() async throws {
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+        let data = FillAssistCachedData(
+            cid: "sha256:abc",
+            rules: ["example.com": FillAssistHostRules(fields: [:])],
+            sourceUrl: "https://example.com",
+        )
+
+        try await subject.save(data, userId: "1")
+        // After save, the generated key is in the mock; make subsequent calls return it.
+        let storedKey = keychainRepository.setUserAuthKeyReceivedArguments?.value ?? ""
+        keychainRepository.getUserAuthKeyValueThrowableError = nil
+        keychainRepository.getUserAuthKeyValueReturnValue = storedKey
+
+        let loaded = try await subject.load(userId: "1")
+
+        #expect(loaded == data)
+        #expect(keychainRepository.setUserAuthKeyCalled)
+    }
+
+    /// `load(userId:)` returns `nil` when no file exists for the user.
+    @Test
+    func load_noFile_returnsNil() async throws {
+        let result = try await subject.load(userId: "nonexistent")
+        #expect(result == nil)
+    }
+
+    /// `save(_:userId:)` reuses the existing Keychain key on subsequent saves.
+    @Test
+    func save_reuseExistingKey() async throws {
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+        let data = FillAssistCachedData(cid: "sha256:abc", rules: [:], sourceUrl: "https://example.com")
+
+        // First save: no key yet → generates and stores one.
+        try await subject.save(data, userId: "1")
+        let storedKey = keychainRepository.setUserAuthKeyReceivedArguments?.value ?? ""
+        // Second save: key exists → getUserAuthKeyValue returns it, no new key generated.
+        keychainRepository.getUserAuthKeyValueThrowableError = nil
+        keychainRepository.getUserAuthKeyValueReturnValue = storedKey
+
+        try await subject.save(data, userId: "1")
+
+        #expect(keychainRepository.setUserAuthKeyCallsCount == 1, "Key should be generated only once")
+    }
+
+    /// `load(userId:)` propagates Keychain errors rather than generating a new key.
+    @Test
+    func load_keychainError_propagates() async throws {
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+        let data = FillAssistCachedData(cid: "sha256:abc", rules: [:], sourceUrl: "https://example.com")
+        // Save to create the encrypted file.
+        try await subject.save(data, userId: "1")
+        // Simulate a Keychain error (e.g. locked device) on the subsequent load.
+        keychainRepository.getUserAuthKeyValueThrowableError = URLError(.notConnectedToInternet)
+
+        await #expect(throws: URLError.self) {
+            _ = try await subject.load(userId: "1")
+        }
+        #expect(keychainRepository.setUserAuthKeyCallsCount == 1, "Must not generate a new key on Keychain error")
+    }
+
+    /// `delete(userId:)` removes the file and deletes the Keychain key.
+    @Test
+    func delete_removesFileAndKey() async throws {
+        defer { try? FileManager.default.removeItem(at: tempDirectory) }
+        let data = FillAssistCachedData(cid: "sha256:abc", rules: [:], sourceUrl: "https://example.com")
+        try await subject.save(data, userId: "1")
+
+        try await subject.delete(userId: "1")
+
+        let loaded = try await subject.load(userId: "1")
+        #expect(loaded == nil)
+        #expect(keychainRepository.deleteUserAuthKeyCalled)
+    }
+
+    /// `delete(userId:)` succeeds even if no file exists.
+    @Test
+    func delete_noFile_succeeds() async throws {
+        await #expect(throws: Never.self) {
+            try await subject.delete(userId: "nonexistent")
+        }
+    }
+}

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStoreTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistDataStoreTests.swift
@@ -114,10 +114,13 @@ struct FillAssistDataStoreTests {
         #expect(keychainRepository.deleteUserAuthKeyCalled)
     }
 
-    /// `delete(userId:)` succeeds even if no file exists.
+    /// `delete(userId:)` succeeds even if no file or Keychain key exists.
     @Test
     func delete_noFile_succeeds() async throws {
         defer { try? FileManager.default.removeItem(at: tempDirectory) }
+        keychainRepository.deleteUserAuthKeyThrowableError = KeychainServiceError
+            .keyNotFound(BitwardenKeychainItem.fillAssistEncryptionKey(userId: "nonexistent"))
+
         await #expect(throws: Never.self) {
             try await subject.delete(userId: "nonexistent")
         }

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
@@ -118,10 +118,12 @@ class DefaultFillAssistRepository: FillAssistRepository {
 
         let sourceUrl = environmentService.fillAssistRulesURL
         let userId = try await stateService.getActiveAccountId()
+        let cached = try? await fillAssistDataStore.load(userId: userId)
         let lastFetch = appSettingsStore.fillAssistLastFetchTimestamp(userId: userId)
-        if let lastFetch, timeProvider.presentTime.timeIntervalSince(lastFetch) < Constants.FillAssist.updateInterval {
-            return
-        }
+        let cacheIsStale = lastFetch.map { timestamp in
+            timeProvider.presentTime.timeIntervalSince(timestamp) >= Constants.FillAssist.updateInterval
+        } ?? true
+        guard cached == nil || cacheIsStale else { return }
 
         let manifest = try await fillAssistAPIService.getManifest()
 
@@ -129,7 +131,6 @@ class DefaultFillAssistRepository: FillAssistRepository {
               !entry.deprecated
         else { return }
 
-        let cached = try? await fillAssistDataStore.load(userId: userId)
         if cached?.cid == entry.cid, cached?.sourceUrl == sourceUrl.absoluteString {
             appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
             return

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
@@ -29,7 +29,7 @@ protocol FillAssistRepository { // sourcery: AutoMockable
 class DefaultFillAssistRepository: FillAssistRepository {
     // MARK: Private Properties
 
-    /// The store for persisting fill-assist cached data.
+    /// The store for persisting fill-assist metadata (timestamps, toggle state).
     private let appSettingsStore: AppSettingsStore
 
     /// The service for checking feature flags and configuration.
@@ -44,6 +44,9 @@ class DefaultFillAssistRepository: FillAssistRepository {
     /// The API service for fetching fill-assist data.
     private let fillAssistAPIService: FillAssistAPIService
 
+    /// The encrypted file store for persisting fill-assist cached rules.
+    private let fillAssistDataStore: FillAssistDataStore
+
     /// The service for accessing account state.
     private let stateService: StateService
 
@@ -55,11 +58,12 @@ class DefaultFillAssistRepository: FillAssistRepository {
     /// Creates a `DefaultFillAssistRepository`.
     ///
     /// - Parameters:
-    ///   - appSettingsStore: The store for persisting fill-assist cached data.
+    ///   - appSettingsStore: The store for persisting fill-assist metadata.
     ///   - configService: The service for checking feature flags and configuration.
     ///   - environmentService: The service for accessing environment URLs.
     ///   - errorReporter: The service for reporting non-fatal errors.
     ///   - fillAssistAPIService: The API service for fetching fill-assist data.
+    ///   - fillAssistDataStore: The encrypted file store for cached rules.
     ///   - stateService: The service for accessing account state.
     ///   - timeProvider: The provider of the current time.
     ///
@@ -69,6 +73,7 @@ class DefaultFillAssistRepository: FillAssistRepository {
         environmentService: EnvironmentService,
         errorReporter: ErrorReporter,
         fillAssistAPIService: FillAssistAPIService,
+        fillAssistDataStore: FillAssistDataStore,
         stateService: StateService,
         timeProvider: TimeProvider,
     ) {
@@ -77,6 +82,7 @@ class DefaultFillAssistRepository: FillAssistRepository {
         self.environmentService = environmentService
         self.errorReporter = errorReporter
         self.fillAssistAPIService = fillAssistAPIService
+        self.fillAssistDataStore = fillAssistDataStore
         self.stateService = stateService
         self.timeProvider = timeProvider
     }
@@ -94,12 +100,12 @@ class DefaultFillAssistRepository: FillAssistRepository {
 
     func rules(for hostname: String) async -> FillAssistHostRules? {
         guard let userId = try? await stateService.getActiveAccountId() else { return nil }
-        return appSettingsStore.fillAssistCachedData(userId: userId)?.rules[hostname]
+        return try? await fillAssistDataStore.load(userId: userId)?.rules[hostname]
     }
 
     func clearRules() async throws {
         let userId = try await stateService.getActiveAccountId()
-        appSettingsStore.setFillAssistCachedData(nil, userId: userId)
+        try await fillAssistDataStore.delete(userId: userId)
     }
 
     // MARK: Private
@@ -123,7 +129,7 @@ class DefaultFillAssistRepository: FillAssistRepository {
               !entry.deprecated
         else { return }
 
-        let cached = appSettingsStore.fillAssistCachedData(userId: userId)
+        let cached = try? await fillAssistDataStore.load(userId: userId)
         if cached?.cid == entry.cid, cached?.sourceUrl == sourceUrl.absoluteString {
             appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
             return
@@ -139,7 +145,7 @@ class DefaultFillAssistRepository: FillAssistRepository {
 
         let rules = buildRules(from: formsMap)
         let data = FillAssistCachedData(cid: entry.cid, rules: rules, sourceUrl: sourceUrl.absoluteString)
-        appSettingsStore.setFillAssistCachedData(data, userId: userId)
+        try await fillAssistDataStore.save(data, userId: userId)
         appSettingsStore.setFillAssistLastFetchTimestamp(timeProvider.presentTime, userId: userId)
     }
 

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepository.swift
@@ -120,10 +120,11 @@ class DefaultFillAssistRepository: FillAssistRepository {
         let userId = try await stateService.getActiveAccountId()
         let cached = try? await fillAssistDataStore.load(userId: userId)
         let lastFetch = appSettingsStore.fillAssistLastFetchTimestamp(userId: userId)
-        let cacheIsStale = lastFetch.map { timestamp in
-            timeProvider.presentTime.timeIntervalSince(timestamp) >= Constants.FillAssist.updateInterval
-        } ?? true
-        guard cached == nil || cacheIsStale else { return }
+        if let lastFetch,
+           cached != nil,
+           timeProvider.presentTime.timeIntervalSince(lastFetch) < Constants.FillAssist.updateInterval {
+            return
+        }
 
         let manifest = try await fillAssistAPIService.getManifest()
 

--- a/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
+++ b/BitwardenShared/Core/Autofill/Repositories/FillAssistRepositoryTests.swift
@@ -17,6 +17,7 @@ struct FillAssistRepositoryTests {
     let environmentService: MockEnvironmentService
     let errorReporter: MockErrorReporter
     let fillAssistAPIService: MockFillAssistAPIService
+    let fillAssistDataStore: MockFillAssistDataStore
     let stateService: MockStateService
     let subject: DefaultFillAssistRepository
     let timeProvider: MockTimeProvider
@@ -29,6 +30,7 @@ struct FillAssistRepositoryTests {
         environmentService = MockEnvironmentService()
         errorReporter = MockErrorReporter()
         fillAssistAPIService = MockFillAssistAPIService()
+        fillAssistDataStore = MockFillAssistDataStore()
         stateService = MockStateService()
         stateService.activeAccount = .fixture()
         stateService.fillAssistEnabledByUserId["1"] = true
@@ -40,6 +42,7 @@ struct FillAssistRepositoryTests {
             environmentService: environmentService,
             errorReporter: errorReporter,
             fillAssistAPIService: fillAssistAPIService,
+            fillAssistDataStore: fillAssistDataStore,
             stateService: stateService,
             timeProvider: timeProvider,
         )
@@ -74,7 +77,7 @@ struct FillAssistRepositoryTests {
         configService.featureFlagsBool[.fillAssistTargetingRules] = true
         let sourceUrl = environmentService.fillAssistRulesURL.absoluteString
 
-        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
+        fillAssistDataStore.loadReturnValue = FillAssistCachedData(
             cid: "sha256:abc123",
             rules: [:],
             sourceUrl: sourceUrl,
@@ -101,7 +104,7 @@ struct FillAssistRepositoryTests {
         #expect(fillAssistAPIService.getManifestCalled)
         #expect(fillAssistAPIService.getFormsMapCalled)
         #expect(fillAssistAPIService.getFormsMapReceivedFilename == "forms.v1.json")
-        let cached = appSettingsStore.fillAssistCachedDataByUserId["1"]
+        let cached = fillAssistDataStore.saveReceivedArguments?.data
         #expect(cached != nil)
         #expect(cached?.cid == "sha256:newcid")
         #expect(appSettingsStore.fillAssistLastFetchTimestampByUserId["1"] != nil)
@@ -117,7 +120,7 @@ struct FillAssistRepositoryTests {
 
         await subject.syncRules()
 
-        #expect(appSettingsStore.fillAssistCachedDataByUserId["1"] == nil)
+        #expect(!fillAssistDataStore.saveCalled)
         #expect(appSettingsStore.fillAssistLastFetchTimestampByUserId["1"] != nil)
     }
 
@@ -131,7 +134,7 @@ struct FillAssistRepositoryTests {
 
         await subject.syncRules()
 
-        let hostRules = appSettingsStore.fillAssistCachedDataByUserId["1"]?.rules["example.com"]
+        let hostRules = fillAssistDataStore.saveReceivedArguments?.data.rules["example.com"]
         let usernameAttrs = try #require(hostRules?.fields["username"]?.first)
         #expect(usernameAttrs.id == "user")
         #expect(usernameAttrs.tagName == "input")
@@ -147,7 +150,7 @@ struct FillAssistRepositoryTests {
 
         await subject.syncRules()
 
-        let usernameAttrs = appSettingsStore.fillAssistCachedDataByUserId["1"]?
+        let usernameAttrs = fillAssistDataStore.saveReceivedArguments?.data
             .rules["example.com"]?.fields["username"]
         let count = try #require(usernameAttrs).count
         #expect(count == 2)
@@ -166,7 +169,7 @@ struct FillAssistRepositoryTests {
 
         await subject.syncRules()
 
-        let rules = appSettingsStore.fillAssistCachedDataByUserId["1"]?.rules
+        let rules = fillAssistDataStore.saveReceivedArguments?.data.rules
         #expect(rules?["example.com"] == nil)
     }
 
@@ -180,7 +183,7 @@ struct FillAssistRepositoryTests {
 
         await subject.syncRules()
 
-        let rules = appSettingsStore.fillAssistCachedDataByUserId["1"]?.rules
+        let rules = fillAssistDataStore.saveReceivedArguments?.data.rules
         #expect(rules?.isEmpty == true)
     }
 
@@ -196,7 +199,7 @@ struct FillAssistRepositoryTests {
 
         await subject.syncRules()
 
-        let rules = appSettingsStore.fillAssistCachedDataByUserId["1"]?.rules
+        let rules = fillAssistDataStore.saveReceivedArguments?.data.rules
         #expect(rules?["example.com"] != nil)
         #expect(rules?["other.com"] != nil)
         #expect(rules?.count == 2)
@@ -211,7 +214,7 @@ struct FillAssistRepositoryTests {
         await subject.syncRules()
 
         #expect(errorReporter.errors.count == 1)
-        #expect(appSettingsStore.fillAssistCachedDataByUserId["1"] == nil)
+        #expect(!fillAssistDataStore.saveCalled)
     }
 
     // MARK: Tests - rules(for:)
@@ -220,7 +223,7 @@ struct FillAssistRepositoryTests {
     @Test
     func rules_returnsRulesForHostname() async {
         let hostRules = FillAssistHostRules(fields: ["username": []])
-        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
+        fillAssistDataStore.loadReturnValue = FillAssistCachedData(
             cid: "sha256:abc",
             rules: ["example.com": hostRules],
             sourceUrl: "https://example.com",
@@ -234,7 +237,7 @@ struct FillAssistRepositoryTests {
     /// `rules(for:)` returns `nil` for an unknown hostname.
     @Test
     func rules_returnsNilForUnknownHostname() async {
-        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
+        fillAssistDataStore.loadReturnValue = FillAssistCachedData(
             cid: "sha256:abc",
             rules: [:],
             sourceUrl: "https://example.com",
@@ -250,15 +253,9 @@ struct FillAssistRepositoryTests {
     /// `clearRules()` removes cached data for the active account.
     @Test
     func clearRules_removesCachedData() async throws {
-        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
-            cid: "sha256:abc",
-            rules: [:],
-            sourceUrl: "https://example.com",
-        )
-
         try await subject.clearRules()
 
-        #expect(appSettingsStore.fillAssistCachedDataByUserId["1"] == nil)
+        #expect(fillAssistDataStore.deleteCalled)
     }
 
     // MARK: Tests - FormsMapSelector.attributes
@@ -383,7 +380,7 @@ private extension FillAssistRepositoryTests {
         stateService.fillAssistEnabledByUserId["1"] = true
         fillAssistAPIService.getManifestReturnValue = makeManifest(cid: "sha256:abc")
         // Pre-cache matching cid so sync stops at the "no changes" short-circuit.
-        appSettingsStore.fillAssistCachedDataByUserId["1"] = FillAssistCachedData(
+        fillAssistDataStore.loadReturnValue = FillAssistCachedData(
             cid: "sha256:abc",
             rules: [:],
             sourceUrl: environmentService.fillAssistRulesURL.absoluteString,

--- a/BitwardenShared/Core/Autofill/Services/API/FillAssistAPIService.swift
+++ b/BitwardenShared/Core/Autofill/Services/API/FillAssistAPIService.swift
@@ -24,14 +24,10 @@ protocol FillAssistAPIService { // sourcery: AutoMockable
 
 extension APIService: FillAssistAPIService {
     func getFormsMap(filename: String) async throws -> FormsMapResponseModel {
-        let fileURL = try await fillAssistService.download(filename: filename)
-        let data = try Data(contentsOf: fileURL)
-        return try JSONDecoder.pascalOrSnakeCaseDecoder.decode(FormsMapResponseModel.self, from: data)
+        try await fillAssistService.send(FormsMapRequest(filename: filename))
     }
 
     func getManifest() async throws -> FillAssistManifestResponseModel {
-        let fileURL = try await fillAssistService.download(filename: Constants.FillAssist.manifestFilename)
-        let data = try Data(contentsOf: fileURL)
-        return try JSONDecoder.pascalOrSnakeCaseDecoder.decode(FillAssistManifestResponseModel.self, from: data)
+        try await fillAssistService.send(FillAssistManifestRequest())
     }
 }

--- a/BitwardenShared/Core/Platform/Extensions/FileManager+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/FileManager+Extensions.swift
@@ -17,6 +17,22 @@ extension FileManager {
         .appendingPathComponent("Attachments", isDirectory: true)
     }
 
+    /// Returns a URL for the encrypted Fill Assist rules file for a user.
+    ///
+    /// - Parameter userId: The user ID of the active account.
+    /// - Returns: A URL for the user's encrypted Fill Assist rules file.
+    ///
+    func fillAssistRulesURL(for userId: String) throws -> URL {
+        try url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true,
+        )
+        .appendingPathComponent("FillAssistRules", isDirectory: true)
+        .appendingPathComponent("\(userId).bin")
+    }
+
     /// Returns a URL for an exported vault directory.
     ///
     /// - Returns: A URL for storing a vault export file.

--- a/BitwardenShared/Core/Platform/Extensions/FileManager+Extensions.swift
+++ b/BitwardenShared/Core/Platform/Extensions/FileManager+Extensions.swift
@@ -23,14 +23,12 @@ extension FileManager {
     /// - Returns: A URL for the user's encrypted Fill Assist rules file.
     ///
     func fillAssistRulesURL(for userId: String) throws -> URL {
-        try url(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: true,
-        )
-        .appendingPathComponent("FillAssistRules", isDirectory: true)
-        .appendingPathComponent("\(userId).bin")
+        guard let containerURL = containerURL(forSecurityApplicationGroupIdentifier: Bundle.main.groupIdentifier) else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        return containerURL
+            .appendingPathComponent("FillAssistRules", isDirectory: true)
+            .appendingPathComponent("\(userId).bin")
     }
 
     /// Returns a URL for an exported vault directory.

--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -772,12 +772,14 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             stateService: stateService,
         )
 
+        let fillAssistDataStore = DefaultFillAssistDataStore(keychainRepository: keychainRepository)
         let fillAssistRepository = DefaultFillAssistRepository(
             appSettingsStore: appSettingsStore,
             configService: configService,
             environmentService: environmentService,
             errorReporter: errorReporter,
             fillAssistAPIService: apiService,
+            fillAssistDataStore: fillAssistDataStore,
             stateService: stateService,
             timeProvider: timeProvider,
         )

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1974,6 +1974,7 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
         appSettingsStore.setDisableAutoTotpCopy(nil, userId: knownUserId)
         appSettingsStore.setEncryptedUserKey(key: nil, userId: knownUserId)
         appSettingsStore.setFillAssistLastFetchTimestamp(nil, userId: knownUserId)
+        deleteFillAssistRulesFile(userId: knownUserId)
         appSettingsStore.setHasPerformedSyncAfterLogin(nil, userId: knownUserId)
         appSettingsStore.setLastSyncTime(nil, userId: knownUserId)
         appSettingsStore.setMasterPasswordHash(nil, userId: knownUserId)
@@ -1981,6 +1982,15 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
         try await keychainRepository.clearLocalUserDataKeyStates(userId: knownUserId)
 
         try await dataStore.deleteDataForUser(userId: knownUserId)
+    }
+
+    /// Deletes the Fill Assist encrypted rules file for a user if it exists.
+    /// Errors are swallowed — the Keychain key deletion in `deleteItems(for:)` already ensures
+    /// the file is permanently unreadable even if the file deletion itself fails.
+    ///
+    private func deleteFillAssistRulesFile(userId: String) {
+        guard let fileURL = try? FileManager.default.fillAssistRulesURL(for: userId) else { return }
+        try? FileManager.default.removeItem(at: fileURL)
     }
 
     func pinProtectedUserKey(userId: String?) async throws -> String? {

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1973,7 +1973,6 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
         appSettingsStore.setDefaultUriMatchType(nil, userId: knownUserId)
         appSettingsStore.setDisableAutoTotpCopy(nil, userId: knownUserId)
         appSettingsStore.setEncryptedUserKey(key: nil, userId: knownUserId)
-        appSettingsStore.setFillAssistCachedData(nil, userId: knownUserId)
         appSettingsStore.setFillAssistLastFetchTimestamp(nil, userId: knownUserId)
         appSettingsStore.setHasPerformedSyncAfterLogin(nil, userId: knownUserId)
         appSettingsStore.setLastSyncTime(nil, userId: knownUserId)

--- a/BitwardenShared/Core/Platform/Services/StateService.swift
+++ b/BitwardenShared/Core/Platform/Services/StateService.swift
@@ -1985,8 +1985,8 @@ actor DefaultStateService: StateService, ActiveAccountStateProvider, ConfigState
     }
 
     /// Deletes the Fill Assist encrypted rules file for a user if it exists.
-    /// Errors are swallowed — the Keychain key deletion in `deleteItems(for:)` already ensures
-    /// the file is permanently unreadable even if the file deletion itself fails.
+    /// Errors are swallowed — the Keychain key is deleted by the logout caller before this helper
+    /// is invoked, so the file is already permanently unreadable even if deletion fails here.
     ///
     private func deleteFillAssistRulesFile(userId: String) {
         guard let fileURL = try? FileManager.default.fillAssistRulesURL(for: userId) else { return }

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStore.swift
@@ -186,13 +186,6 @@ protocol AppSettingsStore: AnyObject {
     ///
     func encryptedUserKey(userId: String) -> String?
 
-    /// Gets the cached Fill-Assist rules data for the user ID.
-    ///
-    /// - Parameter userId: The user ID associated with the cached data.
-    /// - Returns: The cached `FillAssistCachedData`, or `nil` if not cached.
-    ///
-    func fillAssistCachedData(userId: String) -> FillAssistCachedData?
-
     /// Gets whether the Fill Assist feature is enabled for the user ID.
     ///
     /// - Parameter userId: The user ID associated with the Fill Assist enabled value.
@@ -451,14 +444,6 @@ protocol AppSettingsStore: AnyObject {
     ///   - userId: The user ID associated with the events.
     ///
     func setEvents(_ events: [EventData], userId: String)
-
-    /// Sets the cached Fill-Assist rules data for the user ID.
-    ///
-    /// - Parameters:
-    ///   - data: The `FillAssistCachedData` to cache, or `nil` to clear.
-    ///   - userId: The user ID associated with the cached data.
-    ///
-    func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String)
 
     /// Sets whether the Fill Assist feature is enabled for the user ID.
     ///
@@ -837,7 +822,6 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         case encryptedPin(userId: String)
         case encryptedUserKey(userId: String)
         case events(userId: String)
-        case fillAssistCachedData(userId: String)
         case fillAssistEnabled(userId: String)
         case fillAssistLastFetchTimestamp(userId: String)
         case flightRecorderData
@@ -927,8 +911,6 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
                 "protectedPin_\(userId)"
             case let .events(userId):
                 "events_\(userId)"
-            case let .fillAssistCachedData(userId):
-                "fillAssistCachedData_\(userId)"
             case let .fillAssistEnabled(userId):
                 "fillAssistEnabled_\(userId)"
             case let .fillAssistLastFetchTimestamp(userId):
@@ -1182,10 +1164,6 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
         fetch(for: .events(userId: userId)) ?? []
     }
 
-    func fillAssistCachedData(userId: String) -> FillAssistCachedData? {
-        fetch(for: .fillAssistCachedData(userId: userId))
-    }
-
     func fillAssistEnabled(userId: String) -> Bool {
         fetch(for: .fillAssistEnabled(userId: userId))
     }
@@ -1326,10 +1304,6 @@ extension DefaultAppSettingsStore: AppSettingsStore, ConfigSettingsStore {
 
     func setEvents(_ events: [EventData], userId: String) {
         store(events, for: .events(userId: userId))
-    }
-
-    func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String) {
-        store(data, for: .fillAssistCachedData(userId: userId))
     }
 
     func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String) {

--- a/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/AppSettingsStoreTests.swift
@@ -474,25 +474,6 @@ class AppSettingsStoreTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertEqual(subject.events(userId: "1"), [])
     }
 
-    /// `fillAssistCachedData(userId:)` returns `nil` if there is no previously stored value.
-    func test_fillAssistCachedData_isInitiallyNil() {
-        XCTAssertNil(subject.fillAssistCachedData(userId: "-1"))
-    }
-
-    /// `fillAssistCachedData(userId:)` can be used to get and set the cached data per user,
-    /// and persists under the expected UserDefaults key.
-    func test_fillAssistCachedData_withValue() {
-        let data1 = FillAssistCachedData(cid: "sha256:abc", rules: [:], sourceUrl: "https://a.example.com")
-        let data2 = FillAssistCachedData(cid: "sha256:def", rules: [:], sourceUrl: "https://b.example.com")
-        subject.setFillAssistCachedData(data1, userId: "1")
-        subject.setFillAssistCachedData(data2, userId: "2")
-
-        XCTAssertEqual(subject.fillAssistCachedData(userId: "1"), data1)
-        XCTAssertEqual(subject.fillAssistCachedData(userId: "2"), data2)
-        XCTAssertNotNil(userDefaults.string(forKey: "bwPreferencesStorage:fillAssistCachedData_1"))
-        XCTAssertNotNil(userDefaults.string(forKey: "bwPreferencesStorage:fillAssistCachedData_2"))
-    }
-
     /// `fillAssistLastFetchTimestamp(userId:)` returns `nil` if there is no previously stored value.
     func test_fillAssistLastFetchTimestamp_isInitiallyNil() {
         XCTAssertNil(subject.fillAssistLastFetchTimestamp(userId: "-1"))

--- a/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
+++ b/BitwardenShared/Core/Platform/Services/Stores/TestHelpers/MockAppSettingsStore.swift
@@ -48,7 +48,6 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
     var encryptedUserKeys = [String: String]()
     var eventsByUserId = [String: [EventData]]()
     var featureFlags = [String: Bool]()
-    var fillAssistCachedDataByUserId = [String: FillAssistCachedData]()
     var fillAssistEnabledByUserId = [String: Bool]()
     var fillAssistLastFetchTimestampByUserId = [String: Date]()
     var hasPerformedSyncAfterLogin = [String: Bool]()
@@ -150,10 +149,6 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func events(userId: String) -> [EventData] {
         eventsByUserId[userId] ?? []
-    }
-
-    func fillAssistCachedData(userId: String) -> FillAssistCachedData? {
-        fillAssistCachedDataByUserId[userId]
     }
 
     func fillAssistEnabled(userId: String) -> Bool {
@@ -307,10 +302,6 @@ class MockAppSettingsStore: AppSettingsStore { // swiftlint:disable:this type_bo
 
     func setEvents(_ events: [EventData], userId: String) {
         eventsByUserId[userId] = events
-    }
-
-    func setFillAssistCachedData(_ data: FillAssistCachedData?, userId: String) {
-        fillAssistCachedDataByUserId[userId] = data
     }
 
     func setFillAssistEnabled(_ fillAssistEnabled: Bool?, userId: String) {

--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -427,6 +427,8 @@ extension DefaultSyncService {
         let account = try await stateService.getActiveAccount()
         let userId = account.profile.userId
 
+        await fillAssistRepository.syncRules()
+
         guard try await needsSync(forceSync: forceSync, isPeriodic: isPeriodic, userId: userId) else {
             return
         }
@@ -478,8 +480,6 @@ extension DefaultSyncService {
                 keyConnectorUrl: keyConnectorUrl,
             )
         }
-
-        await fillAssistRepository.syncRules()
 
         await delegate?.onFetchSyncSucceeded(userId: userId)
     }

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -371,13 +371,28 @@ class SyncServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         )
     }
 
-    /// `fetchSync()` calls `syncRules()` on the fill-assist repository alongside vault sync.
+    /// `fetchSync()` calls `syncRules()` on the fill-assist repository independently of vault sync.
     func test_fetchSync_syncsFillAssistRules() async throws {
         client.result = .httpSuccess(testData: .syncWithCiphers)
         stateService.activeAccount = .fixture()
 
         try await subject.fetchSync(forceSync: false)
 
+        XCTAssertTrue(fillAssistRepository.syncRulesCalled)
+    }
+
+    /// `fetchSync()` calls `syncRules()` even when the vault does not need syncing.
+    func test_fetchSync_syncsFillAssistRules_evenWhenVaultSyncSkipped() async throws {
+        client.result = .httpSuccess(testData: .syncWithCipher)
+        stateService.activeAccount = .fixture()
+        stateService.lastSyncTimeByUserId["1"] = try XCTUnwrap(
+            timeProvider.presentTime.addingTimeInterval(-(Constants.minimumSyncInterval - 1)),
+        )
+        keyConnectorService.userNeedsMigrationResult = .success(false)
+
+        try await subject.fetchSync(forceSync: false, isPeriodic: true)
+
+        XCTAssertTrue(client.requests.isEmpty)
         XCTAssertTrue(fillAssistRepository.syncRulesCalled)
     }
 

--- a/Networking/Sources/Networking/HTTPService.swift
+++ b/Networking/Sources/Networking/HTTPService.swift
@@ -100,19 +100,6 @@ public final class HTTPService: Sendable {
         try await client.download(from: urlRequest)
     }
 
-    /// Downloads the file at `filename` appended to the service's base URL.
-    ///
-    /// Uses `URLSession` download tasks which follow HTTP redirects automatically, making this
-    /// suitable for external CDN URLs that redirect before serving the final content.
-    ///
-    /// - Parameter filename: The filename to append to the base URL (e.g. `"manifest.json"`).
-    /// - Returns: The temporary `URL` of the downloaded file.
-    ///
-    public func download(filename: String) async throws -> URL {
-        let url = baseURL.appendingPathComponent(filename)
-        return try await client.download(from: URLRequest(url: url))
-    }
-
     /// Performs a network request.
     ///
     /// - Parameter request: The request to perform.

--- a/Networking/Tests/NetworkingTests/HTTPServiceTests.swift
+++ b/Networking/Tests/NetworkingTests/HTTPServiceTests.swift
@@ -303,21 +303,6 @@ class HTTPServiceTests: XCTestCase {
             XCTAssertEqual(error as? TestError, .invalidResponse)
         }
     }
-
-    /// `download(filename:)` appends the filename to the base URL and calls the client.
-    func test_download_filename() async throws {
-        let tempFile = FileManager.default.temporaryDirectory.appendingPathComponent("test.json")
-        try "{}".write(to: tempFile, atomically: true, encoding: .utf8)
-        client.downloadResults = [.success(tempFile)]
-
-        let result = try await subject.download(filename: "manifest.json")
-
-        XCTAssertEqual(
-            client.downloadRequests.last?.url?.absoluteString,
-            "https://example.com/manifest.json",
-        )
-        XCTAssertEqual(result, tempFile)
-    }
 }
 
 private struct RequestError: Error {}


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-39851

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Encrypts Fill Assist cached rules data at rest by:
- Adding a per-account encryption key stored in the iOS Keychain (`fillAssistEncryptionKey`)
- Adding a `fillAssistRulesURL` helper to `FileManager+Extensions` for consistent file path resolution
- Improving `FillAssistDataStore` with `keyNotFound` error handling, injectable base URL, and FileManager extension usage
- Deleting the Fill Assist rules file from disk on account logout
- Adding `FillAssistDataStoreTests` to cover the new behavior