### PR TITLE
[PM-37864] feat: Hide create account button based on server disableUserRegistration config

### DIFF
--- a/BitwardenKit/Core/Platform/Models/Domain/ServerConfig.swift
+++ b/BitwardenKit/Core/Platform/Models/Domain/ServerConfig.swift
@@ -26,6 +26,9 @@ public struct ServerConfig: Equatable, Codable, Sendable {
     /// Third party server information.
     public let server: ThirdPartyServerConfig?
 
+    /// Server-level settings.
+    public let settings: ServerSettings?
+
     /// The version of the server.
     public let version: String
 
@@ -36,6 +39,7 @@ public struct ServerConfig: Equatable, Codable, Sendable {
         featureStates = responseModel.featureStates ?? [:]
         gitHash = responseModel.gitHash
         server = responseModel.server.map(ThirdPartyServerConfig.init)
+        settings = responseModel.settings.map(ServerSettings.init)
         version = responseModel.version
     }
 
@@ -191,5 +195,29 @@ public struct ServerCommunicationBootstrapSettings: Equatable, Codable, Sendable
         idpLoginUrl = responseModel.idpLoginUrl
         cookieName = responseModel.cookieName
         cookieDomain = responseModel.cookieDomain
+    }
+}
+
+// MARK: - ServerSettings
+
+/// Domain model for server-level settings.
+public struct ServerSettings: Equatable, Codable, Sendable {
+    // MARK: Properties
+
+    /// Whether user registration is disabled on this server.
+    public let disableUserRegistration: Bool
+
+    // MARK: Initialization
+
+    /// Creates a new `ServerSettings`.
+    ///
+    /// - Parameter disableUserRegistration: Whether user registration is disabled on this server.
+    ///
+    public init(disableUserRegistration: Bool) {
+        self.disableUserRegistration = disableUserRegistration
+    }
+
+    public init(responseModel: ServerSettingsResponseModel) {
+        disableUserRegistration = responseModel.disableUserRegistration
     }
 }

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+Config.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/APITestData+Config.swift
@@ -4,4 +4,9 @@ import TestHelpers
 public extension APITestData {
     /// A valid server configuration to produce a `ConfigResponseModel`.
     static let validServerConfig = loadFromJsonBundle(resource: "ValidServerConfig")
+
+    /// A valid server configuration with `disableUserRegistration` set to `true`.
+    static let validServerConfigDisableRegistration = loadFromJsonBundle(
+        resource: "ValidServerConfigDisableRegistration",
+    )
 }

--- a/BitwardenKit/Core/Platform/Services/API/Fixtures/ValidServerConfigDisableRegistration.json
+++ b/BitwardenKit/Core/Platform/Services/API/Fixtures/ValidServerConfigDisableRegistration.json
@@ -1,0 +1,18 @@
+{
+    "version": "2024.4.2",
+    "gitHash": "75238191",
+    "server": null,
+    "environment": {
+        "cloudRegion": "US",
+        "vault": "https://vault.qa.bitwarden.pw",
+        "api": "https://api.qa.bitwarden.pw",
+        "identity": "https://identity.qa.bitwarden.pw",
+        "notifications": "https://notifications.qa.bitwarden.pw",
+        "sso": "https://sso.qa.bitwarden.pw"
+    },
+    "settings": {
+        "disableUserRegistration": true
+    },
+    "featureStates": {},
+    "object": "config"
+}

