### PR TITLE
[PM-40163] fix: Update text for TOTP Login premium alert.

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1169,3 +1169,4 @@
 "LineOfCredit" = "Line of credit";
 "MoneyMarket" = "Money market";
 "Savings" = "Savings";
+"PremiumRequiredTOTPDescriptionLong" = "Authenticator key (TOTP) is a Premium feature. Your current plan does not include access to this feature.";

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -572,7 +572,7 @@ extension Alert {
         }
         let alert = Alert(
             title: Localizations.premiumSubscriptionRequired,
-            message: Localizations.premiumRequired,
+            message: Localizations.premiumRequiredTOTPDescriptionLong,
             alertActions: [
                 preferredAction,
                 AlertAction(title: Localizations.cancel, style: .cancel),

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -707,7 +707,7 @@ class AlertVaultTests: BitwardenTestCase { // swiftlint:disable:this type_body_l
         let subject = Alert.totpPremiumRequired { called = true }
 
         XCTAssertEqual(subject.title, Localizations.premiumSubscriptionRequired)
-        XCTAssertEqual(subject.message, Localizations.premiumRequired)
+        XCTAssertEqual(subject.message, Localizations.premiumRequiredTOTPDescriptionLong)
         XCTAssertEqual(subject.alertActions.count, 2)
         XCTAssertEqual(subject.alertActions[0].title, Localizations.upgradeToPremium)
         XCTAssertEqual(subject.alertActions[0].style, .default)

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -1752,7 +1752,7 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_receive_premiumSubscriptionRequiredTapped_showsAlert() {
         subject.receive(.premiumSubscriptionRequiredTapped)
         XCTAssertEqual(coordinator.alertShown.last?.title, Localizations.premiumSubscriptionRequired)
-        XCTAssertEqual(coordinator.alertShown.last?.message, Localizations.premiumRequired)
+        XCTAssertEqual(coordinator.alertShown.last?.message, Localizations.premiumRequiredTOTPDescriptionLong)
     }
 
     /// `receive` with `.premiumSubscriptionRequiredTapped` navigates to Premium upgrade when


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-40163

## 📔 Objective

Update the text in the alert that notifies the user that TOTP codes are a Premium feature.
## 📸 Screenshots

<details>
<summary>Click to reveal</summary>

<img width="585" height="1266" alt="premiumTOTPAfterChange" src="https://github.com/user-attachments/assets/de6c5d88-91d2-4db8-a916-b2afa5af59fe" />


</details>

