### PR TITLE
Add get_live_version lane for checking published App Store versions

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -503,4 +503,46 @@ platform :ios do |options|
         UI.message("version_name: #{latest_version_name}")
         UI.message("version_number: #{latest_version_number}")
     end
+
+    # Get the version that's actually live/published to users (READY_FOR_SALE state)
+    # This differs from get_latest_version which returns any submitted version
+    lane :get_live_version do |options|
+        require 'spaceship'
+
+        # Authenticate with App Store Connect using key file path
+        if options[:api_key_path]
+            key_content = JSON.parse(File.read(options[:api_key_path]))
+            Spaceship::ConnectAPI.login(
+                key_id: key_content['key_id'],
+                issuer_id: key_content['issuer_id'],
+                key: key_content['key'],
+                duration: key_content['duration'] || 1200,
+                in_house: key_content['in_house'] || false
+            )
+        end
+
+        # Find the app
+        app = Spaceship::ConnectAPI::App.find(options[:app_identifier])
+        UI.user_error!("Could not find app with identifier #{options[:app_identifier]}") unless app
+
+        # Get the live app store version (the one users can download)
+        live_version = app.get_live_app_store_version
+
+        if live_version
+            version_string = live_version.version_string
+            build = live_version.build
+            build_number = build.version if build
+
+            UI.message("Live version_name: #{version_string}")
+            UI.message("Live version_number: #{build_number}")
+
+            # Output in the same format as get_latest_version for compatibility
+            UI.message("version_name: #{version_string}")
+            UI.message("version_number: #{build_number}")
+        else
+            UI.message("No live version found on the App Store")
+            UI.message("version_name: ")
+            UI.message("version_number: ")
+        end
+    end
 end


### PR DESCRIPTION
## Summary

Adds a new Fastlane lane `get_live_version` that checks the actual live/published version on the App Store (READY_FOR_SALE state) rather than just the latest submitted version.

## Problem

With managed App Store publishing enabled, apps can be:
1. Submitted for review
2. Approved by Apple
3. Waiting to be manually published to users

The existing `get_latest_version` lane uses `app_store_build_number` which returns the latest build submitted to the App Store, **including approved versions that haven't been published yet**. This causes the `bitwarden/deploy` workflows to publish GitHub releases prematurely - before users can actually download the app.

## Solution

The new `get_live_version` lane:
- Uses Spaceship ConnectAPI to authenticate with App Store Connect
- Calls `get_live_app_store_version` to get only the version users can currently download
- Returns the version in the same format as `get_latest_version` (version_name and version_number)
- Returns empty strings if no live version exists

## Usage

```ruby
bundle exec fastlane ios get_live_version \
  api_key_path:$CREDENTIALS_PATH \
  app_identifier:com.8bit.bitwarden
```

## Related

This will be consumed by:
- `publish-ios-password-manager.yml` in bitwarden/deploy
- `publish-ios-authenticator.yml` in bitwarden/deploy

Related deploy PR: https://github.com/bitwarden/deploy/pull/[TBD]

## Testing

After merging both PRs:
1. Submit an iOS build for review
2. Get it approved but **don't publish yet**
3. Verify the hourly `publish-ios-*` workflows do NOT publish the GitHub release
4. Manually publish the app on App Store Connect
5. Verify the next hourly run DOES publish the GitHub release