--- a/BitwardenKit/Core/Platform/Services/API/Response/ConfigResponseModel.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Response/ConfigResponseModel.swift
@@ -23,6 +23,9 @@ public struct ConfigResponseModel: Equatable, JSONResponse {
     /// Third party server information.
     public let server: ThirdPartyConfigResponseModel?
 
+    /// Server-level settings.
+    public let settings: ServerSettingsResponseModel?
+
     /// The version of the server.
     public let version: String
 
@@ -36,6 +39,7 @@ public struct ConfigResponseModel: Equatable, JSONResponse {
     ///   - featureStates: Feature flags to configure the client.
     ///   - gitHash: The git hash of the server.
     ///   - server: Third party server information.
+    ///   - settings: Server-level settings.
     ///   - version: The version of the server.
     public init(
         communication: CommunicationSettingsResponseModel?,
@@ -43,6 +47,7 @@ public struct ConfigResponseModel: Equatable, JSONResponse {
         featureStates: [String: AnyCodable]?,
         gitHash: String?,
         server: ThirdPartyConfigResponseModel?,
+        settings: ServerSettingsResponseModel? = nil,
         version: String,
     ) {
         self.communication = communication
@@ -50,6 +55,7 @@ public struct ConfigResponseModel: Equatable, JSONResponse {
         self.featureStates = featureStates
         self.gitHash = gitHash
         self.server = server
+        self.settings = settings
         self.version = version
     }
 }
@@ -141,6 +147,23 @@ public struct ThirdPartyConfigResponseModel: Equatable, JSONResponse {
     ) {
         self.name = name
         self.url = url
+    }
+}
+
+// MARK: - ServerSettingsResponseModel
+
+/// API response model for server-level settings in a configuration response.
+public struct ServerSettingsResponseModel: Equatable, JSONResponse {
+    /// Whether user registration is disabled on this server.
+    public let disableUserRegistration: Bool
+
+    // MARK: Initializers
+
+    /// Initializes a `ServerSettingsResponseModel`.
+    ///
+    /// - Parameter disableUserRegistration: Whether user registration is disabled on this server.
+    public init(disableUserRegistration: Bool) {
+        self.disableUserRegistration = disableUserRegistration
     }
 }
 

--- a/BitwardenKit/Core/Platform/Services/API/Response/ConfigResponseModelTests.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Response/ConfigResponseModelTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import BitwardenKit
+
+// MARK: - ConfigResponseModelTests
+
+struct ConfigResponseModelTests {
+    /// `ConfigResponseModel` decodes `settings.disableUserRegistration` as `true` when the field
+    /// is present in the JSON response.
+    @Test
+    func decode_disableUserRegistration_true() throws {
+        let subject = try JSONDecoder().decode(
+            ConfigResponseModel.self,
+            from: APITestData.validServerConfigDisableRegistration.data,
+        )
+        #expect(subject.settings?.disableUserRegistration == true)
+    }
+
+    /// `ConfigResponseModel` decodes with `settings` as `nil` when the field is absent from the
+    /// JSON response.
+    @Test
+    func decode_settings_absent() throws {
+        let subject = try JSONDecoder().decode(
+            ConfigResponseModel.self,
+            from: APITestData.validServerConfig.data,
+        )
+        #expect(subject.settings == nil)
+    }
+}

--- a/BitwardenKit/Core/Platform/Services/API/Response/ConfigResponseModelTests.swift
+++ b/BitwardenKit/Core/Platform/Services/API/Response/ConfigResponseModelTests.swift
@@ -1,3 +1,4 @@
+import BitwardenKitMocks
 import Foundation
 import TestHelpers
 import Testing

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -58,6 +58,14 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
             state.isRememberMeOn = rememberedEmail != nil
         }
         super.init(state: state)
+
+        Task {
+            for await metaConfig in await services.configService.configPublisher() {
+                guard metaConfig?.isPreAuth == true else { continue }
+                self.state.isCreateAccountButtonHidden = metaConfig?.serverConfig?
+                    .settings?.disableUserRegistration == true
+            }
+        }
     }
 
     // MARK: Methods

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -61,7 +61,10 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
 
         Task {
             for await metaConfig in await services.configService.configPublisher() {
-                guard metaConfig?.isPreAuth == true else { continue }
+                guard metaConfig?.isPreAuth == true,
+                      await metaConfig?.serverConfig?.isCurrentConfig(
+                          for: services.stateService.getPreAuthEnvironmentURLs(),
+                      ) == true else { continue }
                 self.state.isCreateAccountButtonHidden = metaConfig?.serverConfig?
                     .settings?.disableUserRegistration == true
             }
@@ -73,9 +76,8 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
     override func perform(_ effect: LandingEffect) async {
         switch effect {
         case .appeared:
-            if let serverConfig = await currentPreAuthServerConfig() {
-                state.isCreateAccountButtonHidden = serverConfig.settings?.disableUserRegistration == true
-            }
+            state.isCreateAccountButtonHidden = await currentPreAuthServerConfig()?
+                .settings?.disableUserRegistration == true
             await regionHelper.loadRegion()
             await refreshProfileState()
         case .continuePressed:

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -25,6 +25,9 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
     /// The services required by this processor.
     private let services: Services
 
+    /// Task that observes `configPublisher()` for live `disableUserRegistration` updates.
+    private var configSubscriptionTask: Task<Void, Never>?
+
     /// Helper class with region specific functions
     private lazy var regionHelper = RegionHelper(
         coordinator: coordinator,
@@ -59,8 +62,10 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
         }
         super.init(state: state)
 
-        Task {
+        configSubscriptionTask = Task { [weak self] in
+            guard let self else { return }
             for await metaConfig in await services.configService.configPublisher() {
+                guard let self else { return }
                 guard metaConfig?.isPreAuth == true,
                       await metaConfig?.serverConfig?.isCurrentConfig(
                           for: services.stateService.getPreAuthEnvironmentURLs(),
@@ -69,6 +74,10 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
                     .settings?.disableUserRegistration == true
             }
         }
+    }
+
+    deinit {
+        configSubscriptionTask?.cancel()
     }
 
     // MARK: Methods

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -73,6 +73,9 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
     override func perform(_ effect: LandingEffect) async {
         switch effect {
         case .appeared:
+            if let serverConfig = await currentPreAuthServerConfig() {
+                state.isCreateAccountButtonHidden = serverConfig.settings?.disableUserRegistration == true
+            }
             await regionHelper.loadRegion()
             await refreshProfileState()
         case .continuePressed:
@@ -81,10 +84,8 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
         case let .profileSwitcher(profileEffect):
             await handleProfileSwitcherEffect(profileEffect)
         case .regionPressed:
-            let serverConfig = await services.configService.getConfig(forceRefresh: false, isPreAuth: true)
-            let preAuthURLs = await services.stateService.getPreAuthEnvironmentURLs()
             var excludedRegions: [RegionType] = [.gov]
-            if serverConfig?.isCurrentConfig(for: preAuthURLs) == true,
+            if await currentPreAuthServerConfig() != nil,
                await services.configService.getFeatureFlag(.fedrampGovRegion, isPreAuth: true) {
                 excludedRegions = []
             }
@@ -117,6 +118,16 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
     }
 
     // MARK: Private Methods
+
+    /// Returns the cached pre-auth server config when its vault host matches the current pre-auth
+    /// environment URLs, or `nil` when no config is available or the config belongs to a different region.
+    ///
+    private func currentPreAuthServerConfig() async -> ServerConfig? {
+        let serverConfig = await services.configService.getConfig(forceRefresh: false, isPreAuth: true)
+        let preAuthURLs = await services.stateService.getPreAuthEnvironmentURLs()
+        guard serverConfig?.isCurrentConfig(for: preAuthURLs) == true else { return nil }
+        return serverConfig
+    }
 
     /// Refreshes the configuration by forcing a refresh from the config service
     /// and loads the latest feature flags.

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessor.swift
@@ -62,13 +62,17 @@ class LandingProcessor: StateProcessor<LandingState, LandingAction, LandingEffec
         }
         super.init(state: state)
 
+        // Extract locals so `self` is never read through inside the Task body.
+        // A pre-loop `guard let self` would pin self strongly for the loop's lifetime,
+        // preventing deinit (and therefore cancellation) until the publisher completes.
+        let configService = services.configService
+        let stateService = services.stateService
         configSubscriptionTask = Task { [weak self] in
-            guard let self else { return }
-            for await metaConfig in await services.configService.configPublisher() {
+            for await metaConfig in await configService.configPublisher() {
                 guard let self else { return }
                 guard metaConfig?.isPreAuth == true,
                       await metaConfig?.serverConfig?.isCurrentConfig(
-                          for: services.stateService.getPreAuthEnvironmentURLs(),
+                          for: stateService.getPreAuthEnvironmentURLs(),
                       ) == true else { continue }
                 self.state.isCreateAccountButtonHidden = metaConfig?.serverConfig?
                     .settings?.disableUserRegistration == true

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -169,6 +169,60 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
+    /// `perform(.appeared)` with a config that disables registration hides the create account button.
+    @MainActor
+    func test_perform_appeared_disableUserRegistration_true() async {
+        configService.configSubject.send(MetaServerConfig(
+            isPreAuth: true,
+            userId: nil,
+            serverConfig: ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: nil,
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
+                    version: "2024.4.0",
+                ),
+            ),
+        ))
+        await subject.perform(.appeared)
+        waitFor(subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// `perform(.appeared)` with a config that re-enables registration shows the create account button.
+    @MainActor
+    func test_perform_appeared_disableUserRegistration_false() async {
+        subject.state.isCreateAccountButtonHidden = true
+        configService.configSubject.send(MetaServerConfig(
+            isPreAuth: true,
+            userId: nil,
+            serverConfig: ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: nil,
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: false),
+                    version: "2024.4.0",
+                ),
+            ),
+        ))
+        await subject.perform(.appeared)
+        waitFor(!subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// `perform(.appeared)` with no config emitted leaves the create account button visible.
+    @MainActor
+    func test_perform_appeared_noConfig_showsCreateAccount() async {
+        await subject.perform(.appeared)
+        waitFor(!subject.state.isCreateAccountButtonHidden)
+    }
+
     /// `perform(.appeared)` with an active account and accounts should yield a profile switcher state.
     @MainActor
     func test_perform_appeared_single_active() async {

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -102,6 +102,72 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         XCTAssertNil(environmentService.setPreAuthEnvironmentURLsData)
     }
 
+    /// `perform(.appeared)` seeds `isCreateAccountButtonHidden` from the cached pre-auth config when
+    /// the config's vault host matches the current pre-auth URLs (no network round-trip required).
+    @MainActor
+    func test_perform_appeared_cachedConfig_disableUserRegistration_matchingURLs() async {
+        stateService.preAuthEnvironmentURLs = .defaultUS
+        configService.configMocker.withResult(
+            ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: EnvironmentServerConfigResponseModel(
+                        api: nil,
+                        cloudRegion: nil,
+                        fillAssistRules: nil,
+                        identity: nil,
+                        notifications: nil,
+                        sso: nil,
+                        vault: "https://vault.bitwarden.com",
+                    ),
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
+                    version: "2025.1.0",
+                ),
+            ),
+        )
+
+        await subject.perform(.appeared)
+
+        XCTAssertTrue(subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// `perform(.appeared)` ignores a cached pre-auth config whose vault host does not match the
+    /// current pre-auth URLs (stale config from a previously selected region), leaving the button visible.
+    @MainActor
+    func test_perform_appeared_cachedConfig_disableUserRegistration_mismatchedURLs() async {
+        stateService.preAuthEnvironmentURLs = .defaultUS
+        configService.configMocker.withResult(
+            ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: EnvironmentServerConfigResponseModel(
+                        api: nil,
+                        cloudRegion: nil,
+                        fillAssistRules: nil,
+                        identity: nil,
+                        notifications: nil,
+                        sso: nil,
+                        vault: "https://vault.bitwarden.eu",
+                    ),
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
+                    version: "2025.1.0",
+                ),
+            ),
+        )
+
+        await subject.perform(.appeared)
+
+        XCTAssertFalse(subject.state.isCreateAccountButtonHidden)
+    }
+
     /// `perform(.appeared)` with no pre-auth URLs defaults the region and URLs to the US environment.
     @MainActor
     func test_perform_appeared_loadsRegion_noPreAuthUrls() async {

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -495,13 +495,11 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
                 version: "2024.4.0",
             ),
         )
-        configService.configMocker.withResult(config)
         configService.configSubject.send(MetaServerConfig(
             isPreAuth: true,
             userId: nil,
             serverConfig: config,
         ))
-        await subject.perform(.appeared)
         waitFor(subject.state.isCreateAccountButtonHidden)
     }
 
@@ -532,13 +530,11 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
                 version: "2024.4.0",
             ),
         )
