### PR TITLE
[PM-40139] feat: Consolidate Disable Send and Send Options into Send Controls policy

### DIFF
--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+// MARK: - SendPolicyOptions
+
+/// The set of Send restrictions enforced by the Send Controls policy for the active user.
+///
+struct SendPolicyOptions: Equatable, Sendable {
+    // MARK: Properties
+
+    /// Whether the hide-email option is disabled.
+    var isHideEmailDisabled = false
+
+    /// Whether creating and editing Sends is disabled.
+    var isSendDisabled = false
+}
+
+extension SendPolicyOptions {
+    /// Creates the Send policy options from the Send Controls policies that apply to the user.
+    ///
+    /// When multiple policies apply, a restriction is enforced if *any* applying policy enables it.
+    ///
+    /// - Parameter sendControlsPolicies: The `sendControls` policies applying to the active user.
+    ///
+    init(sendControlsPolicies policies: [Policy]) {
+        self.init(
+            isHideEmailDisabled: policies.contains { $0[.disableHideEmail]?.boolValue == true },
+            isSendDisabled: policies.contains { $0[.disableSend]?.boolValue == true },
+        )
+    }
+}

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
@@ -1,0 +1,50 @@
+import BitwardenKit
+import Foundation
+import TestHelpers
+import Testing
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+// MARK: - SendPolicyOptionsTests
+
+struct SendPolicyOptionsTests {
+    // MARK: init(sendControlsPolicies:) Tests
+
+    /// `init(sendControlsPolicies:)` disables the hide email option when a policy enables the
+    /// `disableHideEmail` option.
+    @Test
+    func init_sendControlsPolicies_disableHideEmail() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(data: [PolicyOptionType.disableHideEmail.rawValue: .bool(true)], type: .sendControls),
+        ])
+        #expect(subject.isHideEmailDisabled)
+    }
+
+    /// `init(sendControlsPolicies:)` disables Sends when a policy enables the `disableSend` option.
+    @Test
+    func init_sendControlsPolicies_disableSend() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(data: [PolicyOptionType.disableSend.rawValue: .bool(true)], type: .sendControls),
+        ])
+        #expect(subject.isSendDisabled)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces no restrictions when there are no applying policies.
+    @Test
+    func init_sendControlsPolicies_empty() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [])
+        #expect(!subject.isHideEmailDisabled)
+        #expect(!subject.isSendDisabled)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces a restriction when *any* applying policy enables it.
+    @Test
+    func init_sendControlsPolicies_multiplePolicies_enforcesIfAny() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(data: [PolicyOptionType.disableSend.rawValue: .bool(false)], id: "a", type: .sendControls),
+            .fixture(data: [PolicyOptionType.disableSend.rawValue: .bool(true)], id: "b", type: .sendControls),
+        ])
+        #expect(subject.isSendDisabled)
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
@@ -79,8 +79,11 @@ enum PolicyOptionType: String {
     /// A policy option for whether to require uppercase characters.
     case requireUpper
 
-    // MARK: Send Options
+    // MARK: Send Controls Options
 
     /// A policy option for whether the send should disable the hide email option.
     case disableHideEmail
+
+    /// A policy option for whether the Send Controls policy disables creating and editing Sends.
+    case disableSend
 }

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -47,24 +47,18 @@ protocol PolicyService: AnyObject {
     ///
     func getRestrictedItemCipherTypes() async -> [CipherType]
 
-    /// Returns whether creating and editing Sends is disabled because of a policy.
-    ///
-    /// - Returns: Whether Sends are disabled.
-    ///
-    func isSendDisabledByPolicy() async -> Bool
-
-    /// Returns whether the send hide email option is disabled because of a policy.
-    ///
-    /// - Returns: Whether the send hide email option is disabled.
-    ///
-    func isSendHideEmailDisabledByPolicy() async -> Bool
-
     /// Gets the organization ID with the earliest revision date that is applying a policy to the active user.
     ///
     /// - Parameter policyType: The policy to check.
     /// - Returns: The organization ID with the earliest revision date applying the policy, or `nil` if none.
     ///
     func getEarliestOrganizationApplyingPolicy(_ policyType: PolicyType) async -> String?
+
+    /// Returns the Send restrictions enforced by policy for the active user.
+    ///
+    /// - Returns: A `SendPolicyOptions` describing the Send restrictions that apply to the user.
+    ///
+    func getSendPolicyOptions() async -> SendPolicyOptions
 
     /// Gets the organizations IDs that are applying the policy to the active user.
     ///
@@ -528,23 +522,18 @@ extension DefaultPolicyService {
         return policyWithEarliestRevisionDate(from: policies)?.organizationId
     }
 
-    func isSendDisabledByPolicy() async -> Bool {
-        if await configService.getFeatureFlag(.sendControls) {
-            await policyAppliesToUser(.sendControls) { policy in
-                policy[.disableSend]?.boolValue == true
-            }
-        } else {
-            await policyAppliesToUser(.disableSend)
+    func getSendPolicyOptions() async -> SendPolicyOptions {
+        guard await configService.getFeatureFlag(.sendControls) else {
+            return await SendPolicyOptions(
+                isHideEmailDisabled: policyAppliesToUser(.sendOptions) { policy in
+                    policy[.disableHideEmail]?.boolValue == true
+                },
+                isSendDisabled: policyAppliesToUser(.disableSend),
+            )
         }
-    }
 
-    func isSendHideEmailDisabledByPolicy() async -> Bool {
-        let policyType: PolicyType = await configService.getFeatureFlag(.sendControls)
-            ? .sendControls
-            : .sendOptions
-        return await policyAppliesToUser(policyType) { policy in
-            policy[.disableHideEmail]?.boolValue == true
-        }
+        let policies = await policiesApplyingToUser(.sendControls)
+        return SendPolicyOptions(sendControlsPolicies: policies)
     }
 
     func organizationsApplyingPolicyToUser(_ policyType: PolicyType) async -> [String] {

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -47,6 +47,12 @@ protocol PolicyService: AnyObject {
     ///
     func getRestrictedItemCipherTypes() async -> [CipherType]
 
+    /// Returns whether creating and editing Sends is disabled because of a policy.
+    ///
+    /// - Returns: Whether Sends are disabled.
+    ///
+    func isSendDisabledByPolicy() async -> Bool
+
     /// Returns whether the send hide email option is disabled because of a policy.
     ///
     /// - Returns: Whether the send hide email option is disabled.
@@ -522,8 +528,21 @@ extension DefaultPolicyService {
         return policyWithEarliestRevisionDate(from: policies)?.organizationId
     }
 
+    func isSendDisabledByPolicy() async -> Bool {
+        if await configService.getFeatureFlag(.sendControls) {
+            await policyAppliesToUser(.sendControls) { policy in
+                policy[.disableSend]?.boolValue == true
+            }
+        } else {
+            await policyAppliesToUser(.disableSend)
+        }
+    }
+
     func isSendHideEmailDisabledByPolicy() async -> Bool {
-        await policyAppliesToUser(.sendOptions) { policy in
+        let policyType: PolicyType = await configService.getFeatureFlag(.sendControls)
+            ? .sendControls
+            : .sendOptions
+        return await policyAppliesToUser(policyType) { policy in
             policy[.disableHideEmail]?.boolValue == true
         }
     }

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -511,131 +511,11 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertEqual(organizationId, "org-2")
     }
 
-    // MARK: - isSendDisabledByPolicy Tests
+    // MARK: - getSendPolicyOptions (isHideEmailDisabled) Tests
 
-    /// `isSendDisabledByPolicy()` returns true when the Send Controls policy's `disableSend` option
-    /// is enabled.
-    func test_isSendDisabledByPolicy() async {
-        configService.featureFlagsBool[.sendControls] = true
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success(
-            [
-                .fixture(
-                    data: [PolicyOptionType.disableSend.rawValue: .bool(true)],
-                    type: .sendControls,
-                ),
-            ],
-        )
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertTrue(isDisabled)
-    }
-
-    /// `isSendDisabledByPolicy()` returns false when the Send Controls policy's `disableSend` option
-    /// is disabled.
-    func test_isSendDisabledByPolicy_optionDisabled() async {
-        configService.featureFlagsBool[.sendControls] = true
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success(
-            [
-                .fixture(
-                    data: [PolicyOptionType.disableSend.rawValue: .bool(false)],
-                    type: .sendControls,
-                ),
-            ],
-        )
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
-    }
-
-    /// `isSendDisabledByPolicy()` returns false when the Send Controls policy doesn't contain any
-    /// custom data.
-    func test_isSendDisabledByPolicy_optionNoData() async {
-        configService.featureFlagsBool[.sendControls] = true
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendControls)])
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
-    }
-
-    /// `isSendDisabledByPolicy()` returns false when there's no policies.
-    func test_isSendDisabledByPolicy_noPolicies() async {
-        configService.featureFlagsBool[.sendControls] = true
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success([])
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
-    }
-
-    /// `isSendDisabledByPolicy()` ignores the legacy `disableSend` policy, which is superseded by the
-    /// Send Controls policy.
-    func test_isSendDisabledByPolicy_ignoresLegacyDisableSendPolicy() async {
-        configService.featureFlagsBool[.sendControls] = true
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .disableSend)])
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
-    }
-
-    // MARK: - isSendDisabledByPolicy Tests (Send Controls feature flag disabled)
-
-    /// When the Send Controls feature flag is disabled, `isSendDisabledByPolicy()` returns whether the
-    /// legacy `disableSend` policy applies.
-    func test_isSendDisabledByPolicy_flagOff() async {
-        configService.featureFlagsBool[.sendControls] = false
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .disableSend)])
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertTrue(isDisabled)
-    }
-
-    /// When the Send Controls feature flag is disabled, `isSendDisabledByPolicy()` returns false when
-    /// no policies apply.
-    func test_isSendDisabledByPolicy_flagOff_noPolicies() async {
-        configService.featureFlagsBool[.sendControls] = false
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success([])
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
-    }
-
-    /// When the Send Controls feature flag is disabled, `isSendDisabledByPolicy()` ignores the Send
-    /// Controls policy.
-    func test_isSendDisabledByPolicy_flagOff_ignoresSendControlsPolicy() async {
-        configService.featureFlagsBool[.sendControls] = false
-        stateService.activeAccount = .fixture()
-        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success(
-            [
-                .fixture(
-                    data: [PolicyOptionType.disableSend.rawValue: .bool(true)],
-                    type: .sendControls,
-                ),
-            ],
-        )
-
-        let isDisabled = await subject.isSendDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
-    }
-
-    // MARK: - isSendHideEmailDisabledByPolicy Tests
-
-    /// `isSendHideEmailDisabledByPolicy()` returns whether the Send Controls policy disables the
-    /// hide email option.
-    func test_isSendHideEmailDisabledByPolicy() async {
+    /// `getSendPolicyOptions()` reports the hide email option disabled when the Send Controls policy
+    /// disables it.
+    func test_getSendPolicyOptions_isHideEmailDisabled() async {
         configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
@@ -648,23 +528,24 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
             ],
         )
 
