### PR TITLE
[PM-40755] fix: App crash when fill assist toggle enabled

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/Data.swift
+++ b/BitwardenKit/Core/Platform/Extensions/Data.swift
@@ -34,6 +34,7 @@ public extension Data {
     ///
     /// - Returns: The data as a hash value.
     ///
+    @_optimize(none) // TODO: PM-25026 Remove when optimization for this is fixed on release config.
     func generatedHash(
         using hashFunction: any HashFunction.Type,
     ) -> String {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-40755

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
Fixes a Release-only crash in `DataFingerprintService.fingerprint(for:)`, used by `FillAssistRepository` when the fill assist toggle is enabled.

The Swift compiler miscompiles calls through the `any HashFunction.Type` existential parameter (`hashFunction.hash(data:)`) under Release optimizations. This was previously identified and worked around for `Data.generatedHashBase64Encoded(using:)` via `@_optimize(none)` in PM-25026 (#1871), but the sibling function `Data.generatedHash(using:)` — used by `DataFingerprintService` — was never patched. This is why the crash only reproduces in TestFlight/Release builds and not when run unoptimized via Xcode.

Applies the same `@_optimize(none)` workaround, referencing the existing PM-25026 TODO to remove both once the underlying compiler issue is fixed.

## 📸 Screenshots
N/A — background crash fix, no UI changes.