-        configService.configMocker.withResult(config)
         configService.configSubject.send(MetaServerConfig(
             isPreAuth: true,
             userId: nil,
             serverConfig: config,
         ))
-        await subject.perform(.appeared)
         waitFor(!subject.state.isCreateAccountButtonHidden)
     }
 
@@ -546,41 +542,20 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// no config is emitted.
     @MainActor
     func test_configPublisher_noConfig_showsCreateAccount() async {
-        await subject.perform(.appeared)
+        await Task.yield()
         XCTAssertFalse(subject.state.isCreateAccountButtonHidden)
     }
 
     /// The `configPublisher` subscription in `init` ignores a config whose vault host does not match
-    /// the current pre-auth environment (stale config from a previously selected region), leaving the
-    /// button state set by `.appeared` intact.
+    /// the current pre-auth environment (stale config from a previously selected region).
     @MainActor
     func test_configPublisher_staleConfig_doesNotUpdateButton() async {
         stateService.preAuthEnvironmentURLs = .defaultUS
-        configService.configMocker.withResult(
-            ServerConfig(
-                date: Date(),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: EnvironmentServerConfigResponseModel(
-                        api: nil,
-                        cloudRegion: nil,
-                        fillAssistRules: nil,
-                        identity: nil,
-                        notifications: nil,
-                        sso: nil,
-                        vault: "https://vault.bitwarden.com",
-                    ),
-                    featureStates: [:],
-                    gitHash: nil,
-                    server: nil,
-                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
-                    version: "2025.1.0",
-                ),
-            ),
-        )
+        // Seed the button as hidden (as if the current US server disables registration).
+        subject.state.isCreateAccountButtonHidden = true
 
         // A stale EU config (vault host doesn't match US pre-auth URLs) with disableUserRegistration:
-        // false should not flip the button to visible when the current server disables registration.
+        // false should not flip the button to visible.
         configService.configSubject.send(MetaServerConfig(
             isPreAuth: true,
             userId: nil,
@@ -606,7 +581,6 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
             ),
         ))
 
-        await subject.perform(.appeared)
         await Task.yield()
 
         XCTAssertTrue(subject.state.isCreateAccountButtonHidden)

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -473,7 +473,7 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
     /// emitted config has `disableUserRegistration` set to `true` and its vault host matches the
     /// current pre-auth environment.
     @MainActor
-    func test_configPublisher_disableUserRegistration_true() async {
+    func test_configPublisher_disableUserRegistration_true() async throws {
         stateService.preAuthEnvironmentURLs = .defaultUS
         let config = ServerConfig(
             date: Date(),
@@ -500,14 +500,14 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
             userId: nil,
             serverConfig: config,
         ))
-        waitFor(subject.state.isCreateAccountButtonHidden)
+        try await waitForAsync { self.subject.state.isCreateAccountButtonHidden }
     }
 
     /// The `configPublisher` subscription in `init` shows the create account button when the
     /// emitted config has `disableUserRegistration` set to `false` and its vault host matches the
     /// current pre-auth environment.
     @MainActor
-    func test_configPublisher_disableUserRegistration_false() async {
+    func test_configPublisher_disableUserRegistration_false() async throws {
         stateService.preAuthEnvironmentURLs = .defaultUS
         subject.state.isCreateAccountButtonHidden = true
         let config = ServerConfig(
@@ -535,7 +535,7 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
             userId: nil,
             serverConfig: config,
         ))
-        waitFor(!subject.state.isCreateAccountButtonHidden)
+        try await waitForAsync { !self.subject.state.isCreateAccountButtonHidden }
     }
 
     /// The `configPublisher` subscription in `init` leaves the create account button visible when
