### PR TITLE
[PM-41005] llm: Add dependency error troubleshooting guidance to CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -144,6 +144,16 @@ someFunction(argumentOne: valueOne,
 
 See `build-test-verify` skill for project generation, build commands, test execution, lint, format, code generation, common failures, and debug tips.
 
+### Dependency errors troubleshooting
+
+If you hit package resolution conflicts, "file modified since module was built" errors, or unexplained compile failures, **clear the build folder before investigating further**:
+
+```bash
+xcodebuild clean -workspace Bitwarden.xcworkspace -scheme Bitwarden
+```
+
+Or in Xcode: **Product → Clean Build Folder** (⇧⌘K). Stale build outputs from a previous SDK or package revision are a common cause of these errors and clearing the folder resolves them without needing to touch `Package.resolved` or regenerate projects.
+
 ## Delivery Workflow
 
 **You MUST use the following skills for code delivery tasks** — invoke via the Skill tool:


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41005

## 📔 Objective

Adds a "Dependency errors troubleshooting" section to CLAUDE.md with
guidance to clear the Xcode build folder before investigating package
resolution conflicts, "file modified since module was built" errors, or
unexplained compile failures. Clearing the build folder resolves most
stale-output issues without needing to touch `Package.resolved` or
regenerate projects.

This can save a lot of time as Claude was trying to fix these kind of errors
entering in a loop doing some things repeatedly with no success, wasting
a lot of time when a simple Clear build folder and re-build would fix the
whole thing.