-        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
-        XCTAssertTrue(isDisabled)
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertTrue(options.isHideEmailDisabled)
     }
 
-    /// `isSendHideEmailDisabledByPolicy()` returns false if there's no policies.
-    func test_isSendHideEmailDisabledByPolicy_noPolicies() async {
+    /// `getSendPolicyOptions()` reports the hide email option enabled if there's no policies.
+    func test_getSendPolicyOptions_isHideEmailDisabled_noPolicies() async {
         configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
         policyDataStore.fetchPoliciesResult = .success([])
 
-        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isHideEmailDisabled)
     }
 
-    /// `isSendHideEmailDisabledByPolicy()` returns false if the disable hide email option is disabled.
-    func test_isSendHideEmailDisabledByPolicy_optionDisabled() async {
+    /// `getSendPolicyOptions()` reports the hide email option enabled if the disable hide email
+    /// option is disabled.
+    func test_getSendPolicyOptions_isHideEmailDisabled_optionDisabled() async {
         configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
@@ -677,26 +558,25 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
             ],
         )
 
-        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isHideEmailDisabled)
     }
 
-    /// `isSendHideEmailDisabledByPolicy()` returns false if the policy doesn't contain any custom data.
-    func test_isSendHideEmailDisabledByPolicy_optionNoData() async {
+    /// `getSendPolicyOptions()` reports the hide email option enabled if the policy doesn't contain
+    /// any custom data.
+    func test_getSendPolicyOptions_isHideEmailDisabled_optionNoData() async {
         configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
         policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendControls)])
 
