### PR TITLE
[PM-40262] Complete Device Auth Key core support

### DIFF
--- a/BitwardenShared/Core/Auth/Services/DeviceAuthKeyServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/DeviceAuthKeyServiceTests.swift
@@ -40,23 +40,24 @@ final class DeviceAuthKeyServiceTests: BitwardenTestCase {
 
     // MARK: Tests - assertDeviceAuthKey
 
-    /// `assertDeviceAuthKey(for:recordIdentifier:userId:)` throws notImplemented error.
-    ///
-    func test_assertDeviceAuthKey_throwsNotImplemented() async throws {
+    /// `assertDeviceAuthKey(for:recordIdentifier:userId:)` returns nil when key is unavailable.
+    func test_assertDeviceAuthKey_returnsNilWhenRecordMissing() async throws {
         let allowedCredentials = [
             Data(repeating: 2, count: 32),
             Data(repeating: 5, count: 32),
         ]
         let passkeyParameters = MockPasskeyCredentialRequestParameters(allowedCredentials: allowedCredentials)
         let request = GetAssertionRequest(fido2RequestParameters: passkeyParameters)
+        deviceAuthKeychainRepository.getDeviceAuthKeyReturnValue = nil
 
-        await assertAsyncThrows(error: DeviceAuthKeyError.notImplemented) {
-            _ = try await subject.assertDeviceAuthKey(
-                for: request,
-                recordIdentifier: "record123",
-                userId: "userId123",
-            )
-        }
+        let result = try await subject.assertDeviceAuthKey(
+            for: request,
+            recordIdentifier: "record123",
+            userId: "userId123",
+        )
+        XCTAssertNil(result)
+        XCTAssertEqual(deviceAuthKeychainRepository.getDeviceAuthKeyCallsCount, 1)
+        XCTAssertEqual(deviceAuthKeychainRepository.getDeviceAuthKeyReceivedUserId, "userId123")
     }
 
     // MARK: Tests - createDeviceAuthKey


### PR DESCRIPTION
## Summary

- complete the iOS Device Auth Key service against the current Bitwarden SDK
- keep Account Security UI changes out of this PR to avoid overlap with #2871
- preserve account isolation and fail closed for mismatched credentials

## Current state

This draft currently contains the first TDD specification only. The expected RED is `DeviceAuthKeyError.notImplemented`; implementation commits will follow after that behavior is confirmed in CI.

This continues the core-service direction explored in #2423 without cherry-picking its conflicting branch.

## Test plan

- [ ] RED: missing-record assertion test fails on the current stub
- [ ] GREEN: targeted `DeviceAuthKeyServiceTests` pass
- [ ] related keychain/autofill tests pass
- [ ] `BitwardenShared` generic simulator build passes
