### PR TITLE
[PM-41028] feat: Restrict View Send screen for policy non-compliant Sends

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -426,6 +426,11 @@
 "SendOptionsPolicyInEffect" = "One or more organization policies are affecting your Send options.";
 "SendFilePremiumRequired" = "Free accounts are restricted to sharing text only. A Premium membership is required to use files with Send.";
 "SendFileEmailVerificationRequired" = "You must verify your email to use files with Send. You can verify your email in the web vault.";
+"OrganizationPolicyRestriction" = "Organization policy restriction";
+"TextSendsAreNotAllowedDescriptionLong" = "Text Sends are not allowed for your organization and this Send will automatically expire at the set deletion date.";
+"ThisSendIsNotCompliantDescriptionLong" = "This Send is not compliant with your organization's Send policy and will automatically expire at the set deletion date.";
+"ToEditThisSendMakeACopyDescriptionLong" = "To edit this Send, make a copy. If this Send can expire at the set deletion date, no action is needed.";
+"MakeACopy" = "Make a copy";
 "PasswordPrompt" = "Master password re-prompt";
 "PasswordConfirmation" = "Master password confirmation";
 "PasswordConfirmationDesc" = "This action is protected, to continue please re-enter your master password to verify your identity.";

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -451,6 +451,11 @@
 "SendFileEmailVerificationRequired" = "You must verify your email to use files with Send. You can verify your email in the web vault.";
 /* Alert message shown when Send Controls policy restricts creation to one Send type. %1$@ is the allowed Send type, either "File" or "Text". */
 "DueToAnEnterprisePolicyYouCanOnlyCreateXSends" = "Due to an enterprise policy, you can only create %1$@ Sends.";
+"OrganizationPolicyRestriction" = "Organization policy restriction";
+"TextSendsAreNotAllowedDescriptionLong" = "Text Sends are not allowed for your organization and this Send will automatically expire at the set deletion date.";
+"ThisSendIsNotCompliantDescriptionLong" = "This Send is not compliant with your organization's Send policy and will automatically expire at the set deletion date.";
+"ToEditThisSendMakeACopyDescriptionLong" = "To edit this Send, make a copy. If this Send can expire at the set deletion date, no action is needed.";
+"MakeACopy" = "Make a copy";
 "PasswordPrompt" = "Master password re-prompt";
 "PasswordConfirmation" = "Master password confirmation";
 "PasswordConfirmationDesc" = "This action is protected, to continue please re-enter your master password to verify your identity.";

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptions.swift
@@ -1,3 +1,4 @@
+import BitwardenSdk
 import Foundation
 
 // MARK: - SendPolicyOptions
@@ -91,5 +92,15 @@ extension SendPolicyOptions {
         if restrictedTypes.contains(.text) { return .text }
         if restrictedTypes.contains(.file) { return .file }
         return nil
+    }
+
+    /// Determines whether the given `sendView`'s type is restricted by these Send policy options.
+    ///
+    /// - Parameter sendView: The `SendView` to check.
+    /// - Returns: `true` if the Send's type isn't the one enforced by policy.
+    ///
+    func isSendTypeRestricted(for sendView: SendView) -> Bool {
+        guard let enforcedSendType else { return false }
+        return SendType(sendType: sendView.type) != enforcedSendType
     }
 }

--- a/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
+++ b/BitwardenShared/Core/Tools/Models/Domain/SendPolicyOptionsTests.swift
@@ -1,4 +1,5 @@
 import BitwardenKit
+import BitwardenSdk
 import Foundation
 import TestHelpers
 import Testing
@@ -286,5 +287,30 @@ struct SendPolicyOptionsTests {
             ),
         ])
         #expect(subject.enforcedSendType == .text)
+    }
+
+    // MARK: isSendTypeRestricted(for:) Tests
+
+    /// `isSendTypeRestricted(for:)` returns `false` when no Send type is enforced.
+    @Test
+    func isSendTypeRestricted_unrestricted() {
+        let subject = SendPolicyOptions()
+        #expect(!subject.isSendTypeRestricted(for: .fixture(type: .text)))
+    }
+
+    /// `isSendTypeRestricted(for:)` returns `true` when the Send's type doesn't match the enforced
+    /// Send type.
+    @Test
+    func isSendTypeRestricted_mismatch() {
+        let subject = SendPolicyOptions(enforcedSendType: .file)
+        #expect(subject.isSendTypeRestricted(for: .fixture(type: .text)))
+    }
+
+    /// `isSendTypeRestricted(for:)` returns `false` when the Send's type matches the enforced Send
+    /// type.
+    @Test
+    func isSendTypeRestricted_matches() {
+        let subject = SendPolicyOptions(enforcedSendType: .file)
+        #expect(!subject.isSendTypeRestricted(for: .fixture(type: .file)))
     }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -254,6 +254,9 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
         if state.mode != .edit, let enforcedDeletionDate = state.policyEnforcedDeletionDate {
             state.deletionDate = enforcedDeletionDate
         }
+        if state.sendPolicyOptions.isHideEmailDisabled {
+            state.isHideMyEmailOn = false
+        }
         state.hasPremium = await services.sendRepository.doesActiveAccountHavePremium()
         await refreshProfileState()
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -403,9 +403,9 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
             return false
         }
 
