### PR TITLE
[PM-40248] feat: Enforce Send access controls via Send Controls policy

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -299,6 +299,7 @@
 "NoEmailAddressesEntered" = "No email addresses entered";
 "EnterAtLeastOneValidEmailToShareSend" = "Enter at least one valid email address to share this Send.";
 "OneOrMoreEmailAddressesIncorrect" = "One or more email addresses are incorrect. Please review and try again.";
+"OnlyIncludeTheFollowingDomainsDescriptionLong" = "Only include the following domains: %1$@. Please review and try again.";
 "Cards" = "Cards";
 "Identities" = "Identities";
 "Logins" = "Logins";

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
@@ -7,6 +7,13 @@ import Foundation
 struct SendPolicyOptions: Equatable, Sendable {
     // MARK: Properties
 
+    /// The domains that recipient emails must match when email verification ("Specific people") is
+    /// the enforced access type. Empty when there is no domain restriction.
+    var allowedDomains: [String] = []
+
+    /// The access type the user is required to use, or `nil` if the access type is unrestricted.
+    var enforcedAccessType: SendAccessType?
+
     /// Whether the hide-email option is disabled.
     var isHideEmailDisabled = false
 
@@ -17,12 +24,34 @@ struct SendPolicyOptions: Equatable, Sendable {
 extension SendPolicyOptions {
     /// Creates the Send policy options from the Send Controls policies that apply to the user.
     ///
-    /// When multiple policies apply, a restriction is enforced if *any* applying policy enables it.
+    /// When multiple policies apply, a boolean restriction is enforced if *any* applying policy
+    /// enables it, and the access type is resolved to the most restrictive across all applying
+    /// policies: email verification > password protection > no access control. The `whoCanAccess`
+    /// values are ordered by restrictiveness, so the highest value wins.
     ///
     /// - Parameter sendControlsPolicies: The `sendControls` policies applying to the active user.
     ///
     init(sendControlsPolicies policies: [Policy]) {
+        let enforcedAccessType = SendAccessType(
+            whoCanAccessPolicyValue: policies.compactMap { $0[.whoCanAccess]?.intValue }.max(),
+        )
+
+        // Domain restrictions only apply to email verification. When it's enforced, use the domains
+        // from the earliest-revision policy that enforces it. The server sends `allowedDomains` as a
+        // comma-separated string (e.g. "acme.com, acme.co").
+        let domainsPolicy = enforcedAccessType == .specificPeople
+            ? policies
+                .filter { SendAccessType(whoCanAccessPolicyValue: $0[.whoCanAccess]?.intValue) == .specificPeople }
+                .min { ($0.revisionDate ?? .distantFuture) < ($1.revisionDate ?? .distantFuture) }
+            : nil
+        let allowedDomains = (domainsPolicy?[.allowedDomains]?.stringValue ?? "")
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+
         self.init(
+            allowedDomains: allowedDomains,
+            enforcedAccessType: enforcedAccessType,
             isHideEmailDisabled: policies.contains { $0[.disableHideEmail]?.boolValue == true },
             isSendDisabled: policies.contains { $0[.disableSend]?.boolValue == true },
         )

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
@@ -42,7 +42,7 @@ extension SendPolicyOptions {
         let domainsPolicy = enforcedAccessType == .specificPeople
             ? policies
                 .filter { SendAccessType(whoCanAccessPolicyValue: $0[.whoCanAccess]?.intValue) == .specificPeople }
-                .earliestRevisionDate
+                .policyWithEarliestRevisionDate
             : nil
         let allowedDomains = (domainsPolicy?[.allowedDomains]?.stringValue ?? "")
             .split(separator: ",")

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
@@ -42,7 +42,7 @@ extension SendPolicyOptions {
         let domainsPolicy = enforcedAccessType == .specificPeople
             ? policies
                 .filter { SendAccessType(whoCanAccessPolicyValue: $0[.whoCanAccess]?.intValue) == .specificPeople }
-                .min { ($0.revisionDate ?? .distantFuture) < ($1.revisionDate ?? .distantFuture) }
+                .earliestRevisionDate
             : nil
         let allowedDomains = (domainsPolicy?[.allowedDomains]?.stringValue ?? "")
             .split(separator: ",")

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
@@ -11,6 +11,22 @@ import Testing
 struct SendPolicyOptionsTests {
     // MARK: init(sendControlsPolicies:) Tests
 
+    /// `init(sendControlsPolicies:)` reads the allowed domains from the enforcing policy's
+    /// comma-separated `allowedDomains` string, trimming whitespace.
+    @Test
+    func init_sendControlsPolicies_allowedDomains() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [
+                    PolicyOptionType.whoCanAccess.rawValue: .int(2),
+                    PolicyOptionType.allowedDomains.rawValue: .string("acme.com, acme.co"),
+                ],
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.allowedDomains == ["acme.com", "acme.co"])
+    }
+
     /// `init(sendControlsPolicies:)` disables the hide email option when a policy enables the
     /// `disableHideEmail` option.
     @Test
@@ -30,21 +46,105 @@ struct SendPolicyOptionsTests {
         #expect(subject.isSendDisabled)
     }
 
-    /// `init(sendControlsPolicies:)` enforces no restrictions when there are no applying policies.
+    /// `init(sendControlsPolicies:)` disables Sends when *any* applying policy enables it.
     @Test
-    func init_sendControlsPolicies_empty() {
-        let subject = SendPolicyOptions(sendControlsPolicies: [])
-        #expect(!subject.isHideEmailDisabled)
-        #expect(!subject.isSendDisabled)
-    }
-
-    /// `init(sendControlsPolicies:)` enforces a restriction when *any* applying policy enables it.
-    @Test
-    func init_sendControlsPolicies_multiplePolicies_enforcesIfAny() {
+    func init_sendControlsPolicies_disableSend_multiplePolicies_enforcesIfAny() {
         let subject = SendPolicyOptions(sendControlsPolicies: [
             .fixture(data: [PolicyOptionType.disableSend.rawValue: .bool(false)], id: "a", type: .sendControls),
             .fixture(data: [PolicyOptionType.disableSend.rawValue: .bool(true)], id: "b", type: .sendControls),
         ])
         #expect(subject.isSendDisabled)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces no restrictions when there are no applying policies.
+    @Test
+    func init_sendControlsPolicies_empty() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [])
+        #expect(subject.allowedDomains.isEmpty)
+        #expect(subject.enforcedAccessType == nil)
+        #expect(!subject.isHideEmailDisabled)
+        #expect(!subject.isSendDisabled)
+    }
+
+    /// `init(sendControlsPolicies:)` maps the `whoCanAccess` option to the enforced access type.
+    @Test
+    func init_sendControlsPolicies_enforcedAccessType() {
+        #expect(
+            SendPolicyOptions(sendControlsPolicies: [
+                .fixture(data: [PolicyOptionType.whoCanAccess.rawValue: .int(1)], type: .sendControls),
+            ]).enforcedAccessType == .anyoneWithPassword,
+        )
+        #expect(
+            SendPolicyOptions(sendControlsPolicies: [
+                .fixture(data: [PolicyOptionType.whoCanAccess.rawValue: .int(2)], type: .sendControls),
+            ]).enforcedAccessType == .specificPeople,
+        )
+        #expect(
+            SendPolicyOptions(sendControlsPolicies: [
+                .fixture(data: [PolicyOptionType.whoCanAccess.rawValue: .int(0)], type: .sendControls),
+            ]).enforcedAccessType == nil,
+        )
+        #expect(
+            SendPolicyOptions(sendControlsPolicies: [.fixture(type: .sendControls)]).enforcedAccessType == nil,
+        )
+    }
+
+    /// `init(sendControlsPolicies:)` resolves the access type to the most restrictive across all
+    /// applying policies — email verification beats password protection regardless of revision date.
+    @Test
+    func init_sendControlsPolicies_enforcedAccessType_emailVerificationBeatsPassword() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [PolicyOptionType.whoCanAccess.rawValue: .int(1)],
+                id: "password-later",
+                revisionDate: Date(year: 2024, month: 6, day: 1),
+                type: .sendControls,
+            ),
+            .fixture(
+                data: [PolicyOptionType.whoCanAccess.rawValue: .int(2)],
+                id: "email-earlier",
+                revisionDate: Date(year: 2024, month: 1, day: 1),
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.enforcedAccessType == .specificPeople)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces password protection over no access control.
+    @Test
+    func init_sendControlsPolicies_enforcedAccessType_passwordBeatsNoAccessControl() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(data: [PolicyOptionType.whoCanAccess.rawValue: .int(0)], id: "none", type: .sendControls),
+            .fixture(data: [PolicyOptionType.whoCanAccess.rawValue: .int(1)], id: "password", type: .sendControls),
+        ])
+        #expect(subject.enforcedAccessType == .anyoneWithPassword)
+    }
+
+    /// `init(sendControlsPolicies:)` takes the allowed domains from the earliest-revision policy when
+    /// multiple policies enforce email verification.
+    @Test
+    func init_sendControlsPolicies_allowedDomains_multipleEmailPolicies_earliestRevisionWins() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [
+                    PolicyOptionType.whoCanAccess.rawValue: .int(2),
+                    PolicyOptionType.allowedDomains.rawValue: .string("later.com"),
+                ],
+                id: "later",
+                revisionDate: Date(year: 2024, month: 6, day: 1),
+                type: .sendControls,
+            ),
+            .fixture(
+                data: [
+                    PolicyOptionType.whoCanAccess.rawValue: .int(2),
+                    PolicyOptionType.allowedDomains.rawValue: .string("earlier.com"),
+                ],
+                id: "earlier",
+                revisionDate: Date(year: 2024, month: 1, day: 1),
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.enforcedAccessType == .specificPeople)
+        #expect(subject.allowedDomains == ["earlier.com"])
     }
 }