-        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
-        XCTAssertFalse(isDisabled)
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isHideEmailDisabled)
     }
 
-    // MARK: - isSendHideEmailDisabledByPolicy Tests (Send Controls feature flag disabled)
-
-    /// When the Send Controls feature flag is disabled, `isSendHideEmailDisabledByPolicy()` reads the
-    /// legacy `sendOptions` policy and ignores any `sendControls` policy.
-    func test_isSendHideEmailDisabledByPolicy_flagOff() async {
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` reads the hide email
+    /// option from the legacy `sendOptions` policy and ignores any `sendControls` policy.
+    func test_getSendPolicyOptions_isHideEmailDisabled_flagOff() async {
         configService.featureFlagsBool[.sendControls] = false
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
@@ -713,8 +593,126 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
             ],
         )
 
-        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
-        XCTAssertTrue(isDisabled)
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertTrue(options.isHideEmailDisabled)
+    }
+
+    // MARK: - getSendPolicyOptions (isSendDisabled) Tests
+
+    /// `getSendPolicyOptions()` reports Sends disabled when the Send Controls policy's `disableSend`
+    /// option is enabled.
+    func test_getSendPolicyOptions_isSendDisabled() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableSend.rawValue: .bool(true)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertTrue(options.isSendDisabled)
+    }
+
+    /// `getSendPolicyOptions()` reports Sends enabled when the Send Controls policy's `disableSend`
+    /// option is disabled.
+    func test_getSendPolicyOptions_isSendDisabled_optionDisabled() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableSend.rawValue: .bool(false)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isSendDisabled)
+    }
+
+    /// `getSendPolicyOptions()` reports Sends enabled when the Send Controls policy doesn't contain
+    /// any custom data.
+    func test_getSendPolicyOptions_isSendDisabled_optionNoData() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendControls)])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isSendDisabled)
+    }
+
+    /// `getSendPolicyOptions()` reports Sends enabled when there's no policies.
+    func test_getSendPolicyOptions_isSendDisabled_noPolicies() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isSendDisabled)
+    }
+
+    /// `getSendPolicyOptions()` ignores the legacy `disableSend` policy, which is superseded by the
+    /// Send Controls policy.
+    func test_getSendPolicyOptions_isSendDisabled_ignoresLegacyDisableSendPolicy() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .disableSend)])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isSendDisabled)
+    }
+
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` reports Sends
+    /// disabled based on the legacy `disableSend` policy.
+    func test_getSendPolicyOptions_isSendDisabled_flagOff() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .disableSend)])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertTrue(options.isSendDisabled)
+    }
+
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` reports Sends
+    /// enabled when no policies apply.
+    func test_getSendPolicyOptions_isSendDisabled_flagOff_noPolicies() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isSendDisabled)
+    }
+
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` ignores the Send
+    /// Controls policy when determining whether Sends are disabled.
+    func test_getSendPolicyOptions_isSendDisabled_flagOff_ignoresSendControlsPolicy() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableSend.rawValue: .bool(true)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertFalse(options.isSendDisabled)
     }
 
     /// `fetchTimeoutPolicyValues()` fetches timeout values when the policy contains data.
@@ -1430,22 +1428,48 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertFalse(clientService.mockPolicies.filterByTypeCalled)
     }
 
-    /// `isSendHideEmailDisabledByPolicy()` excludes policies that lack the `disableHideEmail` option
-    /// before invoking the SDK when the `policiesInAcceptedState` flag is enabled — verifying the
-    /// filter is forwarded to `sdkFilterPolicies`.
+    /// `getSendPolicyOptions()` uses the SDK `filterByType` path when the `policiesInAcceptedState`
+    /// flag is enabled, enforcing no Send restrictions when the SDK reports no applying policies.
     @MainActor