@@ -584,6 +584,19 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         await Task.yield()
 
         XCTAssertTrue(subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// The `configPublisher` subscription in `init` does not retain `self`, so the processor can be
+    /// deinitialized while the publisher is still active. Prevents regression of the retain cycle
+    /// where `guard let self` before the `for await` loop would pin `self` for the loop's lifetime.
+    @MainActor
+    func test_configPublisher_doesNotRetainSelf() {
+        weak var weakSubject = subject
+        subject = nil
+        XCTAssertNil(
+            weakSubject,
+            "LandingProcessor was not deinitialized; configSubscriptionTask likely retains self.",
+        )
     }
 
     /// `receive(_:)` with `.createAccountPressed` navigates to the start registration screen.

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -470,49 +470,73 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
     }
 
     /// The `configPublisher` subscription in `init` hides the create account button when the
-    /// emitted config has `disableUserRegistration` set to `true`.
+    /// emitted config has `disableUserRegistration` set to `true` and its vault host matches the
+    /// current pre-auth environment.
     @MainActor
     func test_configPublisher_disableUserRegistration_true() async {
+        stateService.preAuthEnvironmentURLs = .defaultUS
+        let config = ServerConfig(
+            date: Date(),
+            responseModel: ConfigResponseModel(
+                communication: nil,
+                environment: EnvironmentServerConfigResponseModel(
+                    api: nil,
+                    cloudRegion: nil,
+                    fillAssistRules: nil,
+                    identity: nil,
+                    notifications: nil,
+                    sso: nil,
+                    vault: "https://vault.bitwarden.com",
+                ),
+                featureStates: [:],
+                gitHash: nil,
+                server: nil,
+                settings: ServerSettingsResponseModel(disableUserRegistration: true),
+                version: "2024.4.0",
+            ),
+        )
+        configService.configMocker.withResult(config)
         configService.configSubject.send(MetaServerConfig(
             isPreAuth: true,
             userId: nil,
-            serverConfig: ServerConfig(
-                date: Date(),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: nil,
-                    featureStates: [:],
-                    gitHash: nil,
-                    server: nil,
-                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
-                    version: "2024.4.0",
-                ),
-            ),
+            serverConfig: config,
         ))
         await subject.perform(.appeared)
         waitFor(subject.state.isCreateAccountButtonHidden)
     }
 
     /// The `configPublisher` subscription in `init` shows the create account button when the
