### PR TITLE
[PM-35192] feat: Add associated-domains entitlements for FedRAMP environment

### DIFF
--- a/Bitwarden/Application/Support/Bitwarden.entitlements
+++ b/Bitwarden/Application/Support/Bitwarden.entitlements
@@ -9,9 +9,11 @@
 		<string>webcredentials:*.bitwarden.com</string>
 		<string>webcredentials:*.bitwarden.eu</string>
 		<string>webcredentials:*.bitwarden.pw</string>
+		<string>webcredentials:*.bitwarden-gov.com</string>
 		<string>applinks:*.bitwarden.com</string>
 		<string>applinks:*.bitwarden.eu</string>
 		<string>applinks:*.bitwarden.pw</string>
+		<string>applinks:*.bitwarden-gov.com</string>
 	</array>
 	<key>com.apple.developer.authentication-services.autofill-credential-provider</key>
 	<true/>


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35192](https://bitwarden.atlassian.net/browse/PM-35192)

## 📔 Objective

Adds `webcredentials:*.bitwarden-gov.com` and `applinks:*.bitwarden-gov.com` entries to the `com.apple.developer.associated-domains` array in `Bitwarden.entitlements`, so AutoFill password/passkey suggestions and universal links work against the new FedRAMP government cloud environment (`vault.bitwarden-gov.com`), matching the existing pattern already in place for `bitwarden.com`, `bitwarden.eu`, and `bitwarden.pw`.

Part of epic [PM-35110](https://bitwarden.atlassian.net/browse/PM-35110) ([Mobile] Support FedRAMP environment selection).

## 📸 Screenshots

N/A — no UI change.

[PM-35192]: https://bitwarden.atlassian.net/browse/PM-35192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-35110]: https://bitwarden.atlassian.net/browse/PM-35110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