--- a/BitwardenShared/Core/Tools/Models/Enum/SendAccessType.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/SendAccessType.swift
@@ -57,4 +57,23 @@ enum SendAccessType: CaseIterable, Equatable, Hashable, Menuable, Sendable {
             self = .anyoneWithPassword
         }
     }
+
+    /// Creates a `SendAccessType` from the Send Controls policy's `whoCanAccess` value, or `nil`
+    /// when the access type is unrestricted.
+    ///
+    /// The server's `WhoCanAccessType`: `0` = Any (unrestricted), `1` = PasswordProtected,
+    /// `2` = SpecificPeople (email verification).
+    ///
+    /// - Parameter whoCanAccessPolicyValue: The policy's `whoCanAccess` int value.
+    ///
+    init?(whoCanAccessPolicyValue value: Int?) {
+        switch value {
+        case 1:
+            self = .anyoneWithPassword
+        case 2:
+            self = .specificPeople
+        default:
+            return nil
+        }
+    }
 }

--- a/BitwardenShared/Core/Tools/Models/Enum/SendAccessTypeTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Enum/SendAccessTypeTests.swift
@@ -23,6 +23,16 @@ class SendAccessTypeTests: BitwardenTestCase {
         XCTAssertEqual(SendAccessType(authType: .password), .anyoneWithPassword)
     }
 
+    /// `init(whoCanAccessPolicyValue:)` maps the server's `WhoCanAccessType` to the enforced access
+    /// type, returning `nil` when the access type is unrestricted.
+    func test_init_whoCanAccessPolicyValue() {
+        XCTAssertNil(SendAccessType(whoCanAccessPolicyValue: 0))
+        XCTAssertEqual(SendAccessType(whoCanAccessPolicyValue: 1), .anyoneWithPassword)
+        XCTAssertEqual(SendAccessType(whoCanAccessPolicyValue: 2), .specificPeople)
+        XCTAssertNil(SendAccessType(whoCanAccessPolicyValue: nil))
+        XCTAssertNil(SendAccessType(whoCanAccessPolicyValue: 99))
+    }
+
     /// `localizedName` returns the correct localized string for each access type.
     func test_localizedName() {
         XCTAssertEqual(SendAccessType.anyoneWithLink.localizedName, Localizations.anyoneWithTheLink)

--- a/BitwardenShared/Core/Vault/Models/Domain/Policy.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Policy.swift
@@ -52,3 +52,11 @@ extension Policy {
         data?[optionType.rawValue]
     }
 }