-        // When password access is enforced by policy, a password is required (unless the send
-        // being edited already has one).
-        if state.policyEnforcedAccessType == .anyoneWithPassword,
+        // A password is required whenever "Anyone with password" access is selected, whether by
+        // policy or by the user, unless the send being edited already has one.
+        if state.accessType == .anyoneWithPassword,
            state.password.isEmpty,
            state.originalSendView?.hasPassword != true {
             coordinator.showAlert(.validationFieldRequired(fieldName: Localizations.password))

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessor.swift
@@ -254,7 +254,7 @@ class AddEditSendItemProcessor: // swiftlint:disable:this type_body_length
         if state.mode != .edit, let enforcedDeletionDate = state.policyEnforcedDeletionDate {
             state.deletionDate = enforcedDeletionDate
         }
-        if state.sendPolicyOptions.isHideEmailDisabled {
+        if state.mode != .edit, state.sendPolicyOptions.isHideEmailDisabled {
             state.isHideMyEmailOn = false
         }
         state.hasPremium = await services.sendRepository.doesActiveAccountHavePremium()

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -637,6 +637,25 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         }
     }
 
+    /// `perform(_:)` with `.savePressed` shows a validation alert when "Anyone with password" access
+    /// is selected and no password is set, even when policy doesn't enforce password access. This
+    /// covers copying a password-protected Send: the copy preselects "Anyone with password" but
+    /// carries no password, so a password must still be required.
+    @MainActor
+    func test_perform_savePressed_anyoneWithPassword_noPasswordAndNotEnforcedByPolicy() async {
+        let sendView = SendView.fixture(hasPassword: true, type: .text)
+        subject.state = AddEditSendItemState(copyingFrom: sendView)
+        subject.state.name = "Name"
+
+        await subject.perform(.savePressed)
+
+        XCTAssertTrue(coordinator.loadingOverlaysShown.isEmpty)
+        XCTAssertNil(sendRepository.addTextSendSendView)
+        XCTAssertEqual(coordinator.alertShown, [
+            .validationFieldRequired(fieldName: Localizations.password),
+        ])
+    }
+
     /// `perform(_:)` with `.savePressed` and valid input in the share extension saves the item and
     /// copies the share link to the clipboard.
     @MainActor

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -156,6 +156,20 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertFalse(subject.state.isHideMyEmailOn)
     }
 
+    /// `perform(_:)` with `loadData` doesn't clear an existing Send's hide-email value when editing,
+    /// even if the policy disables hide-email, since the field remains editable in that case.
+    @MainActor
+    func test_perform_loadData_doesNotClearHideEmailWhenEditingDisabledByPolicy() async {
+        let sendView = SendView.fixture(hideEmail: true)
+        subject.state = AddEditSendItemState(sendView: sendView)
+        XCTAssertTrue(subject.state.isHideMyEmailOn)
+
+        policyService.getSendPolicyOptionsResult.isHideEmailDisabled = true
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(subject.state.isHideMyEmailOn)
+    }
+
     /// `perform(_:)` with `loadData` loads the policy data for the view.
     @MainActor
     func test_perform_loadData_policies() async {

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemProcessorTests.swift
@@ -142,6 +142,20 @@ class AddEditSendItemProcessorTests: BitwardenTestCase { // swiftlint:disable:th
         XCTAssertEqual(coordinator.routes.last, .deleted)
     }
 
+    /// `perform(_:)` with `loadData` clears a copied Send's hide-email value when the policy
+    /// disables hide-email, so a "Make a copy" of a non-compliant Send isn't saved non-compliant.
+    @MainActor
+    func test_perform_loadData_clearsHideEmailWhenDisabledByPolicy() async {
+        let sendView = SendView.fixture(hideEmail: true)
+        subject.state = AddEditSendItemState(copyingFrom: sendView)
+        XCTAssertTrue(subject.state.isHideMyEmailOn)
+
+        policyService.getSendPolicyOptionsResult.isHideEmailDisabled = true
+        await subject.perform(.loadData)
+
+        XCTAssertFalse(subject.state.isHideMyEmailOn)
+    }
+
     /// `perform(_:)` with `loadData` loads the policy data for the view.
     @MainActor
     func test_perform_loadData_policies() async {

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -257,6 +257,36 @@ extension AddEditSendItemState {
         )
     }
 
+    /// Creates a new `AddEditSendItemState` for creating a policy-compliant copy of a restricted
+    /// `sendView`. Used when the user taps "Make a copy" from the View Send screen's restriction
+    /// banner; unlike `init(sendView:)`, this omits the id, access id, and key so that saving
+    /// creates a brand-new Send rather than updating the original, and defaults to `.add` mode.
+    /// Policy-enforced fields (access type, deletion date) are applied afterward by the existing
+    /// `loadData()` policy-override logic, the same as for any other new Send.
+    ///
+    /// - Parameter sendView: The restricted `SendView` to copy details from.
+    ///
+    init(copyingFrom sendView: SendView) {
+        let accessType: SendAccessType = if sendView.hasPassword {
+            .anyoneWithPassword
+        } else {
+            SendAccessType(authType: sendView.authType)
+        }
+
+        self.init(
+            accessType: accessType,
+            isHideMyEmailOn: sendView.hideEmail,
+            isHideTextByDefaultOn: sendView.text?.hidden ?? false,
+            maximumAccessCount: sendView.maxAccessCount.map(Int.init) ?? 0,
+            mode: .add,
+            name: sendView.name,
+            notes: sendView.notes ?? "",
+            recipientEmails: sendView.emails.isEmpty ? [""] : sendView.emails,
+            text: sendView.text?.text ?? "",
+            type: SendType(sendType: sendView.type),
+        )
+    }
+
     /// Returns a `SendView` based on the properties of the `AddEditSendItemState`.
     ///
     func newSendView() -> SendView {

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -261,6 +261,36 @@ extension AddEditSendItemState {
         )
     }
 
+    /// Creates a new `AddEditSendItemState` for creating a policy-compliant copy of a restricted
+    /// `sendView`. Used when the user taps "Make a copy" from the View Send screen's restriction
+    /// banner; unlike `init(sendView:)`, this omits the id, access id, and key so that saving
+    /// creates a brand-new Send rather than updating the original, and defaults to `.add` mode.
+    /// Policy-enforced fields (access type, deletion date) are applied afterward by the existing
+    /// `loadData()` policy-override logic, the same as for any other new Send.
+    ///
+    /// - Parameter sendView: The restricted `SendView` to copy details from.
+    ///
+    init(copyingFrom sendView: SendView) {
+        let accessType: SendAccessType = if sendView.hasPassword {
+            .anyoneWithPassword
+        } else {
+            SendAccessType(authType: sendView.authType)
+        }
+
+        self.init(
+            accessType: accessType,
+            isHideMyEmailOn: sendView.hideEmail,
+            isHideTextByDefaultOn: sendView.text?.hidden ?? false,
+            maximumAccessCount: sendView.maxAccessCount.map(Int.init) ?? 0,
+            mode: .add,
+            name: sendView.name,
+            notes: sendView.notes ?? "",
+            recipientEmails: sendView.emails.isEmpty ? [""] : sendView.emails,
+            text: sendView.text?.text ?? "",
+            type: SendType(sendType: sendView.type),
+        )
+    }
+
     /// Returns a `SendView` based on the properties of the `AddEditSendItemState`.
     ///
     /// - Throws: `DataMappingError.invalidData` if `type` is `.unknown`. This shouldn't happen in

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -418,6 +418,49 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(subject.accessType, .anyoneWithPassword)
     }
 
