### PR TITLE
[PM-35111] feat: Add FedRAMP (bitwarden-gov.com) entry to region selector

### DIFF
--- a/AuthenticatorShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/AuthenticatorShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -1,49 +1,49 @@
 import BitwardenKit
 import BitwardenKitMocks
-import XCTest
+import Foundation
+import Testing
 
 @testable import AuthenticatorShared
 
-class EnvironmentServiceTests: XCTestCase {
+struct EnvironmentServiceTests {
     // MARK: Properties
 
-    var subject: EnvironmentService!
+    let subject: EnvironmentService
 
     // MARK: Setup & Teardown
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         subject = DefaultEnvironmentService()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-
-        subject = nil
     }
 
     // MARK: Tests
 
-    /// The default US URLs are returned.
-    func test_defaultUrls() {
-        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.fillAssistRulesURL, URL(string: "https://github.com/bitwarden/map-the-web/releases/latest/download"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
+    /// `apiURL` and other URL properties return US default values.
+    @Test
+    func defaultUrls() {
+        #expect(subject.apiURL == URL(string: "https://api.bitwarden.com"))
+        #expect(subject.baseURL == URL(string: "https://vault.bitwarden.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.bitwarden.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://events.bitwarden.com"))
+        #expect(subject.iconsURL == URL(string: "https://icons.bitwarden.net"))
+        #expect(subject.identityURL == URL(string: "https://identity.bitwarden.com"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
+        #expect(subject.region == .unitedStates)
+        #expect(subject.sendShareURL == URL(string: "https://send.bitwarden.com/#"))
+        #expect(subject.settingsURL == URL(string: "https://vault.bitwarden.com/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"),
+        )
+        #expect(
+            subject.fillAssistRulesURL
+                == URL(string: "https://github.com/bitwarden/map-the-web/releases/latest/download"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.bitwarden.com"))
     }
 }

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
@@ -129,7 +129,7 @@ public extension EnvironmentURLData {
             URL(string: "https://send.bitwarden.com/#")!
         case .gov:
             URL(string: "https://send.bitwarden-gov.com/#")!
-        case .europe, .selfHosted:
+        case .europe, .internal, .selfHosted:
             subpageURL(additionalPath: "send")
         }
     }

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
@@ -124,10 +124,14 @@ public extension EnvironmentURLData {
 
     /// The base url for send sharing.
     var sendShareURL: URL? {
-        guard region != .unitedStates else {
-            return URL(string: "https://send.bitwarden.com/#")!
+        switch region {
+        case .unitedStates:
+            URL(string: "https://send.bitwarden.com/#")!
+        case .gov:
+            URL(string: "https://send.bitwarden-gov.com/#")!
+        case .europe, .selfHosted:
+            subpageURL(additionalPath: "send")
         }
-        return subpageURL(additionalPath: "send")
     }
 
     /// The base url for the settings screen.
@@ -195,5 +199,16 @@ public extension EnvironmentURLData {
         identity: URL(string: "https://identity.bitwarden.eu")!,
         notifications: URL(string: "https://notifications.bitwarden.eu")!,
         webVault: URL(string: "https://vault.bitwarden.eu")!,
+    )
+
+    /// The default URLs for the US government cloud (FedRAMP) region.
+    static let defaultGov = EnvironmentURLData(
+        api: URL(string: "https://api.bitwarden-gov.com")!,
+        base: URL(string: "https://vault.bitwarden-gov.com")!,
+        events: URL(string: "https://events.bitwarden-gov.com")!,
+        icons: URL(string: "https://icons.bitwarden-gov.com")!,
+        identity: URL(string: "https://identity.bitwarden-gov.com")!,
+        notifications: URL(string: "https://notifications.bitwarden-gov.com")!,
+        webVault: URL(string: "https://vault.bitwarden-gov.com")!,
     )
 }

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLData.swift
@@ -125,12 +125,12 @@ public extension EnvironmentURLData {
     /// The base url for send sharing.
     var sendShareURL: URL? {
         switch region {
-        case .unitedStates:
-            URL(string: "https://send.bitwarden.com/#")!
-        case .gov:
-            URL(string: "https://send.bitwarden-gov.com/#")!
         case .europe, .internal, .selfHosted:
             subpageURL(additionalPath: "send")
+        case .gov:
+            URL(string: "https://send.bitwarden-gov.com/#")!
+        case .unitedStates:
+            URL(string: "https://send.bitwarden.com/#")!
         }
     }
 

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLDataTests.swift
@@ -60,6 +60,23 @@ class EnvironmentURLDataTests: XCTestCase {
         )
     }
 
+    /// `defaultGov` returns the properly configured `EnvironmentURLData`
+    /// with the default Urls for the government cloud (FedRAMP) region.
+    func test_defaultGov() {
+        XCTAssertEqual(
+            EnvironmentURLData.defaultGov,
+            EnvironmentURLData(
+                api: URL(string: "https://api.bitwarden-gov.com")!,
+                base: URL(string: "https://vault.bitwarden-gov.com")!,
+                events: URL(string: "https://events.bitwarden-gov.com")!,
+                icons: URL(string: "https://icons.bitwarden-gov.com")!,
+                identity: URL(string: "https://identity.bitwarden-gov.com")!,
+                notifications: URL(string: "https://notifications.bitwarden-gov.com")!,
+                webVault: URL(string: "https://vault.bitwarden-gov.com")!,
+            ),
+        )
+    }
+
     /// `importItemsURL` returns the import items URL for the base URL.
     func test_importItemsURL_baseURL() {
         let subject = EnvironmentURLData(base: URL(string: "https://vault.example.com"))
@@ -130,6 +147,12 @@ class EnvironmentURLDataTests: XCTestCase {
         XCTAssertTrue(subject.region == .europe)
     }
 
+    /// `region` returns `.gov` if base URL is the same as the default for the government cloud (FedRAMP) region.
+    func test_region_gov() {
+        let subject = EnvironmentURLData(base: URL(string: "https://vault.bitwarden-gov.com")!)
+        XCTAssertTrue(subject.region == .gov)
+    }
+
     /// `region` returns `.selfHosted` if base URL is neither the default for US nor for EU.
     func test_region_selfHost() {
         let subject = EnvironmentURLData(base: URL(string: "https://example.com")!)
@@ -146,6 +169,12 @@ class EnvironmentURLDataTests: XCTestCase {
     func test_sendShareURL_europe() {
         let subject = EnvironmentURLData.defaultEU
         XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://vault.bitwarden.eu/#/send")
+    }
+
+    /// `sendShareURL` returns the send URL for the government cloud (FedRAMP) region.
+    func test_sendShareURL_gov() {
+        let subject = EnvironmentURLData.defaultGov
+        XCTAssertEqual(subject.sendShareURL?.absoluteString, "https://send.bitwarden-gov.com/#")
     }
 
     /// `sendShareURL` returns the send URL for the base URL.

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
@@ -129,8 +129,8 @@ public extension EnvironmentURLs {
         let environmentURLData: EnvironmentURLData = switch environmentURLData.region {
         case .europe: .defaultEU
         case .gov: .defaultGov
-        case .unitedStates: .defaultUS
         case .internal, .selfHosted: environmentURLData
+        case .unitedStates: .defaultUS
         }
 
         if environmentURLData.region == .selfHosted || environmentURLData.region == .internal,

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLs.swift
@@ -128,6 +128,7 @@ public extension EnvironmentURLs {
         // use their entered URLs, like self-hosted.
         let environmentURLData: EnvironmentURLData = switch environmentURLData.region {
         case .europe: .defaultEU
+        case .gov: .defaultGov
         case .unitedStates: .defaultUS
         case .internal, .selfHosted: environmentURLData
         }

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests+GovTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests+GovTests.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import BitwardenKit
 
@@ -7,13 +8,13 @@ extension EnvironmentURLsTests {
 
     /// `init(environmentURLData:)` sets the URLs from the passed data when such data is the default
     /// government cloud (FedRAMP) region.
-    func test_init_environmentURLData_defaultGov() {
+    @Test
+    func init_environmentURLData_defaultGov() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData.defaultGov,
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden-gov.com")!,
                 baseURL: URL(string: "https://vault.bitwarden-gov.com")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/account")!,
@@ -41,13 +42,13 @@ extension EnvironmentURLsTests {
 
     /// `init(environmentURLData:)` defaults to the pre-defined government cloud (FedRAMP) URLs if the
     /// base URL matches the gov environment.
-    func test_init_environmentURLData_baseURL_gov() {
+    @Test
+    func init_environmentURLData_baseURL_gov() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData(base: URL(string: "https://vault.bitwarden-gov.com")!),
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden-gov.com")!,
                 baseURL: URL(string: "https://vault.bitwarden-gov.com")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/account")!,

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests+GovTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests+GovTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+
+@testable import BitwardenKit
+
+extension EnvironmentURLsTests {
+    // MARK: Tests
+
+    /// `init(environmentURLData:)` sets the URLs from the passed data when such data is the default
+    /// government cloud (FedRAMP) region.
+    func test_init_environmentURLData_defaultGov() {
+        let subject = EnvironmentURLs(
+            environmentURLData: EnvironmentURLData.defaultGov,
+        )
+        XCTAssertEqual(
+            subject,
+            EnvironmentURLs(
+                apiURL: URL(string: "https://api.bitwarden-gov.com")!,
+                baseURL: URL(string: "https://vault.bitwarden-gov.com")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/account")!,
+                eventsURL: URL(string: "https://events.bitwarden-gov.com")!,
+                fillAssistRulesURL: URL(string: "https://github.com/bitwarden/map-the-web/releases/latest/download")!,
+                iconsURL: URL(string: "https://icons.bitwarden-gov.com")!,
+                identityURL: URL(string: "https://identity.bitwarden-gov.com")!,
+                importItemsURL: URL(string: "https://vault.bitwarden-gov.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/subscription")!,
+                proxyCookieRedirectConnectorURL: URL(
+                    string: "https://vault.bitwarden-gov.com/proxy-cookie-redirect-connector.html",
+                )!,
+                recoveryCodeURL: URL(string: "https://vault.bitwarden-gov.com/#/recover-2fa")!,
+                sendShareURL: URL(string: "https://send.bitwarden-gov.com/#")!,
+                settingsURL: URL(string: "https://vault.bitwarden-gov.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/security/two-factor")!,
+                upgradeToPremiumURL: URL(
+                    // swiftlint:disable:next line_length
+                    string: "https://vault.bitwarden-gov.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
+                )!,
+                webVaultURL: URL(string: "https://vault.bitwarden-gov.com")!,
+            ),
+        )
+    }
+
+    /// `init(environmentURLData:)` defaults to the pre-defined government cloud (FedRAMP) URLs if the
+    /// base URL matches the gov environment.
+    func test_init_environmentURLData_baseURL_gov() {
+        let subject = EnvironmentURLs(
+            environmentURLData: EnvironmentURLData(base: URL(string: "https://vault.bitwarden-gov.com")!),
+        )
+        XCTAssertEqual(
+            subject,
+            EnvironmentURLs(
+                apiURL: URL(string: "https://api.bitwarden-gov.com")!,
+                baseURL: URL(string: "https://vault.bitwarden-gov.com")!,
+                changeEmailURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/account")!,
+                eventsURL: URL(string: "https://events.bitwarden-gov.com")!,
+                fillAssistRulesURL: URL(string: "https://github.com/bitwarden/map-the-web/releases/latest/download")!,
+                iconsURL: URL(string: "https://icons.bitwarden-gov.com")!,
+                identityURL: URL(string: "https://identity.bitwarden-gov.com")!,
+                importItemsURL: URL(string: "https://vault.bitwarden-gov.com/#/tools/import")!,
+                manageSubscriptionURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/subscription")!,
+                proxyCookieRedirectConnectorURL: URL(
+                    string: "https://vault.bitwarden-gov.com/proxy-cookie-redirect-connector.html",
+                )!,
+                recoveryCodeURL: URL(string: "https://vault.bitwarden-gov.com/#/recover-2fa")!,
+                sendShareURL: URL(string: "https://send.bitwarden-gov.com/#")!,
+                settingsURL: URL(string: "https://vault.bitwarden-gov.com/#/settings")!,
+                setUpTwoFactorURL: URL(string: "https://vault.bitwarden-gov.com/#/settings/security/two-factor")!,
+                upgradeToPremiumURL: URL(
+                    // swiftlint:disable:next line_length
+                    string: "https://vault.bitwarden-gov.com/#/settings/subscription/premium?callToAction=upgradeToPremium",
+                )!,
+                webVaultURL: URL(string: "https://vault.bitwarden-gov.com")!,
+            ),
+        )
+    }
+}

--- a/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/EnvironmentURLsTests.swift
@@ -1,18 +1,19 @@
-import XCTest
+import Foundation
+import Testing
 
 @testable import BitwardenKit
 
-class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
+struct EnvironmentURLsTests { // swiftlint:disable:this type_body_length
     // MARK: Tests
 
     /// `init(environmentURLData:)` sets the URLs from the passed data when such data is the default US.
-    func test_init_environmentURLData_defaultUS() {
+    @Test
+    func init_environmentURLData_defaultUS() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData.defaultUS,
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden.com/#/settings/account")!,
@@ -38,13 +39,13 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `init(environmentURLData:)` sets the URLs from the passed data when such data is the default EU.
-    func test_init_environmentURLData_defaultEU() {
+    @Test
+    func init_environmentURLData_defaultEU() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData.defaultEU,
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden.eu")!,
                 baseURL: URL(string: "https://vault.bitwarden.eu")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden.eu/#/settings/account")!,
@@ -71,13 +72,13 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `init(environmentURLData:)` sets the URLs from the base URL if one is set and is not
     /// `.unitedStates` nor `.europe` region type.
-    func test_init_environmentURLData_baseURL() {
+    @Test
+    func init_environmentURLData_baseURL() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData(base: URL(string: "https://example.com")!),
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://example.com/api")!,
                 baseURL: URL(string: "https://example.com")!,
                 changeEmailURL: URL(string: "https://example.com/#/settings/account")!,
@@ -103,13 +104,13 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `init(environmentURLData:)` defaults to the pre-defined EU URLs if the base URL matches the EU environment.
-    func test_init_environmentURLData_baseURL_europe() {
+    @Test
+    func init_environmentURLData_baseURL_europe() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData(base: URL(string: "https://vault.bitwarden.eu")!),
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden.eu")!,
                 baseURL: URL(string: "https://vault.bitwarden.eu")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden.eu/#/settings/account")!,
@@ -135,13 +136,13 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `init(environmentURLData:)` defaults to the pre-defined US URLs if the base URL matches the US environment.
-    func test_init_environmentURLData_baseURL_unitedStates() {
+    @Test
+    func init_environmentURLData_baseURL_unitedStates() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData(base: URL(string: "https://vault.bitwarden.com")!),
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden.com/#/settings/account")!,
@@ -167,13 +168,13 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `init(environmentURLData:)` sets the URLs from the base URL which includes a trailing slash.
-    func test_init_environmentURLData_baseURLWithTrailingSlash() {
+    @Test
+    func init_environmentURLData_baseURLWithTrailingSlash() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData(base: URL(string: "https://example.com/")!),
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://example.com/api")!,
                 baseURL: URL(string: "https://example.com/")!,
                 changeEmailURL: URL(string: "https://example.com/#/settings/account")!,
@@ -199,7 +200,8 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `init(environmentURLData:)` sets the URLs based on the corresponding URL if there isn't a base URL.
-    func test_init_environmentURLData_custom() {
+    @Test
+    func init_environmentURLData_custom() {
         let subject = EnvironmentURLs(
             environmentURLData: EnvironmentURLData(
                 api: URL(string: "https://api.example.com")!,
@@ -209,9 +211,8 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
                 webVault: URL(string: "https://example.com")!,
             ),
         )
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.example.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
                 changeEmailURL: URL(string: "https://example.com/#/settings/account")!,
@@ -237,11 +238,11 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
     }
 
     /// `init(environmentURLData:)` sets the URLs to default values if the URLs are empty.
-    func test_init_environmentURLData_empty() {
+    @Test
+    func init_environmentURLData_empty() {
         let subject = EnvironmentURLs(environmentURLData: EnvironmentURLData())
-        XCTAssertEqual(
-            subject,
-            EnvironmentURLs(
+        #expect(
+            subject == EnvironmentURLs(
                 apiURL: URL(string: "https://api.bitwarden.com")!,
                 baseURL: URL(string: "https://vault.bitwarden.com")!,
                 changeEmailURL: URL(string: "https://vault.bitwarden.com")!,
@@ -264,7 +265,8 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
     /// `init(environmentURLData:)` preserves a server-provided `fillAssistRulesUrl` even when the
     /// region maps to a US/EU default (which has `fillAssistRulesUrl = nil`).
-    func test_init_environmentURLData_fillAssistRulesURL_preservedForCloudRegion() {
+    @Test
+    func init_environmentURLData_fillAssistRulesURL_preservedForCloudRegion() {
         let customFillAssistURL = URL(string: "https://custom.example.com/fill-assist")!
         let usData = EnvironmentURLData(
             base: URL(string: "https://vault.bitwarden.com")!,
@@ -273,22 +275,22 @@ class EnvironmentURLsTests: BitwardenTestCase { // swiftlint:disable:this type_b
 
         let subject = EnvironmentURLs(environmentURLData: usData)
 
-        XCTAssertEqual(subject.fillAssistRulesURL, customFillAssistURL)
+        #expect(subject.fillAssistRulesURL == customFillAssistURL)
     }
 
     /// `region` resolves the base URL to the matching region.
-    func test_region() {
-        XCTAssertEqual(EnvironmentURLs(environmentURLData: .defaultUS).region, .unitedStates)
-        XCTAssertEqual(EnvironmentURLs(environmentURLData: .defaultEU).region, .europe)
-        XCTAssertEqual(
-            EnvironmentURLs(environmentURLData: EnvironmentURLData(base: URL(string: "https://bitwarden.pw")!)).region,
-            .internal,
+    @Test
+    func region() {
+        #expect(EnvironmentURLs(environmentURLData: .defaultUS).region == .unitedStates)
+        #expect(EnvironmentURLs(environmentURLData: .defaultEU).region == .europe)
+        #expect(
+            EnvironmentURLs(environmentURLData: EnvironmentURLData(base: URL(string: "https://bitwarden.pw")!))
+                .region == .internal,
         )
-        XCTAssertEqual(
+        #expect(
             EnvironmentURLs(
                 environmentURLData: EnvironmentURLData(base: URL(string: "https://selfhosted.com")!),
-            ).region,
-            .selfHosted,
+            ).region == .selfHosted,
         )
     }
 }

--- a/BitwardenKit/Core/Platform/Models/Domain/ServerConfig.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/ServerConfig.swift
@@ -41,6 +41,22 @@ public struct ServerConfig: Equatable, Codable, Sendable {
 
     // MARK: Methods
 
+    /// Returns `true` when this config's vault host matches the vault host derived from
+    /// `environmentURLs`, confirming that the cached config was fetched for the given
+    /// environment and is not a stale result from a previously selected region.
+    ///
+    /// - Parameter environmentURLs: The environment URLs to compare against (pre- or post-auth).
+    /// - Returns: `true` if the vault hosts match; `false` if either value is missing or they differ.
+    ///
+    public func isCurrentConfig(for environmentURLs: EnvironmentURLData?) -> Bool {
+        guard let vaultString = environment?.vault,
+              let configHost = URL(string: vaultString)?.host,
+              let envHost = environmentURLs?.webVaultHost else {
+            return false
+        }
+        return configHost == envHost
+    }
+
     /// Checks if the server is an official Bitwarden server.
     ///
     /// - Returns: `true` if the server is `nil`, indicating an official Bitwarden server, otherwise `false`.

--- a/BitwardenKit/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenKit/Core/Platform/Models/Enum/RegionType.swift
@@ -10,6 +10,9 @@ public enum RegionType: CaseIterable, Sendable {
     /// The European region.
     case europe
 
+    /// The government cloud (FedRAMP) region.
+    case gov
+
     /// A self-hosted instance.
     case selfHosted
 
@@ -29,6 +32,8 @@ public extension RegionType {
             self = .unitedStates
         } else if baseURL == EnvironmentURLData.defaultEU.base {
             self = .europe
+        } else if baseURL == EnvironmentURLData.defaultGov.base {
+            self = .gov
         } else if let baseURL,
                   let host = URLComponents(url: baseURL, resolvingAgainstBaseURL: false)?.host,
                   host == "bitwarden.pw" || host.hasSuffix(".bitwarden.pw") {

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -563,6 +563,7 @@
 "ThereAreNoBankAccountsInYourVault" = "There are no bank accounts in your vault";
 "US" = "US";
 "EU" = "EU";
+"Gov" = "Gov";
 "SelfHosted" = "Self-hosted";
 "UpdateWeakMasterPasswordWarning" = "Your master password does not meet one or more of your organization policies. In order to access the vault, you must update your master password now. Proceeding will log you out of your current session, requiring you to log back in. Active sessions on other devices may continue to remain active for up to one hour.";
 "CurrentMasterPasswordRequired" = "Current master password (required)";

--- a/BitwardenShared/Core/Platform/Models/Domain/ServerConfigTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Domain/ServerConfigTests.swift
@@ -138,4 +138,96 @@ final class ServerConfigTests: BitwardenTestCase {
 
         XCTAssertEqual(subject.environment?.fillAssistRules, "https://custom.example.com/fill-assist")
     }
+
+    /// `isCurrentConfig(for:)` returns `true` when the config vault host matches the environment vault host.
+    func test_isCurrentConfig_matchingVaultHost_returnsTrue() {
+        let model = ConfigResponseModel(
+            communication: nil,
+            environment: EnvironmentServerConfigResponseModel(
+                api: nil,
+                cloudRegion: nil,
+                fillAssistRules: nil,
+                identity: nil,
+                notifications: nil,
+                sso: nil,
+                vault: "https://vault.bitwarden.com",
+            ),
+            featureStates: [:],
+            gitHash: nil,
+            server: nil,
+            version: "2025.1.0",
+        )
+        let subject = ServerConfig(date: Date(), responseModel: model)
+
+        XCTAssertTrue(subject.isCurrentConfig(for: .defaultUS))
+    }
+
+    /// `isCurrentConfig(for:)` returns `false` when the config vault host does not match.
+    func test_isCurrentConfig_mismatchedVaultHost_returnsFalse() {
+        let model = ConfigResponseModel(
+            communication: nil,
+            environment: EnvironmentServerConfigResponseModel(
+                api: nil,
+                cloudRegion: nil,
+                fillAssistRules: nil,
+                identity: nil,
+                notifications: nil,
+                sso: nil,
+                vault: "https://vault.bitwarden.eu",
+            ),
+            featureStates: [:],
+            gitHash: nil,
+            server: nil,
+            version: "2025.1.0",
+        )
+        let subject = ServerConfig(date: Date(), responseModel: model)
+
+        XCTAssertFalse(subject.isCurrentConfig(for: .defaultUS))
+    }
+
+    /// `isCurrentConfig(for:)` returns `false` when the provided environment URLs are `nil`.
+    func test_isCurrentConfig_nilEnvironmentURLs_returnsFalse() {
+        let model = ConfigResponseModel(
+            communication: nil,
+            environment: EnvironmentServerConfigResponseModel(
+                api: nil,
+                cloudRegion: nil,
+                fillAssistRules: nil,
+                identity: nil,
+                notifications: nil,
+                sso: nil,
+                vault: "https://vault.bitwarden.com",
+            ),
+            featureStates: [:],
+            gitHash: nil,
+            server: nil,
+            version: "2025.1.0",
+        )
+        let subject = ServerConfig(date: Date(), responseModel: model)
+
+        XCTAssertFalse(subject.isCurrentConfig(for: nil))
+    }
+
+    /// `isCurrentConfig(for:)` returns `false` when the config has no environment vault URL.
+    func test_isCurrentConfig_nilEnvironmentVault_returnsFalse() {
+        let model = ConfigResponseModel(
+            communication: nil,
+            environment: EnvironmentServerConfigResponseModel(
+                api: nil,
+                cloudRegion: nil,
+                fillAssistRules: nil,
+                identity: nil,
+                notifications: nil,
+                sso: nil,
+                vault: nil,
+            ),
+            featureStates: [:],
+            gitHash: nil,
+            server: nil,
+            version: "2025.1.0",
+        )
+        let subject = ServerConfig(date: Date(), responseModel: model)
+
+        XCTAssertFalse(subject.isCurrentConfig(for: .defaultUS))
+    }
 }

--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -35,6 +35,9 @@ extension FeatureFlag: @retroactive CaseIterable {
     /// An SDK flag that enables individual cipher encryption.
     static let enableCipherKeyEncryption = FeatureFlag(rawValue: "enableCipherKeyEncryption")
 
+    /// A feature flag to enable/disable the FedRAMP (.gov) region in the region picker.
+    static let fedrampGovRegion = FeatureFlag(rawValue: "fedramp-gov-region")
+
     /// Flag to enable/disable Fill-Assist targeting rules.
     static let fillAssistTargetingRules = FeatureFlag(rawValue: "fill-assist-targeting-rules")
 
@@ -76,6 +79,7 @@ extension FeatureFlag: @retroactive CaseIterable {
             .debugDisableSelfHostPremiumCheck,
             .deviceAuthKey,
             .enableCipherKeyEncryption,
+            .fedrampGovRegion,
             .fillAssistTargetingRules,
             .manageDevices,
             .migrateMyVaultToMyItems,

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
@@ -15,6 +15,7 @@ extension RegionType {
     var authCallbackHost: String? {
         switch self {
         case .europe: "bitwarden.eu"
+        case .gov: "bitwarden-gov.com"
         case .internal: "bitwarden.pw"
         case .selfHosted: nil
         case .unitedStates: "bitwarden.com"
@@ -25,6 +26,7 @@ extension RegionType {
     var localizedName: String {
         switch self {
         case .europe: Localizations.eu
+        case .gov: Localizations.gov
         case .internal: "Internal" // Internal only, hidden from the region picker and not user facing.
         case .selfHosted: Localizations.selfHosted
         case .unitedStates: Localizations.us
@@ -35,6 +37,7 @@ extension RegionType {
     var baseURLDescription: String {
         switch self {
         case .europe: "bitwarden.eu"
+        case .gov: "bitwarden-gov.com"
         // `.internal` is not user facing, so it mirrors self-hosted's description.
         case .internal, .selfHosted: Localizations.selfHosted
         case .unitedStates: "bitwarden.com"
@@ -46,6 +49,8 @@ extension RegionType {
         switch self {
         case .europe:
             .defaultEU
+        case .gov:
+            .defaultGov
         case .unitedStates:
             .defaultUS
         case .internal, .selfHosted:
@@ -57,6 +62,7 @@ extension RegionType {
     var errorReporterName: String {
         switch self {
         case .europe: "EU"
+        case .gov: "Gov"
         case .internal: "Internal"
         case .selfHosted: "Self-Hosted"
         case .unitedStates: "US"
@@ -68,7 +74,7 @@ extension RegionType {
     /// offered as a selectable option.
     var isUserSelectable: Bool {
         switch self {
-        case .europe, .selfHosted, .unitedStates: true
+        case .europe, .gov, .selfHosted, .unitedStates: true
         case .internal: false
         }
     }

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionType.swift
@@ -51,10 +51,10 @@ extension RegionType {
             .defaultEU
         case .gov:
             .defaultGov
-        case .unitedStates:
-            .defaultUS
         case .internal, .selfHosted:
             nil
+        case .unitedStates:
+            .defaultUS
         }
     }
 

--- a/BitwardenShared/Core/Platform/Models/Enum/RegionTypeTests.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/RegionTypeTests.swift
@@ -10,6 +10,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `authCallbackHost` returns the apex host for Cloud regions and `nil` for self-hosted.
     func test_authCallbackHost() {
         XCTAssertEqual(RegionType.europe.authCallbackHost, "bitwarden.eu")
+        XCTAssertEqual(RegionType.gov.authCallbackHost, "bitwarden-gov.com")
         XCTAssertEqual(RegionType.internal.authCallbackHost, "bitwarden.pw")
         XCTAssertNil(RegionType.selfHosted.authCallbackHost)
         XCTAssertEqual(RegionType.unitedStates.authCallbackHost, "bitwarden.com")
@@ -18,6 +19,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:localizedName` returns the correct values.
     func test_localizedName() {
         XCTAssertEqual(RegionType.europe.localizedName, Localizations.eu)
+        XCTAssertEqual(RegionType.gov.localizedName, Localizations.gov)
         XCTAssertEqual(RegionType.internal.localizedName, "Internal")
         XCTAssertEqual(RegionType.selfHosted.localizedName, Localizations.selfHosted)
         XCTAssertEqual(RegionType.unitedStates.localizedName, Localizations.us)
@@ -26,6 +28,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:baseURLDescription` returns the correct values.
     func test_baseURLDescription() {
         XCTAssertEqual(RegionType.europe.baseURLDescription, "bitwarden.eu")
+        XCTAssertEqual(RegionType.gov.baseURLDescription, "bitwarden-gov.com")
         XCTAssertEqual(RegionType.internal.baseURLDescription, Localizations.selfHosted)
         XCTAssertEqual(RegionType.selfHosted.baseURLDescription, Localizations.selfHosted)
         XCTAssertEqual(RegionType.unitedStates.baseURLDescription, "bitwarden.com")
@@ -34,6 +37,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:defaultURLs` returns the correct values.
     func test_defaultURLs() {
         XCTAssertEqual(RegionType.europe.defaultURLs?.api?.absoluteString, "https://api.bitwarden.eu")
+        XCTAssertEqual(RegionType.gov.defaultURLs?.api?.absoluteString, "https://api.bitwarden-gov.com")
         XCTAssertNil(RegionType.internal.defaultURLs)
         XCTAssertNil(RegionType.selfHosted.defaultURLs)
         XCTAssertEqual(RegionType.unitedStates.defaultURLs?.api?.absoluteString, "https://api.bitwarden.com")
@@ -42,6 +46,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:errorReporterName` returns the correct values.
     func test_errorReporterName() {
         XCTAssertEqual(RegionType.europe.errorReporterName, "EU")
+        XCTAssertEqual(RegionType.gov.errorReporterName, "Gov")
         XCTAssertEqual(RegionType.internal.errorReporterName, "Internal")
         XCTAssertEqual(RegionType.selfHosted.errorReporterName, "Self-Hosted")
         XCTAssertEqual(RegionType.unitedStates.errorReporterName, "US")
@@ -50,6 +55,7 @@ class RegionTypeTests: BitwardenTestCase {
     /// `getter:isUserSelectable` is true for the user-facing regions and false for internal.
     func test_isUserSelectable() {
         XCTAssertTrue(RegionType.europe.isUserSelectable)
+        XCTAssertTrue(RegionType.gov.isUserSelectable)
         XCTAssertFalse(RegionType.internal.isUserSelectable)
         XCTAssertTrue(RegionType.selfHosted.isUserSelectable)
         XCTAssertTrue(RegionType.unitedStates.isUserSelectable)
@@ -57,6 +63,6 @@ class RegionTypeTests: BitwardenTestCase {
 
     /// `userSelectableCases` returns the user-facing regions in display order, excluding internal.
     func test_userSelectableCases() {
-        XCTAssertEqual(RegionType.userSelectableCases, [.unitedStates, .europe, .selfHosted])
+        XCTAssertEqual(RegionType.userSelectableCases, [.unitedStates, .europe, .gov, .selfHosted])
     }
 }

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests+GovTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests+GovTests.swift
@@ -1,0 +1,40 @@
+import BitwardenKit
+import XCTest
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+extension EnvironmentServiceTests {
+    // MARK: Tests
+
+    /// `loadURLsForActiveAccount()` handles government cloud (FedRAMP) URLs
+    func test_loadURLsForActiveAccount_gov() async {
+        let urls = EnvironmentURLData.defaultGov
+        let account = Account.fixture(settings: .fixture(environmentURLs: urls))
+        stateService.activeAccount = account
+        stateService.environmentURLs = [account.profile.userId: urls]
+
+        await subject.loadURLsForActiveAccount()
+
+        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden-gov.com"))
+        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden-gov.com"))
+        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden-gov.com/#/settings/account"))
+        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden-gov.com"))
+        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden-gov.com"))
+        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden-gov.com"))
+        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden-gov.com/#/tools/import"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden-gov.com/proxy-cookie-redirect-connector.html"))
+        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden-gov.com/#/recover-2fa"))
+        XCTAssertEqual(subject.region, .gov)
+        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden-gov.com/#"))
+        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden-gov.com/#/settings"))
+        // swiftlint:disable:next line_length
+        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden-gov.com/#/settings/security/two-factor"))
+        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden-gov.com"))
+        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+
+        XCTAssertEqual(errorReporter.region?.region, "Gov")
+        XCTAssertEqual(errorReporter.region?.isPreAuth, false)
+    }
+}

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests+GovTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests+GovTests.swift
@@ -1,5 +1,6 @@
 import BitwardenKit
-import XCTest
+import Foundation
+import Testing
 
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
@@ -7,8 +8,9 @@ import XCTest
 extension EnvironmentServiceTests {
     // MARK: Tests
 
-    /// `loadURLsForActiveAccount()` handles government cloud (FedRAMP) URLs
-    func test_loadURLsForActiveAccount_gov() async {
+    /// `loadURLsForActiveAccount()` handles government cloud (FedRAMP) URLs.
+    @Test
+    func loadURLsForActiveAccount_gov() async {
         let urls = EnvironmentURLData.defaultGov
         let account = Account.fixture(settings: .fixture(environmentURLs: urls))
         stateService.activeAccount = account
@@ -16,25 +18,29 @@ extension EnvironmentServiceTests {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden-gov.com"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden-gov.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden-gov.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden-gov.com"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden-gov.com"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden-gov.com"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden-gov.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden-gov.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden-gov.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .gov)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden-gov.com/#"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden-gov.com/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden-gov.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden-gov.com"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+        #expect(subject.apiURL == URL(string: "https://api.bitwarden-gov.com"))
+        #expect(subject.baseURL == URL(string: "https://vault.bitwarden-gov.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.bitwarden-gov.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://events.bitwarden-gov.com"))
+        #expect(subject.iconsURL == URL(string: "https://icons.bitwarden-gov.com"))
+        #expect(subject.identityURL == URL(string: "https://identity.bitwarden-gov.com"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.bitwarden-gov.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.bitwarden-gov.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.bitwarden-gov.com/#/recover-2fa"))
+        #expect(subject.region == .gov)
+        #expect(subject.sendShareURL == URL(string: "https://send.bitwarden-gov.com/#"))
+        #expect(subject.settingsURL == URL(string: "https://vault.bitwarden-gov.com/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.bitwarden-gov.com/#/settings/security/two-factor"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.bitwarden-gov.com"))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
 
-        XCTAssertEqual(errorReporter.region?.region, "Gov")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, false)
+        #expect(errorReporter.region?.region == "Gov")
+        #expect(errorReporter.region?.isPreAuth == false)
     }
 }

--- a/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
+++ b/BitwardenShared/Core/Platform/Services/EnvironmentServiceTests.swift
@@ -1,26 +1,26 @@
 import BitwardenKit
 import BitwardenKitMocks
-import XCTest
+import Foundation
+import Testing
 
 @testable import BitwardenShared
 @testable import BitwardenSharedMocks
 
-class EnvironmentServiceTests: XCTestCase {
+@Suite(.serialized)
+struct EnvironmentServiceTests { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
-    var errorReporter: MockErrorReporter!
-    var stateService: MockStateService!
-    var standardUserDefaults: UserDefaults!
-    var subject: EnvironmentService!
+    let errorReporter: MockErrorReporter
+    let stateService: MockStateService
+    let standardUserDefaults: UserDefaults
+    let subject: EnvironmentService
 
     // MARK: Setup & Teardown
 
-    override func setUp() {
-        super.setUp()
-
+    init() {
         errorReporter = MockErrorReporter()
         stateService = MockStateService()
-        standardUserDefaults = UserDefaults(suiteName: "test")
+        standardUserDefaults = UserDefaults(suiteName: "test")!
         standardUserDefaults.removeObject(forKey: "com.apple.configuration.managed")
 
         subject = DefaultEnvironmentService(
@@ -30,52 +30,50 @@ class EnvironmentServiceTests: XCTestCase {
         )
     }
 
-    override func tearDown() {
-        super.tearDown()
-
-        errorReporter = nil
-        stateService = nil
-        standardUserDefaults = nil
-        subject = nil
-    }
-
     // MARK: Tests
 
-    /// Concurrent reads and writes to environment properties should not produce a data race.
-    func test_concurrentReadWrite_noDataRace() async {
+    /// `setPreAuthURLs(urls:)` and property reads do not produce a data race under concurrent access.
+    @Test
+    func concurrentReadWrite_noDataRace() async {
         let urls = EnvironmentURLData(base: .example)
 
         await withTaskGroup(of: Void.self) { group in
             for _ in 0 ..< 50 {
-                group.addTask { await self.subject.setPreAuthURLs(urls: urls) }
-                group.addTask { _ = self.subject.apiURL }
-                group.addTask { _ = self.subject.clientCertificateFingerprint }
+                group.addTask { await subject.setPreAuthURLs(urls: urls) }
+                group.addTask { _ = subject.apiURL }
+                group.addTask { _ = subject.clientCertificateFingerprint }
             }
         }
     }
 
-    /// The default US URLs are returned if the URLs haven't been loaded.
-    func test_defaultUrls() {
-        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
+    /// `apiURL` and other URL properties return US default values before URLs are loaded.
+    @Test
+    func defaultUrls() {
+        #expect(subject.apiURL == URL(string: "https://api.bitwarden.com"))
+        #expect(subject.baseURL == URL(string: "https://vault.bitwarden.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.bitwarden.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://events.bitwarden.com"))
+        #expect(subject.iconsURL == URL(string: "https://icons.bitwarden.net"))
+        #expect(subject.identityURL == URL(string: "https://identity.bitwarden.com"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
+        #expect(subject.region == .unitedStates)
+        #expect(subject.sendShareURL == URL(string: "https://send.bitwarden.com/#"))
+        #expect(subject.settingsURL == URL(string: "https://vault.bitwarden.com/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.bitwarden.com"))
     }
 
     /// `loadURLsForActiveAccount()` loads the URLs for the active account.
-    func test_loadURLsForActiveAccount() async {
+    @Test
+    func loadURLsForActiveAccount() async {
         let urls = EnvironmentURLData(base: .example)
         let account = Account.fixture(settings: .fixture(environmentURLs: urls))
         stateService.activeAccount = account
@@ -83,29 +81,32 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://example.com/api"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://example.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://example.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://example.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://example.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://example.com/identity"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://example.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://example.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://example.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .selfHosted)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://example.com/#/send"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://example.com/#/settings"))
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://example.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://example.com"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+        #expect(subject.apiURL == URL(string: "https://example.com/api"))
+        #expect(subject.baseURL == URL(string: "https://example.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://example.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://example.com/events"))
+        #expect(subject.iconsURL == URL(string: "https://example.com/icons"))
+        #expect(subject.identityURL == URL(string: "https://example.com/identity"))
+        #expect(subject.importItemsURL == URL(string: "https://example.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://example.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://example.com/#/recover-2fa"))
+        #expect(subject.region == .selfHosted)
+        #expect(subject.sendShareURL == URL(string: "https://example.com/#/send"))
+        #expect(subject.settingsURL == URL(string: "https://example.com/#/settings"))
+        #expect(subject.setUpTwoFactorURL == URL(string: "https://example.com/#/settings/security/two-factor"))
+        #expect(subject.webVaultURL == URL(string: "https://example.com"))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
 
-        XCTAssertEqual(errorReporter.region?.region, "Self-Hosted")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, false)
+        #expect(errorReporter.region?.region == "Self-Hosted")
+        #expect(errorReporter.region?.isPreAuth == false)
     }
 
     /// `loadURLsForActiveAccount()` loads the client certificate fingerprint from the account URLs.
-    func test_loadURLsForActiveAccount_clientCertificateFingerprint() async {
+    @Test
+    func loadURLsForActiveAccount_clientCertificateFingerprint() async {
         let urls = EnvironmentURLData(base: .example, clientCertificateFingerprint: "test-fingerprint")
         let account = Account.fixture(settings: .fixture(environmentURLs: urls))
         stateService.activeAccount = account
@@ -113,11 +114,12 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.clientCertificateFingerprint, "test-fingerprint")
+        #expect(subject.clientCertificateFingerprint == "test-fingerprint")
     }
 
-    /// `loadURLsForActiveAccount()` handles EU URLs
-    func test_loadURLsForActiveAccount_europe() async {
+    /// `loadURLsForActiveAccount()` handles EU URLs.
+    @Test
+    func loadURLsForActiveAccount_europe() async {
         let urls = EnvironmentURLData.defaultEU
         let account = Account.fixture(settings: .fixture(environmentURLs: urls))
         stateService.activeAccount = account
@@ -125,30 +127,35 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.eu"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.eu"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.eu/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.eu"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.eu"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.eu"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.eu/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden.eu/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.eu/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .europe)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.bitwarden.eu/#/send"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.eu/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.eu/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.eu"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+        #expect(subject.apiURL == URL(string: "https://api.bitwarden.eu"))
+        #expect(subject.baseURL == URL(string: "https://vault.bitwarden.eu"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.bitwarden.eu/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://events.bitwarden.eu"))
+        #expect(subject.iconsURL == URL(string: "https://icons.bitwarden.eu"))
+        #expect(subject.identityURL == URL(string: "https://identity.bitwarden.eu"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.bitwarden.eu/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.bitwarden.eu/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.bitwarden.eu/#/recover-2fa"))
+        #expect(subject.region == .europe)
+        #expect(subject.sendShareURL == URL(string: "https://vault.bitwarden.eu/#/send"))
+        #expect(subject.settingsURL == URL(string: "https://vault.bitwarden.eu/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.bitwarden.eu/#/settings/security/two-factor"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.bitwarden.eu"))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
 
-        XCTAssertEqual(errorReporter.region?.region, "EU")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, false)
+        #expect(errorReporter.region?.region == "EU")
+        #expect(errorReporter.region?.isPreAuth == false)
     }
 
     /// `loadURLsForActiveAccount()` loads the managed config URLs.
-    func test_loadURLsForActiveAccount_managedConfig() async throws {
+    @Test
+    func loadURLsForActiveAccount_managedConfig() async throws {
         standardUserDefaults.setValue(
             ["baseEnvironmentUrl": "https://vault.example.com"],
             forKey: "com.apple.configuration.managed",
@@ -156,29 +163,34 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        let urls = try EnvironmentURLData(base: XCTUnwrap(URL(string: "https://vault.example.com")))
-        XCTAssertEqual(subject.apiURL, URL(string: "https://vault.example.com/api"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.example.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.example.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://vault.example.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://vault.example.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://vault.example.com/identity"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.example.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.example.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.example.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .selfHosted)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://vault.example.com/#/send"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.example.com/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.example.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.example.com"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+        let urls = try EnvironmentURLData(base: #require(URL(string: "https://vault.example.com")))
+        #expect(subject.apiURL == URL(string: "https://vault.example.com/api"))
+        #expect(subject.baseURL == URL(string: "https://vault.example.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.example.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://vault.example.com/events"))
+        #expect(subject.iconsURL == URL(string: "https://vault.example.com/icons"))
+        #expect(subject.identityURL == URL(string: "https://vault.example.com/identity"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.example.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.example.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.example.com/#/recover-2fa"))
+        #expect(subject.region == .selfHosted)
+        #expect(subject.sendShareURL == URL(string: "https://vault.example.com/#/send"))
+        #expect(subject.settingsURL == URL(string: "https://vault.example.com/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.example.com/#/settings/security/two-factor"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.example.com"))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
     }
 
     /// `loadURLsForActiveAccount()` doesn't load the managed config URLs if there's an active
     /// account, but sets the pre-auth URLs to the managed config URLs.
-    func test_loadURLsForActiveAccount_managedConfigActiveAccount() async throws {
+    @Test
+    func loadURLsForActiveAccount_managedConfigActiveAccount() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
         stateService.environmentURLs[account.profile.userId] = .defaultUS
@@ -189,129 +201,141 @@ class EnvironmentServiceTests: XCTestCase {
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
+        #expect(subject.apiURL == URL(string: "https://api.bitwarden.com"))
+        #expect(subject.baseURL == URL(string: "https://vault.bitwarden.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.bitwarden.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://events.bitwarden.com"))
+        #expect(subject.iconsURL == URL(string: "https://icons.bitwarden.net"))
+        #expect(subject.identityURL == URL(string: "https://identity.bitwarden.com"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
+        #expect(subject.region == .unitedStates)
+        #expect(subject.sendShareURL == URL(string: "https://send.bitwarden.com/#"))
+        #expect(subject.settingsURL == URL(string: "https://vault.bitwarden.com/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.bitwarden.com"))
 
-        let urls = try EnvironmentURLData(base: XCTUnwrap(URL(string: "https://vault.example.com")))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+        let urls = try EnvironmentURLData(base: #require(URL(string: "https://vault.example.com")))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
     }
 
     /// `loadURLsForActiveAccount()` loads the default URLs if there's no active account
     /// and no preauth URLs.
-    func test_loadURLsForActiveAccount_noAccount() async {
+    @Test
+    func loadURLsForActiveAccount_noAccount() async {
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://api.bitwarden.com"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://vault.bitwarden.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://vault.bitwarden.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://events.bitwarden.com"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://icons.bitwarden.net"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://identity.bitwarden.com"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://vault.bitwarden.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .unitedStates)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://send.bitwarden.com/#"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://vault.bitwarden.com/#/settings"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://vault.bitwarden.com"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, .defaultUS)
+        #expect(subject.apiURL == URL(string: "https://api.bitwarden.com"))
+        #expect(subject.baseURL == URL(string: "https://vault.bitwarden.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://vault.bitwarden.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://events.bitwarden.com"))
+        #expect(subject.iconsURL == URL(string: "https://icons.bitwarden.net"))
+        #expect(subject.identityURL == URL(string: "https://identity.bitwarden.com"))
+        #expect(subject.importItemsURL == URL(string: "https://vault.bitwarden.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://vault.bitwarden.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://vault.bitwarden.com/#/recover-2fa"))
+        #expect(subject.region == .unitedStates)
+        #expect(subject.sendShareURL == URL(string: "https://send.bitwarden.com/#"))
+        #expect(subject.settingsURL == URL(string: "https://vault.bitwarden.com/#/settings"))
+        #expect(
+            subject.setUpTwoFactorURL
+                == URL(string: "https://vault.bitwarden.com/#/settings/security/two-factor"),
+        )
+        #expect(subject.webVaultURL == URL(string: "https://vault.bitwarden.com"))
+        #expect(stateService.preAuthEnvironmentURLs == .defaultUS)
 
-        XCTAssertEqual(errorReporter.region?.region, "US")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, false)
+        #expect(errorReporter.region?.region == "US")
+        #expect(errorReporter.region?.isPreAuth == false)
     }
 
     /// `loadURLsForActiveAccount()` loads the preAuth URLs if there's no active account
     /// and there are preauth URLs.
-    func test_loadURLsForActiveAccount_preAuth() async {
+    @Test
+    func loadURLsForActiveAccount_preAuth() async {
         let urls = EnvironmentURLData(base: .example)
         stateService.preAuthEnvironmentURLs = urls
 
         await subject.loadURLsForActiveAccount()
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://example.com/api"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://example.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://example.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://example.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://example.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://example.com/identity"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://example.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://example.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://example.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .selfHosted)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://example.com/#/send"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://example.com/#/settings"))
-        XCTAssertEqual(
-            subject.setUpTwoFactorURL,
-            URL(
-                string: "https://example.com/#/settings/security/two-factor",
-            ),
+        #expect(subject.apiURL == URL(string: "https://example.com/api"))
+        #expect(subject.baseURL == URL(string: "https://example.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://example.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://example.com/events"))
+        #expect(subject.iconsURL == URL(string: "https://example.com/icons"))
+        #expect(subject.identityURL == URL(string: "https://example.com/identity"))
+        #expect(subject.importItemsURL == URL(string: "https://example.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://example.com/proxy-cookie-redirect-connector.html"),
         )
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://example.com"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
+        #expect(subject.recoveryCodeURL == URL(string: "https://example.com/#/recover-2fa"))
+        #expect(subject.region == .selfHosted)
+        #expect(subject.sendShareURL == URL(string: "https://example.com/#/send"))
+        #expect(subject.settingsURL == URL(string: "https://example.com/#/settings"))
+        #expect(subject.setUpTwoFactorURL == URL(string: "https://example.com/#/settings/security/two-factor"))
+        #expect(subject.webVaultURL == URL(string: "https://example.com"))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
 
-        XCTAssertEqual(errorReporter.region?.region, "Self-Hosted")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, false)
+        #expect(errorReporter.region?.region == "Self-Hosted")
+        #expect(errorReporter.region?.isPreAuth == false)
     }
 
     /// `region` resolves a `bitwarden.pw` environment (including subdomains) to `.internal`.
-    func test_region_internal() async {
+    @Test
+    func region_internal() async {
         await subject.setPreAuthURLs(urls: EnvironmentURLData(base: URL(string: "https://qa-team.sh.bitwarden.pw")!))
 
-        XCTAssertEqual(subject.region, .internal)
-        XCTAssertEqual(errorReporter.region?.region, "Internal")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, true)
+        #expect(subject.region == .internal)
+        #expect(errorReporter.region?.region == "Internal")
+        #expect(errorReporter.region?.isPreAuth == true)
     }
 
     /// `setPreAuthURLs(urls:)` sets the pre-auth URLs.
-    func test_setPreAuthURLs() async {
+    @Test
+    func setPreAuthURLs() async {
         let urls = EnvironmentURLData(base: .example)
 
         await subject.setPreAuthURLs(urls: urls)
 
-        XCTAssertEqual(subject.apiURL, URL(string: "https://example.com/api"))
-        XCTAssertEqual(subject.baseURL, URL(string: "https://example.com"))
-        XCTAssertEqual(subject.changeEmailURL, URL(string: "https://example.com/#/settings/account"))
-        XCTAssertEqual(subject.eventsURL, URL(string: "https://example.com/events"))
-        XCTAssertEqual(subject.iconsURL, URL(string: "https://example.com/icons"))
-        XCTAssertEqual(subject.identityURL, URL(string: "https://example.com/identity"))
-        XCTAssertEqual(subject.importItemsURL, URL(string: "https://example.com/#/tools/import"))
-        // swiftlint:disable:next line_length
-        XCTAssertEqual(subject.proxyCookieRedirectConnectorURL, URL(string: "https://example.com/proxy-cookie-redirect-connector.html"))
-        XCTAssertEqual(subject.recoveryCodeURL, URL(string: "https://example.com/#/recover-2fa"))
-        XCTAssertEqual(subject.region, .selfHosted)
-        XCTAssertEqual(subject.sendShareURL, URL(string: "https://example.com/#/send"))
-        XCTAssertEqual(subject.settingsURL, URL(string: "https://example.com/#/settings"))
-        XCTAssertEqual(subject.setUpTwoFactorURL, URL(string: "https://example.com/#/settings/security/two-factor"))
-        XCTAssertEqual(subject.webVaultURL, URL(string: "https://example.com"))
-        XCTAssertEqual(stateService.preAuthEnvironmentURLs, urls)
-        XCTAssertEqual(errorReporter.region?.region, "Self-Hosted")
-        XCTAssertEqual(errorReporter.region?.isPreAuth, true)
+        #expect(subject.apiURL == URL(string: "https://example.com/api"))
+        #expect(subject.baseURL == URL(string: "https://example.com"))
+        #expect(subject.changeEmailURL == URL(string: "https://example.com/#/settings/account"))
+        #expect(subject.eventsURL == URL(string: "https://example.com/events"))
+        #expect(subject.iconsURL == URL(string: "https://example.com/icons"))
+        #expect(subject.identityURL == URL(string: "https://example.com/identity"))
+        #expect(subject.importItemsURL == URL(string: "https://example.com/#/tools/import"))
+        #expect(
+            subject.proxyCookieRedirectConnectorURL
+                == URL(string: "https://example.com/proxy-cookie-redirect-connector.html"),
+        )
+        #expect(subject.recoveryCodeURL == URL(string: "https://example.com/#/recover-2fa"))
+        #expect(subject.region == .selfHosted)
+        #expect(subject.sendShareURL == URL(string: "https://example.com/#/send"))
+        #expect(subject.settingsURL == URL(string: "https://example.com/#/settings"))
+        #expect(subject.setUpTwoFactorURL == URL(string: "https://example.com/#/settings/security/two-factor"))
+        #expect(subject.webVaultURL == URL(string: "https://example.com"))
+        #expect(stateService.preAuthEnvironmentURLs == urls)
+        #expect(errorReporter.region?.region == "Self-Hosted")
+        #expect(errorReporter.region?.isPreAuth == true)
     }
 
     /// `setPreAuthURLs(urls:)` sets the client certificate fingerprint from the pre-auth URLs.
-    func test_setPreAuthURLs_clientCertificateFingerprint() async {
+    @Test
+    func setPreAuthURLs_clientCertificateFingerprint() async {
         let urls = EnvironmentURLData(base: .example, clientCertificateFingerprint: "test-fingerprint")
 
         await subject.setPreAuthURLs(urls: urls)
 
-        XCTAssertEqual(subject.clientCertificateFingerprint, "test-fingerprint")
+        #expect(subject.clientCertificateFingerprint == "test-fingerprint")
     }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -73,9 +73,17 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
         case let .profileSwitcher(profileEffect):
             await handleProfileSwitcherEffect(profileEffect)
         case .regionPressed:
+            let serverConfig = await services.configService.getConfig(forceRefresh: false, isPreAuth: true)
+            let preAuthURLs = await services.stateService.getPreAuthEnvironmentURLs()
+            var excludedRegions: [RegionType] = [.gov]
+            if serverConfig?.isCurrentConfig(for: preAuthURLs) == true,
+               await services.configService.getFeatureFlag(.fedrampGovRegion, isPreAuth: true) {
+                excludedRegions = []
+            }
             await regionHelper.presentRegionSelectorAlert(
                 title: Localizations.loggingInOn,
                 currentRegion: state.region,
+                excludingRegions: excludedRegions,
             )
         }
     }

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -430,7 +430,7 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertTrue(subject.state.isContinueButtonEnabled)
     }
 
-    /// `perform(_:)` with `.regionPressed` navigates to the region selection screen.
+    /// `perform(_:)` with `.regionPressed` shows US, EU, Self-Hosted — Gov is excluded by default.
     @MainActor
     func test_perform_regionPressed() async throws {
         await subject.perform(.regionPressed)
@@ -438,7 +438,8 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         var alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.loggingInOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 5)
+        XCTAssertEqual(alert.alertActions.count, 4) // US + EU + Self-Hosted + Cancel (no Gov)
+        XCTAssertNil(alert.alertActions.first(where: { $0.title == "bitwarden-gov.com" }))
 
         XCTAssertEqual(alert.alertActions[0].title, "bitwarden.com")
         try await alert.tapAction(title: "bitwarden.com")
@@ -452,15 +453,81 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
 
         await subject.perform(.regionPressed)
         alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions[2].title, Localizations.selfHosted)
+        try await alert.tapAction(title: Localizations.selfHosted)
+        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .europe))
+    }
+
+    /// `perform(_:)` with `.regionPressed` includes Gov when `fedrampGovRegion` is enabled
+    /// and the cached config matches the current region.
+    @MainActor
+    func test_perform_regionPressed_fedrampGovRegionEnabled() async throws {
+        stateService.preAuthEnvironmentURLs = .defaultUS
+        configService.configMocker.withResult(
+            ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: EnvironmentServerConfigResponseModel(
+                        api: nil,
+                        cloudRegion: nil,
+                        fillAssistRules: nil,
+                        identity: nil,
+                        notifications: nil,
+                        sso: nil,
+                        vault: "https://vault.bitwarden.com",
+                    ),
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    version: "2025.1.0",
+                ),
+            ),
+        )
+        configService.featureFlagsBoolPreAuth[.fedrampGovRegion] = true
+
+        await subject.perform(.regionPressed)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions.count, 5)
         XCTAssertEqual(alert.alertActions[2].title, "bitwarden-gov.com")
         try await alert.tapAction(title: "bitwarden-gov.com")
         XCTAssertEqual(subject.state.region, .gov)
+    }
+
+    /// `perform(_:)` with `.regionPressed` excludes Gov when `fedrampGovRegion` is enabled
+    /// but the cached config belongs to a different region (stale cache).
+    @MainActor
+    func test_perform_regionPressed_fedrampGovRegionEnabled_staleConfig() async throws {
+        stateService.preAuthEnvironmentURLs = .defaultUS
+        configService.configMocker.withResult(
+            ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: EnvironmentServerConfigResponseModel(
+                        api: nil,
+                        cloudRegion: nil,
+                        fillAssistRules: nil,
+                        identity: nil,
+                        notifications: nil,
+                        sso: nil,
+                        vault: "https://vault.bitwarden.eu",
+                    ),
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    version: "2025.1.0",
+                ),
+            ),
+        )
+        configService.featureFlagsBoolPreAuth[.fedrampGovRegion] = true
 
         await subject.perform(.regionPressed)
-        alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.alertActions[3].title, Localizations.selfHosted)
-        try await alert.tapAction(title: Localizations.selfHosted)
-        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .gov))
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertNil(alert.alertActions.first(where: { $0.title == "bitwarden-gov.com" }))
     }
 
     /// `receive(_:)` with `.rememberMeChanged(true)` updates the state to reflect the changes.

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -438,7 +438,7 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         var alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.loggingInOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions.count, 5)
 
         XCTAssertEqual(alert.alertActions[0].title, "bitwarden.com")
         try await alert.tapAction(title: "bitwarden.com")
@@ -452,9 +452,15 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
 
         await subject.perform(.regionPressed)
         alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.selfHosted)
+        XCTAssertEqual(alert.alertActions[2].title, "bitwarden-gov.com")
+        try await alert.tapAction(title: "bitwarden-gov.com")
+        XCTAssertEqual(subject.state.region, .gov)
+
+        await subject.perform(.regionPressed)
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.selfHosted)
         try await alert.tapAction(title: Localizations.selfHosted)
-        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .europe))
+        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .gov))
     }
 
     /// `receive(_:)` with `.rememberMeChanged(true)` updates the state to reflect the changes.

--- a/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/StartRegistration/StartRegistrationProcessorTests.swift
@@ -70,7 +70,7 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
         var alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.creatingOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions.count, 5)
 
         XCTAssertEqual(alert.alertActions[0].title, "bitwarden.com")
         try await alert.tapAction(title: "bitwarden.com")
@@ -84,9 +84,15 @@ class StartRegistrationProcessorTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.perform(.regionTapped)
         alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.selfHosted)
+        XCTAssertEqual(alert.alertActions[2].title, "bitwarden-gov.com")
+        try await alert.tapAction(title: "bitwarden-gov.com")
+        XCTAssertEqual(subject.state.region, .gov)
+
+        await subject.perform(.regionTapped)
+        alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.selfHosted)
         try await alert.tapAction(title: Localizations.selfHosted)
-        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .europe))
+        XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .gov))
     }
 
     /// `perform(_:)` with `.startRegistration` sets preAuthUrls for the given email and navigates to check email.

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelper.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelper.swift
@@ -35,19 +35,30 @@ class RegionHelper {
 
     /// Builds an alert for region selection and navigates to the alert.
     ///
-    func presentRegionSelectorAlert(title: String, currentRegion: RegionType?) async {
-        let actions = RegionType.userSelectableCases.map { region in
-            AlertAction(title: region.baseURLDescription, style: .default) { _ in
-                if let urls = region.defaultURLs {
-                    await self.delegate?.setRegion(region, urls)
-                } else {
-                    await self.coordinator.navigate(
-                        to: .selfHosted(currentRegion: currentRegion ?? .unitedStates),
-                        context: self.delegate,
-                    )
+    /// - Parameters:
+    ///   - title: The title of the alert.
+    ///   - currentRegion: The currently selected region.
+    ///   - excludingRegions: Regions to omit from the picker. Defaults to empty (all selectable regions shown).
+    ///
+    func presentRegionSelectorAlert(
+        title: String,
+        currentRegion: RegionType?,
+        excludingRegions: [RegionType] = [],
+    ) async {
+        let actions = RegionType.userSelectableCases
+            .filter { !excludingRegions.contains($0) }
+            .map { region in
+                AlertAction(title: region.baseURLDescription, style: .default) { _ in
+                    if let urls = region.defaultURLs {
+                        await self.delegate?.setRegion(region, urls)
+                    } else {
+                        await self.coordinator.navigate(
+                            to: .selfHosted(currentRegion: currentRegion ?? .unitedStates),
+                            context: self.delegate,
+                        )
+                    }
                 }
             }
-        }
         let cancelAction = AlertAction(title: Localizations.cancel, style: .cancel)
         let alert = Alert(
             title: title,

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
@@ -47,7 +47,7 @@ class RegionHelperTests: BitwardenTestCase {
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.creatingOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions.count, 5)
 
         XCTAssertEqual(alert.alertActions[0].title, "bitwarden.com")
         try await alert.tapAction(title: "bitwarden.com")
@@ -64,13 +64,30 @@ class RegionHelperTests: BitwardenTestCase {
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.creatingOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions.count, 5)
 
         XCTAssertEqual(alert.alertActions[1].title, "bitwarden.eu")
         try await alert.tapAction(title: "bitwarden.eu")
         XCTAssertTrue(regionDelegate.setRegionCalled)
         XCTAssertEqual(regionDelegate.setRegionType, .europe)
         XCTAssertEqual(regionDelegate.setRegionUrls, RegionType.europe.defaultURLs)
+    }
+
+    /// `presentRegionSelectorAlert(title:currentRegion)` shows alert and tap bitwarden-gov.com.
+    @MainActor
+    func test_presentRegionSelectorAlert_gov() async throws {
+        await subject.presentRegionSelectorAlert(title: Localizations.creatingOn, currentRegion: .unitedStates)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.creatingOn)
+        XCTAssertNil(alert.message)
+        XCTAssertEqual(alert.alertActions.count, 5)
+
+        XCTAssertEqual(alert.alertActions[2].title, "bitwarden-gov.com")
+        try await alert.tapAction(title: "bitwarden-gov.com")
+        XCTAssertTrue(regionDelegate.setRegionCalled)
+        XCTAssertEqual(regionDelegate.setRegionType, .gov)
+        XCTAssertEqual(regionDelegate.setRegionUrls, RegionType.gov.defaultURLs)
     }
 
     /// `presentRegionSelectorAlert(title:currentRegion)` shows alert and tap selfhosted.
@@ -81,9 +98,9 @@ class RegionHelperTests: BitwardenTestCase {
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.creatingOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions.count, 5)
 
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.selfHosted)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.selfHosted)
         try await alert.tapAction(title: Localizations.selfHosted)
         XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .europe))
     }
@@ -96,9 +113,9 @@ class RegionHelperTests: BitwardenTestCase {
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.loggingInOn)
         XCTAssertNil(alert.message)
-        XCTAssertEqual(alert.alertActions.count, 4)
+        XCTAssertEqual(alert.alertActions.count, 5)
 
-        XCTAssertEqual(alert.alertActions[2].title, Localizations.selfHosted)
+        XCTAssertEqual(alert.alertActions[3].title, Localizations.selfHosted)
         try await alert.tapAction(title: Localizations.selfHosted)
         XCTAssertEqual(coordinator.routes.last, .selfHosted(currentRegion: .unitedStates))
     }
@@ -112,7 +129,7 @@ class RegionHelperTests: BitwardenTestCase {
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         let actionTitles = alert.alertActions.map(\.title)
-        XCTAssertEqual(actionTitles, ["bitwarden.com", "bitwarden.eu", Localizations.selfHosted, Localizations.cancel])
+        XCTAssertEqual(actionTitles, ["bitwarden.com", "bitwarden.eu", "bitwarden-gov.com", Localizations.selfHosted, Localizations.cancel])
     }
 
     /// `loadRegion()` with pre auth region as nil default to us
@@ -140,6 +157,15 @@ class RegionHelperTests: BitwardenTestCase {
         XCTAssertTrue(regionDelegate.setRegionCalled)
         XCTAssertEqual(regionDelegate.setRegionType, .europe)
         XCTAssertEqual(regionDelegate.setRegionUrls, RegionType.europe.defaultURLs)
+    }
+
+    /// `loadRegion()` with pre auth region
+    func test_loadRegion_gov() async throws {
+        stateService.preAuthEnvironmentURLs = .defaultGov
+        await subject.loadRegion()
+        XCTAssertTrue(regionDelegate.setRegionCalled)
+        XCTAssertEqual(regionDelegate.setRegionType, .gov)
+        XCTAssertEqual(regionDelegate.setRegionUrls, RegionType.gov.defaultURLs)
     }
 
     /// `loadRegion()` with pre auth region

--- a/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
+++ b/BitwardenShared/UI/Auth/Utilities/RegionHelperTests.swift
@@ -129,7 +129,24 @@ class RegionHelperTests: BitwardenTestCase {
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         let actionTitles = alert.alertActions.map(\.title)
-        XCTAssertEqual(actionTitles, ["bitwarden.com", "bitwarden.eu", "bitwarden-gov.com", Localizations.selfHosted, Localizations.cancel])
+        XCTAssertEqual(
+            actionTitles,
+            ["bitwarden.com", "bitwarden.eu", "bitwarden-gov.com", Localizations.selfHosted, Localizations.cancel],
+        )
+    }
+
+    /// `presentRegionSelectorAlert(title:currentRegion:excludingRegions:)` omits excluded regions.
+    @MainActor
+    func test_presentRegionSelectorAlert_excludingRegions() async throws {
+        await subject.presentRegionSelectorAlert(
+            title: Localizations.creatingOn,
+            currentRegion: .unitedStates,
+            excludingRegions: [.gov],
+        )
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.alertActions.count, 4) // US + EU + Self-Hosted + Cancel
+        XCTAssertNil(alert.alertActions.first(where: { $0.title == "bitwarden-gov.com" }))
     }
 
     /// `loadRegion()` with pre auth region as nil default to us


### PR DESCRIPTION
## 🎟️ Tracking

[PM-35111](https://bitwarden.atlassian.net/browse/PM-35111)

## 📔 Objective

Adds a `.gov` RegionType case backed by bitwarden-gov.com default URLs so users can select the new government cloud environment from the region selector.

## 📸 Screenshots

<img width="314" alt="New fedRAMP gov region option in the picker" src="https://github.com/user-attachments/assets/d30c5db8-5d46-4dfe-910b-68e6ac65f8a6" />


[PM-35111]: https://bitwarden.atlassian.net/browse/PM-35111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