### PR TITLE
[PM-40305] fix: Prevent login-with-device vault key wrapped to a substituted public key

### DIFF
--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessor.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessor.swift
@@ -99,7 +99,11 @@ final class LoginRequestProcessor: StateProcessor<LoginRequestState, LoginReques
             coordinator.showLoadingOverlay(title: Localizations.loading)
 
             // First reload the request to ensure it hasn't expired or been answered already.
-            await reloadData()
+            // If the reload blocked the update, an alert has already been shown; don't
+            // answer the request.
+            guard await reloadData() else {
+                return coordinator.hideLoadingOverlay()
+            }
 
             // Answer the login request.
             try await services.authService.answerLoginRequest(state.request, approve: approve)
@@ -128,31 +132,47 @@ final class LoginRequestProcessor: StateProcessor<LoginRequestState, LoginReques
     }
 
     /// Reload the login request.
-    private func reloadData() async {
+    ///
+    /// - Returns: `false` if the reload found the request has expired or already been answered,
+    ///     and blocked the update, showing an alert in that case. Returns `true` otherwise,
+    ///     including when the request could not be reloaded at all, matching this method's prior
+    ///     behavior of not blocking on a lookup miss or network error.
+    ///
+    /// - Note: This intentionally never writes the reloaded request back into `state.request`.
+    ///     The fingerprint the user verified — and the public key the vault key is later wrapped
+    ///     to — must always be the one from the request as originally loaded, never whatever
+    ///     public key the server returns on a later reload, which could be substituted by a
+    ///     malicious or compromised server.
+    ///
+    @discardableResult
+    private func reloadData() async -> Bool {
         do {
-            // Reload the request.
+            // Reload the request only to check whether it has expired or already been answered.
             let request = try await services.authService.getPendingLoginRequest(withId: state.request.id).first
-            guard let request else { return }
+            guard let request else { return true }
 
             // Show an alert and dismiss the view if the request has expired or been answered.
             guard !request.isExpired else {
-                return coordinator.showAlert(.requestExpired {
+                coordinator.showAlert(.requestExpired {
                     self.coordinator.navigate(to: .dismiss())
                 })
+                return false
             }
             guard !request.isAnswered else {
-                return coordinator.showAlert(.requestAnswered {
+                coordinator.showAlert(.requestAnswered {
                     self.coordinator.navigate(to: .dismiss())
                 })
+                return false
             }
-
-            // Update the data.
-            state.request = request
 
             // Reset the timer.
             setUpdateTimer()
+
+            return true
         } catch {
             services.errorReporter.log(error: error)
+            // A reload failure doesn't block answering, only an expired/answered request does.
+            return true
         }
     }
 

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestProcessorTests.swift
@@ -69,6 +69,19 @@ class LoginRequestProcessorTests: BitwardenTestCase {
         }
     }
 
+    /// `.perform(_:)` with `.answerRequest` always answers using the originally-verified request,
+    /// even if the server returns a different public key on the approve-time reload — the vault
+    /// key must never be wrapped to a public key the user didn't verify.
+    @MainActor
+    func test_perform_answerRequest_doesNotUseReloadedPublicKey() async {
+        authService.getPendingLoginRequestResult = .success([.fixture(publicKey: "attackerPublicKey")])
+
+        await subject.perform(.answerRequest(approve: true))
+
+        XCTAssertEqual(authService.answerLoginRequestRequest, .fixture())
+        XCTAssertNotEqual(authService.answerLoginRequestRequest?.publicKey, "attackerPublicKey")
+    }
+
     /// `.perform(_:)` with `.answerRequest` handles an errors
     @MainActor
     func test_perform_answerRequest_error() async {
@@ -131,6 +144,18 @@ class LoginRequestProcessorTests: BitwardenTestCase {
         let okAction = try XCTUnwrap(coordinator.alertShown.last?.alertActions.first)
         await okAction.handler?(okAction, [])
         XCTAssertEqual(coordinator.routes.last, .dismiss())
+    }
+
+    /// `.perform(_:)` with `.reloadData` never overwrites the currently held request, even when
+    /// the server returns different data for it (e.g. a different public key) — the request
+    /// whose fingerprint the user verified must never be replaced.
+    @MainActor
+    func test_perform_reloadData_doesNotOverwriteRequest() async {
+        authService.getPendingLoginRequestResult = .success([.fixture(publicKey: "attackerPublicKey")])
+
+        await subject.perform(.reloadData)
+
+        XCTAssertEqual(subject.state.request, .fixture())
     }
 
     /// `.receive(_:)` with `.dismiss` dismisses the view.


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-40305](https://bitwarden.atlassian.net/browse/PM-40305)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Fixes an issue where approving a login-with-device request could wrap the vault key to a public key the user never verified.

- On Approve, `LoginRequestProcessor.reloadData()` re-fetched the login request from the server and silently overwrote `state.request` (including `publicKey`) after only checking expiry/answered status — the fingerprint the user had just verified was never re-checked against the key the vault key was ultimately wrapped to.
- A malicious or compromised server could return the genuine device's key while the user verifies the fingerprint, then swap in an attacker key on the approve-time reload, causing the vault key to be wrapped to the attacker's key instead.
- `reloadData()` no longer writes the reloaded request back into `state.request` at all — it only uses the fresh fetch to check `isExpired`/`isAnswered`. The vault key is now always wrapped to the public key from the request as originally loaded and verified, never to whatever key a later reload returns. This also fixes a related gap where `answerRequest` would still call `answerLoginRequest` after `reloadData()` had shown an expired/answered alert.


[PM-40305]: https://bitwarden.atlassian.net/browse/PM-40305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