### PR TITLE
[PM-40043] chore: Exclude .build and .claude folders from lint

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -10,7 +10,7 @@
 --wrapternary before-operators
 
 # file options
---exclude **/Generated,build,vendor/bundle
+--exclude **/Generated,.build,.claude,build,vendor/bundle
 
 # rules
 --disable elseOnSameLine,semicolons,unusedArguments,opaqueGenericParameters,wrapMultilineStatementBraces,preferForLoop,wrapPropertyBodies,wrapFunctionBodies,blankLinesBetweenImports,noForceUnwrapInTests,redundantProperty,redundantThrows,redundantAsync,redundantViewBuilder,simplifyGenericConstraints,emptyExtensions

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -41,6 +41,8 @@ opt_in_rules:
   - yoda_condition
 
 excluded:
+  - .build
+  - .claude
   - BitwardenShared/UI/Platform/Application/Support/Generated
   - BitwardenWatchApp
   - BitwardenWatchShared


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40043](https://bitwarden.atlassian.net/browse/PM-40043)

## 📔 Objective

Exclude `.build` and `.claude` folders from Swift lint as it can cause problems when working with worktrees inside the `.claude` folder.
Particularly, if one has a corktree in the `.claude` folder and wants to compile from the main repo (not the worktree) then Swift lint will try to make it pass inside the `.claude` folder's worktree causing a lot of errors to appear. So in order for this not to happen we can just exclude such folders.


[PM-40043]: https://bitwarden.atlassian.net/browse/PM-40043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