### PR TITLE
[PM-41058] feat: Log FlightRecorder entry when Fill-Assist is invoked

### DIFF
--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelper.swift
@@ -14,6 +14,7 @@ class AutofillHelper {
         & HasErrorReporter
         & HasEventService
         & HasFillAssistRepository
+        & HasFlightRecorder
         & HasPasteboardService
         & HasStateService
         & HasVaultRepository
@@ -173,6 +174,10 @@ class AutofillHelper {
                 username: username,
                 password: password,
             )
+
+            if !assistFields.isEmpty {
+                await services.flightRecorder.log("[Autofill] Fill-Assist invoked for this autofill attempt")
+            }
 
             let combinedFields = (assistFields + cipherFields).nilIfEmpty
 

--- a/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/AutofillHelperTests.swift
@@ -18,6 +18,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
     var coordinator: MockCoordinator<VaultRoute, AuthAction>!
     var errorReporter: MockErrorReporter!
     var fillAssistRepository: MockFillAssistRepository!
+    var flightRecorder: MockFlightRecorder!
     var pasteboardService: MockPasteboardService!
     var stateService: MockStateService!
     var subject: AutofillHelper!
@@ -35,6 +36,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
         fillAssistRepository = MockFillAssistRepository()
+        flightRecorder = MockFlightRecorder()
         pasteboardService = MockPasteboardService()
         stateService = MockStateService()
         stateService.activeAccount = .fixture()
@@ -49,6 +51,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
                 configService: configService,
                 errorReporter: errorReporter,
                 fillAssistRepository: fillAssistRepository,
+                flightRecorder: flightRecorder,
                 pasteboardService: pasteboardService,
                 stateService: stateService,
                 vaultRepository: vaultRepository,
@@ -65,6 +68,7 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         coordinator = nil
         errorReporter = nil
         fillAssistRepository = nil
+        flightRecorder = nil
         pasteboardService = nil
         stateService = nil
         subject = nil
@@ -541,6 +545,36 @@ class AutofillHelperTests: BitwardenTestCase { // swiftlint:disable:this type_bo
         XCTAssertEqual(fields[0].value, "user@bitwarden.com")
         XCTAssertEqual(fields[1].selector, "login-pwd")
         XCTAssertEqual(fields[1].value, "PASSWORD")
+    }
+
+    /// `handleCipherForAutofill` logs to the flight recorder when FillAssist selectors are found
+    /// and used for the autofill attempt.
+    func test_handleCipherForAutofill_fillAssist_rulesFound_logsToFlightRecorder() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.rulesReturnValue = FillAssistHostRules(fields: [
+            "username": [.init(id: "login-email", name: nil, role: nil, tagName: nil, type: nil)],
+        ])
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertEqual(flightRecorder.logMessages, ["[Autofill] Fill-Assist invoked for this autofill attempt"])
+    }
+
+    /// `handleCipherForAutofill` does not log to the flight recorder when no FillAssist selectors
+    /// are found for the host.
+    func test_handleCipherForAutofill_fillAssist_noRulesFound_doesNotLogToFlightRecorder() async {
+        configService.featureFlagsBool[.fillAssistTargetingRules] = true
+        fillAssistRepository.rulesReturnValue = nil
+        vaultRepository.fetchCipherResult = .success(.fixture(
+            login: .fixture(password: "PASSWORD", username: "user@bitwarden.com"),
+        ))
+
+        await subject.handleCipherForAutofill(cipherListView: .fixture(id: "1")) { _ in }
+
+        XCTAssertTrue(flightRecorder.logMessages.isEmpty)
     }
 
     /// `handleCipherForAutofill` falls back to the `name` attribute when `id` is nil.

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListProcessor.swift
@@ -25,6 +25,7 @@ class VaultAutofillListProcessor: StateProcessor<// swiftlint:disable:this type_
         & HasFido2CredentialStore
         & HasFido2UserInterfaceHelper
         & HasFillAssistRepository
+        & HasFlightRecorder
         & HasPasteboardService
         & HasPolicyService
         & HasSearchProcessorMediatorFactory


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41058

## 📔 Objective

Adds a debug-only FlightRecorder log entry when Fill-Assist selectors are actually found and used for an autofill attempt, matching Android's equivalent implementation (bitwarden/android#7208). Gives QA a way to confirm Fill-Assist rules are being applied for a given autofill attempt rather than relying on the visual heuristic alone.

- Adds `HasFlightRecorder` to `AutofillHelper.Services` (and its caller `VaultAutofillListProcessor.Services`)
- Logs `"[Autofill] Fill-Assist invoked for this autofill attempt"` once FillAssist selectors are found and non-empty
- Adds `AutofillHelperTests` coverage for both the logging and non-logging cases

## 📸 Screenshots

No UI changes in this PR.