### PR TITLE
[PM-39767] fix: Show upgrade pending alert when upgrading via Settings > Plan

### DIFF
--- a/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
+++ b/BitwardenShared/UI/Billing/PremiumUpgradeHelper.swift
@@ -20,6 +20,7 @@ protocol PremiumUpgradeRoute {
 
 extension SendItemRoute: PremiumUpgradeRoute {}
 extension SendRoute: PremiumUpgradeRoute {}
+extension SettingsRoute: PremiumUpgradeRoute {}
 extension VaultItemRoute: PremiumUpgradeRoute {}
 extension VaultRoute: PremiumUpgradeRoute {}
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessor.swift
@@ -56,7 +56,7 @@ final class DeleteAccountProcessor: StateProcessor<DeleteAccountState, DeleteAcc
     override func receive(_ action: DeleteAccountAction) {
         switch action {
         case .dismiss:
-            coordinator.navigate(to: .dismiss)
+            coordinator.navigate(to: .dismiss())
         }
     }
 
@@ -158,7 +158,7 @@ final class DeleteAccountProcessor: StateProcessor<DeleteAccountState, DeleteAcc
                 try await services.authRepository.isUserManagedByOrganization()
         } catch {
             await coordinator.showErrorAlert(error: error, onDismissed: {
-                self.coordinator.navigate(to: .dismiss)
+                self.coordinator.navigate(to: .dismiss())
             })
             services.errorReporter.log(error: error)
         }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeleteAccount/DeleteAccountProcessorTests.swift
@@ -53,7 +53,7 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
     func test_receive_dismiss() {
         subject.receive(.dismiss)
 
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(coordinator.routes.last, .dismiss())
     }
 
     /// Perform with `.deleteAccount` presents the master password prompt alert.