-    /// emitted config has `disableUserRegistration` set to `false`.
+    /// emitted config has `disableUserRegistration` set to `false` and its vault host matches the
+    /// current pre-auth environment.
     @MainActor
     func test_configPublisher_disableUserRegistration_false() async {
+        stateService.preAuthEnvironmentURLs = .defaultUS
         subject.state.isCreateAccountButtonHidden = true
+        let config = ServerConfig(
+            date: Date(),
+            responseModel: ConfigResponseModel(
+                communication: nil,
+                environment: EnvironmentServerConfigResponseModel(
+                    api: nil,
+                    cloudRegion: nil,
+                    fillAssistRules: nil,
+                    identity: nil,
+                    notifications: nil,
+                    sso: nil,
+                    vault: "https://vault.bitwarden.com",
+                ),
+                featureStates: [:],
+                gitHash: nil,
+                server: nil,
+                settings: ServerSettingsResponseModel(disableUserRegistration: false),
+                version: "2024.4.0",
+            ),
+        )
+        configService.configMocker.withResult(config)
         configService.configSubject.send(MetaServerConfig(
             isPreAuth: true,
             userId: nil,
-            serverConfig: ServerConfig(
-                date: Date(),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: nil,
-                    featureStates: [:],
-                    gitHash: nil,
-                    server: nil,
-                    settings: ServerSettingsResponseModel(disableUserRegistration: false),
-                    version: "2024.4.0",
-                ),
-            ),
+            serverConfig: config,
         ))
         await subject.perform(.appeared)
         waitFor(!subject.state.isCreateAccountButtonHidden)
@@ -524,6 +548,68 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
     func test_configPublisher_noConfig_showsCreateAccount() async {
         await subject.perform(.appeared)
         XCTAssertFalse(subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// The `configPublisher` subscription in `init` ignores a config whose vault host does not match
+    /// the current pre-auth environment (stale config from a previously selected region), leaving the
+    /// button state set by `.appeared` intact.
+    @MainActor
+    func test_configPublisher_staleConfig_doesNotUpdateButton() async {
+        stateService.preAuthEnvironmentURLs = .defaultUS
+        configService.configMocker.withResult(
+            ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: EnvironmentServerConfigResponseModel(
+                        api: nil,
+                        cloudRegion: nil,
+                        fillAssistRules: nil,
+                        identity: nil,
+                        notifications: nil,
+                        sso: nil,
+                        vault: "https://vault.bitwarden.com",
+                    ),
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
+                    version: "2025.1.0",
+                ),
+            ),
+        )
+
+        // A stale EU config (vault host doesn't match US pre-auth URLs) with disableUserRegistration:
+        // false should not flip the button to visible when the current server disables registration.
+        configService.configSubject.send(MetaServerConfig(
+            isPreAuth: true,
+            userId: nil,
+            serverConfig: ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: EnvironmentServerConfigResponseModel(
+                        api: nil,
+                        cloudRegion: nil,
+                        fillAssistRules: nil,
+                        identity: nil,
+                        notifications: nil,
+                        sso: nil,
+                        vault: "https://vault.bitwarden.eu",
+                    ),
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: false),
+                    version: "2025.1.0",
+                ),
+            ),
+        ))
+
+        await subject.perform(.appeared)
+        await Task.yield()
+
+        XCTAssertTrue(subject.state.isCreateAccountButtonHidden)
     }
 
     /// `receive(_:)` with `.createAccountPressed` navigates to the start registration screen.

