### PR TITLE
[PM-29049] refactor: Validate PIN against pinProtectedUserKeyEnvelope

### DIFF
--- a/BitwardenKit/Core/Auth/Services/SDK/AuthClientService.swift
+++ b/BitwardenKit/Core/Auth/Services/SDK/AuthClientService.swift
@@ -57,10 +57,6 @@ public protocol AuthClientService: AnyObject, Sendable { // sourcery: AutoMockab
     ///
     func validatePasswordUserKey(password: String, encryptedUserKey: String) async throws -> String
 
-    /// Validate the user PIN.
-    ///
-    func validatePin(pin: String, pinProtectedUserKey: EncString) async throws -> Bool
-
     /// Validates a PIN against a PIN-protected user key envelope.
     ///
     func validatePinProtectedUserKeyEnvelope(

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -1198,11 +1198,14 @@ extension DefaultAuthRepository: AuthRepository {
     }
 
     func validatePin(pin: String) async throws -> Bool {
-        guard let pinProtectedUserKey = try? await stateService.pinProtectedUserKey() else {
+        guard let pinProtectedUserKeyEnvelope = try await stateService.pinProtectedUserKeyEnvelope() else {
             return false
         }
 
-        return try await clientService.auth().validatePin(pin: pin, pinProtectedUserKey: pinProtectedUserKey)
+        return try await clientService.auth().validatePinProtectedUserKeyEnvelope(
+            pin: pin,
+            pinProtectedUserKeyEnvelope: pinProtectedUserKeyEnvelope,
+        )
     }
 
     func verifyOtp(_ otp: String) async throws {

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepositoryTests.swift
@@ -133,7 +133,6 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         )
         clientService.mockAuth.registrationReturnValue = clientRegistration
         clientRegistration.postKeysForJitPasswordRegistrationReturnValue = .fixture()
-        clientService.mockAuth.validatePinReturnValue = false
         configService.featureFlagsBool[.accountEncryptionV2JITPassword] = true
         userSessionStateService.getVaultTimeoutReturnValue = .fifteenMinutes
         userSessionStateService.getUnsuccessfulUnlockAttemptsReturnValue = 0
@@ -3603,76 +3602,47 @@ class AuthRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_validatePin() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-        stateService.pinProtectedUserKeyValue[account.profile.userId] = "123"
+        stateService.pinProtectedUserKeyEnvelopeValue[account.profile.userId] = "ENVELOPE"
 
-        clientService.mockAuth.validatePinReturnValue = true
+        clientService.mockAuth.validatePinProtectedUserKeyEnvelopeReturnValue = true
 
         let isPinValid = try await subject.validatePin(pin: "123")
 
         XCTAssertTrue(isPinValid)
-    }
-
-    /// `validatePin(_:)` returns `false` if the there is no active account.
-    func test_validatePin_noActiveAccount() async throws {
-        let isPinValid = try await subject.validatePin(pin: "123")
-
-        XCTAssertFalse(isPinValid)
-    }
-
-    /// `validatePin(_:)` returns `false` if the there is no pin protected user key.
-    func test_validatePin_noPinProtectedUserKey() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-
-        let isPinValid = try await subject.validatePin(pin: "123")
-
-        XCTAssertFalse(isPinValid)
+        XCTAssertEqual(
+            clientService.mockAuth.validatePinProtectedUserKeyEnvelopeReceivedArguments?.pin,
+            "123",
+        )
+        XCTAssertEqual(
+            clientService.mockAuth.validatePinProtectedUserKeyEnvelopeReceivedArguments?.pinProtectedUserKeyEnvelope,
+            "ENVELOPE",
+        )
     }
 
     /// `validatePin(_:)` returns `false` if the pin is not valid.
     func test_validatePin_notValid() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
+        stateService.pinProtectedUserKeyEnvelopeValue[account.profile.userId] = "ENVELOPE"
 
-        stateService.pinProtectedUserKeyValue[account.profile.userId] = "123"
-
-        clientService.mockAuth.validatePinReturnValue = false
+        clientService.mockAuth.validatePinProtectedUserKeyEnvelopeReturnValue = false
 
         let isPinValid = try await subject.validatePin(pin: "123")
 
         XCTAssertFalse(isPinValid)
     }
 
-    /// `validatePin(_:)` throws when validating.
-    func test_validatePin_throws() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
-
-        stateService.pinProtectedUserKeyValue[account.profile.userId] = "123"
-
-        clientService.mockAuth.validatePinThrowableError = BitwardenTestError.example
-
-        await assertAsyncThrows(error: BitwardenTestError.example) {
+    /// `validatePin(_:)` throws if the there is no active account.
+    func test_validatePin_noActiveAccount() async throws {
+        await assertAsyncThrows(error: StateServiceError.noActiveAccount) {
             _ = try await subject.validatePin(pin: "123")
         }
     }
 
-    /// `validatePin(_:)` returns `false` if initializing org crypto throws.
-    func test_validatePin_initializeOrgCryptoThrows() async throws {
+    /// `validatePin(_:)` returns `false` if the there is no pin protected user key envelope.
+    func test_validatePin_noPinProtectedUserKeyEnvelope() async throws {
         let account = Account.fixture()
         stateService.activeAccount = account
-
-        stateService.accountEncryptionKeys = [
-            "1": AccountEncryptionKeys(
-                cryptographicState: .fixtureV2(),
-                encryptedUserKey: "USER_KEY",
-            ),
-        ]
-
-        stateService.encryptedPinByUserId[account.profile.userId] = "123"
-        stateService.pinProtectedUserKeyValue[account.profile.userId] = "123"
-
-        organizationService.initializeOrganizationCryptoError = BitwardenTestError.example
 
         let isPinValid = try await subject.validatePin(pin: "123")
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-29049](https://bitwarden.atlassian.net/browse/PM-29049)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Updates the SDK method used for validating PINs to `validatePinProtectedUserKeyEnvelope(pin: pinProtectedUserKeyEnvelope:)`. After migrating to the pin protected user key envelope in https://github.com/bitwarden/ios/pull/1876, PIN validation needs to also use the envelope in order to validate correctly.

[PM-29049]: https://bitwarden.atlassian.net/browse/PM-29049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