+    // MARK: init(copyingFrom:) Tests
+
+    /// `init(copyingFrom:)` sets `.add` mode and omits the id, access id, and key so saving creates
+    /// a new Send rather than updating the original.
+    func test_init_copyingFrom_addMode() {
+        let sendView = SendView.fixture(id: "original-id", accessId: "original-access-id", key: "original-key")
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+
+        XCTAssertEqual(subject.mode, .add)
+        XCTAssertNil(subject.id)
+        XCTAssertNil(subject.accessId)
+        XCTAssertNil(subject.key)
+        XCTAssertNil(subject.originalSendView)
+    }
+
+    /// `init(copyingFrom:)` copies the name, notes, text, hide-email, and recipient emails from the
+    /// original Send.
+    func test_init_copyingFrom_copiesFields() {
+        let sendView = SendView.fixture(
+            name: "Original name",
+            notes: "Some notes",
+            text: .fixture(hidden: true, text: "Some text"),
+            hideEmail: true,
+            emails: ["test@example.com"],
+        )
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+
+        XCTAssertEqual(subject.name, "Original name")
+        XCTAssertEqual(subject.notes, "Some notes")
+        XCTAssertEqual(subject.text, "Some text")
+        XCTAssertTrue(subject.isHideTextByDefaultOn)
+        XCTAssertTrue(subject.isHideMyEmailOn)
+        XCTAssertEqual(subject.recipientEmails, ["test@example.com"])
+    }
+
+    /// `init(copyingFrom:)` sets access type to "Anyone with password" when the original Send has a
+    /// password.
+    func test_init_copyingFrom_withPassword_setsAnyoneWithPassword() {
+        let sendView = SendView.fixture(hasPassword: true, authType: .none)
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+        XCTAssertEqual(subject.accessType, .anyoneWithPassword)
+    }
+
     // MARK: shouldShowHideEmailField
 
     /// `shouldShowHideEmailField` is `true` when the hide-email option is not disabled by policy,

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -407,6 +407,49 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(subject.accessType, .anyoneWithPassword)
     }
 
