### PR TITLE
llm: Add Step 7 verify/lint/format section to implementing-ios-code skill

### DIFF
--- a/.claude/skills/implementing-ios-code/SKILL.md
+++ b/.claude/skills/implementing-ios-code/SKILL.md
@@ -86,6 +86,30 @@ All new public types and methods require DocC (`///`) documentation.
 Exceptions: protocol property/function implementations (docs live in the protocol), mock classes.
 Use pragma marks to organize code. `// MARK: -` is used to denote different objects in the same file; `// MARK:` is used to denote different sections within an object.
 
+## Step 7: Verify — Lint, Format, and Regenerate
+
+Run these checks after all code and tests are written, **before** handing back. Fix every violation found — do not leave warnings for the commit phase.
+
+**If new localization strings were added**, regenerate first so SwiftGen picks them up:
+```bash
+mint run swiftgen config run --config swiftgen-bwr.yml   # BitwardenResources (most common)
+# Run the appropriate swiftgen-*.yml if strings landed in a different target
+```
+
+**Then lint and format:**
+```bash
+mint run swiftlint                        # Fix all violations before continuing
+mint run swiftformat --lint --lenient .   # Fix all violations before continuing
+typos                                     # Flag any new spell-check errors
+```
+
+For SwiftLint violations, prefer fixing the root cause over suppressing with `// swiftlint:disable` comments. Suppression is appropriate when the violation is structural and fixing it would require an artificial or non-idiomatic refactor. Common cases:
+- **`line_length`** — wrap long lines using Xcode's ⌃M style (each argument on its own indented line); fix rather than suppress
+- **`file_length`** — if a `#if DEBUG` preview section pushed a file over the limit, add `// swiftlint:disable file_length` at the top of the file (this is the established pattern — do NOT move previews to a separate file)
+- **`type_body_length`** — split large types using `// MARK:` extensions in separate files if needed; suppress only if the type is inherently large and splitting would hurt readability
+
+Only hand back once `swiftlint` and `swiftformat --lint --lenient` both produce zero violations for files touched in this session.
+
 ## Conventions
 
 - **Member ordering** — within a `// MARK:` section, keep members in a single alphabetical order (stored properties, computed properties, methods, and static members share that order), and alphabetize function and initializer parameters the same way (default-valued, variadic, then trailing-closure parameters last). Insert new members and parameters at their alphabetical position rather than appending. Exceptions: UI objects (views, view modifiers) follow visual layout order, not alphabetical; and protocol *conformance* ordering is not enforced.

--- a/.claude/skills/implementing-ios-code/SKILL.md
+++ b/.claude/skills/implementing-ios-code/SKILL.md
@@ -96,19 +96,19 @@ mint run swiftgen config run --config swiftgen-bwr.yml   # BitwardenResources (m
 # Run the appropriate swiftgen-*.yml if strings landed in a different target
 ```
 
-**Then lint and format:**
+**Then run the pre-commit checks:**
 ```bash
-mint run swiftlint                        # Fix all violations before continuing
-mint run swiftformat --lint --lenient .   # Fix all violations before continuing
-typos                                     # Flag any new spell-check errors
+./Scripts/pre-commit
 ```
 
-For SwiftLint violations, prefer fixing the root cause over suppressing with `// swiftlint:disable` comments. Suppression is appropriate when the violation is structural and fixing it would require an artificial or non-idiomatic refactor. Common cases:
+This runs spell-check, SwiftFormat, and SwiftLint on changed files — the same checks that run at commit time. If violations are reported, fix them and re-run until it passes cleanly.
+
+For SwiftLint violations that require manual fixes, prefer fixing the root cause over suppressing with `// swiftlint:disable` comments. Suppression is appropriate when the violation is structural and fixing it would require an artificial or non-idiomatic refactor. Common cases:
 - **`line_length`** — wrap long lines using Xcode's ⌃M style (each argument on its own indented line); fix rather than suppress
 - **`file_length`** — if a `#if DEBUG` preview section pushed a file over the limit, add `// swiftlint:disable file_length` at the top of the file (this is the established pattern — do NOT move previews to a separate file)
 - **`type_body_length`** — split large types using `// MARK:` extensions in separate files if needed; suppress only if the type is inherently large and splitting would hurt readability
 
-Only hand back once `swiftlint` and `swiftformat --lint --lenient` both produce zero violations for files touched in this session.
+Only hand back once `./Scripts/pre-commit` passes cleanly for files touched in this session.
 
 ## Conventions
 


### PR DESCRIPTION
## 🎟️ Tracking

## 📔 Objective

Adds a "Step 7: Verify — Lint, Format, and Regenerate" section to the `implementing-ios-code` skill. This makes the post-implementation verification step explicit and actionable:

- SwiftGen regeneration command if new localization strings were added
- `swiftlint`, `swiftformat --lint --lenient`, and `typos` commands
- Guidance on when to suppress vs. fix SwiftLint violations (`line_length`, `file_length`, `type_body_length`)

Without this step, implementations were sometimes handed back with lint or format violations, or with missing SwiftGen output after adding localization strings — requiring a follow-up round of corrections. Making verification explicit and placing it before the handoff point means violations get caught and fixed in the same session, not discovered during preflight or review.