### PR TITLE
[PM-40460] feat: Enforce Send type restriction via Send Controls policy

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -448,6 +448,7 @@
 "SendOptionsPolicyInEffect" = "One or more organization policies are affecting your Send options.";
 "SendFilePremiumRequired" = "Free accounts are restricted to sharing text only. A Premium membership is required to use files with Send.";
 "SendFileEmailVerificationRequired" = "You must verify your email to use files with Send. You can verify your email in the web vault.";
+"DueToAnEnterprisePolicyYouCanOnlyCreateXSends" = "Due to an enterprise policy, you can only create %1$@ Sends.";
 "PasswordPrompt" = "Master password re-prompt";
 "PasswordConfirmation" = "Master password confirmation";
 "PasswordConfirmationDesc" = "This action is protected, to continue please re-enter your master password to verify your identity.";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -448,6 +448,7 @@
 "SendOptionsPolicyInEffect" = "One or more organization policies are affecting your Send options.";
 "SendFilePremiumRequired" = "Free accounts are restricted to sharing text only. A Premium membership is required to use files with Send.";
 "SendFileEmailVerificationRequired" = "You must verify your email to use files with Send. You can verify your email in the web vault.";
+/* Alert message shown when Send Controls policy restricts creation to one Send type. %1$@ is the allowed Send type, either "File" or "Text". */
 "DueToAnEnterprisePolicyYouCanOnlyCreateXSends" = "Due to an enterprise policy, you can only create %1$@ Sends.";
 "PasswordPrompt" = "Master password re-prompt";
 "PasswordConfirmation" = "Master password confirmation";

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
@@ -14,6 +14,9 @@ struct SendPolicyOptions: Equatable, Sendable {
     /// The access type the user is required to use, or `nil` if the access type is unrestricted.
     var enforcedAccessType: SendAccessType?
 
+    /// The Send type the user is required to use, or `nil` if both types are allowed (unrestricted).
+    var enforcedSendType: SendType?
+
     /// Whether the hide-email option is disabled.
     var isHideEmailDisabled = false
 
@@ -24,10 +27,12 @@ struct SendPolicyOptions: Equatable, Sendable {
 extension SendPolicyOptions {
     /// Creates the Send policy options from the Send Controls policies that apply to the user.
     ///
-    /// When multiple policies apply, a boolean restriction is enforced if *any* applying policy
-    /// enables it, and the access type is resolved to the most restrictive across all applying
-    /// policies: email verification > password protection > no access control. The `whoCanAccess`
-    /// values are ordered by restrictiveness, so the highest value wins.
+    /// When multiple policies apply, a restriction is enforced if *any* applying policy enables it.
+    /// The enforced access type is resolved to the most restrictive across all applying policies
+    /// (email verification > password protection > no access control, the `whoCanAccess` values are
+    /// ordered by restrictiveness and the highest value wins, and the enforced Send type is the
+    /// most restrictive across all applying policies (per the order text > file >
+    /// both/unrestricted).
     ///
     /// - Parameter sendControlsPolicies: The `sendControls` policies applying to the active user.
     ///
@@ -52,8 +57,30 @@ extension SendPolicyOptions {
         self.init(
             allowedDomains: allowedDomains,
             enforcedAccessType: enforcedAccessType,
+            enforcedSendType: Self.enforcedSendType(from: policies),
             isHideEmailDisabled: policies.contains { $0[.disableHideEmail]?.boolValue == true },
             isSendDisabled: policies.contains { $0[.disableSend]?.boolValue == true },
         )
+    }
+
+    /// Determines the Send type the user is restricted to from the applying `sendControls` policies.
+    ///
+    /// The server sends `allowedSendTypes` as an array of `SendType` raw values (`0` = text,
+    /// `1` = file); a policy restricts the type when it allows exactly one type. When multiple
+    /// policies apply, the most restrictive wins per the order text > file > both/unrestricted.
+    ///
+    /// - Parameter policies: The `sendControls` policies applying to the active user.
+    /// - Returns: The enforced `SendType`, or `nil` if both types are allowed (unrestricted).
+    ///
+    private static func enforcedSendType(from policies: [Policy]) -> SendType? {
+        let restrictedTypes = policies.compactMap { policy -> SendType? in
+            guard let rawTypes = policy[.allowedSendTypes]?.arrayValue else { return nil }
+            let allowedTypes = Set(rawTypes.compactMap(\.intValue).compactMap(SendType.init(rawValue:)))
+            return allowedTypes.count == 1 ? allowedTypes.first : nil
+        }
+
+        if restrictedTypes.contains(.text) { return .text }
+        if restrictedTypes.contains(.file) { return .file }
+        return nil
     }
 }

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
@@ -62,6 +62,7 @@ struct SendPolicyOptionsTests {
         let subject = SendPolicyOptions(sendControlsPolicies: [])
         #expect(subject.allowedDomains.isEmpty)
         #expect(subject.enforcedAccessType == nil)
+        #expect(subject.enforcedSendType == nil)
         #expect(!subject.isHideEmailDisabled)
         #expect(!subject.isSendDisabled)
     }
@@ -146,5 +147,106 @@ struct SendPolicyOptionsTests {
         ])
         #expect(subject.enforcedAccessType == .specificPeople)
         #expect(subject.allowedDomains == ["earlier.com"])
+    }
+
+    /// `init(sendControlsPolicies:)` maps a single-element `allowedSendTypes` array to the enforced
+    /// Send type.
+    @Test
+    func init_sendControlsPolicies_enforcedSendType() {
+        #expect(
+            SendPolicyOptions(sendControlsPolicies: [
+                .fixture(data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0)])], type: .sendControls),
+            ]).enforcedSendType == .text,
+        )
+        #expect(
+            SendPolicyOptions(sendControlsPolicies: [
+                .fixture(data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(1)])], type: .sendControls),
+            ]).enforcedSendType == .file,
+        )
+    }
+
+    /// `init(sendControlsPolicies:)` enforces no Send type when both types are allowed.
+    @Test
+    func init_sendControlsPolicies_enforcedSendType_bothAllowed() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0), .int(1)])],
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.enforcedSendType == nil)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces no Send type when no policy specifies `allowedSendTypes`.
+    @Test
+    func init_sendControlsPolicies_enforcedSendType_missing() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [.fixture(type: .sendControls)])
+        #expect(subject.enforcedSendType == nil)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces no Send type when the `allowedSendTypes` array is empty.
+    @Test
+    func init_sendControlsPolicies_enforcedSendType_emptyArray() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(data: [PolicyOptionType.allowedSendTypes.rawValue: .array([])], type: .sendControls),
+        ])
+        #expect(subject.enforcedSendType == nil)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces the most restrictive Send type across applying
+    /// policies (a single-type restriction wins over an unrestricted "both" policy).
+    @Test
+    func init_sendControlsPolicies_enforcedSendType_multiplePolicies_mostRestrictiveWins() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0), .int(1)])],
+                id: "both",
+                type: .sendControls,
+            ),
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0)])],
+                id: "text-only",
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.enforcedSendType == .text)
+    }
+
+    /// `init(sendControlsPolicies:)` enforces the file type when a file-only policy applies
+    /// alongside an unrestricted "both" policy.
+    @Test
+    func init_sendControlsPolicies_enforcedSendType_multiplePolicies_fileOnly() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0), .int(1)])],
+                id: "both",
+                type: .sendControls,
+            ),
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(1)])],
+                id: "file-only",
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.enforcedSendType == .file)
+    }
+
+    /// `init(sendControlsPolicies:)` resolves a text-only vs file-only conflict to the most
+    /// restrictive type (text wins per the order text > file > both).
+    @Test
+    func init_sendControlsPolicies_enforcedSendType_multiplePolicies_conflictTextWins() {
+        let subject = SendPolicyOptions(sendControlsPolicies: [
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0)])],
+                id: "text-only",
+                type: .sendControls,
+            ),
+            .fixture(
+                data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(1)])],
+                id: "file-only",
+                type: .sendControls,
+            ),
+        ])
+        #expect(subject.enforcedSendType == .text)
     }
 }