-    func test_isSendHideEmailDisabledByPolicy_sdkPath_filterExcludesPolicyWithoutOption() async {
+    func test_getSendPolicyOptions_sdkPath_noApplyingPolicies() async {
         stateService.activeAccount = .fixture()
         configService.featureFlagsBool[.policiesInAcceptedState] = true
         configService.featureFlagsBool[.sendControls] = true
         organizationService.fetchAllOrganizationsResult = .success([.fixture(id: "org-1", status: .accepted)])
-
-        // Policy without disableHideEmail — { policy[.disableHideEmail]?.boolValue == true } excludes it.
         policyDataStore.fetchPoliciesNewResult = .success([.fixture(type: .sendControls)])
+        clientService.mockPolicies.filterByTypeReturnValue = []
 
-        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
+        let options = await subject.getSendPolicyOptions()
 
-        XCTAssertFalse(isDisabled)
-        XCTAssertFalse(clientService.mockPolicies.filterByTypeCalled)
+        XCTAssertTrue(clientService.mockPolicies.filterByTypeCalled)
+        XCTAssertFalse(options.isSendDisabled)
+        XCTAssertFalse(options.isHideEmailDisabled)
+    }
+
+    /// `getSendPolicyOptions()` parses the Send restrictions from the policies the SDK reports as
+    /// applying when the `policiesInAcceptedState` flag is enabled.
+    @MainActor
+    func test_getSendPolicyOptions_sdkPath_parsesApplyingPolicies() async {
+        stateService.activeAccount = .fixture()
+        configService.featureFlagsBool[.policiesInAcceptedState] = true
+        configService.featureFlagsBool[.sendControls] = true
+        organizationService.fetchAllOrganizationsResult = .success([.fixture(id: "org-1", status: .accepted)])
+        policyDataStore.fetchPoliciesNewResult = .success([.fixture(type: .sendControls)])
+        clientService.mockPolicies.filterByTypeReturnValue = [
+            BitwardenSdk.PolicyView(
+                id: "policy-1",
+                organizationId: "org-1",
+                type: .sendControls,
+                data: #"{"disableSend": true, "disableHideEmail": true}"#,
+                enabled: true,
+                revisionDate: nil,
+            ),
+        ]
+
+        let options = await subject.getSendPolicyOptions()
+
+        XCTAssertTrue(clientService.mockPolicies.filterByTypeCalled)
+        XCTAssertTrue(options.isSendDisabled)
+        XCTAssertTrue(options.isHideEmailDisabled)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -511,17 +511,139 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertEqual(organizationId, "org-2")
     }
 
+    // MARK: - isSendDisabledByPolicy Tests
+
+    /// `isSendDisabledByPolicy()` returns true when the Send Controls policy's `disableSend` option
+    /// is enabled.
+    func test_isSendDisabledByPolicy() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableSend.rawValue: .bool(true)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertTrue(isDisabled)
+    }
+
+    /// `isSendDisabledByPolicy()` returns false when the Send Controls policy's `disableSend` option
+    /// is disabled.
+    func test_isSendDisabledByPolicy_optionDisabled() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableSend.rawValue: .bool(false)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertFalse(isDisabled)
+    }
+
+    /// `isSendDisabledByPolicy()` returns false when the Send Controls policy doesn't contain any
+    /// custom data.
+    func test_isSendDisabledByPolicy_optionNoData() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendControls)])
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertFalse(isDisabled)
+    }
+
+    /// `isSendDisabledByPolicy()` returns false when there's no policies.
+    func test_isSendDisabledByPolicy_noPolicies() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([])
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertFalse(isDisabled)
+    }
+
+    /// `isSendDisabledByPolicy()` ignores the legacy `disableSend` policy, which is superseded by the
+    /// Send Controls policy.
+    func test_isSendDisabledByPolicy_ignoresLegacyDisableSendPolicy() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .disableSend)])
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertFalse(isDisabled)
+    }
+
+    // MARK: - isSendDisabledByPolicy Tests (Send Controls feature flag disabled)
+
+    /// When the Send Controls feature flag is disabled, `isSendDisabledByPolicy()` returns whether the
+    /// legacy `disableSend` policy applies.
+    func test_isSendDisabledByPolicy_flagOff() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .disableSend)])
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertTrue(isDisabled)
+    }
+
+    /// When the Send Controls feature flag is disabled, `isSendDisabledByPolicy()` returns false when
+    /// no policies apply.
+    func test_isSendDisabledByPolicy_flagOff_noPolicies() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([])
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertFalse(isDisabled)
+    }
+
+    /// When the Send Controls feature flag is disabled, `isSendDisabledByPolicy()` ignores the Send
+    /// Controls policy.
+    func test_isSendDisabledByPolicy_flagOff_ignoresSendControlsPolicy() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableSend.rawValue: .bool(true)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let isDisabled = await subject.isSendDisabledByPolicy()
+        XCTAssertFalse(isDisabled)
+    }
+
     // MARK: - isSendHideEmailDisabledByPolicy Tests
 
-    /// `isSendHideEmailDisabledByPolicy()` returns whether the send's hide email option is disabled.
+    /// `isSendHideEmailDisabledByPolicy()` returns whether the Send Controls policy disables the
+    /// hide email option.
     func test_isSendHideEmailDisabledByPolicy() async {
+        configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
         policyDataStore.fetchPoliciesResult = .success(
             [
                 .fixture(
                     data: [PolicyOptionType.disableHideEmail.rawValue: .bool(true)],
-                    type: .sendOptions,
+                    type: .sendControls,
                 ),
             ],
         )
@@ -532,6 +654,7 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
 
     /// `isSendHideEmailDisabledByPolicy()` returns false if there's no policies.
     func test_isSendHideEmailDisabledByPolicy_noPolicies() async {
+        configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
         policyDataStore.fetchPoliciesResult = .success([])
@@ -542,13 +665,14 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
 
     /// `isSendHideEmailDisabledByPolicy()` returns false if the disable hide email option is disabled.
     func test_isSendHideEmailDisabledByPolicy_optionDisabled() async {
+        configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
         policyDataStore.fetchPoliciesResult = .success(
             [
                 .fixture(
                     data: [PolicyOptionType.disableHideEmail.rawValue: .bool(false)],
-                    type: .sendOptions,
+                    type: .sendControls,
                 ),
             ],
         )
@@ -559,12 +683,38 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
 
     /// `isSendHideEmailDisabledByPolicy()` returns false if the policy doesn't contain any custom data.
     func test_isSendHideEmailDisabledByPolicy_optionNoData() async {
+        configService.featureFlagsBool[.sendControls] = true
         stateService.activeAccount = .fixture()
         organizationService.fetchAllOrganizationsResult = .success([.fixture()])
-        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendOptions)])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendControls)])
 
         let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
         XCTAssertFalse(isDisabled)