+    // MARK: init(copyingFrom:) Tests
+
+    /// `init(copyingFrom:)` sets `.add` mode and omits the id, access id, and key so saving creates
+    /// a new Send rather than updating the original.
+    func test_init_copyingFrom_addMode() {
+        let sendView = SendView.fixture(id: "original-id", accessId: "original-access-id", key: "original-key")
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+
+        XCTAssertEqual(subject.mode, .add)
+        XCTAssertNil(subject.id)
+        XCTAssertNil(subject.accessId)
+        XCTAssertNil(subject.key)
+        XCTAssertNil(subject.originalSendView)
+    }
+
+    /// `init(copyingFrom:)` copies the name, notes, text, hide-email, and recipient emails from the
+    /// original Send.
+    func test_init_copyingFrom_copiesFields() {
+        let sendView = SendView.fixture(
+            name: "Original name",
+            notes: "Some notes",
+            text: .fixture(hidden: true, text: "Some text"),
+            hideEmail: true,
+            emails: ["test@example.com"],
+        )
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+
+        XCTAssertEqual(subject.name, "Original name")
+        XCTAssertEqual(subject.notes, "Some notes")
+        XCTAssertEqual(subject.text, "Some text")
+        XCTAssertTrue(subject.isHideTextByDefaultOn)
+        XCTAssertTrue(subject.isHideMyEmailOn)
+        XCTAssertEqual(subject.recipientEmails, ["test@example.com"])
+    }
+
+    /// `init(copyingFrom:)` sets access type to "Anyone with password" when the original Send has a
+    /// password.
+    func test_init_copyingFrom_withPassword_setsAnyoneWithPassword() {
+        let sendView = SendView.fixture(hasPassword: true, authType: .none)
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+        XCTAssertEqual(subject.accessType, .anyoneWithPassword)
+    }
+
     // MARK: shouldShowHideEmailField
 
     /// `shouldShowHideEmailField` is `true` when the hide-email option is not disabled by policy,

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -453,6 +453,14 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(subject.recipientEmails, ["test@example.com"])
     }
 