--- a/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepository.swift
@@ -85,9 +85,14 @@ public protocol SendRepository: AnyObject {
 
     /// A publisher for all the sends in the user's account.
     ///
+    /// - Parameter includeTypesSection: Whether to include the "Types" filter section (the Text/File
+    ///   groups) in the returned sections. Pass `false` to omit it, e.g. when the user is restricted
+    ///   to a single Send type and filtering by type is no longer meaningful.
     /// - Returns: A publisher for the list of sends in the user's account.
     ///
-    func sendListPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>>
+    func sendListPublisher(
+        includeTypesSection: Bool,
+    ) async throws -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>>
 
     /// A publisher for a send.
     ///
@@ -278,10 +283,12 @@ class DefaultSendRepository: SendRepository {
         }.eraseToAnyPublisher().values
     }
 
-    func sendListPublisher() async throws -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>> {
+    func sendListPublisher(
+        includeTypesSection: Bool,
+    ) async throws -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>> {
         try await sendService.sendsPublisher()
             .asyncTryMap { sends in
-                try await self.sendListSections(from: sends)
+                try await self.sendListSections(from: sends, includeTypesSection: includeTypesSection)
             }
             .eraseToAnyPublisher()
             .values
@@ -312,16 +319,33 @@ class DefaultSendRepository: SendRepository {
 
     /// Returns a list of the sections in the vault list from a sync response.
     ///
-    /// - Parameter sends: The sends used to build the list of sections.
+    /// - Parameters:
+    ///   - sends: The sends used to build the list of sections.
+    ///   - includeTypesSection: Whether to include the "Types" filter section (the Text/File groups).
     /// - Returns: A list of the sections to display in the vault list.
     ///
-    private func sendListSections(from sends: [Send]) async throws -> [SendListSection] {
+    private func sendListSections(
+        from sends: [Send],
+        includeTypesSection: Bool,
+    ) async throws -> [SendListSection] {
         let sends = try await sends
             .asyncMap { try await clientService.sends().decrypt(send: $0) }
             .sorted { $0.name.localizedStandardCompare($1.name) == .orderedAscending }
 
         guard !sends.isEmpty else {
             return []
+        }
+
+        let allSendsSection = SendListSection(
+            id: "AllSends",
+            items: sends.compactMap(SendListItem.init),
+            name: Localizations.allSends,
+        )
+
+        // The "Types" filter section is omitted when filtering by type is not meaningful, e.g. when
+        // the user is restricted to a single Send type by policy.
+        guard includeTypesSection else {
+            return [allSendsSection]
         }
 
         let fileSendsCount = sends
@@ -335,19 +359,13 @@ class DefaultSendRepository: SendRepository {
             SendListItem(id: "Types.File", itemType: .group(.file, fileSendsCount)),
         ]
 
-        let allItems = sends.compactMap(SendListItem.init)
-
         return [
             SendListSection(
                 id: "Types",
                 items: types,
                 name: Localizations.types,
             ),
-            SendListSection(
-                id: "AllSends",
-                items: allItems,
-                name: Localizations.allSends,
-            ),
+            allSendsSection,
         ]
     }
 

--- a/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
+++ b/BitwardenShared/Core/Tools/Repositories/SendRepositoryTests.swift
@@ -317,7 +317,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     func test_sendListPublisher_withoutValues() async throws {
         sendService.sendsSubject.send([])
 
-        var iterator = try await subject.sendListPublisher().makeAsyncIterator()
+        var iterator = try await subject.sendListPublisher(includeTypesSection: true).makeAsyncIterator()
         let sections = try await iterator.next()
 
         try assertInlineSnapshot(of: dumpSendListSections(XCTUnwrap(sections)), as: .lines) {
@@ -342,7 +342,7 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             ),
         ])
 
-        var iterator = try await subject.sendListPublisher().makeAsyncIterator()
+        var iterator = try await subject.sendListPublisher(includeTypesSection: true).makeAsyncIterator()
         let sections = try await iterator.next()
 
         try assertInlineSnapshot(of: dumpSendListSections(XCTUnwrap(sections)), as: .lines) {
@@ -353,6 +353,34 @@ class SendRepositoryTests: BitwardenTestCase { // swiftlint:disable:this type_bo
             Section: All Sends
               - Send: encrypted name
               - Send: encrypted name
+            """
+        }
+    }
+
+    /// `sendListPublisher(includeTypesSection:)` omits the "Types" filter section when
+    /// `includeTypesSection` is `false`.
+    func test_sendListPublisher_includeTypesSectionFalse_omitsTypesSection() async throws {
+        sendService.sendsSubject.send([
+            .fixture(
+                name: "encrypted text name",
+                text: .init(hidden: false, text: "encrypted text"),
+                type: .text,
+            ),
+            .fixture(
+                file: .init(fileName: "test.txt", id: "1", size: "123", sizeName: "123 KB"),
+                name: "encrypted file name",
+                type: .file,
+            ),
+        ])
+
+        var iterator = try await subject.sendListPublisher(includeTypesSection: false).makeAsyncIterator()
+        let sections = try await iterator.next()
+
+        try assertInlineSnapshot(of: dumpSendListSections(XCTUnwrap(sections)), as: .lines) {
+            """
+            Section: All Sends
+              - Send: encrypted file name
+              - Send: encrypted text name
             """
         }
     }

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -24,6 +24,7 @@ class MockSendRepository: BitwardenShared.SendRepository {
     var searchSendSubject = CurrentValueSubject<[SendListItem], Error>([])
 
     var sendListSubject = CurrentValueSubject<[SendListSection], Error>([])
+    var sendListPublisherIncludeTypesSection: Bool?
 
     var sendSubject = CurrentValueSubject<SendView?, Error>(nil)
 
@@ -102,8 +103,11 @@ class MockSendRepository: BitwardenShared.SendRepository {
         return searchSendSubject.eraseToAnyPublisher().values
     }
 
-    func sendListPublisher() -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>> {
-        sendListSubject
+    func sendListPublisher(
+        includeTypesSection: Bool,
+    ) -> AsyncThrowingPublisher<AnyPublisher<[SendListSection], Error>> {
+        sendListPublisherIncludeTypesSection = includeTypesSection
+        return sendListSubject
             .eraseToAnyPublisher()
             .values
     }

--- a/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
+++ b/BitwardenShared/Core/Tools/Repositories/TestHelpers/MockSendRepository.swift
@@ -23,8 +23,8 @@ class MockSendRepository: BitwardenShared.SendRepository {
     var searchSendType: BitwardenShared.SendType?
     var searchSendSubject = CurrentValueSubject<[SendListItem], Error>([])
 
-    var sendListSubject = CurrentValueSubject<[SendListSection], Error>([])
     var sendListPublisherIncludeTypesSection: Bool?
+    var sendListSubject = CurrentValueSubject<[SendListSection], Error>([])
 
     var sendSubject = CurrentValueSubject<SendView?, Error>(nil)
 

--- a/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/PolicyOptionType.swift
@@ -85,6 +85,11 @@ enum PolicyOptionType: String {
     /// control is email verification ("Specific people"). Encoded as a comma-separated string.
     case allowedDomains
 
+    /// A policy option for the Send types users are allowed to create. Encoded as an array of
+    /// `SendType` raw values (`0` = text, `1` = file); `[0, 1]` or a missing key means both types
+    /// are allowed.
+    case allowedSendTypes
+
     /// A policy option for whether the send should disable the hide email option.
     case disableHideEmail
 

--- a/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/PolicyServiceTests.swift
@@ -658,6 +658,62 @@ class PolicyServiceTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertNil(options.enforcedAccessType)
     }
 
+    // MARK: - getSendPolicyOptions (enforcedSendType) Tests
+
+    /// `getSendPolicyOptions()` maps a single-type `allowedSendTypes` array to the enforced Send type.
+    func test_getSendPolicyOptions_enforcedSendType() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(1)])],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertEqual(options.enforcedSendType, .file)
+    }
+
+    /// `getSendPolicyOptions()` enforces no Send type when both types are allowed.
+    func test_getSendPolicyOptions_enforcedSendType_bothAllowed() async {
+        configService.featureFlagsBool[.sendControls] = true
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(0), .int(1)])],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertNil(options.enforcedSendType)
+    }
+
+    /// When the Send Controls feature flag is disabled, `getSendPolicyOptions()` enforces no Send type.
+    func test_getSendPolicyOptions_enforcedSendType_flagOff() async {
+        configService.featureFlagsBool[.sendControls] = false
+        stateService.activeAccount = .fixture()
+        organizationService.fetchAllOrganizationsResult = .success([.fixture()])
+        policyDataStore.fetchPoliciesResult = .success(
+            [
+                .fixture(
+                    data: [PolicyOptionType.allowedSendTypes.rawValue: .array([.int(1)])],
+                    type: .sendControls,
+                ),
+            ],
+        )
+
+        let options = await subject.getSendPolicyOptions()
+        XCTAssertNil(options.enforcedSendType)
+    }
+
     // MARK: - getSendPolicyOptions (isHideEmailDisabled) Tests
 
     /// `getSendPolicyOptions()` reports the hide email option disabled when the Send Controls policy

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessor.swift
@@ -195,7 +195,9 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
     /// Load any initial data for the view.
     ///
     private func loadData() async {
-        state.isSendDisabled = await services.policyService.getSendPolicyOptions().isSendDisabled
+        let policyOptions = await services.policyService.getSendPolicyOptions()
+        state.isSendDisabled = policyOptions.isSendDisabled
+        state.restrictedSendType = policyOptions.enforcedSendType
     }
 
     /// Removes the password from the provided send.
@@ -235,7 +237,9 @@ final class SendListProcessor: StateProcessor<SendListState, SendListAction, Sen
                     }
                 }
             } else {
-                for try await sections in try await services.sendRepository.sendListPublisher() {
+                for try await sections in try await services.sendRepository.sendListPublisher(
+                    includeTypesSection: state.restrictedSendType == nil,
+                ) {
                     let needsSync = try await services.vaultRepository.needsSync()
 
                     if needsSync, sections.isEmpty {

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListProcessorTests.swift
@@ -116,10 +116,19 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
     func test_perform_loadData_policies() async {
         await subject.perform(.loadData)
         XCTAssertFalse(subject.state.isSendDisabled)
+        XCTAssertNil(subject.state.restrictedSendType)
 
         policyService.getSendPolicyOptionsResult.isSendDisabled = true
         await subject.perform(.loadData)
         XCTAssertTrue(subject.state.isSendDisabled)
+    }
+
+    /// `perform(_:)` with `loadData` sets the restricted Send type from the enforced policy type.
+    @MainActor
+    func test_perform_loadData_restrictedSendType() async {
+        policyService.getSendPolicyOptionsResult.enforcedSendType = .file
+        await subject.perform(.loadData)
+        XCTAssertEqual(subject.state.restrictedSendType, .file)
     }
 
     /// `perform(_:)` with `refresh` requests a fetch sync update, but does not force a sync.
@@ -428,6 +437,25 @@ class SendListProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertEqual(sections.count, 1)
         XCTAssertEqual(sections[0].items, [sendListItem])
         XCTAssertTrue(vaultRepository.needsSyncCalled)
+    }
+
+    /// `perform(_:)` with `.streamSendList` tells the repository to omit the "Types" filter section
+    /// when the user is restricted to a single Send type.
+    @MainActor
+    func test_perform_streamSendList_restrictedSendType() throws {
+        subject.state.restrictedSendType = .file
+        sendRepository.sendListSubject.send([
+            SendListSection(id: "AllSends", items: [], name: "All sends"),
+        ])
+
+        let task = Task {
+            await subject.perform(.streamSendList)
+        }
+
+        waitFor(sendRepository.sendListPublisherIncludeTypesSection != nil)
+        task.cancel()
+
+        XCTAssertEqual(sendRepository.sendListPublisherIncludeTypesSection, false)
     }
 
     /// `perform(_:)` with `.streamSendList` updates the state's send list whenever it changes.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListState.swift
@@ -25,6 +25,11 @@ struct SendListState: Sendable {
     /// The navigation title for this screen.
     var navigationTitle: String { type?.localizedName ?? Localizations.send }
 
+    /// The single Send type the user is restricted to by policy, or `nil` if both types are
+    /// allowed. When set, the add-Send entry points open this type directly (bypassing the
+    /// text/file chooser) and the "Types" filter section is hidden.
+    var restrictedSendType: SendType?
+
     /// The text that the user is currently searching for.
     var searchText: String = ""
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView+ViewInspectorTests.swift
@@ -33,6 +33,18 @@ class SendListViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// When restricted to a single Send type by policy, tapping the floating action button opens
+    /// that type directly, performing the `.addItemPressed` effect without showing the menu.
+    @MainActor
+    func test_addItemFloatingActionButton_restrictedSendType_tap() async throws {
+        processor.state.restrictedSendType = .text
+        let fab = try subject.inspect().find(
+            floatingActionButtonWithAccessibilityIdentifier: "AddItemFloatingActionButton",
+        )
+        try await fab.tap()
+        XCTAssertEqual(processor.effects.last, .addItemPressed(.text))
+    }
+
     /// Tapping the add item floating action button in the file type list performs the `.addItemPressed` effect.
     @MainActor
     func test_addItemFloatingActionButton_sendTypeFile_tap() async throws {
@@ -63,12 +75,31 @@ class SendListViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.effects.last, .addItemPressed(.file))
     }
 
+    /// When restricted to a single Send type by policy, the add item floating action menu is not
+    /// shown (the chooser is bypassed).
+    @MainActor
+    func test_addItemFloatingActionMenu_restrictedSendType_hidden() throws {
+        processor.state.restrictedSendType = .text
+        XCTAssertThrowsError(try subject.inspect().find(asyncButton: Localizations.file))
+    }
+
     /// Tapping the add item floating action menu and selecting the text type performs the `.addItemPressed` effect.
     @MainActor
     func test_addItemFloatingActionMenu_text_tap() async throws {
         let fabMenuButton = try subject.inspect().find(asyncButton: Localizations.text)
         try await fabMenuButton.tap()
         XCTAssertEqual(processor.effects.last, .addItemPressed(.text))
+    }
+
+    /// When restricted to a single Send type by policy, tapping the empty state's New Send button
+    /// opens that type directly, performing the `.addItemPressed` effect without showing the menu.
+    @MainActor
+    func test_emptyState_addSendButton_restrictedSendType_tap() async throws {
+        processor.state = .empty
+        processor.state.restrictedSendType = .file
+        let button = try subject.inspect().find(asyncButton: Localizations.newSend)
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .addItemPressed(.file))
     }
 
     /// Tapping the add a send button in the empty state performs the `.addItemPressed` effect.

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListView.swift
@@ -38,7 +38,7 @@ private struct MainSendListView: View {
             content
                 .hidden(isSearching)
                 .overlay(alignment: .bottomTrailing) {
-                    if let sendType = store.state.type {
+                    if let sendType = store.state.type ?? store.state.restrictedSendType {
                         addItemFloatingActionButton {
                             await store.perform(.addItemPressed(sendType))
                         }
@@ -96,7 +96,7 @@ private struct MainSendListView: View {
             ) {
                 Group {
                     let newSendLabel = Label(Localizations.newSend, image: SharedAsset.Icons.plus16.swiftUIImage)
-                    if let sendType = store.state.type {
+                    if let sendType = store.state.type ?? store.state.restrictedSendType {
                         AsyncButton {
                             await store.perform(.addItemPressed(sendType))
                         } label: {
@@ -280,7 +280,7 @@ struct SendListView: View {
             )
             .task { await store.perform(.appeared) }
             .task { await store.perform(.loadData) }
-            .task { await store.perform(.streamSendList) }
+            .task(id: store.state.restrictedSendType) { await store.perform(.streamSendList) }
             .searchDebouncedTask(id: store.state.searchText) {
                 await store.perform(.search(store.state.searchText))
             }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -229,6 +229,22 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
     private func loadData() async {
         state.isSendControlsPolicyEnabled = await services.configService.getFeatureFlag(.sendControls)
         state.sendPolicyOptions = await services.policyService.getSendPolicyOptions()
+
+        // The share extension sets `state.type` directly from the shared content (file vs. text)
+        // without going through `SendListProcessor`'s `restrictedSendType`, so it's the only mode
+        // that can actually reach here with a disallowed type; `.add` is already constrained by
+        // the Send list's add button before this screen is shown. Only block creating a new Send
+        // of a disallowed type; editing an existing Send whose type no longer matches the policy
+        // (e.g. the policy was enforced after the Send was created) should still be allowed.
+        if state.mode != .edit,
+           let enforcedSendType = state.sendPolicyOptions.enforcedSendType,
+           enforcedSendType != state.type {
+            coordinator.showAlert(.sendTypeRestrictedByPolicy(enforcedSendType) { [weak self] in
+                self?.coordinator.navigate(to: .cancel)
+            })
+            return
+        }
+
         if let enforcedAccessType = state.sendPolicyOptions.enforcedAccessType {
             state.accessType = enforcedAccessType
         }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -180,6 +180,45 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(subject.state.accessType, .specificPeople)
     }
 
+    /// `perform(_:)` with `loadData` shows an alert and exits the flow when the current Send type
+    /// conflicts with the policy-enforced Send type.
+    @MainActor
+    func test_perform_loadData_enforcedSendType_mismatch() async throws {
+        subject.state.type = .file
+        policyService.getSendPolicyOptionsResult.enforcedSendType = .text
+        await subject.perform(.loadData)
+
+        XCTAssertEqual(coordinator.alertShown, [.sendTypeRestrictedByPolicy(.text) {}])
+        XCTAssertFalse(subject.state.hasPremium)
+
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        try await alert.tapAction(title: Localizations.ok)
+        XCTAssertEqual(coordinator.routes.last, .cancel)
+    }
+
+    /// `perform(_:)` with `loadData` does not show an alert when the current Send type matches
+    /// the policy-enforced Send type.
+    @MainActor
+    func test_perform_loadData_enforcedSendType_matching() async {
+        subject.state.type = .text
+        policyService.getSendPolicyOptionsResult.enforcedSendType = .text
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+    }
+
+    /// `perform(_:)` with `loadData` does not show an alert when editing an existing Send whose
+    /// type no longer matches a policy that was enforced after the Send was created.
+    @MainActor
+    func test_perform_loadData_enforcedSendType_editModeMismatch() async {
+        subject.state.mode = .edit
+        subject.state.type = .file
+        policyService.getSendPolicyOptionsResult.enforcedSendType = .text
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+    }
+
     /// `perform(_:)` with `loadData` loads whether the Send Controls policy feature flag is enabled.
     @MainActor
     func test_perform_loadData_sendControlsPolicyFlag() async {

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -536,6 +536,26 @@ extension Alert {
         )
     }
 
+    /// Returns an alert notifying the user that an enterprise policy restricts them to a single
+    /// Send type, and that the current action can't be completed.
+    ///
+    /// - Parameters:
+    ///   - allowedType: The Send type permitted by policy.
+    ///   - action: A closure to execute when the user acknowledges the alert.
+    /// - Returns: The alert shown when a Send of the disallowed type would otherwise be created.
+    static func sendTypeRestrictedByPolicy(
+        _ allowedType: SendType,
+        action: @escaping () -> Void,
+    ) -> Alert {
+        Alert(
+            title: nil,
+            message: Localizations.dueToAnEnterprisePolicyYouCanOnlyCreateXSends(allowedType.localizedName),
+            alertActions: [
+                AlertAction(title: Localizations.ok, style: .default) { _, _ in action() },
+            ],
+        )
+    }
+
     /// Returns an alert for when the "Specific People" Send feature is unavailable due to
     /// lack of Premium subscription.
     ///

--- a/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
+++ b/BitwardenShared/UI/Vault/Extensions/AlertVaultTests.swift
@@ -670,6 +670,25 @@ class AlertVaultTests: BitwardenTestCase { // swiftlint:disable:this type_body_l
         XCTAssertEqual(subject.alertActions.first?.style, .default)
     }
 
+    /// `sendTypeRestrictedByPolicy(_:action:)` returns an `Alert` notifying the user that an
+    /// enterprise policy restricts them to a single Send type.
+    func test_sendTypeRestrictedByPolicy() async throws {
+        var called = false
+        let subject = Alert.sendTypeRestrictedByPolicy(.text) { called = true }
+
+        XCTAssertNil(subject.title)
+        XCTAssertEqual(
+            subject.message,
+            Localizations.dueToAnEnterprisePolicyYouCanOnlyCreateXSends(SendType.text.localizedName),
+        )
+        XCTAssertEqual(subject.alertActions.count, 1)
+        XCTAssertEqual(subject.alertActions[0].title, Localizations.ok)
+        XCTAssertEqual(subject.alertActions[0].style, .default)
+
+        try await subject.tapAction(title: Localizations.ok)
+        XCTAssertTrue(called)
+    }
+
     /// `specificPeopleUnavailable(action:)` returns an `Alert` notifying the user that the
     /// "Specific People" Send feature requires Premium.
     func test_specificPeopleUnavailable() async throws {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-40460](https://bitwarden.atlassian.net/browse/PM-40460)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Enforce the new **restrict Send type** option of the Send Controls policy (`pm-31885-send-controls`). When an organization restricts Send creation to a single type, non-owner/non-admin members should only be able to create that type — with no chooser to pick text vs. file — and the "Types" filter should disappear from the Send list.

The policy is delivered on the existing `sendControls` policy via a new `allowedSendTypes` data key: an array of `SendType` raw values (`0` = text, `1` = file). `[0, 1]` (or a missing key) means both types are allowed; `[0]` restricts to text-only and `[1]` to file-only. This builds directly on the consolidated `SendPolicyOptions` (#2877) and the access-control enforcement added in #2906.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Text Only | File Only | Both |
|--------|--------|--------|
| <video src="https://github.com/user-attachments/assets/ea2cdb55-9dd0-4f84-bae4-2e0292ec8329" /> | <video src="https://github.com/user-attachments/assets/8de68b19-4834-44bf-9e04-e0ebaf3f5b92" /> | <video src="https://github.com/user-attachments/assets/7410a7a6-622d-45a8-9eda-2136b0fe682d" /> | 

















[PM-40460]: https://bitwarden.atlassian.net/browse/PM-40460?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