+
+extension [Policy] {
+    /// The policy with the earliest revision date, or `nil` if the list is empty.
+    ///
+    var earliestRevisionDate: Policy? {
+        self.min { ($0.revisionDate ?? .distantFuture) < ($1.revisionDate ?? .distantFuture) }
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Domain/Policy.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/Policy.swift
@@ -56,7 +56,7 @@ extension Policy {
 extension [Policy] {
     /// The policy with the earliest revision date, or `nil` if the list is empty.
     ///
-    var earliestRevisionDate: Policy? {
+    var policyWithEarliestRevisionDate: Policy? {
         self.min { ($0.revisionDate ?? .distantFuture) < ($1.revisionDate ?? .distantFuture) }
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Domain/PolicyTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/PolicyTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import BitwardenShared
+@testable import BitwardenSharedMocks
+
+struct PolicyTests {
+    // MARK: Tests
+
+    /// `earliestRevisionDate` returns `nil` for an empty list.
+    @Test
+    func earliestRevisionDate_empty() {
+        let policies: [Policy] = []
+        #expect(policies.earliestRevisionDate == nil)
+    }
+
+    /// `earliestRevisionDate` returns the policy with the earliest revision date.
+    @Test
+    func earliestRevisionDate_multiplePolicies() {
+        let earliest = Policy.fixture(id: "policy-2", revisionDate: Date(year: 2024, month: 1, day: 10))
+        let policies = [
+            Policy.fixture(id: "policy-1", revisionDate: Date(year: 2024, month: 3, day: 15)),
+            earliest,
+            Policy.fixture(id: "policy-3", revisionDate: Date(year: 2024, month: 2, day: 20)),
+        ]
+
+        #expect(policies.earliestRevisionDate == earliest)
+    }
+
+    /// `earliestRevisionDate` treats a `nil` revision date as `.distantFuture`, so a policy with an
+    /// actual date is preferred over one with a `nil` date.
+    @Test
+    func earliestRevisionDate_nilRevisionDate() {
+        let earliest = Policy.fixture(id: "policy-2", revisionDate: Date(year: 2024, month: 1, day: 10))
+        let policies = [
+            Policy.fixture(id: "policy-1", revisionDate: nil),
+            earliest,
+        ]
+
+        #expect(policies.earliestRevisionDate == earliest)
+    }
+}

--- a/BitwardenShared/Core/Vault/Models/Domain/PolicyTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Domain/PolicyTests.swift
@@ -7,16 +7,16 @@ import Testing
 struct PolicyTests {
     // MARK: Tests
 
-    /// `earliestRevisionDate` returns `nil` for an empty list.
+    /// `policyWithEarliestRevisionDate` returns `nil` for an empty list.
     @Test
-    func earliestRevisionDate_empty() {
+    func policyWithEarliestRevisionDate_empty() {
         let policies: [Policy] = []
-        #expect(policies.earliestRevisionDate == nil)
+        #expect(policies.policyWithEarliestRevisionDate == nil)
     }
 
-    /// `earliestRevisionDate` returns the policy with the earliest revision date.
+    /// `policyWithEarliestRevisionDate` returns the policy with the earliest revision date.
     @Test
-    func earliestRevisionDate_multiplePolicies() {
+    func policyWithEarliestRevisionDate_multiplePolicies() {
         let earliest = Policy.fixture(id: "policy-2", revisionDate: Date(year: 2024, month: 1, day: 10))
         let policies = [
             Policy.fixture(id: "policy-1", revisionDate: Date(year: 2024, month: 3, day: 15)),
@@ -24,19 +24,19 @@ struct PolicyTests {
             Policy.fixture(id: "policy-3", revisionDate: Date(year: 2024, month: 2, day: 20)),
         ]
 
-        #expect(policies.earliestRevisionDate == earliest)
+        #expect(policies.policyWithEarliestRevisionDate == earliest)
     }
 
-    /// `earliestRevisionDate` treats a `nil` revision date as `.distantFuture`, so a policy with an
+    /// `policyWithEarliestRevisionDate` treats a `nil` revision date as `.distantFuture`, so a policy with an
     /// actual date is preferred over one with a `nil` date.
     @Test
-    func earliestRevisionDate_nilRevisionDate() {
+    func policyWithEarliestRevisionDate_nilRevisionDate() {
         let earliest = Policy.fixture(id: "policy-2", revisionDate: Date(year: 2024, month: 1, day: 10))
         let policies = [
             Policy.fixture(id: "policy-1", revisionDate: nil),
             earliest,
         ]
 
-        #expect(policies.earliestRevisionDate == earliest)
+        #expect(policies.policyWithEarliestRevisionDate == earliest)
     }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
@@ -81,9 +81,19 @@ enum PolicyOptionType: String {
 
     // MARK: Send Controls Options
 
+    /// A policy option for the domains that recipient emails must match when the enforced access
+    /// control is email verification ("Specific people"). Encoded as a comma-separated string.
+    case allowedDomains
+
     /// A policy option for whether the send should disable the hide email option.
     case disableHideEmail
 
     /// A policy option for whether the Send Controls policy disables creating and editing Sends.
     case disableSend
+
+    /// A policy option for the access control (auth type) users are required to use on Sends.
+    ///
+    /// Encoded as an int matching the server's `WhoCanAccessType`: `0` = Any (unrestricted),
+    /// `1` = PasswordProtected, `2` = SpecificPeople (email verification).
+    case whoCanAccess
 }

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -424,7 +424,7 @@ extension DefaultPolicyService {
 
         let policies = await policiesApplyingToUser(.organizationUserNotification)
 
-        guard let policy = policies.earliestRevisionDate,
+        guard let policy = policies.policyWithEarliestRevisionDate,
               let description = policy[.description]?.stringValue
         else { return nil }
 
@@ -512,7 +512,7 @@ extension DefaultPolicyService {
 
     func getEarliestOrganizationApplyingPolicy(_ policyType: PolicyType) async -> String? {
         let policies = await policiesApplyingToUser(policyType, filter: nil)
-        return policies.earliestRevisionDate?.organizationId
+        return policies.policyWithEarliestRevisionDate?.organizationId
     }
 
     func getSendPolicyOptions() async -> SendPolicyOptions {

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -314,15 +314,6 @@ actor DefaultPolicyService: PolicyService {
 
         return filter.map { policies.filter($0) } ?? policies
     }
-
-    /// Returns the policy with the earliest revision date from the given list, or `nil` if the list is empty.
-    ///
-    /// - Parameter policies: The list of policies to search.
-    /// - Returns: The policy with the earliest revision date.
-    ///
-    private func policyWithEarliestRevisionDate(from policies: [Policy]) -> Policy? {
-        policies.min { ($0.revisionDate ?? .distantFuture) < ($1.revisionDate ?? .distantFuture) }
-    }
 }
 
 extension DefaultPolicyService {
@@ -433,7 +424,7 @@ extension DefaultPolicyService {
 
         let policies = await policiesApplyingToUser(.organizationUserNotification)
 
-        guard let policy = policyWithEarliestRevisionDate(from: policies),
+        guard let policy = policies.earliestRevisionDate,
               let description = policy[.description]?.stringValue
         else { return nil }
 
@@ -521,7 +512,7 @@ extension DefaultPolicyService {
 
     func getEarliestOrganizationApplyingPolicy(_ policyType: PolicyType) async -> String? {
         let policies = await policiesApplyingToUser(policyType, filter: nil)
-        return policyWithEarliestRevisionDate(from: policies)?.organizationId
+        return policies.earliestRevisionDate?.organizationId
     }
 
     func getSendPolicyOptions() async -> SendPolicyOptions {

--- a/BitwardenShared/Core/Vault/Services/PolicyService.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyService.swift
@@ -527,6 +527,7 @@ extension DefaultPolicyService {
     func getSendPolicyOptions() async -> SendPolicyOptions {
         guard await configService.getFeatureFlag(.sendControls) else {
             return await SendPolicyOptions(
+                enforcedAccessType: nil,
                 isHideEmailDisabled: policyAppliesToUser(.sendOptions) { policy in
                     policy[.disableHideEmail]?.boolValue == true
                 },

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -511,6 +511,153 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertEqual(organizationId, "org-2")
     }
 
+    // MARK: - getSendPolicyOptions (allowedDomains) Tests
+
+    /// `getSendPolicyOptions()` surfaces the allowed domains from the Send Controls policy when
+    /// email verification is enforced.
+    func test_getSendPolicyOptions_allowedDomains() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [
+                        PolicyOptionType.whoCanAccess.rawValue: .int(2),
+                        PolicyOptionType.allowedDomains.rawValue: .string("acme.com, acme.co"),
+                    ],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertEqual(options.allowedDomains, ["acme.com", "acme.co"])
+    }
+
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` surfaces no allowed
+    /// domains.
+    func test_getSendPolicyOptions_allowedDomains_flagOff() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [
+                        PolicyOptionType.whoCanAccess.rawValue: .int(2),
+                        PolicyOptionType.allowedDomains.rawValue: .string("acme.com"),
+                    ],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertTrue(options.allowedDomains.isEmpty)
+    }
+
+    // MARK: - getSendPolicyOptions (enforcedAccessType) Tests
+
+    /// `getSendPolicyOptions()` enforces the "anyone with password" access type when the Send
+    /// Controls policy's `whoCanAccess` is `1` (PasswordProtected).
+    func test_getSendPolicyOptions_enforcedAccessType_passwordProtected() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.whoCanAccess.rawValue: .int(1)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertEqual(options.enforcedAccessType, .anyoneWithPassword)
+    }
+
+    /// `getSendPolicyOptions()` enforces the "specific people" access type when the Send Controls
+    /// policy's `whoCanAccess` is `2` (SpecificPeople).
+    func test_getSendPolicyOptions_enforcedAccessType_specificPeople() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.whoCanAccess.rawValue: .int(2)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertEqual(options.enforcedAccessType, .specificPeople)
+    }
+
+    /// `getSendPolicyOptions()` enforces no access type when the Send Controls policy's `whoCanAccess`
+    /// is `0` (Any).
+    func test_getSendPolicyOptions_enforcedAccessType_any() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.whoCanAccess.rawValue: .int(0)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertNil(options.enforcedAccessType)
+    }
+
+    /// `getSendPolicyOptions()` enforces no access type when the Send Controls policy doesn't contain
+    /// a `whoCanAccess` value.
+    func test_getSendPolicyOptions_enforcedAccessType_optionNoData() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([.fixture(type: .sendControls)])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertNil(options.enforcedAccessType)
+    }
+
+    /// `getSendPolicyOptions()` enforces no access type when there's no policies.
+    func test_getSendPolicyOptions_enforcedAccessType_noPolicies() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success([])
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertNil(options.enforcedAccessType)
+    }
+
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` enforces no access
+    /// type even when a `sendControls` policy sets `whoCanAccess`.
+    func test_getSendPolicyOptions_enforcedAccessType_flagOff() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.whoCanAccess.rawValue: .int(1)],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertNil(options.enforcedAccessType)
+    }
+
     // MARK: - getSendPolicyOptions (isHideEmailDisabled) Tests
 
     /// `getSendPolicyOptions()` reports the hide email option disabled when the Send Controls policy
@@ -1448,6 +1595,7 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertTrue(clientService.mockPolicies.filterByTypeCalled)
         XCTAssertFalse(options.isSendDisabled)
         XCTAssertFalse(options.isHideEmailDisabled)
+        XCTAssertNil(options.enforcedAccessType)
     }
 
     /// `getSendPolicyOptions()` parses the Send restrictions from the policies the SDK reports as
@@ -1464,7 +1612,7 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
                 id: "policy-1",
                 organizationId: "org-1",
                 type: .sendControls,
-                data: #"{"disableSend": true, "disableHideEmail": true}"#,
+                data: #"{"disableSend": true, "disableHideEmail": true, "whoCanAccess": 2}"#,
                 enabled: true,
                 revisionDate: nil,
             ),
@@ -1475,5 +1623,6 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertTrue(clientService.mockPolicies.filterByTypeCalled)
         XCTAssertTrue(options.isSendDisabled)
         XCTAssertTrue(options.isHideEmailDisabled)
+        XCTAssertEqual(options.enforcedAccessType, .specificPeople)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Platform/Application/Extensions/Alert+Extensions.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/Alert+Extensions.swift
@@ -131,6 +131,24 @@ extension Alert {
         )
     }
 
+    /// An alert to show when one or more recipient email addresses don't match the domains allowed
+    /// by the organization's Send Controls policy.
+    ///
+    /// - Parameter allowedDomains: The domains that recipient emails are allowed to use.
+    /// - Returns: An alert listing the allowed domains.
+    ///
+    static func invalidEmailAddressesForDomains(_ allowedDomains: [String]) -> Alert {
+        Alert(
+            title: Localizations.invalidEmailAddresses,
+            message: Localizations.onlyIncludeTheFollowingDomainsDescriptionLong(
+                allowedDomains.joined(separator: ", "),
+            ),
+            alertActions: [
+                AlertAction(title: Localizations.ok, style: .default),
+            ],
+        )
+    }
+
     /// An alert to allow the user to add or edit the name of a custom field.
     ///
     /// - Parameters:

--- a/BitwardenShared/UI/Platform/Application/Extensions/Alert+Extensions.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/Alert+Extensions.swift
@@ -1,5 +1,6 @@
 import BitwardenKit
 import BitwardenResources
+import Foundation
 
 // MARK: - Alert
 
@@ -141,7 +142,7 @@ extension Alert {
         Alert(
             title: Localizations.invalidEmailAddresses,
             message: Localizations.onlyIncludeTheFollowingDomainsDescriptionLong(
-                allowedDomains.joined(separator: ", "),
+                allowedDomains.formatted(.list(type: .and, width: .narrow)),
             ),
             alertActions: [
                 AlertAction(title: Localizations.ok, style: .default),

--- a/BitwardenShared/UI/Platform/Application/Extensions/Alert+ExtensionsTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/Alert+ExtensionsTests.swift
@@ -40,6 +40,24 @@ class AlertExtensionsTests: BitwardenTestCase {
         XCTAssertNil(action.handler)
     }
 
+    /// `invalidEmailAddressesForDomains(_:)` builds an `Alert` listing the allowed domains.
+    func test_invalidEmailAddressesForDomains() {
+        let subject = Alert.invalidEmailAddressesForDomains(["Acme.com", "Acme.co"])
+
+        XCTAssertEqual(subject.title, Localizations.invalidEmailAddresses)
+        XCTAssertEqual(
+            subject.message,
+            Localizations.onlyIncludeTheFollowingDomainsDescriptionLong("Acme.com, Acme.co"),
+        )
+        XCTAssertEqual(subject.preferredStyle, .alert)
+        XCTAssertEqual(subject.alertActions.count, 1)
+
+        let action = subject.alertActions[0]
+        XCTAssertEqual(action.title, Localizations.ok)
+        XCTAssertEqual(action.style, .default)
+        XCTAssertNil(action.handler)
+    }
+
     /// `noEmailAddressesEntered` builds an `Alert` with the no email addresses entered title and message.
     func test_noEmailAddressesEntered() {
         let subject = Alert.noEmailAddressesEntered

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -107,10 +107,6 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
                 return
             }
             state.accessType = newValue
-            // Ensure there's at least one email row when selecting "Specific People"
-            if newValue == .specificPeople, state.recipientEmails.isEmpty {
-                state.recipientEmails.append("")
-            }
         case .addRecipientEmail:
             state.recipientEmails.append("")
             state.focusedRecipientEmailIndex = state.recipientEmails.count - 1
@@ -232,9 +228,10 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     ///
     private func loadData() async {
         state.isSendControlsPolicyEnabled = await services.configService.getFeatureFlag(.sendControls)
-        let sendPolicyOptions = await services.policyService.getSendPolicyOptions()
-        state.isSendDisabled = sendPolicyOptions.isSendDisabled
-        state.isSendHideEmailDisabled = sendPolicyOptions.isHideEmailDisabled
+        state.sendPolicyOptions = await services.policyService.getSendPolicyOptions()
+        if let enforcedAccessType = state.sendPolicyOptions.enforcedAccessType {
+            state.accessType = enforcedAccessType
+        }
         state.hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
         await refreshProfileState()
 
@@ -370,6 +367,15 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
             return false
         }
 
+        // When password access is enforced by policy, a password is required (unless the send
+        // being edited already has one).
+        if state.policyEnforcedAccessType == .anyoneWithPassword,
+           state.password.isEmpty,
+           state.originalSendView?.hasPassword != true {
+            coordinator.showAlert(.validationFieldRequired(fieldName: Localizations.password))
+            return false
+        }
+
         // Validate recipient emails for "Specific people" access type.
         if state.accessType == .specificPeople {
             // Check if at least one email is provided
@@ -383,6 +389,19 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
                 guard email.isValidEmail() else {
                     coordinator.showAlert(.invalidEmailAddresses)
                     return false
+                }
+            }
+
+            // When the policy restricts recipients to specific domains, validate each email's domain.
+            let allowedDomains = state.sendPolicyOptions.allowedDomains
+            if !allowedDomains.isEmpty {
+                let normalizedAllowedDomains = Set(allowedDomains.map { $0.lowercased() })
+                for email in state.normalizedRecipientEmails {
+                    let domain = email.split(separator: "@").last.map(String.init) ?? ""
+                    guard normalizedAllowedDomains.contains(domain) else {
+                        coordinator.showAlert(.invalidEmailAddressesForDomains(allowedDomains))
+                        return false
+                    }
                 }
             }
         }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -287,6 +287,12 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
             let newSend = try await services.sendRepository.removePassword(from: sendView)
             var newState = AddEditSendItemState(sendView: newSend)
             newState.isOptionsExpanded = state.isOptionsExpanded
+            newState.isSendControlsPolicyEnabled = state.isSendControlsPolicyEnabled
+            newState.sendPolicyOptions = state.sendPolicyOptions
+            newState.hasPremium = state.hasPremium
+            if let enforcedAccessType = state.sendPolicyOptions.enforcedAccessType {
+                newState.accessType = enforcedAccessType
+            }
             state = newState
 
             coordinator.hideLoadingOverlay()

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -161,6 +161,25 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertTrue(subject.state.isSendHideEmailDisabled)
     }
 
+    /// `perform(_:)` with `loadData` applies a policy-enforced access type, forcing the access type
+    /// and marking it enforced.
+    @MainActor
+    func test_perform_loadData_enforcedAccessType() async {
+        await subject.perform(.loadData)
+        XCTAssertNil(subject.state.policyEnforcedAccessType)
+
+        policyService.getSendPolicyOptionsResult.enforcedAccessType = .anyoneWithPassword
+        await subject.perform(.loadData)
+        XCTAssertEqual(subject.state.policyEnforcedAccessType, .anyoneWithPassword)
+        XCTAssertEqual(subject.state.accessType, .anyoneWithPassword)
+        XCTAssertTrue(subject.state.isAccessTypeEnforcedByPolicy)
+
+        policyService.getSendPolicyOptionsResult.enforcedAccessType = .specificPeople
+        await subject.perform(.loadData)
+        XCTAssertEqual(subject.state.policyEnforcedAccessType, .specificPeople)
+        XCTAssertEqual(subject.state.accessType, .specificPeople)
+    }
+
     /// `perform(_:)` with `loadData` loads whether the Send Controls policy feature flag is enabled.
     @MainActor
     func test_perform_loadData_sendControlsPolicyFlag() async {
@@ -556,6 +575,89 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         ])
     }
 
+    /// `perform(_:)` with `.savePressed` shows a validation alert when password access is enforced
+    /// by policy and no password is set.
+    @MainActor
+    func test_perform_savePressed_passwordEnforced_noPassword() async {
+        subject.state.name = "Name"
+        subject.state.type = .text
+        subject.state.accessType = .anyoneWithPassword
+        subject.state.sendPolicyOptions.enforcedAccessType = .anyoneWithPassword
+        subject.state.password = ""
+        await subject.perform(.savePressed)
+
+        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
+        XCTAssertNil(sendRepository.addTextSendSendView)
+        XCTAssertEqual(coordinator.alertShown, [
+            .validationFieldRequired(fieldName: Localizations.password),
+        ])
+    }
+
+    /// `perform(_:)` with `.savePressed` succeeds when password access is enforced by policy and the
+    /// edited send already has a password, even if the password field is left empty.
+    @MainActor
+    func test_perform_savePressed_passwordEnforced_editExistingPassword() async {
+        let sendView = SendView.fixture(id: "SEND_ID", name: "Name", hasPassword: true)
+        subject.state = AddEditSendItemState(sendView: sendView)
+        subject.state.sendPolicyOptions.enforcedAccessType = .anyoneWithPassword
+        subject.state.password = ""
+        sendRepository.updateSendResult = .success(sendView)
+
+        await subject.perform(.savePressed)
+
+        XCTAssertFalse(
+            coordinator.alertShown.contains(.validationFieldRequired(fieldName: Localizations.password)),
+        )
+        XCTAssertEqual(sendRepository.updateSendSendView?.id, "SEND_ID")
+    }
+
+    /// `perform(_:)` with `.savePressed` shows an alert listing the allowed domains when a recipient
+    /// email's domain isn't permitted by the Send Controls policy.
+    @MainActor
+    func test_perform_savePressed_specificPeople_invalidDomain() async {
+        subject.state.name = "Name"
+        subject.state.type = .text
+        subject.state.accessType = .specificPeople
+        subject.state.recipientEmails = ["user@notallowed.com"]
+        subject.state.sendPolicyOptions.allowedDomains = ["Acme.com", "Acme.co"]
+        await subject.perform(.savePressed)
+
+        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
+        XCTAssertNil(sendRepository.addTextSendSendView)
+        XCTAssertEqual(coordinator.alertShown, [.invalidEmailAddressesForDomains(["Acme.com", "Acme.co"])])
+    }
+
+    /// `perform(_:)` with `.savePressed` saves the send when the recipient email domains are allowed
+    /// by the Send Controls policy (case-insensitively).
+    @MainActor
+    func test_perform_savePressed_specificPeople_validDomain() async {
+        subject.state.name = "Name"
+        subject.state.type = .text
+        subject.state.accessType = .specificPeople
+        subject.state.recipientEmails = ["User@Acme.com"]
+        subject.state.sendPolicyOptions.allowedDomains = ["acme.com"]
+        sendRepository.addTextSendResult = .success(.fixture())
+        await subject.perform(.savePressed)
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+        XCTAssertEqual(sendRepository.addTextSendSendView?.name, "Name")
+    }
+
+    /// `perform(_:)` with `.savePressed` doesn't apply domain validation when the policy specifies no
+    /// allowed domains.
+    @MainActor
+    func test_perform_savePressed_specificPeople_noAllowedDomains() async {
+        subject.state.name = "Name"
+        subject.state.type = .text
+        subject.state.accessType = .specificPeople
+        subject.state.recipientEmails = ["user@anywhere.com"]
+        sendRepository.addTextSendResult = .success(.fixture())
+        await subject.perform(.savePressed)
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+        XCTAssertEqual(sendRepository.addTextSendSendView?.name, "Name")
+    }
+
     /// `receive(_:)` with `.chooseFilePressed` navigates to the document browser.
     @MainActor
     func test_receive_chooseFilePressed() async throws {
@@ -769,20 +871,9 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(subject.state.accessType, .anyoneWithPassword)
     }
 
-    /// `receive(_:)` with `.accessTypeChanged` to specific people adds an empty email row for Premium users.
+    /// `receive(_:)` with `.accessTypeChanged` to specific people preserves existing recipient emails.
     @MainActor
-    func test_receive_accessTypeChanged_specificPeople_addsEmptyEmail() {
-        subject.state.hasPremium = true
-        subject.state.accessType = .anyoneWithLink
-        subject.state.recipientEmails = []
-        subject.receive(.accessTypeChanged(.specificPeople))
-        XCTAssertEqual(subject.state.accessType, .specificPeople)
-        XCTAssertEqual(subject.state.recipientEmails, [""])
-    }
-
-    /// `receive(_:)` with `.accessTypeChanged` to specific people doesn't add email if already exists.
-    @MainActor
-    func test_receive_accessTypeChanged_specificPeople_existingEmails() {
+    func test_receive_accessTypeChanged_specificPeople_preservesExistingEmails() {
         subject.state.hasPremium = true
         subject.state.accessType = .anyoneWithLink
         subject.state.recipientEmails = ["test@example.com"]

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -223,6 +223,29 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.sendPasswordRemoved))
     }
 
+    /// `perform(_:)` with `sendListItemRow(removePassword())` preserves the policy and premium
+    /// state on the rebuilt state so that a policy-enforced access type remains enforced after
+    /// the password is removed.
+    @MainActor
+    func test_perform_removePassword_success_preservesPolicyState() async throws {
+        let sendView = SendView.fixture(id: "SEND_ID")
+        subject.state.originalSendView = sendView
+        subject.state.isSendControlsPolicyEnabled = true
+        subject.state.hasPremium = true
+        subject.state.sendPolicyOptions = SendPolicyOptions(enforcedAccessType: .specificPeople)
+        sendRepository.removePasswordFromSendResult = .success(sendView)
+        await subject.perform(.removePassword)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.remove)
+
+        XCTAssertTrue(subject.state.isSendControlsPolicyEnabled)
+        XCTAssertTrue(subject.state.hasPremium)
+        XCTAssertEqual(subject.state.sendPolicyOptions.enforcedAccessType, .specificPeople)
+        XCTAssertEqual(subject.state.accessType, .specificPeople)
+        XCTAssertTrue(subject.state.isAccessTypeEnforcedByPolicy)
+    }
+
     /// `perform(_:)` with `sendListItemRow(removePassword())` uses the send repository to remove
     /// the password from a send.
     @MainActor

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -77,12 +77,6 @@ struct AddEditSendItemState: Equatable, Sendable {
     /// Whether the Send Controls policy feature flag is enabled.
     var isSendControlsPolicyEnabled = false
 
-    /// Whether sends are disabled via a policy.
-    var isSendDisabled = false
-
-    /// Whether the send hide email option is disabled via a policy.
-    var isSendHideEmailDisabled = false
-
     /// The key for this send.
     var key: String?
 
@@ -107,8 +101,12 @@ struct AddEditSendItemState: Equatable, Sendable {
     /// A password that can be used to limit access to this item.
     var password: String = ""
 
-    /// The list of recipient emails for the "specific people" access type.
-    var recipientEmails: [String] = []
+    /// The list of recipient emails for the "specific people" access type. Defaults to a single
+    /// empty row so the email field is always present when "Specific people" is selected.
+    var recipientEmails: [String] = [""]
+
+    /// The Send restrictions enforced by policy for the active user.
+    var sendPolicyOptions = SendPolicyOptions()
 
     /// The contents of this item.
     var text: String = ""
@@ -119,18 +117,10 @@ struct AddEditSendItemState: Equatable, Sendable {
     /// The type of this item.
     var type: SendType = .text
 
-    // MARK: Computed Properties
-
-    /// The recipient emails filtered to remove empty entries and normalized
-    /// (trimmed whitespace and lowercased) for validation and API submission.
-    var normalizedRecipientEmails: [String] {
-        recipientEmails
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
-            .filter { !$0.isEmpty }
-    }
-
     /// The URL to open in Safari (e.g., upgrade to Premium page).
     var url: URL?
+
+    // MARK: Computed Properties
 
     /// The deletion date options available in the menu.
     var availableDeletionDateTypes: [SendDeletionDateType] {
@@ -140,6 +130,21 @@ struct AddEditSendItemState: Equatable, Sendable {
         case .edit:
             [.oneHour, .oneDay, .twoDays, .threeDays, .sevenDays, .thirtyDays, .custom(customDeletionDate)]
         }
+    }
+
+    /// Whether the access type is enforced by policy, which hides the "who can view" menu.
+    var isAccessTypeEnforcedByPolicy: Bool {
+        sendPolicyOptions.enforcedAccessType != nil
+    }
+
+    /// Whether sends are disabled via a policy.
+    var isSendDisabled: Bool {
+        sendPolicyOptions.isSendDisabled
+    }
+
+    /// Whether the send hide email option is disabled via a policy.
+    var isSendHideEmailDisabled: Bool {
+        sendPolicyOptions.isHideEmailDisabled
     }
 
     /// The navigation title to use for the view.
@@ -161,6 +166,20 @@ struct AddEditSendItemState: Equatable, Sendable {
                 Localizations.editTextSend
             }
         }
+    }
+
+    /// The recipient emails filtered to remove empty entries and normalized
+    /// (trimmed whitespace and lowercased) for validation and API submission.
+    var normalizedRecipientEmails: [String] {
+        recipientEmails
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+            .filter { !$0.isEmpty }
+    }
+
+    /// The access type the user is required to use by policy, or `nil` if the access type is not
+    /// restricted by policy.
+    var policyEnforcedAccessType: SendAccessType? {
+        sendPolicyOptions.enforcedAccessType
     }
 
     /// Whether the hide-email field should be shown.
@@ -218,7 +237,7 @@ extension AddEditSendItemState {
             notes: sendView.notes ?? "",
             originalSendView: sendView,
             password: "",
-            recipientEmails: sendView.emails,
+            recipientEmails: sendView.emails.isEmpty ? [""] : sendView.emails,
             text: sendView.text?.text ?? "",
             type: SendType(sendType: sendView.type),
         )

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -6,6 +6,22 @@ import XCTest
 class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Tests
 
+    // MARK: isAccessTypeEnforcedByPolicy
+
+    /// `isAccessTypeEnforcedByPolicy` is `false` when no access type is enforced by policy.
+    func test_isAccessTypeEnforcedByPolicy_notEnforced() {
+        let subject = AddEditSendItemState(sendPolicyOptions: SendPolicyOptions(enforcedAccessType: nil))
+        XCTAssertFalse(subject.isAccessTypeEnforcedByPolicy)
+    }
+
+    /// `isAccessTypeEnforcedByPolicy` is `true` when an access type is enforced by policy.
+    func test_isAccessTypeEnforcedByPolicy_enforced() {
+        let subject = AddEditSendItemState(
+            sendPolicyOptions: SendPolicyOptions(enforcedAccessType: .anyoneWithPassword),
+        )
+        XCTAssertTrue(subject.isAccessTypeEnforcedByPolicy)
+    }
+
     // MARK: normalizedRecipientEmails
 
     /// `normalizedRecipientEmails` applies all transformations: trim, lowercase, and filter.
@@ -322,6 +338,12 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
         )
     }
 
+    /// `init(sendView:)` uses a single empty row when the send has no recipient emails.
+    func test_init_sendView_noEmails_recipientEmailsHasEmptyRow() {
+        let subject = AddEditSendItemState(sendView: .fixture(emails: []))
+        XCTAssertEqual(subject.recipientEmails, [""])
+    }
+
     // MARK: init(sendView:) - Access Type Tests
 
     /// `init(sendView:)` sets access type to "Anyone with password" when hasPassword is true.
@@ -362,7 +384,7 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
     /// `shouldShowHideEmailField` is `true` when the hide-email option is not disabled by policy,
     /// regardless of the Send Controls feature flag.
     func test_shouldShowHideEmailField_notDisabled() {
-        var subject = AddEditSendItemState(isSendHideEmailDisabled: false)
+        var subject = AddEditSendItemState(sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: false))
 
         subject.isSendControlsPolicyEnabled = false
         XCTAssertTrue(subject.shouldShowHideEmailField)
@@ -376,7 +398,7 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
     func test_shouldShowHideEmailField_disabled_flagOff() {
         let subject = AddEditSendItemState(
             isSendControlsPolicyEnabled: false,
-            isSendHideEmailDisabled: true,
+            sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: true),
         )
         XCTAssertTrue(subject.shouldShowHideEmailField)
     }
@@ -386,7 +408,7 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
     func test_shouldShowHideEmailField_disabled_flagOn() {
         let subject = AddEditSendItemState(
             isSendControlsPolicyEnabled: true,
-            isSendHideEmailDisabled: true,
+            sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: true),
         )
         XCTAssertFalse(subject.shouldShowHideEmailField)
     }
@@ -395,7 +417,7 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
 
     /// `shouldShowHideEmailPolicyBanner` is `false` when the hide-email option is not disabled.
     func test_shouldShowHideEmailPolicyBanner_notDisabled() {
-        var subject = AddEditSendItemState(isSendHideEmailDisabled: false)
+        var subject = AddEditSendItemState(sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: false))
 
         subject.isSendControlsPolicyEnabled = false
         XCTAssertFalse(subject.shouldShowHideEmailPolicyBanner)
@@ -409,7 +431,7 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
     func test_shouldShowHideEmailPolicyBanner_disabled_flagOff() {
         let subject = AddEditSendItemState(
             isSendControlsPolicyEnabled: false,
-            isSendHideEmailDisabled: true,
+            sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: true),
         )
         XCTAssertTrue(subject.shouldShowHideEmailPolicyBanner)
     }
@@ -419,7 +441,7 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
     func test_shouldShowHideEmailPolicyBanner_disabled_flagOn() {
         let subject = AddEditSendItemState(
             isSendControlsPolicyEnabled: true,
-            isSendHideEmailDisabled: true,
+            sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: true),
         )
         XCTAssertFalse(subject.shouldShowHideEmailPolicyBanner)
     }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView+SnapshotTests.swift
@@ -105,13 +105,13 @@ class AddEditSendItemViewTests: BitwardenTestCase {
 
     @MainActor
     func disabletest_snapshot_sendDisabled() {
-        processor.state.isSendDisabled = true
+        processor.state.sendPolicyOptions.isSendDisabled = true
         assertSnapshot(of: subject.navStackWrapped, as: .defaultPortrait)
     }
 
     @MainActor
     func disabletest_snapshot_sendHideEmailDisabled() {
-        processor.state.isSendHideEmailDisabled = true
+        processor.state.sendPolicyOptions.isHideEmailDisabled = true
         assertSnapshot(of: subject.navStackWrapped, as: .defaultPortrait)
     }
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView+ViewInspectorTests.swift
@@ -128,7 +128,7 @@ class AddEditSendItemViewTests: BitwardenTestCase {
     /// Setting `isSendDisabled` disables the controls within the view.
     @MainActor
     func test_sendDisabled() async throws {
-        processor.state.isSendDisabled = true
+        processor.state.sendPolicyOptions.isSendDisabled = true
 
         let infoContainer = try subject.inspect().find(InfoContainer<Text>.self)
         try XCTAssertEqual(infoContainer.text().string(), Localizations.sendDisabledWarning)
@@ -144,7 +144,7 @@ class AddEditSendItemViewTests: BitwardenTestCase {
     /// Setting `isSendHideEmailDisabled` disables the hide email control within the view.
     @MainActor
     func test_sendHideEmailDisabled() async throws {
-        processor.state.isSendHideEmailDisabled = true
+        processor.state.sendPolicyOptions.isHideEmailDisabled = true
 
         let infoContainer = try subject.inspect().find(InfoContainer<Text>.self)
         try XCTAssertEqual(infoContainer.text().string(), Localizations.sendOptionsPolicyInEffect)
@@ -169,6 +169,17 @@ class AddEditSendItemViewTests: BitwardenTestCase {
         let menuField = try subject.inspect().find(bitwardenMenuField: Localizations.whoCanView)
         try menuField.select(newValue: SendAccessType.anyoneWithPassword)
         XCTAssertEqual(processor.dispatchedActions.last, .accessTypeChanged(.anyoneWithPassword))
+    }
+
+    /// The access type menu remains visible but is disabled when the access type is enforced by policy.
+    @MainActor
+    func test_accessTypeMenu_disabledWhenEnforcedByPolicy() throws {
+        var menuField = try subject.inspect().find(bitwardenMenuField: Localizations.whoCanView)
+        XCTAssertFalse(menuField.isDisabled())
+
+        processor.state.sendPolicyOptions.enforcedAccessType = .anyoneWithPassword
+        menuField = try subject.inspect().find(bitwardenMenuField: Localizations.whoCanView)
+        XCTAssertTrue(menuField.isDisabled())
     }
 
     /// Updating the password textfield when "Anyone with password" is selected sends the `.passwordChanged` action.

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView+ViewInspectorTests.swift
@@ -112,6 +112,27 @@ class AddEditSendItemViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .optionsPressed)
     }
 
+    /// The "Remove password" menu item is shown when editing a send with a password and no
+    /// policy enforces the access type.
+    @MainActor
+    func test_removePasswordButton_shown() throws {
+        processor.state.mode = .edit
+        processor.state.originalSendView = .fixture(hasPassword: true)
+
+        XCTAssertNoThrow(try subject.inspect().find(asyncButton: Localizations.removePassword))
+    }
+
+    /// The "Remove password" menu item is hidden when the access type is enforced by policy,
+    /// even though the send has a password, since removing it would violate the policy.
+    @MainActor
+    func test_removePasswordButton_hidden_whenAccessTypeEnforcedByPolicy() throws {
+        processor.state.mode = .edit
+        processor.state.originalSendView = .fixture(hasPassword: true)
+        processor.state.sendPolicyOptions.enforcedAccessType = .specificPeople
+
+        XCTAssertThrowsError(try subject.inspect().find(asyncButton: Localizations.removePassword))
+    }
+
     /// Tapping the save button performs the `.savePressed` effect.
     @MainActor
     func test_saveButton_tap() async throws {

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -323,6 +323,8 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
     /// The "Who can view" section for access type selection.
     @ViewBuilder private var whoCanView: some View {
         ContentBlock(dividerLeadingPadding: 16) {
+            // When the access type is enforced by policy, the menu shows the enforced selection but
+            // is disabled so the user can't change it.
             BitwardenMenuField(
                 title: Localizations.whoCanView,
                 accessibilityIdentifier: "SendAccessTypePicker",
@@ -332,6 +334,7 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                     send: AddEditSendItemAction.accessTypeChanged,
                 ),
             )
+            .disabled(store.state.isAccessTypeEnforcedByPolicy)
 
             whoCanViewContent
         }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -85,7 +85,8 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                     if store.state.mode == .edit {
                         optionsToolbarMenu {
                             if !store.state.isSendDisabled {
-                                if store.state.originalSendView?.hasPassword ?? false {
+                                if store.state.originalSendView?.hasPassword ?? false,
+                                   !store.state.isAccessTypeEnforcedByPolicy {
                                     AsyncButton(Localizations.removePassword) {
                                         await store.perform(.removePassword)
                                     }


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-40248](https://bitwarden.atlassian.net/browse/PM-40248)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enforce the Send Controls policy's **access control** option (`whoCanAccess`) on iOS, behind the `pm-31885-send-controls` feature flag. When an organization requires a specific access option, the Send add/edit "Who can view" menu shows the enforced value and is disabled, and the required option is forced:
- **Password protected** (`whoCanAccess = 1`) → access type forced to *Anyone with a password*, and a password is required to save.
- **Email verification** (`whoCanAccess = 2`) → access type forced to *Specific people*, and at least one recipient email is required to save.
- **Any** (`0`) / flag off / no applying policy → no change to existing behavior.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Password protected | Email verification | Email domain validation |
|--------|--------|--------|
| <img width="568" height="1084" alt="Screenshot 2026-07-23 at 11 11 01 AM" src="https://github.com/user-attachments/assets/390e6bb1-ccf1-4b76-a957-1790dba82ed8" /> | <img width="568" height="1084" alt="Screenshot 2026-07-23 at 11 10 37 AM" src="https://github.com/user-attachments/assets/61a130e0-2008-458c-a2bf-7bca228b6200" /> | <img width="568" height="1084" alt="Screenshot 2026-07-23 at 11 09 00 AM" src="https://github.com/user-attachments/assets/a730b8cc-ff1d-4858-b5b0-c6f2acc74dd8" /> | 




[PM-40248]: https://bitwarden.atlassian.net/browse/PM-40248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