@@ -307,6 +307,6 @@ class DeleteAccountProcessorTests: BitwardenTestCase {
 
         coordinator.alertOnDismissed?()
 
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(coordinator.routes.last, .dismiss())
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessor.swift
@@ -66,7 +66,7 @@ final class PendingRequestsProcessor: StateProcessor<
         case .declineAllRequestsTapped:
             confirmDenyAllRequests()
         case .dismiss:
-            coordinator.navigate(to: .dismiss, context: self)
+            coordinator.navigate(to: .dismiss(), context: self)
         case let .requestTapped(request):
             coordinator.navigate(to: .loginRequest(request), context: self)
         case let .toastShown(newValue):

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/PendingRequests/PendingRequestsProcessorTests.swift
@@ -122,7 +122,7 @@ class PendingRequestsProcessorTests: BitwardenTestCase {
     @MainActor
     func test_receive_dismiss() {
         subject.receive(.dismiss)
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(coordinator.routes.last, .dismiss())
     }
 
     /// `receive(_:)` with `.requestTapped(_)` shows the login request view.

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessor.swift
@@ -21,8 +21,10 @@ protocol SettingsProcessorDelegate: AnyObject {
 final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, SettingsEffect> {
     // MARK: Types
 
-    typealias Services = HasBillingService
+    typealias Services = HasBillingRepository
+        & HasBillingService
         & HasConfigService
+        & HasEnvironmentService
         & HasErrorReporter
         & HasStateService
         & HasStorefrontService
@@ -38,6 +40,13 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
 
     /// A delegate of the processor that is notified when the settings tab badge needs to be updated.
     private weak var delegate: SettingsProcessorDelegate?
+
+    /// The helper used to navigate to the Premium upgrade flow.
+    lazy var premiumUpgradeHelper: PremiumUpgradeHelper = DefaultPremiumUpgradeHelper(
+        services: services,
+        coordinator: coordinator,
+        setURL: { [weak self] url in self?.state.url = url },
+    )
 
     /// The services used by this processor.
     private var services: Services
@@ -126,7 +135,7 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
         case .clearUrl:
             state.url = nil
         case .dismiss:
-            coordinator.navigate(to: .dismiss)
+            coordinator.navigate(to: .dismiss())
         case .learnMoreAboutPremium:
             state.url = ExternalLinksConstants.learnMoreAboutPremium
             state.shouldShowUpgradedToPremiumActionCard = false
@@ -156,10 +165,10 @@ final class SettingsProcessor: StateProcessor<SettingsState, SettingsAction, Set
             if subscription.status.isTroubleState {
                 coordinator.navigate(to: .premiumPlan(subscription))
             } else {
-                coordinator.navigate(to: .premiumUpgrade)
+                premiumUpgradeHelper.startInAppPremiumUpgrade(onConfirmed: nil)
             }
         } catch is GetSubscriptionRequestError {
-            coordinator.navigate(to: .premiumUpgrade)
+            premiumUpgradeHelper.startInAppPremiumUpgrade(onConfirmed: nil)
         } catch {
             services.errorReporter.log(error: error)
             await coordinator.showErrorAlert(error: error)

--- a/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/SettingsProcessorTests.swift
@@ -17,6 +17,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     var coordinator: MockCoordinator<SettingsRoute, SettingsEvent>!
     var delegate: MockSettingsProcessorDelegate!
     var errorReporter: MockErrorReporter!
+    var premiumUpgradeHelper: MockPremiumUpgradeHelper!
     var subject: SettingsProcessor!
     var stateService: MockStateService!
     var storefrontService: MockStorefrontService!
@@ -34,6 +35,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         coordinator = MockCoordinator()
         delegate = MockSettingsProcessorDelegate()
         errorReporter = MockErrorReporter()
+        premiumUpgradeHelper = MockPremiumUpgradeHelper()
         stateService = MockStateService()
         storefrontService = MockStorefrontService()
         storefrontService.isUSStorefrontReturnValue = true
@@ -50,6 +52,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         coordinator = nil
         delegate = nil
         errorReporter = nil
+        premiumUpgradeHelper = nil
         subject = nil
         stateService = nil
         storefrontService = nil
@@ -71,6 +74,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
             ),
             state: SettingsState(presentationMode: presentationMode),
         )
+        subject.premiumUpgradeHelper = premiumUpgradeHelper
     }
 
     // MARK: Tests
@@ -161,7 +165,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_receive_dismiss() {
         subject.receive(.dismiss)
 
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(coordinator.routes.last, .dismiss())
     }
 
     /// Receiving `.otherPressed` navigates to the other screen.
@@ -221,7 +225,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertTrue(premiumUpgradeHelper.startInAppPremiumUpgradeCalled)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
         XCTAssertFalse(errorReporter.errors.contains { $0 is GetSubscriptionRequestError })
     }
@@ -249,7 +253,7 @@ class SettingsProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
 
         await subject.perform(.planPressed)
 
-        XCTAssertEqual(coordinator.routes.last, .premiumUpgrade)
+        XCTAssertTrue(premiumUpgradeHelper.startInAppPremiumUpgradeCalled)
         XCTAssertEqual(coordinator.loadingOverlaysShown, [LoadingOverlayState(title: Localizations.loading)])
     }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessor.swift
