### PR TITLE
[pm-27137] feat:  Add manage passkeys view to Test Harness

### DIFF
--- a/TestHarness/Application/Support/Entitlements/TestHarness.entitlements
+++ b/TestHarness/Application/Support/Entitlements/TestHarness.entitlements
@@ -13,6 +13,12 @@
 		<string>group.${BASE_BUNDLE_ID}</string>
 		<string>$(SHARED_APP_GROUP_IDENTIFIER)</string>
 	</array>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>webcredentials:*.bitwarden.com</string>
+		<string>webcredentials:*.bitwarden.eu</string>
+		<string>webcredentials:*.bitwarden.pw</string>
+	</array>
 	<key>keychain-access-groups</key>
 	<array>
 		<string>$(AppIdentifierPrefix)com.bitwarden.testharness</string>

--- a/TestHarnessShared/Core/Autofill/Services/PasskeyCredentialStore.swift
+++ b/TestHarnessShared/Core/Autofill/Services/PasskeyCredentialStore.swift
@@ -5,7 +5,7 @@ import Foundation
 /// A store for passkey credentials created during Test Harness registration flows, so they can
 /// later be used to test the assertion/verification flow.
 ///
-protocol PasskeyCredentialStore {
+protocol PasskeyCredentialStore { // sourcery: AutoMockable
     /// Removes the previously saved passkey credential with the given identifier, if one exists.
     ///
     /// - Parameter id: The `StoredPasskeyCredential.id` of the credential to remove.

--- a/TestHarnessShared/Core/Autofill/Services/PasskeyCredentialStore.swift
+++ b/TestHarnessShared/Core/Autofill/Services/PasskeyCredentialStore.swift
@@ -6,14 +6,24 @@ import Foundation
 /// later be used to test the assertion/verification flow.
 ///
 protocol PasskeyCredentialStore {
+    /// Removes the previously saved passkey credential with the given identifier, if one exists.
+    ///
+    /// - Parameter id: The `StoredPasskeyCredential.id` of the credential to remove.
+    ///
+    func delete(id: String) throws
+
+    /// Removes all previously saved passkey credentials.
+    ///
+    func deleteAll() throws
+
+    /// Returns all previously saved passkey credentials, in the order they were created.
+    func fetchAll() throws -> [StoredPasskeyCredential]
+
     /// Persists a newly created passkey credential, appending it to the existing list.
     ///
     /// - Parameter credential: The credential to persist.
     ///
     func save(_ credential: StoredPasskeyCredential) throws
-
-    /// Returns all previously saved passkey credentials, in the order they were created.
-    func fetchAll() throws -> [StoredPasskeyCredential]
 }
 
 // MARK: - DefaultPasskeyCredentialStore
@@ -41,14 +51,23 @@ final class DefaultPasskeyCredentialStore: PasskeyCredentialStore {
 
     // MARK: Methods
 
-    func save(_ credential: StoredPasskeyCredential) throws {
-        var credentials = try fetchAll()
-        credentials.append(credential)
+    func delete(id: String) throws {
+        let credentials = try fetchAll().filter { $0.id != id }
         try userDefaults.set(JSONEncoder().encode(credentials), forKey: Self.storageKey)
+    }
+
+    func deleteAll() throws {
+        userDefaults.removeObject(forKey: Self.storageKey)
     }
 
     func fetchAll() throws -> [StoredPasskeyCredential] {
         guard let data = userDefaults.data(forKey: Self.storageKey) else { return [] }
         return try JSONDecoder().decode([StoredPasskeyCredential].self, from: data)
+    }
+
+    func save(_ credential: StoredPasskeyCredential) throws {
+        var credentials = try fetchAll()
+        credentials.append(credential)
+        try userDefaults.set(JSONEncoder().encode(credentials), forKey: Self.storageKey)
     }
 }

--- a/TestHarnessShared/Core/Autofill/Services/PasskeyCredentialStoreTests.swift
+++ b/TestHarnessShared/Core/Autofill/Services/PasskeyCredentialStoreTests.swift
@@ -79,4 +79,53 @@ class PasskeyCredentialStoreTests: BitwardenTestCase {
         let secondInstance = DefaultPasskeyCredentialStore(userDefaults: userDefaults)
         XCTAssertEqual(try secondInstance.fetchAll(), [.fixture()])
     }
+
+    /// `delete(id:)` removes only the credential with the matching identifier, leaving the rest.
+    func test_delete_removesMatchingCredential() throws {
+        let first = StoredPasskeyCredential.fixture(rpId: "bitwarden.com", credentialId: Data([0x01]))
+        let second = StoredPasskeyCredential.fixture(rpId: "example.com", credentialId: Data([0x02]))
+        try subject.save(first)
+        try subject.save(second)
+
+        try subject.delete(id: first.id)
+
+        XCTAssertEqual(try subject.fetchAll(), [second])
+    }
+
+    /// `delete(id:)` is a no-op when no stored credential matches the given identifier.
+    func test_delete_nonexistentId_isNoOp() throws {
+        try subject.save(.fixture())
+
+        try subject.delete(id: "nonexistent")
+
+        XCTAssertEqual(try subject.fetchAll(), [.fixture()])
+    }
+
+    /// `deleteAll()` removes every stored credential.
+    func test_deleteAll_removesAllCredentials() throws {
+        try subject.save(.fixture(rpId: "bitwarden.com", credentialId: Data([0x01])))
+        try subject.save(.fixture(rpId: "example.com", credentialId: Data([0x02])))
+
+        try subject.deleteAll()
+
+        XCTAssertEqual(try subject.fetchAll(), [])
+    }
+
+    /// `deleteAll()` is a no-op when there are no stored credentials.
+    func test_deleteAll_whenAlreadyEmpty_isNoOp() throws {
+        try subject.deleteAll()
+
+        XCTAssertEqual(try subject.fetchAll(), [])
+    }
+
+    /// A credential deleted via one store instance is also gone for a second store instance
+    /// backed by the same `UserDefaults`.
+    func test_delete_persistsAcrossNewStoreInstance() throws {
+        try subject.save(.fixture())
+
+        try subject.delete(id: StoredPasskeyCredential.fixture().id)
+
+        let secondInstance = DefaultPasskeyCredentialStore(userDefaults: userDefaults)
+        XCTAssertEqual(try secondInstance.fetchAll(), [])
+    }
 }

--- a/TestHarnessShared/UI/Autofill/CreatePasskey/CreatePasskeyProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/CreatePasskey/CreatePasskeyProcessorTests.swift
@@ -166,12 +166,23 @@ class MockPasskeyCredentialStore: PasskeyCredentialStore {
     var saveError: Error?
     var fetchAllResult: [StoredPasskeyCredential] = []
     var fetchAllError: Error?
+    var deletedIds: [String] = []
+    var deleteError: Error?
+    var deleteAllCalled = false
+    var deleteAllError: Error?
 
-    func save(_ credential: StoredPasskeyCredential) throws {
-        if let saveError {
-            throw saveError
+    func delete(id: String) throws {
+        if let deleteError {
+            throw deleteError
         }
-        savedCredentials.append(credential)
+        deletedIds.append(id)
+    }
+
+    func deleteAll() throws {
+        if let deleteAllError {
+            throw deleteAllError
+        }
+        deleteAllCalled = true
     }
 
     func fetchAll() throws -> [StoredPasskeyCredential] {
@@ -179,5 +190,12 @@ class MockPasskeyCredentialStore: PasskeyCredentialStore {
             throw fetchAllError
         }
         return fetchAllResult
+    }
+
+    func save(_ credential: StoredPasskeyCredential) throws {
+        if let saveError {
+            throw saveError
+        }
+        savedCredentials.append(credential)
     }
 }

--- a/TestHarnessShared/UI/Autofill/CreatePasskey/CreatePasskeyProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/CreatePasskey/CreatePasskeyProcessorTests.swift
@@ -79,7 +79,7 @@ class CreatePasskeyProcessorTests: BitwardenTestCase {
         )
         await subject.perform(.registerPasskey)
         XCTAssertEqual(subject.state.status, .success)
-        XCTAssertEqual(credentialStore.savedCredentials, [.fixture()])
+        XCTAssertEqual(credentialStore.saveReceivedCredential, .fixture())
     }
 
     /// `perform(.registerPasskey)` sets status to `.failure` and does not persist a credential
@@ -95,7 +95,7 @@ class CreatePasskeyProcessorTests: BitwardenTestCase {
         )
         await subject.perform(.registerPasskey)
         XCTAssertEqual(subject.state.status, .failure(testError.localizedDescription))
-        XCTAssertTrue(credentialStore.savedCredentials.isEmpty)
+        XCTAssertFalse(credentialStore.saveCalled)
     }
 
     /// `perform(.registerPasskey)` sets status to `.persistenceFailure` when the credential was
@@ -103,7 +103,7 @@ class CreatePasskeyProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_registerPasskey_credentialStoreSaveThrows() async {
         let testError = BitwardenTestError.example
-        credentialStore.saveError = testError
+        credentialStore.saveThrowableError = testError
         let subject = CreatePasskeyProcessor(
             coordinator: coordinator.asAnyCoordinator(),
             delegate: delegate,
@@ -156,46 +156,5 @@ class MockCreatePasskeyProcessorDelegate: CreatePasskeyProcessorDelegate {
     func presentationAnchorForPasskeyRegistration() async -> ASPresentationAnchor {
         presentationAnchorCalled = true
         return presentationAnchorResult
-    }
-}
-
-// MARK: - MockPasskeyCredentialStore
-
-class MockPasskeyCredentialStore: PasskeyCredentialStore {
-    var savedCredentials: [StoredPasskeyCredential] = []
-    var saveError: Error?
-    var fetchAllResult: [StoredPasskeyCredential] = []
-    var fetchAllError: Error?
-    var deletedIds: [String] = []
-    var deleteError: Error?
-    var deleteAllCalled = false
-    var deleteAllError: Error?
-
-    func delete(id: String) throws {
-        if let deleteError {
-            throw deleteError
-        }
-        deletedIds.append(id)
-    }
-
-    func deleteAll() throws {
-        if let deleteAllError {
-            throw deleteAllError
-        }
-        deleteAllCalled = true
-    }
-
-    func fetchAll() throws -> [StoredPasskeyCredential] {
-        if let fetchAllError {
-            throw fetchAllError
-        }
-        return fetchAllResult
-    }
-
-    func save(_ credential: StoredPasskeyCredential) throws {
-        if let saveError {
-            throw saveError
-        }
-        savedCredentials.append(credential)
     }
 }

--- a/TestHarnessShared/UI/Autofill/CreatePasskey/CreatePasskeyView.swift
+++ b/TestHarnessShared/UI/Autofill/CreatePasskey/CreatePasskeyView.swift
@@ -19,6 +19,7 @@ struct CreatePasskeyView: View {
 
     // MARK: Private Views
 
+    /// The main content view.
     private var content: some View {
         Form {
             credentialsSection

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysAction.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysAction.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Actions that can be processed by a `ManagePasskeysProcessor`.
+///
+/// This screen has no synchronous user interactions of its own; loading and deleting stored
+/// credentials are handled as `ManagePasskeysEffect`s.
+///
+enum ManagePasskeysAction: Equatable {}

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysAction.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysAction.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-/// Actions that can be processed by a `ManagePasskeysProcessor`.
-///
-/// This screen has no synchronous user interactions of its own; loading and deleting stored
-/// credentials are handled as `ManagePasskeysEffect`s.
-///
-enum ManagePasskeysAction: Equatable {}

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysEffect.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysEffect.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Effects that can be processed by a `ManagePasskeysProcessor`.
+///
+enum ManagePasskeysEffect: Equatable {
+    /// The user tapped the button to delete all stored passkey credentials.
+    case deleteAll
+
+    /// The user tapped the button to delete the stored passkey credential with the given
+    /// identifier.
+    case deleteCredential(id: String)
+
+    /// The view appeared and the stored passkey credentials should be loaded.
+    case loadCredentials
+}

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
@@ -6,7 +6,7 @@ import BitwardenKit
 ///
 class ManagePasskeysProcessor: StateProcessor<
     ManagePasskeysState,
-    ManagePasskeysAction,
+    Void,
     ManagePasskeysEffect,
 > {
     // MARK: Private Properties

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
@@ -1,0 +1,113 @@
+import BitwardenKit
+
+// MARK: - ManagePasskeysProcessor
+
+/// The processor for the manage passkeys test screen.
+///
+class ManagePasskeysProcessor: StateProcessor<
+    ManagePasskeysState,
+    ManagePasskeysAction,
+    ManagePasskeysEffect,
+> {
+    // MARK: Private Properties
+
+    /// The coordinator that handles navigation.
+    private let coordinator: AnyCoordinator<RootRoute, Void>
+
+    // MARK: Internal for Testability
+
+    /// Reads, deletes, and clears previously created passkey credentials. Defaults to a
+    /// `UserDefaults`-backed store; overridable in tests.
+    let credentialStore: PasskeyCredentialStore
+
+    // MARK: Initialization
+
+    /// Initializes a `ManagePasskeysProcessor`.
+    ///
+    /// - Parameters:
+    ///   - coordinator: The coordinator that handles navigation.
+    ///   - credentialStore: Reads, deletes, and clears previously created passkey credentials.
+    ///     Defaults to a `UserDefaults`-backed store; overridable in tests.
+    ///
+    init(
+        coordinator: AnyCoordinator<RootRoute, Void>,
+        credentialStore: PasskeyCredentialStore = DefaultPasskeyCredentialStore(),
+    ) {
+        self.coordinator = coordinator
+        self.credentialStore = credentialStore
+        super.init(state: ManagePasskeysState())
+    }
+
+    // MARK: Static Methods
+
+    /// Builds a destructive confirmation alert with the given title.
+    ///
+    /// - Parameters:
+    ///   - title: The alert's title.
+    ///   - confirmationHandler: Called if the user confirms the destructive action.
+    /// - Returns: The confirmation alert.
+    ///
+    private static func confirmationAlert(title: String, confirmationHandler: @escaping () async -> Void) -> Alert {
+        Alert(
+            title: title,
+            message: nil,
+            alertActions: [
+                AlertAction(title: Localizations.cancel, style: .cancel),
+                AlertAction(title: Localizations.delete, style: .destructive) { _ in
+                    await confirmationHandler()
+                },
+            ],
+        )
+    }
+
+    // MARK: Methods
+
+    override func perform(_ effect: ManagePasskeysEffect) async {
+        switch effect {
+        case .deleteAll:
+            coordinator.showAlert(Self.confirmationAlert(title: Localizations.areYouSureDeleteAllPasskeys) {
+                await self.performDeleteAll()
+            })
+        case let .deleteCredential(id):
+            coordinator.showAlert(Self.confirmationAlert(title: Localizations.areYouSureDeleteThisPasskey) {
+                await self.performDelete(id: id)
+            })
+        case .loadCredentials:
+            await loadCredentials()
+        }
+    }
+
+    // MARK: Private
+
+    /// Loads the stored passkey credentials into state, most recently created first.
+    ///
+    private func loadCredentials() async {
+        do {
+            state.credentials = try credentialStore.fetchAll().sorted { $0.createdAt > $1.createdAt }
+        } catch {
+            await coordinator.showErrorAlert(error: error)
+        }
+    }
+
+    /// Deletes the stored passkey credential with the given identifier and reloads the list.
+    ///
+    private func performDelete(id: String) async {
+        do {
+            try credentialStore.delete(id: id)
+            await loadCredentials()
+        } catch {
+            await coordinator.showErrorAlert(error: error)
+        }
+    }
+
+    /// Deletes all stored passkey credentials and reloads the list.
+    ///
+    private func performDeleteAll() async {
+        do {
+            try credentialStore.deleteAll()
+            await loadCredentials()
+        } catch {
+            await coordinator.showErrorAlert(error: error)
+        }
+    }
+}

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
@@ -38,40 +38,14 @@ class ManagePasskeysProcessor: StateProcessor<
         super.init(state: ManagePasskeysState())
     }
 
-    // MARK: Static Methods
-
-    /// Builds a destructive confirmation alert with the given title.
-    ///
-    /// - Parameters:
-    ///   - title: The alert's title.
-    ///   - confirmationHandler: Called if the user confirms the destructive action.
-    /// - Returns: The confirmation alert.
-    ///
-    private static func confirmationAlert(title: String, confirmationHandler: @escaping () async -> Void) -> Alert {
-        Alert(
-            title: title,
-            message: Localizations.deletePasskeyDescriptionLong,
-            alertActions: [
-                AlertAction(title: Localizations.cancel, style: .cancel),
-                AlertAction(title: Localizations.delete, style: .destructive) { _ in
-                    await confirmationHandler()
-                },
-            ],
-        )
-    }
-
     // MARK: Methods
 
     override func perform(_ effect: ManagePasskeysEffect) async {
         switch effect {
         case .deleteAll:
-            coordinator.showAlert(Self.confirmationAlert(title: Localizations.areYouSureDeleteAllPasskeys) {
-                await self.performDeleteAll()
-            })
+            await performDeleteAll()
         case let .deleteCredential(id):
-            coordinator.showAlert(Self.confirmationAlert(title: Localizations.areYouSureDeleteThisPasskey) {
-                await self.performDelete(id: id)
-            })
+            await performDelete(id: id)
         case .loadCredentials:
             await loadCredentials()
         }

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessor.swift
@@ -50,7 +50,7 @@ class ManagePasskeysProcessor: StateProcessor<
     private static func confirmationAlert(title: String, confirmationHandler: @escaping () async -> Void) -> Alert {
         Alert(
             title: title,
-            message: nil,
+            message: Localizations.deletePasskeyDescriptionLong,
             alertActions: [
                 AlertAction(title: Localizations.cancel, style: .cancel),
                 AlertAction(title: Localizations.delete, style: .destructive) { _ in

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
@@ -44,7 +44,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
     func test_perform_loadCredentials() async {
         let older = StoredPasskeyCredential.fixture(rpId: "older.com", createdAt: Date(timeIntervalSince1970: 0))
         let newer = StoredPasskeyCredential.fixture(rpId: "newer.com", createdAt: Date(timeIntervalSince1970: 100))
-        credentialStore.fetchAllResult = [older, newer]
+        credentialStore.fetchAllReturnValue = [older, newer]
 
         await subject.perform(.loadCredentials)
 
@@ -54,7 +54,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
     /// `perform(.loadCredentials)` shows an error alert if fetching the stored credentials fails.
     @MainActor
     func test_perform_loadCredentials_error() async {
-        credentialStore.fetchAllError = BitwardenTestError.example
+        credentialStore.fetchAllThrowableError = BitwardenTestError.example
 
         await subject.perform(.loadCredentials)
 
@@ -67,7 +67,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
     @MainActor
     func test_perform_deleteCredential() async throws {
         let remaining = StoredPasskeyCredential.fixture(rpId: "remaining.com")
-        credentialStore.fetchAllResult = [remaining]
+        credentialStore.fetchAllReturnValue = [remaining]
 
         await subject.perform(.deleteCredential(id: "deleteMe"))
 
@@ -76,17 +76,17 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
         XCTAssertEqual(alert.message, Localizations.deletePasskeyDescriptionLong)
 
         try await alert.tapCancel()
-        XCTAssertTrue(credentialStore.deletedIds.isEmpty)
+        XCTAssertFalse(credentialStore.deleteCalled)
 
         try await alert.tapAction(title: Localizations.delete)
-        XCTAssertEqual(credentialStore.deletedIds, ["deleteMe"])
+        XCTAssertEqual(credentialStore.deleteReceivedId, "deleteMe")
         XCTAssertEqual(subject.state.credentials, [remaining])
     }
 
     /// `perform(.deleteCredential)` shows an error alert if deleting the credential fails.
     @MainActor
     func test_perform_deleteCredential_error() async throws {
-        credentialStore.deleteError = BitwardenTestError.example
+        credentialStore.deleteThrowableError = BitwardenTestError.example
 
         await subject.perform(.deleteCredential(id: "deleteMe"))
 
@@ -100,7 +100,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
     /// credentials and reloads the list.
     @MainActor
     func test_perform_deleteAll() async throws {
-        credentialStore.fetchAllResult = [.fixture()]
+        credentialStore.fetchAllReturnValue = [.fixture()]
 
         await subject.perform(.deleteAll)
 
@@ -111,7 +111,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
         try await alert.tapCancel()
         XCTAssertFalse(credentialStore.deleteAllCalled)
 
-        credentialStore.fetchAllResult = []
+        credentialStore.fetchAllReturnValue = []
         try await alert.tapAction(title: Localizations.delete)
         XCTAssertTrue(credentialStore.deleteAllCalled)
         XCTAssertTrue(subject.state.credentials.isEmpty)
@@ -120,7 +120,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
     /// `perform(.deleteAll)` shows an error alert if deleting all credentials fails.
     @MainActor
     func test_perform_deleteAll_error() async throws {
-        credentialStore.deleteAllError = BitwardenTestError.example
+        credentialStore.deleteAllThrowableError = BitwardenTestError.example
 
         await subject.perform(.deleteAll)
 

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
@@ -1,0 +1,130 @@
+import BitwardenKit
+import BitwardenKitMocks
+import TestHelpers
+import XCTest
+
+@testable import TestHarnessShared
+
+// MARK: - ManagePasskeysProcessorTests
+
+/// Tests for `ManagePasskeysProcessor`.
+///
+class ManagePasskeysProcessorTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var coordinator: MockCoordinator<RootRoute, Void>!
+    var credentialStore: MockPasskeyCredentialStore!
+    var subject: ManagePasskeysProcessor!
+
+    // MARK: Setup & Teardown
+
+    @MainActor
+    override func setUp() {
+        super.setUp()
+        coordinator = MockCoordinator()
+        credentialStore = MockPasskeyCredentialStore()
+        subject = ManagePasskeysProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            credentialStore: credentialStore,
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        coordinator = nil
+        credentialStore = nil
+        subject = nil
+    }
+
+    // MARK: Effect Tests
+
+    /// `perform(.loadCredentials)` populates state with the stored credentials, most recently
+    /// created first.
+    @MainActor
+    func test_perform_loadCredentials() async {
+        let older = StoredPasskeyCredential.fixture(rpId: "older.com", createdAt: Date(timeIntervalSince1970: 0))
+        let newer = StoredPasskeyCredential.fixture(rpId: "newer.com", createdAt: Date(timeIntervalSince1970: 100))
+        credentialStore.fetchAllResult = [older, newer]
+
+        await subject.perform(.loadCredentials)
+
+        XCTAssertEqual(subject.state.credentials, [newer, older])
+    }
+
+    /// `perform(.loadCredentials)` shows an error alert if fetching the stored credentials fails.
+    @MainActor
+    func test_perform_loadCredentials_error() async {
+        credentialStore.fetchAllError = BitwardenTestError.example
+
+        await subject.perform(.loadCredentials)
+
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
+        XCTAssertTrue(subject.state.credentials.isEmpty)
+    }
+
+    /// `perform(.deleteCredential)` shows a confirmation alert and, once confirmed, deletes the
+    /// credential and reloads the list.
+    @MainActor
+    func test_perform_deleteCredential() async throws {
+        let remaining = StoredPasskeyCredential.fixture(rpId: "remaining.com")
+        credentialStore.fetchAllResult = [remaining]
+
+        await subject.perform(.deleteCredential(id: "deleteMe"))
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.areYouSureDeleteThisPasskey)
+
+        try await alert.tapCancel()
+        XCTAssertTrue(credentialStore.deletedIds.isEmpty)
+
+        try await alert.tapAction(title: Localizations.delete)
+        XCTAssertEqual(credentialStore.deletedIds, ["deleteMe"])
+        XCTAssertEqual(subject.state.credentials, [remaining])
+    }
+
+    /// `perform(.deleteCredential)` shows an error alert if deleting the credential fails.
+    @MainActor
+    func test_perform_deleteCredential_error() async throws {
+        credentialStore.deleteError = BitwardenTestError.example
+
+        await subject.perform(.deleteCredential(id: "deleteMe"))
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.delete)
+
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
+    }
+
+    /// `perform(.deleteAll)` shows a confirmation alert and, once confirmed, deletes all
+    /// credentials and reloads the list.
+    @MainActor
+    func test_perform_deleteAll() async throws {
+        credentialStore.fetchAllResult = [.fixture()]
+
+        await subject.perform(.deleteAll)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.areYouSureDeleteAllPasskeys)
+
+        try await alert.tapCancel()
+        XCTAssertFalse(credentialStore.deleteAllCalled)
+
+        credentialStore.fetchAllResult = []
+        try await alert.tapAction(title: Localizations.delete)
+        XCTAssertTrue(credentialStore.deleteAllCalled)
+        XCTAssertTrue(subject.state.credentials.isEmpty)
+    }
+
+    /// `perform(.deleteAll)` shows an error alert if deleting all credentials fails.
+    @MainActor
+    func test_perform_deleteAll_error() async throws {
+        credentialStore.deleteAllError = BitwardenTestError.example
+
+        await subject.perform(.deleteAll)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.delete)
+
+        XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
+    }
+}

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
@@ -62,70 +62,47 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
         XCTAssertTrue(subject.state.credentials.isEmpty)
     }
 
-    /// `perform(.deleteCredential)` shows a confirmation alert and, once confirmed, deletes the
-    /// credential and reloads the list.
+    /// `perform(.deleteCredential)` deletes the credential and reloads the list.
     @MainActor
-    func test_perform_deleteCredential() async throws {
+    func test_perform_deleteCredential() async {
         let remaining = StoredPasskeyCredential.fixture(rpId: "remaining.com")
         credentialStore.fetchAllReturnValue = [remaining]
 
         await subject.perform(.deleteCredential(id: "deleteMe"))
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, Localizations.areYouSureDeleteThisPasskey)
-        XCTAssertEqual(alert.message, Localizations.deletePasskeyDescriptionLong)
-
-        try await alert.tapCancel()
-        XCTAssertFalse(credentialStore.deleteCalled)
-
-        try await alert.tapAction(title: Localizations.delete)
         XCTAssertEqual(credentialStore.deleteReceivedId, "deleteMe")
         XCTAssertEqual(subject.state.credentials, [remaining])
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
     }
 
     /// `perform(.deleteCredential)` shows an error alert if deleting the credential fails.
     @MainActor
-    func test_perform_deleteCredential_error() async throws {
+    func test_perform_deleteCredential_error() async {
         credentialStore.deleteThrowableError = BitwardenTestError.example
 
         await subject.perform(.deleteCredential(id: "deleteMe"))
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.tapAction(title: Localizations.delete)
-
         XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
     }
 
-    /// `perform(.deleteAll)` shows a confirmation alert and, once confirmed, deletes all
-    /// credentials and reloads the list.
+    /// `perform(.deleteAll)` deletes all credentials and reloads the list.
     @MainActor
-    func test_perform_deleteAll() async throws {
-        credentialStore.fetchAllReturnValue = [.fixture()]
+    func test_perform_deleteAll() async {
+        credentialStore.fetchAllReturnValue = []
 
         await subject.perform(.deleteAll)
 
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        XCTAssertEqual(alert.title, Localizations.areYouSureDeleteAllPasskeys)
-        XCTAssertEqual(alert.message, Localizations.deletePasskeyDescriptionLong)
-
-        try await alert.tapCancel()
-        XCTAssertFalse(credentialStore.deleteAllCalled)
-
-        credentialStore.fetchAllReturnValue = []
-        try await alert.tapAction(title: Localizations.delete)
         XCTAssertTrue(credentialStore.deleteAllCalled)
         XCTAssertTrue(subject.state.credentials.isEmpty)
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
     }
 
     /// `perform(.deleteAll)` shows an error alert if deleting all credentials fails.
     @MainActor
-    func test_perform_deleteAll_error() async throws {
+    func test_perform_deleteAll_error() async {
         credentialStore.deleteAllThrowableError = BitwardenTestError.example
 
         await subject.perform(.deleteAll)
-
-        let alert = try XCTUnwrap(coordinator.alertShown.last)
-        try await alert.tapAction(title: Localizations.delete)
 
         XCTAssertEqual(coordinator.errorAlertsShown as? [BitwardenTestError], [.example])
     }

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysProcessorTests.swift
@@ -73,6 +73,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.areYouSureDeleteThisPasskey)
+        XCTAssertEqual(alert.message, Localizations.deletePasskeyDescriptionLong)
 
         try await alert.tapCancel()
         XCTAssertTrue(credentialStore.deletedIds.isEmpty)
@@ -105,6 +106,7 @@ class ManagePasskeysProcessorTests: BitwardenTestCase {
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.areYouSureDeleteAllPasskeys)
+        XCTAssertEqual(alert.message, Localizations.deletePasskeyDescriptionLong)
 
         try await alert.tapCancel()
         XCTAssertFalse(credentialStore.deleteAllCalled)

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysState.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysState.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// The state for the manage passkeys test screen.
+///
+struct ManagePasskeysState: Equatable {
+    // MARK: Properties
+
+    /// The stored passkey credentials, sorted by creation date, most recent first.
+    var credentials: [StoredPasskeyCredential] = []
+
+    /// The title of the screen.
+    var title: String = Localizations.managePasskeys
+}

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
@@ -1,0 +1,118 @@
+import BitwardenKit
+import SwiftUI
+
+/// A view that lists passkey credentials stored by other Test Harness passkey scenarios, and
+/// allows deleting them to clean up test data.
+///
+struct ManagePasskeysView: View {
+    // MARK: Properties
+
+    /// The store used to render the view.
+    @ObservedObject var store: Store<ManagePasskeysState, ManagePasskeysAction, ManagePasskeysEffect>
+
+    // MARK: View
+
+    var body: some View {
+        content
+            .navigationTitle(store.state.title)
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(Localizations.deleteAll, role: .destructive) {
+                        Task { await store.perform(.deleteAll) }
+                    }
+                    .accessibilityIdentifier("DeleteAllButton")
+                    .disabled(store.state.credentials.isEmpty)
+                }
+            }
+            .task {
+                await store.perform(.loadCredentials)
+            }
+    }
+
+    // MARK: Private Views
+
+    /// The main content view.
+    @ViewBuilder private var content: some View {
+        if store.state.credentials.isEmpty {
+            emptyState
+        } else {
+            credentialsList
+        }
+    }
+
+    /// The list of stored passkey credentials, each deletable via a swipe action.
+    private var credentialsList: some View {
+        List {
+            ForEach(store.state.credentials) { credential in
+                credentialRow(credential)
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            Task { await store.perform(.deleteCredential(id: credential.id)) }
+                        } label: {
+                            Label(Localizations.delete, systemImage: "trash")
+                        }
+                        .accessibilityIdentifier("DeleteCredentialButton")
+                    }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    /// The message shown when there are no stored passkey credentials.
+    private var emptyState: some View {
+        Text(Localizations.noPasskeysStored)
+            .foregroundColor(.secondary)
+            .accessibilityIdentifier("ManagePasskeysEmptyStateLabel")
+    }
+
+    /// A row displaying the metadata for a single stored passkey credential.
+    private func credentialRow(_ credential: StoredPasskeyCredential) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(Localizations.xColonY(Localizations.relyingPartyId, credential.rpId))
+            Text(Localizations.xColonY(Localizations.username, credential.userName))
+            Text(Localizations.xColonY(Localizations.displayName, credential.displayName))
+            Text(Localizations.xColonY(Localizations.createdAt, credential.createdAt.formatted()))
+        }
+        .font(.footnote)
+    }
+}
+
+// MARK: - Previews
+
+#if DEBUG
+#Preview("Empty") {
+    NavigationView {
+        ManagePasskeysView(store: Store(processor: StateProcessor(state: ManagePasskeysState())))
+    }
+}
+
+#Preview("Populated") {
+    NavigationView {
+        ManagePasskeysView(
+            store: Store(processor: StateProcessor(state: {
+                var state = ManagePasskeysState()
+                state.credentials = [
+                    StoredPasskeyCredential(
+                        createdAt: Date(),
+                        credentialId: Data([0x01, 0x02, 0x03]),
+                        displayName: "User One",
+                        publicKeyX963: Data(repeating: 0x04, count: 65),
+                        rpId: "bitwarden.pw",
+                        userName: "user1",
+                    ),
+                    StoredPasskeyCredential(
+                        createdAt: Date(timeIntervalSinceNow: -86400),
+                        credentialId: Data([0x05, 0x06, 0x07]),
+                        displayName: "User Two",
+                        publicKeyX963: Data(repeating: 0x08, count: 65),
+                        rpId: "bitwarden.com",
+                        userName: "user2",
+                    ),
+                ]
+                return state
+            }())),
+        )
+    }
+}
+#endif

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
@@ -8,7 +8,7 @@ struct ManagePasskeysView: View {
     // MARK: Properties
 
     /// The store used to render the view.
-    @ObservedObject var store: Store<ManagePasskeysState, ManagePasskeysAction, ManagePasskeysEffect>
+    @ObservedObject var store: Store<ManagePasskeysState, Void, ManagePasskeysEffect>
 
     // MARK: View
 

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
@@ -52,7 +52,7 @@ struct ManagePasskeysView: View {
                         } label: {
                             Label(Localizations.delete, systemImage: "trash")
                         }
-                        .accessibilityIdentifier("DeleteCredentialButton")
+                        .accessibilityIdentifier("DeleteCredentialButton_\(credential.id)")
                     }
             }
         }

--- a/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
+++ b/TestHarnessShared/UI/Autofill/ManagePasskeys/ManagePasskeysView.swift
@@ -13,50 +13,50 @@ struct ManagePasskeysView: View {
     // MARK: View
 
     var body: some View {
-        content
-            .navigationTitle(store.state.title)
-            .navigationBarTitleDisplayMode(.large)
-            .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(Localizations.deleteAll, role: .destructive) {
-                        Task { await store.perform(.deleteAll) }
-                    }
-                    .accessibilityIdentifier("DeleteAllButton")
-                    .disabled(store.state.credentials.isEmpty)
+        List {
+            Section {} footer: {
+                Text(Localizations.deletePasskeyDescriptionLong)
+                    .accessibilityIdentifier("ManagePasskeysDisclaimerLabel")
+            }
+
+            if store.state.credentials.isEmpty {
+                emptyState
+            } else {
+                credentialRows
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(store.state.title)
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(Localizations.deleteAll, role: .destructive) {
+                    Task { await store.perform(.deleteAll) }
                 }
+                .accessibilityIdentifier("DeleteAllButton")
+                .disabled(store.state.credentials.isEmpty)
             }
-            .task {
-                await store.perform(.loadCredentials)
-            }
+        }
+        .task {
+            await store.perform(.loadCredentials)
+        }
     }
 
     // MARK: Private Views
 
-    /// The main content view.
-    @ViewBuilder private var content: some View {
-        if store.state.credentials.isEmpty {
-            emptyState
-        } else {
-            credentialsList
-        }
-    }
-
-    /// The list of stored passkey credentials, each deletable via a swipe action.
-    private var credentialsList: some View {
-        List {
-            ForEach(store.state.credentials) { credential in
-                credentialRow(credential)
-                    .swipeActions(edge: .trailing) {
-                        Button(role: .destructive) {
-                            Task { await store.perform(.deleteCredential(id: credential.id)) }
-                        } label: {
-                            Label(Localizations.delete, systemImage: "trash")
-                        }
-                        .accessibilityIdentifier("DeleteCredentialButton_\(credential.id)")
+    /// The rows for each stored passkey credential, each deletable via a swipe action.
+    private var credentialRows: some View {
+        ForEach(store.state.credentials) { credential in
+            credentialRow(credential)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button(role: .destructive) {
+                        Task { await store.perform(.deleteCredential(id: credential.id)) }
+                    } label: {
+                        Label(Localizations.delete, systemImage: "trash")
                     }
-            }
+                    .accessibilityIdentifier("DeleteCredentialButton_\(credential.id)")
+                }
         }
-        .listStyle(.insetGrouped)
     }
 
     /// The message shown when there are no stored passkey credentials.

--- a/TestHarnessShared/UI/Autofill/UsePasskey/UsePasskeyProcessorTests.swift
+++ b/TestHarnessShared/UI/Autofill/UsePasskey/UsePasskeyProcessorTests.swift
@@ -26,6 +26,7 @@ class UsePasskeyProcessorTests: BitwardenTestCase {
         super.setUp()
         coordinator = MockCoordinator()
         credentialStore = MockPasskeyCredentialStore()
+        credentialStore.fetchAllReturnValue = []
         delegate = MockUsePasskeyProcessorDelegate()
         subject = UsePasskeyProcessor(
             coordinator: coordinator.asAnyCoordinator(),
@@ -148,7 +149,7 @@ class UsePasskeyProcessorTests: BitwardenTestCase {
     func test_perform_assertPasskey_filtersStoredCredentialsByRpId() async {
         let matching = StoredPasskeyCredential.fixture(rpId: "example.com")
         let nonMatching = StoredPasskeyCredential.fixture(rpId: "other.com")
-        credentialStore.fetchAllResult = [matching, nonMatching]
+        credentialStore.fetchAllReturnValue = [matching, nonMatching]
 
         var capturedCredentials: [StoredPasskeyCredential]?
         let subject = UsePasskeyProcessor(

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -93,6 +93,7 @@
 "TapTheTOTPCodeFieldAndSelectDescriptionLong" = "Tap the TOTP Code field and select a code from Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Login with a TOTP seed.";
 "TOTPCode" = "TOTP Code";
 "UnexpectedAssertionClientDataTypeExplanationLong" = "The client data's \"type\" field was something other than \"webauthn.get\" — for example, a registration ceremony's \"webauthn.create\" sent where an assertion was expected.";
+"UnexpectedCredentialTypeReceived" = "Unexpected credential type received.";
 "UnexpectedAssertionClientDataTypeReceived" = "The client data type (%@) was not \"webauthn.get\".";
 "UnexpectedAssertionClientDataTypeTitle" = "Unexpected client data type";
 "UnexpectedClientDataTypeReceived" = "The client data type (%@) was not \"webauthn.create\".";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -31,6 +31,7 @@
 "Credentials" = "Credentials";
 "Delete" = "Delete";
 "DeleteAll" = "Delete All";
+"DeletePasskeyDescriptionLong" = "This only removes the local test record used to verify sign-in attempts. It does not delete the underlying passkey from your AutoFill provider.";
 "DisplayName" = "Display Name";
 "EnterCardDetailsAbove" = "Enter card details above";
 "EnterCredentialsAbove" = "Enter credentials above";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
 "AuthDataTooShort" = "Authenticator data too short";
 "AuthDataTooShortReceived" = "The authenticator data was too short to contain the expected fields.";
 "CardAutofillForm" = "Card Autofill Form";
+"CreatePasskey" = "Create Passkey";
 "CardAutofillFormDescriptionLong" = "Long press a field, then select Autofill and Password to autofill with Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Card cipher.";
 "CardDetails" = "Card Details";
 "CardholderName" = "Cardholder Name";
@@ -55,6 +56,8 @@
 "MissingClientDataTypeReceived" = "The client data JSON did not contain a type field.";
 "MissingClientDataTypeTitle" = "Missing type field";
 "PasskeyAssertedSuccessfully" = "Passkey sign-in succeeded.";
+"PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
+"PasskeyAutofill" = "Passkey Autofill";
 "PasskeyCreatedButNotSaved" = "Passkey created, but not saved for later verification.";
 "PasskeyErrorReference" = "Passkey Error Reference";
 "PasskeyErrorReferenceDescriptionLong" = "Every error the client data parser and assertion verifier can produce for a passkey sign-in, in the order each is checked. Use this to see what a failure looks like without needing to trigger it.";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 "SignatureInvalidExplanationLong" = "The ECDSA signature over the authenticator data plus the SHA-256 hash of the client data JSON did not verify against the stored credential's public key — for example, the wrong key, a corrupted signature, or tampered data.";
 "SignatureInvalidReceived" = "The assertion signature could not be verified against the stored public key.";
 "SignatureInvalidTitle" = "Signature invalid";
+"SignInWithPasskey" = "Sign In with Passkey";
 "SimpleLoginForm" = "Simple Login Form";
 "SimpleLoginFormDescription" = "Use this simple login form to test autofill functionality.";
 "SignInWithPasskey" = "Sign In with Passkey";
@@ -96,10 +97,10 @@
 "UnexpectedAssertionClientDataTypeReceived" = "The client data type (%@) was not \"webauthn.get\".";
 "UnexpectedAssertionClientDataTypeTitle" = "Unexpected client data type";
 "UnexpectedClientDataTypeReceived" = "The client data type (%@) was not \"webauthn.create\".";
+"UnexpectedCredentialTypeReceived" = "Unexpected credential type received.";
 "UnsupportedAlgorithmReceived" = "The credential's public key algorithm (%d) is not supported; expected ES256.";
 "UnsupportedCurveReceived" = "The credential's public key curve (%d) is not supported; expected P-256.";
 "UnsupportedKeyTypeReceived" = "The credential's public key type (%d) is not supported; expected EC2.";
-"UnexpectedCredentialTypeReceived" = "Unexpected credential type received.";
 "Username" = "Username";
 "UserPresenceNotAssertedExplanationLong" = "The authenticator data's flags byte did not have the \"user present\" bit set.";
 "UserPresenceNotAssertedReceived" = "The authenticator did not assert user presence.";
@@ -110,7 +111,6 @@
 "UsernameValue" = "Username: %@";
 "VerificationErrors" = "Verification Errors";
 "VerificationErrorsDescriptionLong" = "Occur while matching the parsed assertion against a stored credential, in the order they are checked.";
-"UsernameValue" = "Username: %@";
 "XColonY" = "%@: %@";
 "DateFieldPicker" = "Date Field Picker";
 "DateFieldPickerDescription" = "Tap the field to expand the inline calendar and select a date.";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 "AccountCreatedSuccessfully" = "Account created successfully";
 "AccountDetails" = "Account Details";
-"AreYouSureDeleteAllPasskeys" = "Are you sure you want to delete all passkeys?";
-"AreYouSureDeleteThisPasskey" = "Are you sure you want to delete this passkey?";
+"AreYouSureDeleteAllPasskeys" = "Are you sure you want to delete all stored test passkeys?";
+"AreYouSureDeleteThisPasskey" = "Are you sure you want to delete this stored test passkey?";
 "AssertionResult" = "Assertion Result";
 "AuthDataTooShort" = "Authenticator data too short";
 "AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -100,13 +100,13 @@
 "UnsupportedAlgorithmReceived" = "The credential's public key algorithm (%d) is not supported; expected ES256.";
 "UnsupportedCurveReceived" = "The credential's public key curve (%d) is not supported; expected P-256.";
 "UnsupportedKeyTypeReceived" = "The credential's public key type (%d) is not supported; expected EC2.";
+"UsePasskeyFormDescriptionLong" = "Enter a relying party ID below, then tap Sign In with Passkey. The Bitwarden AutoFill sheet will appear to select a credential.";
+"UseThisLoginFormToTestAutofillFunctionality" = "Use this login form to test autofill functionality.";
 "Username" = "Username";
 "UserPresenceNotAssertedExplanationLong" = "The authenticator data's flags byte did not have the \"user present\" bit set.";
 "UserPresenceNotAssertedReceived" = "The authenticator did not assert user presence.";
 "UserPresenceNotAssertedTitle" = "User presence not asserted";
 "UsePasskey" = "Use passkey";
-"UsePasskeyFormDescriptionLong" = "Enter a relying party ID above, then tap Sign In with Passkey. The Bitwarden AutoFill sheet will appear to select a credential.";
-"UseThisLoginFormToTestAutofillFunctionality" = "Use this login form to test autofill functionality.";
 "Username" = "Username";
 "UsernameValue" = "Username: %@";
 "VerificationErrors" = "Verification Errors";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -61,6 +61,7 @@
 "MissingClientDataTypeReceived" = "The client data JSON did not contain a type field.";
 "MissingClientDataTypeTitle" = "Missing type field";
 "NoPasskeysStored" = "No passkeys stored.";
+"Other" = "Other";
 "PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
 "PasskeyAssertedSuccessfully" = "Passkey sign-in succeeded.";
 "PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
@@ -70,6 +71,7 @@
 "PasskeyErrorReferenceDescriptionLong" = "Every error the client data parser and assertion verifier can produce for a passkey sign-in, in the order each is checked. Use this to see what a failure looks like without needing to trigger it.";
 "PasskeyRegistrationNotAvailable" = "Passkey registration requires iOS 17 or later.";
 "PasskeyRegisteredSuccessfully" = "Passkey registered successfully.";
+"Passkeys" = "Passkeys";
 "PasskeyVerificationFailed" = "Passkey verification failed.";
 "Password" = "Password";
 "PasswordsDoNotMatch" = "Passwords do not match";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1,8 +1,8 @@
 "AccountCreatedSuccessfully" = "Account created successfully";
 "AccountDetails" = "Account Details";
 "AssertionResult" = "Assertion Result";
-"AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
 "AuthDataTooShort" = "Authenticator data too short";
+"AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
 "AuthDataTooShortReceived" = "The authenticator data was too short to contain the expected fields.";
 "CardAutofillForm" = "Card Autofill Form";
 "CreatePasskey" = "Create Passkey";
@@ -84,7 +84,6 @@
 "SignatureInvalidExplanationLong" = "The ECDSA signature over the authenticator data plus the SHA-256 hash of the client data JSON did not verify against the stored credential's public key — for example, the wrong key, a corrupted signature, or tampered data.";
 "SignatureInvalidReceived" = "The assertion signature could not be verified against the stored public key.";
 "SignatureInvalidTitle" = "Signature invalid";
-"SignInWithPasskey" = "Sign In with Passkey";
 "SimpleLoginForm" = "Simple Login Form";
 "SimpleLoginFormDescription" = "Use this simple login form to test autofill functionality.";
 "SignInWithPasskey" = "Sign In with Passkey";
@@ -108,6 +107,7 @@
 "UsePasskey" = "Use passkey";
 "UsePasskeyFormDescriptionLong" = "Enter a relying party ID above, then tap Sign In with Passkey. The Bitwarden AutoFill sheet will appear to select a credential.";
 "UseThisLoginFormToTestAutofillFunctionality" = "Use this login form to test autofill functionality.";
+"Username" = "Username";
 "UsernameValue" = "Username: %@";
 "VerificationErrors" = "Verification Errors";
 "VerificationErrorsDescriptionLong" = "Occur while matching the parsed assertion against a stored credential, in the order they are checked.";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -5,6 +5,7 @@
 "AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
 "AuthDataTooShortReceived" = "The authenticator data was too short to contain the expected fields.";
 "CardAutofillForm" = "Card Autofill Form";
+"CreatePasskey" = "Create Passkey";
 "CardAutofillFormDescriptionLong" = "Long press a field, then select Autofill and Password to autofill with Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Card cipher.";
 "CardDetails" = "Card Details";
 "CardholderName" = "Cardholder Name";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -5,7 +5,6 @@
 "AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
 "AuthDataTooShortReceived" = "The authenticator data was too short to contain the expected fields.";
 "CardAutofillForm" = "Card Autofill Form";
-"CreatePasskey" = "Create Passkey";
 "CardAutofillFormDescriptionLong" = "Long press a field, then select Autofill and Password to autofill with Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Card cipher.";
 "CardDetails" = "Card Details";
 "CardholderName" = "Cardholder Name";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -99,12 +99,12 @@
 "UnsupportedAlgorithmReceived" = "The credential's public key algorithm (%d) is not supported; expected ES256.";
 "UnsupportedCurveReceived" = "The credential's public key curve (%d) is not supported; expected P-256.";
 "UnsupportedKeyTypeReceived" = "The credential's public key type (%d) is not supported; expected EC2.";
-"UsePasskeyFormDescriptionLong" = "Enter a relying party ID below, then tap Sign In with Passkey. The Bitwarden AutoFill sheet will appear to select a credential.";
-"UseThisLoginFormToTestAutofillFunctionality" = "Use this login form to test autofill functionality.";
 "UserPresenceNotAssertedExplanationLong" = "The authenticator data's flags byte did not have the \"user present\" bit set.";
 "UserPresenceNotAssertedReceived" = "The authenticator did not assert user presence.";
 "UserPresenceNotAssertedTitle" = "User presence not asserted";
 "UsePasskey" = "Use passkey";
+"UsePasskeyFormDescriptionLong" = "Enter a relying party ID above, then tap Sign In with Passkey. The Bitwarden AutoFill sheet will appear to select a credential.";
+"UseThisLoginFormToTestAutofillFunctionality" = "Use this login form to test autofill functionality.";
 "Username" = "Username";
 "UsernameValue" = "Username: %@";
 "VerificationErrors" = "Verification Errors";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1,9 +1,12 @@
 "AccountCreatedSuccessfully" = "Account created successfully";
 "AccountDetails" = "Account Details";
+"AreYouSureDeleteAllPasskeys" = "Are you sure you want to delete all passkeys?";
+"AreYouSureDeleteThisPasskey" = "Are you sure you want to delete this passkey?";
 "AssertionResult" = "Assertion Result";
 "AuthDataTooShort" = "Authenticator data too short";
 "AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
 "AuthDataTooShortReceived" = "The authenticator data was too short to contain the expected fields.";
+"Cancel" = "Cancel";
 "CardAutofillForm" = "Card Autofill Form";
 "CardAutofillFormDescriptionLong" = "Long press a field, then select Autofill and Password to autofill with Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Card cipher.";
 "CardDetails" = "Card Details";
@@ -20,11 +23,14 @@
 "CreateAccountFormDescriptionLong" = "Fill in the form and tap Create Account. On supported devices, iOS will prompt to save the credential via the active password provider.";
 "CreatePasskey" = "Create Passkey";
 "CreatePasskeyFormDescriptionLong" = "Fill in the fields above, then tap Register Passkey. The Bitwarden AutoFill sheet will appear to save the credential.";
+"CreatedAt" = "Created At";
 "CredentialId" = "Credential ID";
 "CredentialNotFoundExplanationLong" = "The assertion's credential ID did not match any credential stored for this relying party. This is the first check performed, before the authenticator or client data is inspected.";
 "CredentialNotFoundReceived" = "No stored passkey credential matches the one returned by the authenticator.";
 "CredentialNotFoundTitle" = "Credential not found";
 "Credentials" = "Credentials";
+"Delete" = "Delete";
+"DeleteAll" = "Delete All";
 "DisplayName" = "Display Name";
 "EnterCardDetailsAbove" = "Enter card details above";
 "EnterCredentialsAbove" = "Enter credentials above";
@@ -44,6 +50,7 @@
 "MalformedCOSEKeyReceived" = "The credential's public key could not be decoded.";
 "MalformedCredentialIdLengthReceived" = "The credential ID length did not fit within the authenticator data.";
 "MalformedTopLevelCBORReceived" = "The attestation object's top-level CBOR structure could not be decoded.";
+"ManagePasskeys" = "Manage Passkeys";
 "MessageShown" = "Message shown";
 "MissingAttestationObjectReceived" = "The authorization response did not include an attestation object.";
 "MissingAttestedCredentialDataReceived" = "The authenticator data did not include attested credential data.";
@@ -54,6 +61,8 @@
 "MissingClientDataTypeExplanationLong" = "The decoded client data JSON did not contain a \"type\" field.";
 "MissingClientDataTypeReceived" = "The client data JSON did not contain a type field.";
 "MissingClientDataTypeTitle" = "Missing type field";
+"NoPasskeysStored" = "No passkeys stored.";
+"PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
 "PasskeyAssertedSuccessfully" = "Passkey sign-in succeeded.";
 "PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
 "PasskeyAutofill" = "Passkey Autofill";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -110,6 +110,7 @@
 "UsernameValue" = "Username: %@";
 "VerificationErrors" = "Verification Errors";
 "VerificationErrorsDescriptionLong" = "Occur while matching the parsed assertion against a stored credential, in the order they are checked.";
+"UsernameValue" = "Username: %@";
 "XColonY" = "%@: %@";
 "DateFieldPicker" = "Date Field Picker";
 "DateFieldPickerDescription" = "Tap the field to expand the inline calendar and select a date.";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -5,7 +5,6 @@
 "AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
 "AuthDataTooShortReceived" = "The authenticator data was too short to contain the expected fields.";
 "CardAutofillForm" = "Card Autofill Form";
-"CreatePasskey" = "Create Passkey";
 "CardAutofillFormDescriptionLong" = "Long press a field, then select Autofill and Password to autofill with Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Card cipher.";
 "CardDetails" = "Card Details";
 "CardholderName" = "Cardholder Name";
@@ -102,7 +101,6 @@
 "UnsupportedKeyTypeReceived" = "The credential's public key type (%d) is not supported; expected EC2.";
 "UsePasskeyFormDescriptionLong" = "Enter a relying party ID below, then tap Sign In with Passkey. The Bitwarden AutoFill sheet will appear to select a credential.";
 "UseThisLoginFormToTestAutofillFunctionality" = "Use this login form to test autofill functionality.";
-"Username" = "Username";
 "UserPresenceNotAssertedExplanationLong" = "The authenticator data's flags byte did not have the \"user present\" bit set.";
 "UserPresenceNotAssertedReceived" = "The authenticator did not assert user presence.";
 "UserPresenceNotAssertedTitle" = "User presence not asserted";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -1,7 +1,5 @@
 "AccountCreatedSuccessfully" = "Account created successfully";
 "AccountDetails" = "Account Details";
-"AreYouSureDeleteAllPasskeys" = "Are you sure you want to delete all stored test passkeys?";
-"AreYouSureDeleteThisPasskey" = "Are you sure you want to delete this stored test passkey?";
 "AssertionResult" = "Assertion Result";
 "AuthDataTooShort" = "Authenticator data too short";
 "AuthDataTooShortExplanationLong" = "The raw authenticator data was shorter than the fixed 37-byte prefix (32-byte relying party hash, 1-byte flags, 4-byte signature counter), so the relying party hash and flags could not be read.";
@@ -31,7 +29,7 @@
 "Credentials" = "Credentials";
 "Delete" = "Delete";
 "DeleteAll" = "Delete All";
-"DeletePasskeyDescriptionLong" = "This only removes the local test record used to verify sign-in attempts. It does not delete the underlying passkey from your AutoFill provider.";
+"DeletePasskeyDescriptionLong" = "Deleting only removes the local test record used to verify sign-in attempts. It does not delete the underlying passkey from your AutoFill provider.";
 "DisplayName" = "Display Name";
 "EnterCardDetailsAbove" = "Enter card details above";
 "EnterCredentialsAbove" = "Enter credentials above";

--- a/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
+++ b/TestHarnessShared/UI/Platform/Application/Support/Localizations/en.lproj/Localizable.strings
@@ -62,7 +62,6 @@
 "MissingClientDataTypeTitle" = "Missing type field";
 "NoPasskeysStored" = "No passkeys stored.";
 "Other" = "Other";
-"PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
 "PasskeyAssertedSuccessfully" = "Passkey sign-in succeeded.";
 "PasskeyAssertionNotAvailable" = "Passkey assertion requires iOS 17 or later.";
 "PasskeyAutofill" = "Passkey Autofill";
@@ -102,7 +101,6 @@
 "TapTheTOTPCodeFieldAndSelectDescriptionLong" = "Tap the TOTP Code field and select a code from Bitwarden. Requires Bitwarden PM as AutoFill provider and a saved Login with a TOTP seed.";
 "TOTPCode" = "TOTP Code";
 "UnexpectedAssertionClientDataTypeExplanationLong" = "The client data's \"type\" field was something other than \"webauthn.get\" — for example, a registration ceremony's \"webauthn.create\" sent where an assertion was expected.";
-"UnexpectedCredentialTypeReceived" = "Unexpected credential type received.";
 "UnexpectedAssertionClientDataTypeReceived" = "The client data type (%@) was not \"webauthn.get\".";
 "UnexpectedAssertionClientDataTypeTitle" = "Unexpected client data type";
 "UnexpectedClientDataTypeReceived" = "The client data type (%@) was not \"webauthn.create\".";

--- a/TestHarnessShared/UI/Platform/Root/RootCoordinator.swift
+++ b/TestHarnessShared/UI/Platform/Root/RootCoordinator.swift
@@ -45,6 +45,8 @@ class RootCoordinator: Coordinator, HasStackNavigator {
             showDateFieldPickerShowcase()
         case .fileShare:
             showFileShare()
+        case .managePasskeys:
+            showManagePasskeys()
         case .registerPasskey:
             showCreatePasskey()
         case .scenarioPicker:
@@ -112,6 +114,16 @@ class RootCoordinator: Coordinator, HasStackNavigator {
         stackNavigator?.push(viewController)
     }
 
+    /// Shows the manage passkeys test screen.
+    ///
+    private func showManagePasskeys() {
+        guard #available(iOS 17, *) else { return }
+        let processor = ManagePasskeysProcessor(coordinator: asAnyCoordinator())
+        let view = ManagePasskeysView(store: Store(processor: processor))
+        let viewController = UIHostingController(rootView: view)
+        stackNavigator?.push(viewController)
+    }
+
     /// Shows the scenario picker screen.
     ///
     private func showScenarioPicker() {
@@ -134,12 +146,6 @@ class RootCoordinator: Coordinator, HasStackNavigator {
     private func showTOTPAutofillForm() {
         let processor = TOTPAutofillFormProcessor(coordinator: asAnyCoordinator())
         let view = TOTPAutofillFormView(store: Store(processor: processor))
-
-    /// Shows the use passkey test screen.
-    ///
-    private func showUsePasskey() {
-        let processor = UsePasskeyProcessor(coordinator: asAnyCoordinator(), delegate: self)
-        let view = UsePasskeyView(store: Store(processor: processor))
         let viewController = UIHostingController(rootView: view)
         stackNavigator?.push(viewController)
     }

--- a/TestHarnessShared/UI/Platform/Root/RootCoordinator.swift
+++ b/TestHarnessShared/UI/Platform/Root/RootCoordinator.swift
@@ -134,6 +134,12 @@ class RootCoordinator: Coordinator, HasStackNavigator {
     private func showTOTPAutofillForm() {
         let processor = TOTPAutofillFormProcessor(coordinator: asAnyCoordinator())
         let view = TOTPAutofillFormView(store: Store(processor: processor))
+
+    /// Shows the use passkey test screen.
+    ///
+    private func showUsePasskey() {
+        let processor = UsePasskeyProcessor(coordinator: asAnyCoordinator(), delegate: self)
+        let view = UsePasskeyView(store: Store(processor: processor))
         let viewController = UIHostingController(rootView: view)
         stackNavigator?.push(viewController)
     }

--- a/TestHarnessShared/UI/Platform/Root/RootRoute.swift
+++ b/TestHarnessShared/UI/Platform/Root/RootRoute.swift
@@ -15,7 +15,7 @@ public enum RootRoute {
     /// A route to the file share test screen.
     case fileShare
 
-    /// A route to the create passkey test screen.
+    /// A route to the register passkey test screen.
     case registerPasskey
 
     /// A route to the scenario picker home screen.

--- a/TestHarnessShared/UI/Platform/Root/RootRoute.swift
+++ b/TestHarnessShared/UI/Platform/Root/RootRoute.swift
@@ -15,6 +15,9 @@ public enum RootRoute {
     /// A route to the file share test screen.
     case fileShare
 
+    /// A route to the manage passkeys test screen.
+    case managePasskeys
+
     /// A route to the register passkey test screen.
     case registerPasskey
 

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
@@ -47,7 +47,7 @@ struct ScenarioPickerState: Equatable {
         if #available(iOS 16.0, *) {
             items.append(
                 ScenarioItem(id: "fileShare", title: Localizations.fileShare, route: .fileShare),
-            ])
+            )
         }
         scenarios = items
     }

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
@@ -39,7 +39,7 @@ struct ScenarioPickerState: Equatable {
         if #available(iOS 17, *) {
             items.append(contentsOf: [
                 ScenarioItem(id: "registerPasskey", title: Localizations.registerPasskey, route: .registerPasskey),
-                ScenarioItem(id: "usePasskey", title: Localizations.usePasskey, route: .usePasskey),
+                ScenarioItem(id: "usePasskey", title: Localizations.passkeyAutofill, route: .usePasskey),
                 ScenarioItem(id: "cardAutofillForm", title: Localizations.cardAutofillForm, route: .cardAutofillForm),
                 ScenarioItem(id: "passkeyAutofill", title: Localizations.passkeyAutofill, route: .usePasskey),
             ])

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
@@ -41,6 +41,7 @@ struct ScenarioPickerState: Equatable {
                 ScenarioItem(id: "registerPasskey", title: Localizations.registerPasskey, route: .registerPasskey),
                 ScenarioItem(id: "usePasskey", title: Localizations.usePasskey, route: .usePasskey),
                 ScenarioItem(id: "cardAutofillForm", title: Localizations.cardAutofillForm, route: .cardAutofillForm),
+                ScenarioItem(id: "passkeyAutofill", title: Localizations.passkeyAutofill, route: .usePasskey),
             ])
         }
         if #available(iOS 16.0, *) {

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
@@ -1,5 +1,27 @@
 import Foundation
 
+/// A section used to group related scenarios in the scenario picker.
+///
+enum ScenarioSection: CaseIterable, Hashable {
+    /// The remaining, uncategorized scenarios.
+    case general
+
+    /// Scenarios that don't fit into a more specific section.
+    case other
+
+    /// Scenarios related to passkey registration, autofill, and management.
+    case passkeys
+
+    /// The display title for the section header.
+    var title: String {
+        switch self {
+        case .general: Localizations.testScenarios
+        case .other: Localizations.other
+        case .passkeys: Localizations.passkeys
+        }
+    }
+}
+
 /// A scenario that can be selected in the test harness.
 ///
 struct ScenarioItem: Equatable, Identifiable {
@@ -13,11 +35,90 @@ struct ScenarioItem: Equatable, Identifiable {
 
     /// The route to navigate to when this scenario is selected.
     let route: RootRoute?
+
+    /// The section this scenario belongs to in the scenario picker.
+    let section: ScenarioSection
 }
 
 /// The state for the scenario picker screen.
 ///
 struct ScenarioPickerState: Equatable {
+    // MARK: Private Type Properties
+
+    /// Scenarios that don't belong to a more specific section.
+    private static var generalScenarios: [ScenarioItem] {
+        var items = [
+            ScenarioItem(
+                id: "createAccountForm",
+                title: Localizations.createAccountForm,
+                route: .createAccountForm,
+                section: .general,
+            ),
+            ScenarioItem(
+                id: "simpleLoginForm",
+                title: Localizations.simpleLoginForm,
+                route: .simpleLoginForm,
+                section: .general,
+            ),
+            ScenarioItem(
+                id: "totpAutofillForm",
+                title: Localizations.totpAutofillForm,
+                route: .totpAutofillForm,
+                section: .general,
+            ),
+            ScenarioItem(
+                id: "dateFieldPicker",
+                title: Localizations.dateFieldPicker,
+                route: .dateFieldPickerShowcase,
+                section: .general,
+            ),
+        ]
+        if #available(iOS 17, *) {
+            items.append(
+                ScenarioItem(
+                    id: "cardAutofillForm",
+                    title: Localizations.cardAutofillForm,
+                    route: .cardAutofillForm,
+                    section: .general,
+                ),
+            )
+        }
+        return items
+    }
+
+    /// Passkey-related scenarios, available on iOS 17 and later.
+    private static var passkeyScenarios: [ScenarioItem] {
+        guard #available(iOS 17, *) else { return [] }
+        return [
+            ScenarioItem(
+                id: "registerPasskey",
+                title: Localizations.registerPasskey,
+                route: .registerPasskey,
+                section: .passkeys,
+            ),
+            ScenarioItem(
+                id: "usePasskey",
+                title: Localizations.passkeyAutofill,
+                route: .usePasskey,
+                section: .passkeys,
+            ),
+            ScenarioItem(
+                id: "managePasskeys",
+                title: Localizations.managePasskeys,
+                route: .managePasskeys,
+                section: .passkeys,
+            ),
+        ]
+    }
+
+    /// Scenarios that don't fit into a more specific section, available on iOS 16 and later.
+    private static var otherScenarios: [ScenarioItem] {
+        guard #available(iOS 16, *) else { return [] }
+        return [
+            ScenarioItem(id: "fileShare", title: Localizations.fileShare, route: .fileShare, section: .other),
+        ]
+    }
+
     // MARK: Properties
 
     /// The title of the screen.
@@ -29,27 +130,6 @@ struct ScenarioPickerState: Equatable {
     // MARK: Initialization
 
     init() {
-        var items: [ScenarioItem] = [
-            ScenarioItem(id: "createAccountForm", title: Localizations.createAccountForm, route: .createAccountForm),
-            ScenarioItem(id: "simpleLoginForm", title: Localizations.simpleLoginForm, route: .simpleLoginForm),
-            ScenarioItem(id: "totpAutofillForm", title: Localizations.totpAutofillForm, route: .totpAutofillForm),
-            ScenarioItem(id: "dateFieldPicker", title: Localizations.dateFieldPicker, route: .dateFieldPickerShowcase),
-        ]
-
-        if #available(iOS 17, *) {
-            items.append(contentsOf: [
-                ScenarioItem(id: "registerPasskey", title: Localizations.registerPasskey, route: .registerPasskey),
-                ScenarioItem(id: "usePasskey", title: Localizations.passkeyAutofill, route: .usePasskey),
-                ScenarioItem(id: "cardAutofillForm", title: Localizations.cardAutofillForm, route: .cardAutofillForm),
-                ScenarioItem(id: "passkeyAutofill", title: Localizations.passkeyAutofill, route: .usePasskey),
-                ScenarioItem(id: "managePasskeys", title: Localizations.managePasskeys, route: .managePasskeys),
-            ])
-        }
-        if #available(iOS 16.0, *) {
-            items.append(
-                ScenarioItem(id: "fileShare", title: Localizations.fileShare, route: .fileShare),
-            )
-        }
-        scenarios = items
+        scenarios = Self.generalScenarios + Self.passkeyScenarios + Self.otherScenarios
     }
 }

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
@@ -47,7 +47,7 @@ struct ScenarioPickerState: Equatable {
         if #available(iOS 16.0, *) {
             items.append(
                 ScenarioItem(id: "fileShare", title: Localizations.fileShare, route: .fileShare),
-            )
+            ])
         }
         scenarios = items
     }

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerState.swift
@@ -42,6 +42,7 @@ struct ScenarioPickerState: Equatable {
                 ScenarioItem(id: "usePasskey", title: Localizations.passkeyAutofill, route: .usePasskey),
                 ScenarioItem(id: "cardAutofillForm", title: Localizations.cardAutofillForm, route: .cardAutofillForm),
                 ScenarioItem(id: "passkeyAutofill", title: Localizations.passkeyAutofill, route: .usePasskey),
+                ScenarioItem(id: "managePasskeys", title: Localizations.managePasskeys, route: .managePasskeys),
             ])
         }
         if #available(iOS 16.0, *) {

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerView.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerView.swift
@@ -40,6 +40,7 @@ struct ScenarioPickerView: View {
                         case Localizations.cardAutofillForm: "ScenarioButton_CardForm"
                         case Localizations.createAccountForm: "ScenarioButton_CreateAccountForm"
                         case Localizations.fileShare: "ScenarioButton_FileShare"
+                        case Localizations.managePasskeys: "ScenarioButton_ManagePasskeys"
                         case Localizations.registerPasskey: "ScenarioButton_RegisterPasskey"
                         case Localizations.simpleLoginForm: "ScenarioButton_LoginForm"
                         case Localizations.totpAutofillForm: "ScenarioButton_TOTPForm"

--- a/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerView.swift
+++ b/TestHarnessShared/UI/Platform/Root/ScenarioPicker/ScenarioPickerView.swift
@@ -22,39 +22,50 @@ struct ScenarioPickerView: View {
     /// The main content view.
     private var content: some View {
         List {
-            Section {
-                ForEach(store.state.scenarios) { scenario in
-                    Button {
-                        store.send(.scenarioTapped(scenario))
-                    } label: {
-                        HStack {
-                            Text(scenario.title)
-                                .styleGuide(.body)
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.secondary)
+            ForEach(ScenarioSection.allCases, id: \.self) { section in
+                let scenarios = store.state.scenarios.filter { $0.section == section }
+                if !scenarios.isEmpty {
+                    Section {
+                        ForEach(scenarios) { scenario in
+                            scenarioRow(scenario)
                         }
+                    } header: {
+                        Text(section.title)
                     }
-                    .accessibilityIdentifier({
-                        switch scenario.title {
-                        case Localizations.cardAutofillForm: "ScenarioButton_CardForm"
-                        case Localizations.createAccountForm: "ScenarioButton_CreateAccountForm"
-                        case Localizations.fileShare: "ScenarioButton_FileShare"
-                        case Localizations.managePasskeys: "ScenarioButton_ManagePasskeys"
-                        case Localizations.registerPasskey: "ScenarioButton_RegisterPasskey"
-                        case Localizations.simpleLoginForm: "ScenarioButton_LoginForm"
-                        case Localizations.totpAutofillForm: "ScenarioButton_TOTPForm"
-                        case Localizations.usePasskey: "ScenarioButton_UsePasskey"
-                        default: "ScenarioButton_\(scenario.title)"
-                        }
-                    }())
-                    .foregroundColor(.primary)
                 }
-            } header: {
-                Text(Localizations.testScenarios)
             }
         }
         .listStyle(.insetGrouped)
+    }
+
+    /// A row displaying a single scenario.
+    private func scenarioRow(_ scenario: ScenarioItem) -> some View {
+        Button {
+            store.send(.scenarioTapped(scenario))
+        } label: {
+            HStack {
+                Text(scenario.title)
+                    .styleGuide(.body)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .foregroundColor(.secondary)
+            }
+        }
+        .accessibilityIdentifier({
+            switch scenario.title {
+            case Localizations.cardAutofillForm: "ScenarioButton_CardForm"
+            case Localizations.createAccountForm: "ScenarioButton_CreateAccountForm"
+            case Localizations.fileShare: "ScenarioButton_FileShare"
+            case Localizations.managePasskeys: "ScenarioButton_ManagePasskeys"
+            case Localizations.passkeyAutofill: "ScenarioButton_Passkey"
+            case Localizations.registerPasskey: "ScenarioButton_RegisterPasskey"
+            case Localizations.simpleLoginForm: "ScenarioButton_LoginForm"
+            case Localizations.totpAutofillForm: "ScenarioButton_TOTPForm"
+            case Localizations.usePasskey: "ScenarioButton_UsePasskey"
+            default: "ScenarioButton_\(scenario.title)"
+            }
+        }())
+        .foregroundColor(.primary)
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-27137

## 📔 Objective

 Add a feature where users of the Test Harness app can view and cleanup passkey credential data stored locally.

## 📸 Screenshots


<img width="293" height="633" alt="IMG_0022 copy" src="https://github.com/user-attachments/assets/f700a037-21cd-40e0-9708-cd6e5f4a3f6c" />