+    }
+
+    // MARK: - isSendHideEmailDisabledByPolicy Tests (Send Controls feature flag disabled)
+
+    /// When the Send Controls feature flag is disabled, `isSendHideEmailDisabledByPolicy()` reads the
+    /// legacy `sendOptions` policy and ignores any `sendControls` policy.
+    func test_isSendHideEmailDisabledByPolicy_flagOff() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.disableHideEmail.rawValue: .bool(false)],
+                    type: .sendControls,
+                ),
+                .fixture(
+                    data: [PolicyOptionType.disableHideEmail.rawValue: .bool(true)],
+                    type: .sendOptions,
+                ),
+            ],
+        )
+
+        let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
+        XCTAssertTrue(isDisabled)
     }
 
     /// `fetchTimeoutPolicyValues()` fetches timeout values when the policy contains data.
@@ -1281,16 +1431,17 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
     }
 
     /// `isSendHideEmailDisabledByPolicy()` excludes policies that lack the `disableHideEmail` option
-    /// before invoking the SDK when the feature flag is enabled — verifying the filter is forwarded
-    /// to `sdkFilterPolicies`.
+    /// before invoking the SDK when the `policiesInAcceptedState` flag is enabled — verifying the
+    /// filter is forwarded to `sdkFilterPolicies`.
     @MainActor
     func test_isSendHideEmailDisabledByPolicy_sdkPath_filterExcludesPolicyWithoutOption() async {
         stateService.activeAccount = .fixture()
         configService.featureFlagsBool[.policiesInAcceptedState] = true
+        configService.featureFlagsBool[.sendControls] = true
         organizationService.fetchAllOrganizationsResult = .success([.fixture(id: "org-1", status: .accepted)])
 
         // Policy without disableHideEmail — { policy[.disableHideEmail]?.boolValue == true } excludes it.
-        policyDataStore.fetchPoliciesNewResult = .success([.fixture(type: .sendOptions)])
+        policyDataStore.fetchPoliciesNewResult = .success([.fixture(type: .sendControls)])
 
         let isDisabled = await subject.isSendHideEmailDisabledByPolicy()
 

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockPolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockPolicyService.swift
@@ -20,9 +20,7 @@ class MockPolicyService: PolicyService {
         ),
     )
 
-    var isSendDisabledByPolicy = false
-
-    var isSendHideEmailDisabledByPolicy = false
+    var getSendPolicyOptionsResult = SendPolicyOptions()
 
     var fetchTimeoutPolicyValuesResult: Result<SessionTimeoutPolicy?, Error> = .success(nil)
 
@@ -71,12 +69,8 @@ class MockPolicyService: PolicyService {
         try getMasterPasswordPolicyOptionsResult.get()
     }
 
