### PR TITLE
[PM-40478] fix: Update Send tab visibility immediately after policy sync

### DIFF
--- a/BitwardenShared/Core/Vault/Services/SyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncService.swift
@@ -78,6 +78,12 @@ protocol SyncService: AnyObject {
     /// - Returns: The organization ID if migration is needed, or `nil` if not.
     ///
     func organizationIdRequiringVaultMigration() async throws -> String?
+
+    /// A publisher for when a sync completes successfully.
+    ///
+    /// Emits after all sync data has been persisted.
+    ///
+    func syncCompletePublisher() -> AsyncPublisher<AnyPublisher<Void, Never>>
 }
 
 extension SyncService {
@@ -200,6 +206,9 @@ class DefaultSyncService: SyncService {
     /// The API service used to perform sync API requests.
     private let syncAPIService: SyncAPIService
 
+    /// The subject tracking when a sync completes successfully.
+    private let syncCompleteSubject = CurrentValueSubject<Void, Never>(())
+
     /// A delegate of the `SyncService` that is notified if a user's security stamp changes.
     weak var delegate: SyncServiceDelegate?
 
@@ -301,6 +310,10 @@ class DefaultSyncService: SyncService {
         }
 
         return organizationId
+    }
+
+    func syncCompletePublisher() -> AsyncPublisher<AnyPublisher<Void, Never>> {
+        syncCompleteSubject.eraseToAnyPublisher().values
     }
 
     // MARK: Private
@@ -482,6 +495,7 @@ extension DefaultSyncService {
         }
 
         await delegate?.onFetchSyncSucceeded(userId: userId)
+        syncCompleteSubject.send(())
     }
 
     func deleteCipher(data: SyncCipherNotification) async throws {

--- a/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
+++ b/BitwardenShared/Core/Vault/Services/SyncServiceTests.swift
@@ -1187,6 +1187,60 @@ class SyncServiceTests: BitwardenTestCase { // swiftlint:disable:this type_body_
         XCTAssertNil(syncServiceDelegate.onFetchSyncSucceededCalledWithuserId)
     }
 
+    /// `fetchSync()` emits on `syncCompletePublisher()` once the sync succeeds.
+    func test_fetchSync_syncCompletePublisher_emitsOnSuccess() async throws {
+        client.result = .httpSuccess(testData: .syncWithCiphers)
+        stateService.activeAccount = .fixture()
+
+        var didSubscribe = false
+        var didEmitAfterSync = false
+        let publisherTask = Task {
+            var iterator = subject.syncCompletePublisher().makeAsyncIterator()
+            _ = await iterator.next() // The subject's initial replayed value, proving subscription is live.
+            didSubscribe = true
+            _ = await iterator.next() // The emission fired at the end of a successful `fetchSync()`.
+            didEmitAfterSync = true
+        }
+        defer { publisherTask.cancel() }
+        try await waitForAsync { didSubscribe }
+
+        try await subject.fetchSync(forceSync: false)
+
+        try await waitForAsync { didEmitAfterSync }
+    }
+
+    /// `fetchSync()` does not emit on `syncCompletePublisher()` if the request fails.
+    func test_fetchSync_syncCompletePublisher_doesNotEmitOnError() async throws {
+        client.result = .httpFailure()
+        stateService.activeAccount = .fixture()
+
+        var didSubscribe = false
+        var didEmit = false
+        let publisherTask = Task {
+            var iterator = subject.syncCompletePublisher().makeAsyncIterator()
+            _ = await iterator.next() // The subject's initial replayed value, proving subscription is live.
+            didSubscribe = true
+            _ = await iterator.next() // Should never resolve, since the sync fails.
+            didEmit = true
+        }
+        defer { publisherTask.cancel() }
+        try await waitForAsync { didSubscribe }
+
+        await assertAsyncThrows {
+            try await subject.fetchSync(forceSync: false)
+        }
+
+        // `fetchSync()` has already thrown by this point, so any `syncCompleteSubject.send(())` call
+        // it would have made already happened synchronously, within that same call, before it
+        // returned — there's no real-time event left to wait out. Yielding gives the scheduler a
+        // chance to run `publisherTask` and observe an already-buffered value, if one incorrectly
+        // exists, without an arbitrary wall-clock delay.
+        for _ in 0 ..< 5 {
+            await Task.yield()
+        }
+        XCTAssertFalse(didEmit)
+    }
+
     func test_deleteCipher() async throws {
         stateService.activeAccount = .fixture()
         cipherService.deleteCipherWithLocalStorageResult = .success(())

--- a/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
+++ b/BitwardenShared/Core/Vault/Services/TestHelpers/MockSyncService.swift
@@ -35,6 +35,8 @@ class MockSyncService: SyncService {
     var organizationIdRequiringVaultMigrationCalled = false // swiftlint:disable:this identifier_name
     var organizationIdRequiringVaultMigrationResult: Result<String?, Error> = .success(nil) // swiftlint:disable:this identifier_name line_length
 
+    var syncCompleteSubject = CurrentValueSubject<Void, Never>(())
+
     func deleteCipher(data: SyncCipherNotification) async throws {
         deleteCipherData = data
         return try deleteCipherResult.get()
@@ -81,5 +83,9 @@ class MockSyncService: SyncService {
     func organizationIdRequiringVaultMigration() async throws -> String? {
         organizationIdRequiringVaultMigrationCalled = true
         return try organizationIdRequiringVaultMigrationResult.get()
+    }
+
+    func syncCompletePublisher() -> AsyncPublisher<AnyPublisher<Void, Never>> {
+        syncCompleteSubject.eraseToAnyPublisher().values
     }
 }

--- a/BitwardenShared/UI/Platform/Application/Views/BitwardenTabBarController+SnapshotTests.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/BitwardenTabBarController+SnapshotTests.swift
@@ -16,6 +16,7 @@ class BitwardenTabBarControllerTests: BitwardenTestCase {
     var rootNavigator: MockRootNavigator!
     var settingsDelegate: MockSettingsCoordinatorDelegate!
     var subject: BitwardenTabBarController!
+    var syncService: MockSyncService!
     var vaultDelegate: MockVaultCoordinatorDelegate!
     var vaultRepository: MockVaultRepository!
 
@@ -29,6 +30,7 @@ class BitwardenTabBarControllerTests: BitwardenTestCase {
         policyService = MockPolicyService()
         rootNavigator = MockRootNavigator()
         settingsDelegate = MockSettingsCoordinatorDelegate()
+        syncService = MockSyncService()
         vaultDelegate = MockVaultCoordinatorDelegate()
         vaultRepository = MockVaultRepository()
         subject = BitwardenTabBarController()
@@ -39,6 +41,7 @@ class BitwardenTabBarControllerTests: BitwardenTestCase {
             policyService: policyService,
             rootNavigator: rootNavigator,
             settingsDelegate: settingsDelegate,
+            syncService: syncService,
             tabNavigator: subject,
             vaultDelegate: vaultDelegate,
             vaultRepository: vaultRepository,
@@ -57,6 +60,7 @@ class BitwardenTabBarControllerTests: BitwardenTestCase {
         rootNavigator = nil
         settingsDelegate = nil
         subject = nil
+        syncService = nil
         vaultDelegate = nil
         vaultRepository = nil
     }

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -63,6 +63,12 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
     /// A delegate of the `SettingsCoordinator`.
     private weak var settingsDelegate: SettingsCoordinatorDelegate?
 
+    /// A task to handle the sync-complete stream.
+    private var syncCompleteStreamTask: Task<Void, Never>?
+
+    /// The sync service used to detect when a sync has completed, to refresh tab visibility.
+    private let syncService: SyncService
+
     /// The coordinator used to navigate to `VaultRoute`s.
     private var vaultCoordinator: AnyCoordinator<VaultRoute, AuthAction>?
 
@@ -85,6 +91,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
     ///   - policyService: The policy service used to check for active policies.
     ///   - rootNavigator: The root navigator used to display this coordinator's interface.
     ///   - settingsDelegate: A delegate of the `SettingsCoordinator`.
+    ///   - syncService: The sync service used to detect when a sync has completed, to refresh tab visibility.
     ///   - tabNavigator: The tab navigator that is managed by this coordinator.
     ///   - vaultDelegate: A delegate of the `VaultCoordinator`.
     ///   - vaultRepository: A vault repository used to the vault tab title.
@@ -95,6 +102,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         policyService: PolicyService,
         rootNavigator: RootNavigator,
         settingsDelegate: SettingsCoordinatorDelegate,
+        syncService: SyncService,
         tabNavigator: TabNavigator,
         vaultDelegate: VaultCoordinatorDelegate,
         vaultRepository: VaultRepository,
@@ -104,6 +112,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         self.policyService = policyService
         self.rootNavigator = rootNavigator
         self.settingsDelegate = settingsDelegate
+        self.syncService = syncService
         self.tabNavigator = tabNavigator
         self.vaultDelegate = vaultDelegate
         self.vaultRepository = vaultRepository
@@ -112,6 +121,8 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
     deinit {
         organizationStreamTask?.cancel()
         organizationStreamTask = nil
+        syncCompleteStreamTask?.cancel()
+        syncCompleteStreamTask = nil
     }
 
     // MARK: Methods
@@ -194,6 +205,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
             await MainActor.run { self?.updateTabs(isSendEnabled: !isSendDisabled) }
         }
         streamOrganizations()
+        streamSyncComplete()
     }
 
     // MARK: Private Methods
@@ -233,6 +245,19 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
                 }
             } catch {
                 errorReporter.log(error: error)
+            }
+        }
+    }
+
+    /// Streams sync-complete events, re-checking the Send policy and updating tab visibility once
+    /// a sync has fully persisted (organizations and policies both included).
+    private func streamSyncComplete() {
+        syncCompleteStreamTask = Task { [policyService, syncService] in
+            for await _ in syncService.syncCompletePublisher() {
+                let isSendDisabled = await policyService.policyAppliesToUser(.disableSend)
+                await MainActor.run { [weak self] in
+                    self?.updateTabs(isSendEnabled: !isSendDisabled)
+                }
             }
         }
     }

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -249,7 +249,7 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
     private func streamSyncComplete() {
         syncCompleteStreamTask = Task { [policyService, syncService] in
             for await _ in syncService.syncCompletePublisher() {
-                let isSendDisabled = await policyService.policyAppliesToUser(.disableSend)
+                let isSendDisabled = await policyService.getSendPolicyOptions().isSendDisabled
                 await MainActor.run { [weak self] in
                     self?.updateTabs(isSendEnabled: !isSendDisabled)
                 }

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinator.swift
@@ -225,9 +225,9 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
         return sendNav
     }
 
-    /// Streams the user's organizations, updating the vault title and send tab visibility reactively.
+    /// Streams the user's organizations, updating the vault title reactively.
     private func streamOrganizations() {
-        organizationStreamTask = Task { [errorReporter, tabNavigator, vaultRepository, policyService] in
+        organizationStreamTask = Task { [errorReporter, tabNavigator, vaultRepository] in
             do {
                 for try await organizations in try await vaultRepository.organizationsPublisher() {
                     guard let navigator = tabNavigator?.navigator(for: TabRoute.vault(.list)) else { return }
@@ -236,11 +236,6 @@ final class TabCoordinator: Coordinator, HasTabNavigator {
                         navigator.rootViewController?.title = Localizations.myVault
                     } else {
                         navigator.rootViewController?.title = Localizations.vaults
-                    }
-
-                    let isSendDisabled = await policyService.getSendPolicyOptions().isSendDisabled
-                    await MainActor.run { [weak self] in
-                        self?.updateTabs(isSendEnabled: !isSendDisabled)
                     }
                 }
             } catch {

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -295,7 +295,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         let mockRoot = MockRootNavigator()
         mockRoot.rootViewController = UIViewController()
         tabNavigator.navigatorForTabReturns = mockRoot
-        policyService.policyAppliesToUserResult[.disableSend] = false
+        policyService.getSendPolicyOptionsResult.isSendDisabled = false
         vaultRepository.organizationsSubject = .init([])
 
         subject.start()
@@ -303,7 +303,7 @@ class TabCoordinatorTests: BitwardenTestCase {
 
         // Simulate the policy becoming active and a sync completing, signaled via the sync-complete
         // publisher alone (no new organizations-publisher emission).
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         syncService.syncCompleteSubject.send(())
 
         waitFor { self.tabNavigator.navigators.count == 3 }
@@ -317,13 +317,13 @@ class TabCoordinatorTests: BitwardenTestCase {
         let mockRoot = MockRootNavigator()
         mockRoot.rootViewController = UIViewController()
         tabNavigator.navigatorForTabReturns = mockRoot
-        policyService.policyAppliesToUserResult[.disableSend] = true
+        policyService.getSendPolicyOptionsResult.isSendDisabled = true
         vaultRepository.organizationsSubject = .init([])
 
         subject.start()
         waitFor { self.tabNavigator.navigators.count == 3 }
 
-        policyService.policyAppliesToUserResult[.disableSend] = false
+        policyService.getSendPolicyOptionsResult.isSendDisabled = false
         syncService.syncCompleteSubject.send(())
 
         waitFor { self.tabNavigator.navigators.count == 4 }

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 // MARK: - TabCoordinatorTests
 
-class TabCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
+class TabCoordinatorTests: BitwardenTestCase {
     // MARK: Properties
 
     var errorReporter: MockErrorReporter!
@@ -285,27 +285,6 @@ class TabCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         waitFor(!errorReporter.errors.isEmpty)
         let error = try XCTUnwrap(errorReporter.errors.first as? BitwardenTestError)
         XCTAssertEqual(error, expectedError)
-    }
-
-    /// The organization stream reactively updates the Send tab visibility when the policy changes mid-session.
-    @MainActor
-    func test_start_organizationStream_updatesSendTabVisibility() {
-        let mockRoot = MockRootNavigator()
-        mockRoot.rootViewController = UIViewController()
-        tabNavigator.navigatorForTabReturns = mockRoot
-        policyService.getSendPolicyOptionsResult.isSendDisabled = false
-        vaultRepository.organizationsSubject = .init([])
-
-        subject.start()
-        // start() calls updateTabs(isSendEnabled: true) synchronously — 4 tabs immediately.
-        XCTAssertEqual(tabNavigator.navigators.count, 4)
-
-        // Simulate an org stream event while the policy is now active.
-        policyService.getSendPolicyOptionsResult.isSendDisabled = true
-        vaultRepository.organizationsSubject.send([])
-
-        waitFor { self.tabNavigator.navigators.count == 3 }
-        XCTAssertEqual(tabNavigator.navigators.count, 3)
     }
 
     /// The sync-complete stream reactively hides the Send tab when the policy becomes active, even

--- a/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabCoordinatorTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 // MARK: - TabCoordinatorTests
 
-class TabCoordinatorTests: BitwardenTestCase {
+class TabCoordinatorTests: BitwardenTestCase { // swiftlint:disable:this type_body_length
     // MARK: Properties
 
     var errorReporter: MockErrorReporter!
@@ -19,6 +19,7 @@ class TabCoordinatorTests: BitwardenTestCase {
     var rootNavigator: MockRootNavigator!
     var settingsDelegate: MockSettingsCoordinatorDelegate!
     var subject: TabCoordinator!
+    var syncService: MockSyncService!
     var tabNavigator: MockTabNavigator!
     var vaultDelegate: MockVaultCoordinatorDelegate!
     var vaultRepository: MockVaultRepository!
@@ -33,6 +34,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         rootNavigator = MockRootNavigator()
         tabNavigator = MockTabNavigator()
         settingsDelegate = MockSettingsCoordinatorDelegate()
+        syncService = MockSyncService()
         vaultDelegate = MockVaultCoordinatorDelegate()
         vaultRepository = MockVaultRepository()
         subject = TabCoordinator(
@@ -41,6 +43,7 @@ class TabCoordinatorTests: BitwardenTestCase {
             policyService: policyService,
             rootNavigator: rootNavigator,
             settingsDelegate: settingsDelegate,
+            syncService: syncService,
             tabNavigator: tabNavigator,
             vaultDelegate: vaultDelegate,
             vaultRepository: vaultRepository,
@@ -54,6 +57,7 @@ class TabCoordinatorTests: BitwardenTestCase {
         policyService = nil
         rootNavigator = nil
         subject = nil
+        syncService = nil
         tabNavigator = nil
         vaultDelegate = nil
         vaultRepository = nil
@@ -150,6 +154,7 @@ class TabCoordinatorTests: BitwardenTestCase {
             policyService: policyService,
             rootNavigator: rootNavigator!,
             settingsDelegate: MockSettingsCoordinatorDelegate(),
+            syncService: syncService,
             tabNavigator: tabNavigator,
             vaultDelegate: MockVaultCoordinatorDelegate(),
             vaultRepository: vaultRepository,
@@ -301,6 +306,49 @@ class TabCoordinatorTests: BitwardenTestCase {
 
         waitFor { self.tabNavigator.navigators.count == 3 }
         XCTAssertEqual(tabNavigator.navigators.count, 3)
+    }
+
+    /// The sync-complete stream reactively hides the Send tab when the policy becomes active, even
+    /// without a corresponding organizations-publisher emission (simulating a sync where organizations
+    /// don't change but policies do — this is the scenario that previously required two syncs).
+    @MainActor
+    func test_start_syncCompleteStream_hidesSendTab_whenPolicyApplies() {
+        let mockRoot = MockRootNavigator()
+        mockRoot.rootViewController = UIViewController()
+        tabNavigator.navigatorForTabReturns = mockRoot
+        policyService.policyAppliesToUserResult[.disableSend] = false
+        vaultRepository.organizationsSubject = .init([])
+
+        subject.start()
+        waitFor { self.tabNavigator.navigators.count == 4 }
+
+        // Simulate the policy becoming active and a sync completing, signaled via the sync-complete
+        // publisher alone (no new organizations-publisher emission).
+        policyService.policyAppliesToUserResult[.disableSend] = true
+        syncService.syncCompleteSubject.send(())
+
+        waitFor { self.tabNavigator.navigators.count == 3 }
+        XCTAssertEqual(tabNavigator.navigators.count, 3)
+    }
+
+    /// The sync-complete stream reactively shows the Send tab again when the policy is no longer
+    /// active, signaled via the sync-complete publisher alone.
+    @MainActor
+    func test_start_syncCompleteStream_showsSendTab_whenPolicyNoLongerApplies() {
+        let mockRoot = MockRootNavigator()
+        mockRoot.rootViewController = UIViewController()
+        tabNavigator.navigatorForTabReturns = mockRoot
+        policyService.policyAppliesToUserResult[.disableSend] = true
+        vaultRepository.organizationsSubject = .init([])
+
+        subject.start()
+        waitFor { self.tabNavigator.navigators.count == 3 }
+
+        policyService.policyAppliesToUserResult[.disableSend] = false
+        syncService.syncCompleteSubject.send(())
+
+        waitFor { self.tabNavigator.navigators.count == 4 }
+        XCTAssertEqual(tabNavigator.navigators.count, 4)
     }
 
     /// `start()` shows all four tabs when `disableSend` policy does not apply.

--- a/BitwardenShared/UI/Platform/Tabs/TabModule.swift
+++ b/BitwardenShared/UI/Platform/Tabs/TabModule.swift
@@ -45,6 +45,7 @@ extension DefaultAppModule: TabModule {
             policyService: services.policyService,
             rootNavigator: rootNavigator,
             settingsDelegate: settingsDelegate,
+            syncService: services.syncService,
             tabNavigator: tabNavigator,
             vaultDelegate: vaultDelegate,
             vaultRepository: vaultRepository,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-40478](https://bitwarden.atlassian.net/browse/PM-40478)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- The Send tab's visibility (driven by the `disableSend` organization policy) previously took two syncs to update after the policy was toggled server-side. `TabCoordinator` recomputed visibility only when `vaultRepository.organizationsPublisher()` emitted, but `SyncService.fetchSync()` persists organizations *before* policies, so that emission always raced ahead of the policy data it was meant to reflect.
- Adds `SyncService.syncCompletePublisher()`, a new multicast completion signal fired at the true end of a successful sync (alongside the existing `onFetchSyncSucceeded` delegate call), modeled on `NotificationCenterService.didEnterBackgroundPublisher()`.
- `TabCoordinator` now also subscribes to this publisher and rechecks the `disableSend` policy once a sync has fully settled, in addition to its existing organizations-driven subscription (which continues to drive the vault title unchanged).

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/a2944342-92cb-4be4-a43a-13f0ef14b5b8" /> | <video src="https://github.com/user-attachments/assets/c4440cd9-9aa4-4d21-bdd6-6dd133096fbb" /> | 







[PM-40478]: https://bitwarden.atlassian.net/browse/PM-40478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