+    /// `init(copyingFrom:)` defaults `recipientEmails` to a single empty entry when the original
+    /// Send has no recipient emails, so the "Specific people" recipient list has a row to edit.
+    func test_init_copyingFrom_emptyEmails_defaultsToSingleEmptyRecipient() {
+        let sendView = SendView.fixture(emails: [])
+        let subject = AddEditSendItemState(copyingFrom: sendView)
+        XCTAssertEqual(subject.recipientEmails, [""])
+    }
+
     /// `init(copyingFrom:)` sets access type to "Anyone with password" when the original Send has a
     /// password.
     func test_init_copyingFrom_withPassword_setsAnyoneWithPassword() {

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinator.swift
@@ -146,6 +146,8 @@ final class SendItemCoordinator: Coordinator, HasStackNavigator, ProfileSwitcher
     private func showAddItem(content: AddSendContentType?) {
         var state = AddEditSendItemState()
         switch content {
+        case let .copy(sendView):
+            state = AddEditSendItemState(copyingFrom: sendView)
         case let .file(fileName, fileData):
             state.fileName = fileName
             state.fileData = fileData

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinatorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemCoordinatorTests.swift
@@ -50,6 +50,21 @@ class SendItemCoordinatorTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// `navigate(to:)` with `.add()` shows the add item screen pre-filled from a copied Send, in
+    /// add mode with no id/access id/key so saving creates a new Send.
+    @MainActor
+    func test_navigateTo_add_copyContent() throws {
+        let sendView = SendView.fixture(id: "original-id", name: "Original name")
+        subject.navigate(to: .add(content: .copy(sendView)))
+
+        let action = try XCTUnwrap(stackNavigator.actions.last)
+        XCTAssertEqual(action.type, .replaced)
+        let view = try XCTUnwrap(action.view as? AddEditSendItemView)
+        XCTAssertEqual(view.store.state.mode, .add)
+        XCTAssertNil(view.store.state.id)
+        XCTAssertEqual(view.store.state.name, "Original name")
+    }
+
     /// `navigate(to:)` with `.add()` shows the add item screen.
     @MainActor
     func test_navigateTo_add_noContent() throws {

--- a/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/SendItemRoute.swift
@@ -6,6 +6,10 @@ import Foundation
 /// Values describing content that can be used to pre-fill the add send screen.
 ///
 public enum AddSendContentType: Equatable, Hashable {
+    /// A copy of an existing, policy-restricted send, whose details should be pre-filled and then
+    /// adjusted to comply with the active Send Controls policy.
+    case copy(SendView)
+
     /// A file type, with the provided name and data.
     case file(fileName: String, fileData: Data)
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemAction.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemAction.swift
@@ -17,6 +17,9 @@ enum ViewSendItemAction: Equatable {
     /// The edit item button was tapped.
     case editItem
 
+    /// The "Make a copy" restriction banner action was tapped.
+    case makeCopy
+
     /// The share button was tapped.
     case shareSend
 

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessor.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessor.swift
@@ -10,6 +10,7 @@ class ViewSendItemProcessor: StateProcessor<ViewSendItemState, ViewSendItemActio
 
     typealias Services = HasErrorReporter
         & HasPasteboardService
+        & HasPolicyService
         & HasSendRepository
 
     // MARK: Private Properties
@@ -68,6 +69,8 @@ class ViewSendItemProcessor: StateProcessor<ViewSendItemState, ViewSendItemActio
             coordinator.navigate(to: .cancel)
         case .editItem:
             coordinator.navigate(to: .edit(state.sendView))
+        case .makeCopy:
+            coordinator.navigate(to: .add(content: .copy(state.sendView)))
         case .shareSend:
             guard let shareURL = state.shareURL else { return }
             coordinator.navigate(to: .share(url: shareURL))
@@ -99,6 +102,7 @@ class ViewSendItemProcessor: StateProcessor<ViewSendItemState, ViewSendItemActio
     /// Loads the data for the view.
     ///
     private func loadData() async {
+        state.sendPolicyOptions = await services.policyService.getSendPolicyOptions()
         do {
             state.shareURL = try await services.sendRepository.shareURL(for: state.sendView)
         } catch {

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemProcessorTests.swift
@@ -13,6 +13,7 @@ class ViewSendItemProcessorTests: BitwardenTestCase {
     var coordinator: MockCoordinator<SendItemRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
     var pasteboardService: MockPasteboardService!
+    var policyService: MockPolicyService!
     var sendRepository: MockSendRepository!
     var subject: ViewSendItemProcessor!
 
@@ -24,6 +25,7 @@ class ViewSendItemProcessorTests: BitwardenTestCase {
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
         pasteboardService = MockPasteboardService()
+        policyService = MockPolicyService()
         sendRepository = MockSendRepository()
 
         subject = ViewSendItemProcessor(
@@ -31,6 +33,7 @@ class ViewSendItemProcessorTests: BitwardenTestCase {
             services: ServiceContainer.withMocks(
                 errorReporter: errorReporter,
                 pasteboardService: pasteboardService,
+                policyService: policyService,
                 sendRepository: sendRepository,
             ),
             state: ViewSendItemState(sendView: .fixture()),
@@ -43,6 +46,7 @@ class ViewSendItemProcessorTests: BitwardenTestCase {
         coordinator = nil
         errorReporter = nil
         pasteboardService = nil
+        policyService = nil
         sendRepository = nil
         subject = nil
     }
@@ -91,6 +95,14 @@ class ViewSendItemProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(coordinator.loadingOverlaysShown.last?.title, Localizations.deleting)
         XCTAssertEqual(coordinator.routes.last, .deleted)
+    }
+
+    /// `perform(_:)` with `loadData` loads the Send policy options for the view.
+    @MainActor
+    func test_perform_loadData_sendPolicyOptions() async {
+        policyService.getSendPolicyOptionsResult.enforcedSendType = .file
+        await subject.perform(.loadData)
+        XCTAssertEqual(subject.state.sendPolicyOptions.enforcedSendType, .file)
     }
 
     /// `perform(_:)` with `loadData` loads the share URL for the view.
@@ -196,6 +208,18 @@ class ViewSendItemProcessorTests: BitwardenTestCase {
         subject.receive(.editItem)
 
         XCTAssertEqual(coordinator.routes.last, .edit(subject.state.sendView))
+    }
+
+    /// `receive(_:)` with `.makeCopy` navigates to the add item route pre-filled with a copy of the
+    /// send's details.
+    @MainActor
+    func test_receive_makeCopy() {
+        let sendView = SendView.fixture()
+        subject.state = ViewSendItemState(sendView: sendView)
+
+        subject.receive(.makeCopy)
+
+        XCTAssertEqual(coordinator.routes.last, .add(content: .copy(sendView)))
     }
 
     /// `receive(_:)` with `.shareSend` navigates to the share route.

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
@@ -13,6 +13,9 @@ struct ViewSendItemState: Equatable {
     /// Whether the additional options section is expanded.
     var isAdditionalOptionsExpanded = false
 
+    /// The Send restrictions enforced by policy for the active user.
+    var sendPolicyOptions = SendPolicyOptions()
+
     /// The send to show the details of.
     var sendView: SendView
 
@@ -24,9 +27,28 @@ struct ViewSendItemState: Equatable {
 
     // MARK: Computed Properties
 
+    /// Whether the "Make a copy" action should be offered for this disabled Send.
+    ///
+    /// Only offered for a disabled Text Send whose type isn't itself restricted by policy; a
+    /// Send-type violation has no compliant equivalent to copy to, and File Sends can't have their
+    /// attachment carried into a new Send.
+    var canMakeCopy: Bool {
+        isDisabled && sendView.type == .text && !isSendTypeRestricted
+    }
+
     /// The send's share URL without a scheme for displaying in the UI.
     var displayShareURL: String? {
         shareURL?.withoutScheme
+    }
+
+    /// Whether this Send has been disabled.
+    var isDisabled: Bool {
+        sendView.disabled
+    }
+
+    /// Whether this Send's type is restricted by the active Send Controls policy.
+    var isSendTypeRestricted: Bool {
+        sendPolicyOptions.isSendTypeRestricted(for: sendView)
     }
 
     /// The navigation title of the view.
@@ -35,5 +57,18 @@ struct ViewSendItemState: Equatable {
         case .file: Localizations.viewFileSend
         case .text: Localizations.viewTextSend
         }
+    }
+
+    /// The message to show in the organization policy restriction banner, or `nil` if the Send isn't
+    /// disabled.
+    var restrictionBannerMessage: String? {
+        guard isDisabled else { return nil }
+        if sendView.type == .text, isSendTypeRestricted {
+            return Localizations.textSendsAreNotAllowedDescriptionLong
+        }
+        if sendView.type == .text {
+            return Localizations.toEditThisSendMakeACopyDescriptionLong
+        }
+        return Localizations.thisSendIsNotCompliantDescriptionLong
     }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemState.swift
@@ -13,6 +13,9 @@ struct ViewSendItemState: Equatable {
     /// Whether the additional options section is expanded.
     var isAdditionalOptionsExpanded = false
 
+    /// The Send restrictions enforced by policy for the active user.
+    var sendPolicyOptions = SendPolicyOptions()
+
     /// The send to show the details of.
     var sendView: SendView
 
@@ -24,9 +27,28 @@ struct ViewSendItemState: Equatable {
 
     // MARK: Computed Properties
 
+    /// Whether the "Make a copy" action should be offered for this disabled Send.
+    ///
+    /// Only offered for a disabled Text Send whose type isn't itself restricted by policy; a
+    /// Send-type violation has no compliant equivalent to copy to, and File Sends can't have their
+    /// attachment carried into a new Send.
+    var canMakeCopy: Bool {
+        isDisabled && sendView.type == .text && !isSendTypeRestricted
+    }
+
     /// The send's share URL without a scheme for displaying in the UI.
     var displayShareURL: String? {
         shareURL?.withoutScheme
+    }
+
+    /// Whether this Send has been disabled.
+    var isDisabled: Bool {
+        sendView.disabled
+    }
+
+    /// Whether this Send's type is restricted by the active Send Controls policy.
+    var isSendTypeRestricted: Bool {
+        sendPolicyOptions.isSendTypeRestricted(for: sendView)
     }
 
     /// The navigation title of the view.
@@ -37,5 +59,18 @@ struct ViewSendItemState: Equatable {
         // TODO: PM-41094 - Share: Implement Share panel and vault item menu integration.
         case .item: ""
         }
+    }
+
+    /// The message to show in the organization policy restriction banner, or `nil` if the Send isn't
+    /// disabled.
+    var restrictionBannerMessage: String? {
+        guard isDisabled else { return nil }
+        if sendView.type == .text, isSendTypeRestricted {
+            return Localizations.textSendsAreNotAllowedDescriptionLong
+        }
+        if sendView.type == .text {
+            return Localizations.toEditThisSendMakeACopyDescriptionLong
+        }
+        return Localizations.thisSendIsNotCompliantDescriptionLong
     }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemStateTests.swift
@@ -21,17 +21,20 @@ class ViewSendItemStateTests: BitwardenTestCase {
         XCTAssertNil(subject.displayShareURL)
     }
 
-    /// `isDisabled`, `restrictionBannerMessage`, and `canMakeCopy` reflect a non-disabled Send.
-    func test_isDisabled_notDisabled() {
-        let subject = ViewSendItemState(sendView: .fixture(disabled: false))
-        XCTAssertFalse(subject.isDisabled)
-        XCTAssertNil(subject.restrictionBannerMessage)
-        XCTAssertFalse(subject.canMakeCopy)
+    /// `navigationTitle` returns the navigation title based on the send's type.
+    func test_navigationTitle() {
+        let textSubject = ViewSendItemState(sendView: .fixture())
+        XCTAssertEqual(textSubject.navigationTitle, Localizations.viewTextSend)
+
+        let fileSubject = ViewSendItemState(sendView: .fixture(type: .file))
+        XCTAssertEqual(fileSubject.navigationTitle, Localizations.viewFileSend)
     }
 
-    /// A disabled File Send shows the generic non-compliant message and offers no copy, regardless of
-    /// whether its type is restricted by policy.
-    func test_isDisabled_disabledFileSend() {
+    // MARK: Restriction State Tests (`isDisabled`, `restrictionBannerMessage`, `canMakeCopy`)
+
+    /// A disabled File Send shows the generic non-compliant message and offers no copy, regardless
+    /// of whether its type is restricted by policy.
+    func test_restrictionState_disabledFileSend() {
         let subject = ViewSendItemState(sendView: .fixture(type: .file, disabled: true))
 
         XCTAssertTrue(subject.isDisabled)
@@ -39,9 +42,9 @@ class ViewSendItemStateTests: BitwardenTestCase {
         XCTAssertFalse(subject.canMakeCopy)
     }
 
-    /// A disabled Text Send whose type is restricted by policy shows the text-restricted message and
-    /// offers no copy.
-    func test_isDisabled_disabledTextSend_typeRestricted() {
+    /// A disabled Text Send whose type is restricted by policy shows the text-restricted message
+    /// and offers no copy.
+    func test_restrictionState_disabledTextSend_typeRestricted() {
         var subject = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
         subject.sendPolicyOptions = SendPolicyOptions(enforcedSendType: .file)
 
@@ -51,7 +54,7 @@ class ViewSendItemStateTests: BitwardenTestCase {
     }
 
     /// A disabled Text Send whose type isn't restricted by policy offers the "Make a copy" action.
-    func test_isDisabled_disabledTextSend_typeNotRestricted() {
+    func test_restrictionState_disabledTextSend_typeNotRestricted() {
         let subject = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
 
         XCTAssertTrue(subject.isDisabled)
@@ -59,12 +62,11 @@ class ViewSendItemStateTests: BitwardenTestCase {
         XCTAssertTrue(subject.canMakeCopy)
     }
 
-    /// `navigationTitle` returns the navigation title based on the send's type.
-    func test_navigationTitle() {
-        let textSubject = ViewSendItemState(sendView: .fixture())
-        XCTAssertEqual(textSubject.navigationTitle, Localizations.viewTextSend)
-
-        let fileSubject = ViewSendItemState(sendView: .fixture(type: .file))
-        XCTAssertEqual(fileSubject.navigationTitle, Localizations.viewFileSend)
+    /// A non-disabled Send has no restrictions.
+    func test_restrictionState_notDisabled() {
+        let subject = ViewSendItemState(sendView: .fixture(disabled: false))
+        XCTAssertFalse(subject.isDisabled)
+        XCTAssertNil(subject.restrictionBannerMessage)
+        XCTAssertFalse(subject.canMakeCopy)
     }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemStateTests.swift
@@ -21,6 +21,44 @@ class ViewSendItemStateTests: BitwardenTestCase {
         XCTAssertNil(subject.displayShareURL)
     }
 
+    /// `isDisabled`, `restrictionBannerMessage`, and `canMakeCopy` reflect a non-disabled Send.
+    func test_isDisabled_notDisabled() {
+        let subject = ViewSendItemState(sendView: .fixture(disabled: false))
+        XCTAssertFalse(subject.isDisabled)
+        XCTAssertNil(subject.restrictionBannerMessage)
+        XCTAssertFalse(subject.canMakeCopy)
+    }
+
+    /// A disabled File Send shows the generic non-compliant message and offers no copy, regardless of
+    /// whether its type is restricted by policy.
+    func test_isDisabled_disabledFileSend() {
+        let subject = ViewSendItemState(sendView: .fixture(type: .file, disabled: true))
+
+        XCTAssertTrue(subject.isDisabled)
+        XCTAssertEqual(subject.restrictionBannerMessage, Localizations.thisSendIsNotCompliantDescriptionLong)
+        XCTAssertFalse(subject.canMakeCopy)
+    }
+
+    /// A disabled Text Send whose type is restricted by policy shows the text-restricted message and
+    /// offers no copy.
+    func test_isDisabled_disabledTextSend_typeRestricted() {
+        var subject = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
+        subject.sendPolicyOptions = SendPolicyOptions(enforcedSendType: .file)
+
+        XCTAssertTrue(subject.isDisabled)
+        XCTAssertEqual(subject.restrictionBannerMessage, Localizations.textSendsAreNotAllowedDescriptionLong)
+        XCTAssertFalse(subject.canMakeCopy)
+    }
+
+    /// A disabled Text Send whose type isn't restricted by policy offers the "Make a copy" action.
+    func test_isDisabled_disabledTextSend_typeNotRestricted() {
+        let subject = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
+
+        XCTAssertTrue(subject.isDisabled)
+        XCTAssertEqual(subject.restrictionBannerMessage, Localizations.toEditThisSendMakeACopyDescriptionLong)
+        XCTAssertTrue(subject.canMakeCopy)
+    }
+
     /// `navigationTitle` returns the navigation title based on the send's type.
     func test_navigationTitle() {
         let textSubject = ViewSendItemState(sendView: .fixture())

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView+SnapshotTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView+SnapshotTests.swift
@@ -85,4 +85,52 @@ class ViewSendItemViewTests: BitwardenTestCase {
             as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 2)],
         )
     }
+
+    /// The view send view for a disabled file send renders correctly, with the send-link section
+    /// and edit FAB hidden and no "Make a copy" action.
+    @MainActor
+    func disabletest_snapshot_viewSend_disabledFileSend() {
+        processor.state = ViewSendItemState(
+            sendView: .fixture(
+                type: .file,
+                file: .fixture(fileName: "photo_123.jpg", sizeName: "3.25 MB"),
+                disabled: true,
+            ),
+            shareURL: URL(string: "send.bitwarden.com/39ngaol3"),
+        )
+        assertSnapshots(
+            of: subject.navStackWrapped,
+            as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 2)],
+        )
+    }
+
+    /// The view send view for a disabled text send whose type is restricted by policy renders
+    /// correctly, with the send-link section and edit FAB hidden.
+    @MainActor
+    func disabletest_snapshot_viewSend_disabledTextSend_typeRestricted() {
+        var state = ViewSendItemState(
+            sendView: .fixture(name: "My text send", text: .fixture(text: "Some text to send"), disabled: true),
+            shareURL: URL(string: "send.bitwarden.com/39ngaol3"),
+        )
+        state.sendPolicyOptions = SendPolicyOptions(enforcedSendType: .file)
+        processor.state = state
+        assertSnapshots(
+            of: subject.navStackWrapped,
+            as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 2)],
+        )
+    }
+
+    /// The view send view for a disabled text send whose type isn't restricted by policy renders
+    /// correctly, with the "Make a copy" action shown in the banner.
+    @MainActor
+    func disabletest_snapshot_viewSend_disabledTextSend_makeACopy() {
+        processor.state = ViewSendItemState(
+            sendView: .fixture(name: "My text send", text: .fixture(text: "Some text to send"), disabled: true),
+            shareURL: URL(string: "send.bitwarden.com/39ngaol3"),
+        )
+        assertSnapshots(
+            of: subject.navStackWrapped,
+            as: [.defaultPortrait, .defaultPortraitDark, .tallPortraitAX5(heightMultiple: 2)],
+        )
+    }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView+ViewInspectorTests.swift
@@ -56,4 +56,48 @@ class ViewSendItemViewTests: BitwardenTestCase {
         try await fab.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .editItem)
     }
+
+    /// The edit floating action button is hidden when the Send is disabled/restricted.
+    @MainActor
+    func test_editItemFloatingActionButton_hiddenWhenRestricted() throws {
+        processor.state = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
+
+        XCTAssertThrowsError(
+            try subject.inspect().find(floatingActionButtonWithAccessibilityIdentifier: "EditItemFloatingActionButton"),
+        )
+    }
+
+    /// The restriction banner has no action button for a disabled File Send.
+    @MainActor
+    func test_restrictionBanner_disabledFileSend_noMakeACopy() throws {
+        processor.state = ViewSendItemState(sendView: .fixture(type: .file, disabled: true))
+
+        let banner = try subject.inspect().find(viewWithAccessibilityIdentifier: "ViewSendRestrictionBanner")
+        XCTAssertNotNil(banner)
+        XCTAssertThrowsError(try subject.inspect().find(asyncButton: Localizations.makeACopy))
+    }
+
+    /// The restriction banner is shown with the "Make a copy" action for a disabled Text Send whose
+    /// type isn't restricted by policy, and tapping it sends the `.makeCopy` action.
+    @MainActor
+    func test_restrictionBanner_makeACopy_tap() async throws {
+        processor.state = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
+
+        let button = try subject.inspect().find(asyncButton: Localizations.makeACopy)
+        try await button.tap()
+
+        XCTAssertEqual(processor.dispatchedActions.last, .makeCopy)
+    }
+
+    /// The restriction banner has no action button for a disabled Text Send whose type is restricted
+    /// by policy.
+    @MainActor
+    func test_restrictionBanner_sendTypeRestricted_noMakeACopy() throws {
+        processor.state = ViewSendItemState(sendView: .fixture(type: .text, disabled: true))
+        processor.state.sendPolicyOptions = SendPolicyOptions(enforcedSendType: .file)
+
+        let banner = try subject.inspect().find(viewWithAccessibilityIdentifier: "ViewSendRestrictionBanner")
+        XCTAssertNotNil(banner)
+        XCTAssertThrowsError(try subject.inspect().find(asyncButton: Localizations.makeACopy))
+    }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/ViewSendItem/ViewSendItemView.swift
@@ -19,8 +19,10 @@ struct ViewSendItemView: View {
             .scrollView()
             .navigationBar(title: store.state.navigationTitle, titleDisplayMode: .inline)
             .overlay(alignment: .bottomTrailing) {
-                editItemFloatingActionButton {
-                    store.send(.editItem)
+                if !store.state.isDisabled {
+                    editItemFloatingActionButton {
+                        store.send(.editItem)
+                    }
                 }
             }
             .task { await store.perform(.loadData) }
@@ -55,7 +57,11 @@ struct ViewSendItemView: View {
     /// The main content of the view.
     @ViewBuilder private var content: some View {
         VStack(spacing: 16) {
-            sendLink
+            restrictionBanner
+
+            if !store.state.isDisabled {
+                sendLink
+            }
 
             sendDetailsSection
 
@@ -100,6 +106,25 @@ struct ViewSendItemView: View {
                     .accessibilityIdentifier("ViewSendNotes")
                 }
             }
+        }
+    }
+
+    /// The banner shown when this Send is disabled due to a Send Controls policy violation.
+    @ViewBuilder private var restrictionBanner: some View {
+        if store.state.isDisabled, let message = store.state.restrictionBannerMessage {
+            ActionCard(
+                title: Localizations.organizationPolicyRestriction,
+                message: message,
+                actionButtonState: store.state.canMakeCopy
+                    ? ActionCard.ButtonState(title: Localizations.makeACopy) {
+                        store.send(.makeCopy)
+                    }
+                    : nil,
+            ) {
+                SharedAsset.Icons.informationCircle24.swiftUIImage
+                    .foregroundStyle(SharedAsset.Colors.iconSecondary.swiftUIColor)
+            }
+            .accessibilityIdentifier("ViewSendRestrictionBanner")
         }
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-41028](https://bitwarden.atlassian.net/browse/PM-41028)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Add `SendPolicyOptions.isSendTypeRestricted(for:)` to determine whether an existing Send violates the active Send Controls policy (restricted type takes priority over restricted access type/deletion date/hide-email).
- View Send screen now hides the send-link (copy/share) section and the floating edit button, and shows an `ActionCard` "Organization policy restriction" banner for non-compliant Sends, with copy varying by violation: restricted text type, restricted file type, or restricted fields (with a "Make a copy" action).
- File Sends never offer "Make a copy" (an existing attachment can't be carried into a new Send), regardless of which policy field is actually violated.
- "Make a copy" opens a new Send pre-filled from the original Send's data, adjusted to comply with the active policy via the existing `AddEditSendItemProcessor` policy-enforcement logic.


## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Send Text Restriction |
|--------|
| <img width="426" alt="send-text-restriction" src="https://github.com/user-attachments/assets/2a5cfb23-ea9e-43df-81ae-7cf751095fb2" /> | 

| Send File Restriction |
|--------|
| <img width="426" alt="send-file-restriction" src="https://github.com/user-attachments/assets/26d1c46a-e843-4a06-8230-1d46f090de79" /> | 


| Send Restricted Field |
|--------|
| <img width="426" alt="send-restricted-field" src="https://github.com/user-attachments/assets/313c737a-d3d6-4775-a2bc-90b3aaeee1ae" /> | 


[PM-41028]: https://bitwarden.atlassian.net/browse/PM-41028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