@@ -64,7 +64,7 @@ final class ExportVaultProcessor: StateProcessor<ExportVaultState, ExportVaultAc
         switch action {
         case .dismiss:
             services.exportVaultService.clearTemporaryFiles()
-            coordinator.navigate(to: .dismiss)
+            coordinator.navigate(to: .dismiss())
         case let .fileFormatTypeChanged(fileFormat):
             state.fileFormat = fileFormat
         case let .filePasswordTextChanged(newValue):

--- a/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/Vault/ExportVault/ExportVaultToFile/ExportVaultProcessorTests.swift
@@ -125,7 +125,7 @@ class ExportVaultProcessorTests: BitwardenTestCase { // swiftlint:disable:this t
         subject.receive(.dismiss)
 
         XCTAssertTrue(exportService.didClearFiles)
-        XCTAssertEqual(coordinator.routes.last, .dismiss)
+        XCTAssertEqual(coordinator.routes.last, .dismiss())
     }
 
     /// `.receive()` with  `.exportVaultTapped` shows the confirm alert for encrypted formats and

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinator.swift
@@ -69,6 +69,7 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
         & HasAuthRepository
         & HasAuthService
         & HasAutofillCredentialService
+        & HasBillingRepository
         & HasBillingService
         & HasBiometricsRepository
         & HasConfigService
@@ -170,8 +171,16 @@ final class SettingsCoordinator: Coordinator, HasStackNavigator { // swiftlint:d
             showAutoFill()
         case .deleteAccount:
             showDeleteAccount()
-        case .dismiss:
-            stackNavigator?.dismiss()
+        case let .dismiss(action):
+            // If we're presenting a more complicated stack of view controllers (in particular, this could happen
+            // if the user navigates to the Premium upgrade flow) then we only want to dismiss the presented one,
+            // not the full stack.
+            let completion = action?.action
+            if let presentedViewController = stackNavigator?.rootViewController?.presentedViewController {
+                presentedViewController.dismiss(animated: UI.animated, completion: completion)
+            } else {
+                stackNavigator?.dismiss(completion: completion)
+            }
         case .exportVault:
             showExportVault()
         case .exportVaultToApp:

--- a/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsCoordinatorTests.swift
@@ -169,10 +169,23 @@ class SettingsCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this ty
     /// `navigate(to:)` with `.dismiss` dismisses the view.
     @MainActor
     func test_navigate_dismiss() throws {
-        subject.navigate(to: .dismiss)
+        subject.navigate(to: .dismiss())
 
         let action = try XCTUnwrap(stackNavigator.actions.last)
-        XCTAssertEqual(action.type, .dismissed)
+        XCTAssertEqual(action.type, .dismissedWithCompletionHandler)
+    }
+
+    /// `navigate(to:)` with `.dismiss` and a `DismissAction` passes the completion to the
+    /// underlying dismiss call and invokes it when dismissal completes.
+    @MainActor
+    func test_navigate_dismiss_withDismissAction() throws {
+        var completionCalled = false
+
+        subject.navigate(to: .dismiss(DismissAction { completionCalled = true }))
+
+        XCTAssertTrue(completionCalled)
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .dismissedWithCompletionHandler)
     }
 
     /// `navigate(to:)` with `.exportVault` pushes the export settings view.

--- a/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
+++ b/BitwardenShared/UI/Platform/Settings/SettingsRoute.swift
@@ -33,7 +33,10 @@ public enum SettingsRoute: Equatable, Hashable {
     case deleteAccount
 
     /// A route that dismisses the current view.
-    case dismiss
+    ///
+    /// - Parameter action: The action to perform on dismiss.
+    ///
+    case dismiss(_ action: DismissAction? = nil)
 
     /// A route to the export vault settings view or export to file view depending on feature flag.
     case exportVault


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-39767

## 📔 Objective

Fixes a bug where initiating the Premium upgrade flow via **Settings > Plan** never showed the "Upgrade Pending" dialog when the post-payment sync call was interrupted — even though the identical scenario worked correctly from the Vault tab's upgrade CTA.

**Root cause:** the "Upgrade Pending" alert is driven by `DefaultPremiumUpgradeHelper`, which subscribes to the checkout-status publisher before navigating to the Premium upgrade screen. Vault and Send screens already construct this helper; `SettingsProcessor.navigateToPlan()` navigated straight to `.premiumUpgrade` without ever creating it, so nothing was ever subscribed to catch the `.pending` status on that path.

**Fix:** wire `SettingsProcessor` into the same helper the other 8 entry points already use — `SettingsRoute` now conforms to `PremiumUpgradeRoute`, gaining an associated `DismissAction` on its `.dismiss` case (mirroring `VaultRoute`), and `navigateToPlan()` routes through `premiumUpgradeHelper.startInAppPremiumUpgrade()` instead of navigating directly.

Giving `.dismiss` an associated value surfaced a few unrelated pre-existing call sites that referenced it bare (no parens) in `ExportVaultProcessor`, `PendingRequestsProcessor`, and `DeleteAccountProcessor` — fixed those to the explicit `.dismiss()` call form, since a defaulted associated value isn't auto-applied outside of a direct call expression.

This is a narrower fix than a fuller centralization (moving pending-checkout detection into a shared app-lifetime service) that was evaluated and intentionally shelved as out of scope for this ticket — worth a follow-up ticket if we want to prevent a future entry point from repeating this same gap.

## 📸 Screenshots

Not applicable — no UI changes.