--- a/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingProcessorTests.swift
@@ -235,60 +235,6 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
         )
     }
 
-    /// `perform(.appeared)` with a config that disables registration hides the create account button.
-    @MainActor
-    func test_perform_appeared_disableUserRegistration_true() async {
-        configService.configSubject.send(MetaServerConfig(
-            isPreAuth: true,
-            userId: nil,
-            serverConfig: ServerConfig(
-                date: Date(),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: nil,
-                    featureStates: [:],
-                    gitHash: nil,
-                    server: nil,
-                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
-                    version: "2024.4.0",
-                ),
-            ),
-        ))
-        await subject.perform(.appeared)
-        waitFor(subject.state.isCreateAccountButtonHidden)
-    }
-
-    /// `perform(.appeared)` with a config that re-enables registration shows the create account button.
-    @MainActor
-    func test_perform_appeared_disableUserRegistration_false() async {
-        subject.state.isCreateAccountButtonHidden = true
-        configService.configSubject.send(MetaServerConfig(
-            isPreAuth: true,
-            userId: nil,
-            serverConfig: ServerConfig(
-                date: Date(),
-                responseModel: ConfigResponseModel(
-                    communication: nil,
-                    environment: nil,
-                    featureStates: [:],
-                    gitHash: nil,
-                    server: nil,
-                    settings: ServerSettingsResponseModel(disableUserRegistration: false),
-                    version: "2024.4.0",
-                ),
-            ),
-        ))
-        await subject.perform(.appeared)
-        waitFor(!subject.state.isCreateAccountButtonHidden)
-    }
-
-    /// `perform(.appeared)` with no config emitted leaves the create account button visible.
-    @MainActor
-    func test_perform_appeared_noConfig_showsCreateAccount() async {
-        await subject.perform(.appeared)
-        waitFor(!subject.state.isCreateAccountButtonHidden)
-    }
-
     /// `perform(.appeared)` with an active account and accounts should yield a profile switcher state.
     @MainActor
     func test_perform_appeared_single_active() async {
@@ -521,6 +467,63 @@ class LandingProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_
 
         XCTAssertEqual(subject.state.email, "email@example.com")
         XCTAssertTrue(subject.state.isRememberMeOn)
+    }
+
+    /// The `configPublisher` subscription in `init` hides the create account button when the
+    /// emitted config has `disableUserRegistration` set to `true`.
+    @MainActor
+    func test_configPublisher_disableUserRegistration_true() async {
+        configService.configSubject.send(MetaServerConfig(
+            isPreAuth: true,
+            userId: nil,
+            serverConfig: ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: nil,
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: true),
+                    version: "2024.4.0",
+                ),
+            ),
+        ))
+        await subject.perform(.appeared)
+        waitFor(subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// The `configPublisher` subscription in `init` shows the create account button when the
+    /// emitted config has `disableUserRegistration` set to `false`.
+    @MainActor
+    func test_configPublisher_disableUserRegistration_false() async {
+        subject.state.isCreateAccountButtonHidden = true
+        configService.configSubject.send(MetaServerConfig(
+            isPreAuth: true,
+            userId: nil,
+            serverConfig: ServerConfig(
+                date: Date(),
+                responseModel: ConfigResponseModel(
+                    communication: nil,
+                    environment: nil,
+                    featureStates: [:],
+                    gitHash: nil,
+                    server: nil,
+                    settings: ServerSettingsResponseModel(disableUserRegistration: false),
+                    version: "2024.4.0",
+                ),
+            ),
+        ))
+        await subject.perform(.appeared)
+        waitFor(!subject.state.isCreateAccountButtonHidden)
+    }
+
+    /// The `configPublisher` subscription in `init` leaves the create account button visible when
+    /// no config is emitted.
+    @MainActor
+    func test_configPublisher_noConfig_showsCreateAccount() async {
+        await subject.perform(.appeared)
+        XCTAssertFalse(subject.state.isCreateAccountButtonHidden)
     }
 
     /// `receive(_:)` with `.createAccountPressed` navigates to the start registration screen.

--- a/BitwardenShared/UI/Auth/Landing/LandingState.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingState.swift
@@ -15,6 +15,9 @@ struct LandingState: Equatable {
         !email.isEmpty
     }
 
+    /// A flag indicating if the create account button should be hidden.
+    var isCreateAccountButtonHidden: Bool
+
     /// A flag indicating if the "Remember Me" toggle is on.
     var isRememberMeOn: Bool
 
@@ -33,12 +36,14 @@ struct LandingState: Equatable {
     ///
     /// - Parameters:
     ///   - email: The email address provided by the user.
+    ///   - isCreateAccountButtonHidden: A flag indicating if the create account button should be hidden.
     ///   - isRememberMeOn: A flag indicating if the "Remember Me" toggle is on.
     ///   - profileSwitcherState: State for the profile switcher.
     ///   - region: The region selected by the user.
     ///
     init(
         email: String = "",
+        isCreateAccountButtonHidden: Bool = false,
         isRememberMeOn: Bool = false,
         profileSwitcherState: ProfileSwitcherState = .empty(
             shouldAlwaysHideAddAccount: true,
@@ -47,6 +52,7 @@ struct LandingState: Equatable {
         region: RegionType = .unitedStates,
     ) {
         self.email = email
+        self.isCreateAccountButtonHidden = isCreateAccountButtonHidden
         self.isRememberMeOn = isRememberMeOn
         self.profileSwitcherState = profileSwitcherState
         self.region = region

--- a/BitwardenShared/UI/Auth/Landing/LandingStateTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingStateTests.swift
@@ -21,4 +21,9 @@ class LandingStateTests: BitwardenTestCase {
         let subject = LandingState(email: "email@example.com")
         XCTAssertTrue(subject.isContinueButtonEnabled)
     }
+
+    func test_isCreateAccountButtonHidden_defaultsFalse() {
+        let subject = LandingState()
+        XCTAssertFalse(subject.isCreateAccountButtonHidden)
+    }
 }

--- a/BitwardenShared/UI/Auth/Landing/LandingView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView+SnapshotTests.swift
@@ -71,6 +71,13 @@ class LandingViewTests: BitwardenTestCase {
         assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
     }
 
+    /// Check the snapshot when user registration is disabled (create account button hidden).
+    @MainActor
+    func disabletest_snapshot_createAccountHidden() {
+        processor.state.isCreateAccountButtonHidden = true
+        assertSnapshots(of: subject, as: [.defaultPortrait, .defaultPortraitDark, .defaultPortraitAX5])
+    }
+
     /// Check the snapshot for the profiles closed
     @MainActor
     func disabletest_snapshot_profilesClosed() {

--- a/BitwardenShared/UI/Auth/Landing/LandingView.swift
+++ b/BitwardenShared/UI/Auth/Landing/LandingView.swift
@@ -142,18 +142,20 @@ struct LandingView: View {
             .disabled(!store.state.isContinueButtonEnabled)
             .buttonStyle(.primary())
 
-            HStack(spacing: 4) {
-                Spacer()
-                Text(Localizations.newAroundHere)
-                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                Button(Localizations.createAccount) {
-                    store.send(.createAccountPressed)
+            if !store.state.isCreateAccountButtonHidden {
+                HStack(spacing: 4) {
+                    Spacer()
+                    Text(Localizations.newAroundHere)
+                        .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
+                    Button(Localizations.createAccount) {
+                        store.send(.createAccountPressed)
+                    }
+                    .accessibilityIdentifier("CreateAccountButton")
+                    .foregroundColor(SharedAsset.Colors.textInteraction.swiftUIColor)
+                    Spacer()
                 }
-                .accessibilityIdentifier("CreateAccountButton")
-                .foregroundColor(SharedAsset.Colors.textInteraction.swiftUIColor)
-                Spacer()
+                .styleGuide(.footnote)
             }
-            .styleGuide(.footnote)
 
             Button {
                 store.send(.showPreLoginSettings)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37864
https://bitwarden.atlassian.net/browse/PM-35123

## 📔 Objective

Adds a `settings.disableUserRegistration` field to `ConfigResponseModel` and the `ServerConfig` domain model, populated from the server's `/config` response.

The landing processor subscribes to `configPublisher` in `init` and reactively updates `LandingState.isCreateAccountButtonHidden` whenever a pre-auth config is emitted. The "New around here? Create account" row in `LandingView` is removed from the view hierarchy entirely when the flag is `true`.