-    func isSendDisabledByPolicy() async -> Bool {
-        isSendDisabledByPolicy
-    }
-
-    func isSendHideEmailDisabledByPolicy() async -> Bool {
-        isSendHideEmailDisabledByPolicy
+    func getSendPolicyOptions() async -> SendPolicyOptions {
+        getSendPolicyOptionsResult
     }
 
     func fetchTimeoutPolicyValues() async throws -> SessionTimeoutPolicy? {

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockPolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockPolicyService.swift
@@ -20,6 +20,8 @@ class MockPolicyService: PolicyService {
         ),
     )
 
+    var isSendDisabledByPolicy = false
+
     var isSendHideEmailDisabledByPolicy = false
 
     var fetchTimeoutPolicyValuesResult: Result<SessionTimeoutPolicy?, Error> = .success(nil)
@@ -67,6 +69,10 @@ class MockPolicyService: PolicyService {
 
     func getMasterPasswordPolicyOptions() async throws -> MasterPasswordPolicyOptions? {
         try getMasterPasswordPolicyOptionsResult.get()
+    }
+
+    func isSendDisabledByPolicy() async -> Bool {
+        isSendDisabledByPolicy
     }
 
     func isSendHideEmailDisabledByPolicy() async -> Bool {

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -190,7 +190,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         updateTabs(isSendEnabled: true)
 
         Task { [weak self, policyService] in
-            let isSendDisabled = await policyService.policyAppliesToUser(.disableSend)
+            let isSendDisabled = await policyService.isSendDisabledByPolicy()
             await MainActor.run { self?.updateTabs(isSendEnabled: !isSendDisabled) }
         }
         streamOrganizations()
@@ -226,7 +226,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
                         navigator.rootViewController?.title = Localizations.vaults
                     }
 
-                    let isSendDisabled = await policyService.policyAppliesToUser(.disableSend)
+                    let isSendDisabled = await policyService.isSendDisabledByPolicy()
                     await MainActor.run { [weak self] in
                         self?.updateTabs(isSendEnabled: !isSendDisabled)
                     }

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -190,7 +190,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         updateTabs(isSendEnabled: true)
 
         Task { [weak self, policyService] in
-            let isSendDisabled = await policyService.isSendDisabledByPolicy()
+            let isSendDisabled = await policyService.getSendPolicyOptions().isSendDisabled
             await MainActor.run { self?.updateTabs(isSendEnabled: !isSendDisabled) }
         }
         streamOrganizations()
@@ -226,7 +226,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
                         navigator.rootViewController?.title = Localizations.vaults
                     }
 
-                    let isSendDisabled = await policyService.isSendDisabledByPolicy()
+                    let isSendDisabled = await policyService.getSendPolicyOptions().isSendDisabled
                     await MainActor.run { [weak self] in
                         self?.updateTabs(isSendEnabled: !isSendDisabled)
                     }

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -71,7 +71,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// When `disableSend` policy applies, `navigate(to: .generator)` uses visual index 1 (Send tab absent).
     @MainActor
     func test_navigate_generator_sendHidden_usesAdjustedIndex() {
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -83,7 +83,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// `navigate(to:)` with a non-canonical `.generator` route and Send hidden uses visual index 1.
     @MainActor
     func test_navigate_generator_nonCanonicalRoute_sendHidden_usesAdjustedIndex() {
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -102,7 +102,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// When `disableSend` policy applies, `navigate(to: .send)` is ignored and `selectedIndex` is unchanged.
     @MainActor
     func test_navigate_send_whenPolicyActive_isIgnored() {
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -124,7 +124,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// When `disableSend` policy applies, `navigate(to: .settings)` uses visual index 2 (Send tab absent).
     @MainActor
     func test_navigate_settings_sendHidden_usesAdjustedIndex() {
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -288,7 +288,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         let mockRoot = MockRootNavigator()
         mockRoot.rootViewController = UIViewController()
         tabNavigator.navigatorForTabReturns = mockRoot
-        policyService.policyAppliesToUserResult[.disableSend] = false
+        policyService.isSendDisabledByPolicy = false
         vaultRepository.organizationsSubject = .init([])
 
         subject.start()
@@ -296,7 +296,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         XCTAssertEqual(tabNavigator.navigators.count, 4)
 
         // Simulate an org stream event while the policy is now active.
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         vaultRepository.organizationsSubject.send([])
 
         waitFor { self.tabNavigator.navigators.count == 3 }
@@ -306,7 +306,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// `start()` shows all four tabs when `disableSend` policy does not apply.
     @MainActor
     func test_start_sendTabShown_whenDisableSendPolicyNotApplied() {
-        policyService.policyAppliesToUserResult[.disableSend] = false
+        policyService.isSendDisabledByPolicy = false
         subject.start()
 
         // updateTabs(isSendEnabled: true) is called synchronously in start(), so count is 4 immediately.
@@ -316,7 +316,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// `start()` hides the Send tab when `disableSend` policy applies to the user.
     @MainActor
     func test_start_sendTabHidden_whenDisableSendPolicyApplies() {
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         subject.start()
 
         // start() calls updateTabs(isSendEnabled: true) synchronously first, then the async

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -71,7 +71,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// When `disableSend` policy applies, `navigate(to: .generator)` uses visual index 1 (Send tab absent).
     @MainActor
     func test_navigate_generator_sendHidden_usesAdjustedIndex() {
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -83,7 +83,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// `navigate(to:)` with a non-canonical `.generator` route and Send hidden uses visual index 1.
     @MainActor
     func test_navigate_generator_nonCanonicalRoute_sendHidden_usesAdjustedIndex() {
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -102,7 +102,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// When `disableSend` policy applies, `navigate(to: .send)` is ignored and `selectedIndex` is unchanged.
     @MainActor
     func test_navigate_send_whenPolicyActive_isIgnored() {
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -124,7 +124,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// When `disableSend` policy applies, `navigate(to: .settings)` uses visual index 2 (Send tab absent).
     @MainActor
     func test_navigate_settings_sendHidden_usesAdjustedIndex() {
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
@@ -288,7 +288,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         let mockRoot = MockRootNavigator()
         mockRoot.rootViewController = UIViewController()
         tabNavigator.navigatorForTabReturns = mockRoot
-        policyService.isSendDisabledByPolicy = false
+        policyService.getSendPolicyOptionsResult.isSendDisabled = false
         vaultRepository.organizationsSubject = .init([])
 
         subject.start()
@@ -296,7 +296,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         XCTAssertEqual(tabNavigator.navigators.count, 4)
 
         // Simulate an org stream event while the policy is now active.
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         vaultRepository.organizationsSubject.send([])
 
         waitFor { self.tabNavigator.navigators.count == 3 }
@@ -306,7 +306,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// `start()` shows all four tabs when `disableSend` policy does not apply.
     @MainActor
     func test_start_sendTabShown_whenDisableSendPolicyNotApplied() {
-        policyService.isSendDisabledByPolicy = false
+        policyService.getSendPolicyOptionsResult.isSendDisabled = false
         subject.start()
 
         // updateTabs(isSendEnabled: true) is called synchronously in start(), so count is 4 immediately.
@@ -316,7 +316,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     /// `start()` hides the Send tab when `disableSend` policy applies to the user.
     @MainActor
     func test_start_sendTabHidden_whenDisableSendPolicyApplies() {
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         subject.start()
 
         // start() calls updateTabs(isSendEnabled: true) synchronously first, then the async

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -195,7 +195,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     /// Load any initial data for the view.
     ///
     private func loadData() async {
-        state.isSendDisabled = await services.policyService.policyAppliesToUser(.disableSend)
+        state.isSendDisabled = await services.policyService.isSendDisabledByPolicy()
     }
 
     /// Removes the password from the provided send.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -195,7 +195,7 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     /// Load any initial data for the view.
     ///
     private func loadData() async {
-        state.isSendDisabled = await services.policyService.isSendDisabledByPolicy()
+        state.isSendDisabled = await services.policyService.getSendPolicyOptions().isSendDisabled
     }
 
     /// Removes the password from the provided send.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -117,7 +117,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await subject.perform(.loadData)
         XCTAssertFalse(subject.state.isSendDisabled)
 
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         await subject.perform(.loadData)
         XCTAssertTrue(subject.state.isSendDisabled)
     }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -117,7 +117,7 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         await subject.perform(.loadData)
         XCTAssertFalse(subject.state.isSendDisabled)
 
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         await subject.perform(.loadData)
         XCTAssertTrue(subject.state.isSendDisabled)
     }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -230,7 +230,7 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     /// Load any initial data for the view.
     ///
     private func loadData() async {
-        state.isSendDisabled = await services.policyService.policyAppliesToUser(.disableSend)
+        state.isSendDisabled = await services.policyService.isSendDisabledByPolicy()
         state.isSendHideEmailDisabled = await services.policyService.isSendHideEmailDisabledByPolicy()
         state.hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
         await refreshProfileState()

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -14,6 +14,7 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     typealias Services = HasAuthRepository
         & HasBillingRepository
         & HasBillingService
+        & HasConfigService
         & HasEnvironmentService
         & HasErrorReporter
         & HasPasteboardService
@@ -230,6 +231,7 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     /// Load any initial data for the view.
     ///
     private func loadData() async {
+        state.isSendControlsPolicyEnabled = await services.configService.getFeatureFlag(.sendControls)
         let sendPolicyOptions = await services.policyService.getSendPolicyOptions()
         state.isSendDisabled = sendPolicyOptions.isSendDisabled
         state.isSendHideEmailDisabled = sendPolicyOptions.isHideEmailDisabled

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -230,8 +230,9 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     /// Load any initial data for the view.
     ///
     private func loadData() async {
-        state.isSendDisabled = await services.policyService.isSendDisabledByPolicy()
-        state.isSendHideEmailDisabled = await services.policyService.isSendHideEmailDisabledByPolicy()
+        let sendPolicyOptions = await services.policyService.getSendPolicyOptions()
+        state.isSendDisabled = sendPolicyOptions.isSendDisabled
+        state.isSendHideEmailDisabled = sendPolicyOptions.isHideEmailDisabled
         state.hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
         await refreshProfileState()
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -145,13 +145,13 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertFalse(subject.state.isSendDisabled)
         XCTAssertFalse(subject.state.isSendHideEmailDisabled)
 
-        policyService.isSendDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         await subject.perform(.loadData)
         XCTAssertTrue(subject.state.isSendDisabled)
         XCTAssertFalse(subject.state.isSendHideEmailDisabled)
 
-        policyService.isSendDisabledByPolicy = false
-        policyService.isSendHideEmailDisabledByPolicy = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = false
+        policyService.getSendPolicyOptionsResult.isHideEmailDisabled = true
         await subject.perform(.loadData)
         XCTAssertFalse(subject.state.isSendDisabled)
         XCTAssertTrue(subject.state.isSendHideEmailDisabled)

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -13,6 +13,7 @@ import XCTest
 class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
+    var configService: MockConfigService!
     var coordinator: MockCoordinator<SendItemRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
     var pasteboardService: MockPasteboardService!
@@ -29,6 +30,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
     override func setUp() {
         super.setUp()
+        configService = MockConfigService()
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
         pasteboardService = MockPasteboardService()
@@ -39,6 +41,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         subject = AddEditSendItemProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             services: ServiceContainer.withMocks(
+                configService: configService,
                 errorReporter: errorReporter,
                 pasteboardService: pasteboardService,
                 policyService: policyService,
@@ -52,6 +55,7 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
 
     override func tearDown() {
         super.tearDown()
+        configService = nil
         coordinator = nil
         errorReporter = nil
         pasteboardService = nil
@@ -155,6 +159,17 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         await subject.perform(.loadData)
         XCTAssertFalse(subject.state.isSendDisabled)
         XCTAssertTrue(subject.state.isSendHideEmailDisabled)
+    }
+
+    /// `perform(_:)` with `loadData` loads whether the Send Controls policy feature flag is enabled.
+    @MainActor
+    func test_perform_loadData_sendControlsPolicyFlag() async {
+        await subject.perform(.loadData)
+        XCTAssertFalse(subject.state.isSendControlsPolicyEnabled)
+
+        configService.featureFlagsBool[.sendControls] = true
+        await subject.perform(.loadData)
+        XCTAssertTrue(subject.state.isSendControlsPolicyEnabled)
     }
 
     /// `perform(_:)` with `loadData` loads the correct maximum access count in the TextField.

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -145,12 +145,12 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertFalse(subject.state.isSendDisabled)
         XCTAssertFalse(subject.state.isSendHideEmailDisabled)
 
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.isSendDisabledByPolicy = true
         await subject.perform(.loadData)
         XCTAssertTrue(subject.state.isSendDisabled)
         XCTAssertFalse(subject.state.isSendHideEmailDisabled)
 
-        policyService.policyAppliesToUserResult[.disableSend] = false
+        policyService.isSendDisabledByPolicy = false
         policyService.isSendHideEmailDisabledByPolicy = true
         await subject.perform(.loadData)
         XCTAssertFalse(subject.state.isSendDisabled)

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -74,6 +74,9 @@ struct AddEditSendItemState: Equatable, Sendable {
     /// Whether the user has a Premium account.
     var hasPremium = false
 
+    /// Whether the Send Controls policy feature flag is enabled.
+    var isSendControlsPolicyEnabled = false
+
     /// Whether sends are disabled via a policy.
     var isSendDisabled = false
 
@@ -158,6 +161,22 @@ struct AddEditSendItemState: Equatable, Sendable {
                 Localizations.editTextSend
             }
         }
+    }
+
+    /// Whether the hide-email field should be shown.
+    ///
+    /// When the Send Controls policy disables hiding the sender's email, the field is hidden
+    /// entirely; under the legacy Send Options policy it remains visible but disabled.
+    var shouldShowHideEmailField: Bool {
+        !(isSendHideEmailDisabled && isSendControlsPolicyEnabled)
+    }
+
+    /// Whether the banner noting that Send policies are in effect should be shown.
+    ///
+    /// Only shown when the hide-email restriction comes from the legacy Send Options policy. The
+    /// Send Controls policy hides the affected field entirely rather than showing a banner.
+    var shouldShowHideEmailPolicyBanner: Bool {
+        isSendHideEmailDisabled && !isSendControlsPolicyEnabled
     }
 }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -356,4 +356,71 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
         let subject = AddEditSendItemState(sendView: sendView)
         XCTAssertEqual(subject.accessType, .anyoneWithPassword)
     }
-}
+
+    // MARK: shouldShowHideEmailField
+
+    /// `shouldShowHideEmailField` is `true` when the hide-email option is not disabled by policy,
+    /// regardless of the Send Controls feature flag.
+    func test_shouldShowHideEmailField_notDisabled() {
+        var subject = AddEditSendItemState(isSendHideEmailDisabled: false)
+
+        subject.isSendControlsPolicyEnabled = false
+        XCTAssertTrue(subject.shouldShowHideEmailField)
+
+        subject.isSendControlsPolicyEnabled = true
+        XCTAssertTrue(subject.shouldShowHideEmailField)
+    }
+
+    /// `shouldShowHideEmailField` is `true` when hide-email is disabled by the legacy Send Options
+    /// policy (feature flag off) so the field remains visible but disabled.
+    func test_shouldShowHideEmailField_disabled_flagOff() {
+        let subject = AddEditSendItemState(
+            isSendControlsPolicyEnabled: false,
+            isSendHideEmailDisabled: true,
+        )
+        XCTAssertTrue(subject.shouldShowHideEmailField)
+    }
+
+    /// `shouldShowHideEmailField` is `false` when hide-email is disabled by the Send Controls policy
+    /// (feature flag on) so the field is hidden entirely.
+    func test_shouldShowHideEmailField_disabled_flagOn() {
+        let subject = AddEditSendItemState(
+            isSendControlsPolicyEnabled: true,
+            isSendHideEmailDisabled: true,
+        )
+        XCTAssertFalse(subject.shouldShowHideEmailField)
+    }
+
+    // MARK: shouldShowHideEmailPolicyBanner
+
+    /// `shouldShowHideEmailPolicyBanner` is `false` when the hide-email option is not disabled.
+    func test_shouldShowHideEmailPolicyBanner_notDisabled() {
+        var subject = AddEditSendItemState(isSendHideEmailDisabled: false)
+
+        subject.isSendControlsPolicyEnabled = false
+        XCTAssertFalse(subject.shouldShowHideEmailPolicyBanner)
+
+        subject.isSendControlsPolicyEnabled = true
+        XCTAssertFalse(subject.shouldShowHideEmailPolicyBanner)
+    }
+
+    /// `shouldShowHideEmailPolicyBanner` is `true` when hide-email is disabled by the legacy Send
+    /// Options policy (feature flag off).
+    func test_shouldShowHideEmailPolicyBanner_disabled_flagOff() {
+        let subject = AddEditSendItemState(
+            isSendControlsPolicyEnabled: false,
+            isSendHideEmailDisabled: true,
+        )
+        XCTAssertTrue(subject.shouldShowHideEmailPolicyBanner)
+    }
+
+    /// `shouldShowHideEmailPolicyBanner` is `false` when hide-email is disabled by the Send Controls
+    /// policy (feature flag on); the field is hidden instead of showing a banner.
+    func test_shouldShowHideEmailPolicyBanner_disabled_flagOn() {
+        let subject = AddEditSendItemState(
+            isSendControlsPolicyEnabled: true,
+            isSendHideEmailDisabled: true,
+        )
+        XCTAssertFalse(subject.shouldShowHideEmailPolicyBanner)
+    }
+} // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -28,7 +28,7 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                 if store.state.isSendDisabled {
                     InfoContainer(Localizations.sendDisabledWarning)
                         .accessibilityIdentifier("DisabledSendPolicyLabel")
-                } else if store.state.isSendHideEmailDisabled {
+                } else if store.state.shouldShowHideEmailPolicyBanner {
                     InfoContainer(Localizations.sendOptionsPolicyInEffect)
                         .accessibilityIdentifier("HideEmailAddressPolicyLabel")
                 }
@@ -150,13 +150,15 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                 ),
             )
 
-            ContentBlock(dividerLeadingPadding: 16) {
-                BitwardenToggle(Localizations.hideEmail, isOn: store.binding(
-                    get: \.isHideMyEmailOn,
-                    send: AddEditSendItemAction.hideMyEmailChanged,
-                ))
-                .accessibilityIdentifier("SendHideEmailSwitch")
-                .disabled(!store.state.isHideMyEmailOn && store.state.isSendHideEmailDisabled)
+            if store.state.shouldShowHideEmailField {
+                ContentBlock(dividerLeadingPadding: 16) {
+                    BitwardenToggle(Localizations.hideEmail, isOn: store.binding(
+                        get: \.isHideMyEmailOn,
+                        send: AddEditSendItemAction.hideMyEmailChanged,
+                    ))
+                    .accessibilityIdentifier("SendHideEmailSwitch")
+                    .disabled(!store.state.isHideMyEmailOn && store.state.isSendHideEmailDisabled)
+                }
             }
 
             BitwardenTextView(


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-40139](https://bitwarden.atlassian.net/browse/PM-40139)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Consolidates the two existing Send policies (Disable Send and Send Options) into the new Send Controls policy.

- Consolidates the two Send restriction behaviors behind the `pm-31885-send-controls` feature flag, completing the enforcement work deferred by PM-38792 (which added the policy type, SDK mapping, and flag plumbing).
- When the flag is **on**, "Sends disabled" and "hide-email disabled" are read from the new `sendControls` org policy (type 21) data — `data["disableSend"]` and `data["disableHideEmail"]`. When **off**, the app keeps respecting the legacy `disableSend` (type 6, presence-based) and `sendOptions` (type 7, `disableHideEmail`) policies unchanged.
- Adds `PolicyOptionType.disableSend`; centralizes the flag branch in `PolicyService` (`isSendDisabledByPolicy()` new, `isSendHideEmailDisabledByPolicy()` updated) so the four UI-layer call sites (`AddEditSendItemProcessor`, `SendListProcessor`, `TabCoordinator` ×2) stay thin service calls with no flag logic.

[PM-40139]: https://bitwarden.atlassian.net/browse/PM-40139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