### PR TITLE
[PM-41097] fix: Announce Fill Assist toggle name and info icon to VoiceOver

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Appearance/Styles/BitwardenToggleStyle.swift
+++ b/BitwardenKit/UI/Platform/Application/Appearance/Styles/BitwardenToggleStyle.swift
@@ -11,12 +11,7 @@ public struct BitwardenToggleStyle: ToggleStyle {
 
     public func makeBody(configuration: Configuration) -> some View {
         Toggle(configuration)
-            .styleGuide(.body)
-            .foregroundColor(
-                isEnabled
-                    ? SharedAsset.Colors.textPrimary.swiftUIColor
-                    : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor,
-            )
+            .bitwardenToggleLabelStyle(isEnabled: isEnabled)
             .tint(SharedAsset.Colors.iconSecondary.swiftUIColor)
     }
 }
@@ -26,4 +21,22 @@ public struct BitwardenToggleStyle: ToggleStyle {
 public extension ToggleStyle where Self == BitwardenToggleStyle {
     /// The style for toggles used in this application.
     static var bitwarden: BitwardenToggleStyle { BitwardenToggleStyle() }
+}
+
+// MARK: - View
+
+extension View {
+    /// Applies the label styling used by `BitwardenToggleStyle`, so toggle titles remain visually
+    /// consistent whether they're rendered through a `Toggle`'s label or as standalone content.
+    ///
+    /// - Parameter isEnabled: Whether the toggle is currently enabled.
+    /// - Returns: The view styled to match `BitwardenToggleStyle`.
+    func bitwardenToggleLabelStyle(isEnabled: Bool) -> some View {
+        styleGuide(.body)
+            .foregroundColor(
+                isEnabled
+                    ? SharedAsset.Colors.textPrimary.swiftUIColor
+                    : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor,
+            )
+    }
 }

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenToggle.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenToggle.swift
@@ -42,12 +42,7 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View, Accessory
             if let accessoryContent {
                 HStack(spacing: 8) {
                     titleContent
-                        .styleGuide(.body)
-                        .foregroundColor(
-                            isEnabled
-                                ? SharedAsset.Colors.textPrimary.swiftUIColor
-                                : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor,
-                        )
+                        .bitwardenToggleLabelStyle(isEnabled: isEnabled)
                     accessoryContent
                     Spacer(minLength: 0)
                     Toggle(isOn: $isOn) { EmptyView() }
@@ -59,7 +54,10 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View, Accessory
                 .padding(.vertical, 12)
                 .padding(.horizontal, 16)
                 .contentShape(Rectangle())
-                .onTapGesture { isOn.toggle() }
+                .onTapGesture {
+                    guard isEnabled else { return }
+                    isOn.toggle()
+                }
             } else {
                 Toggle(isOn: $isOn) {
                     titleContent

--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenToggle.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenToggle.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 /// A wrapper around a `Toggle` that is customized based on the Bitwarden design system.
 ///
-public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
+public struct BitwardenToggle<TitleContent: View, FooterContent: View, AccessoryContent: View>: View {
     // MARK: Properties
 
     /// The accessibility identifier for the toggle.
@@ -14,12 +14,20 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
     /// The accessibility label for the toggle.
     let accessibilityLabel: String?
 
+    /// Additional content displayed adjacent to the title, outside of the toggle's own
+    /// accessibility element so it remains independently reachable by VoiceOver (e.g. an
+    /// info button that opens an external link).
+    let accessoryContent: AccessoryContent?
+
     /// The footer text displayed below the toggle.
     let footer: String?
 
     /// The footer content displayed below the toggle. This can be used for more customized content
     /// than just plain text. The `footer` string will take precedence over this if provided.
     let footerContent: FooterContent?
+
+    /// A value indicating whether the toggle is currently enabled or disabled.
+    @Environment(\.isEnabled) private var isEnabled
 
     /// A binding for whether the toggle is on.
     @Binding var isOn: Bool
@@ -31,14 +39,37 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Toggle(isOn: $isOn) {
-                titleContent
+            if let accessoryContent {
+                HStack(spacing: 8) {
+                    titleContent
+                        .styleGuide(.body)
+                        .foregroundColor(
+                            isEnabled
+                                ? SharedAsset.Colors.textPrimary.swiftUIColor
+                                : SharedAsset.Colors.buttonFilledDisabledForeground.swiftUIColor,
+                        )
+                    accessoryContent
+                    Spacer(minLength: 0)
+                    Toggle(isOn: $isOn) { EmptyView() }
+                        .labelsHidden()
+                        .toggleStyle(.bitwarden)
+                        .accessibilityIdentifier(accessibilityIdentifier ?? "")
+                        .accessibilityLabel(accessibilityLabel ?? "")
+                }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+                .contentShape(Rectangle())
+                .onTapGesture { isOn.toggle() }
+            } else {
+                Toggle(isOn: $isOn) {
+                    titleContent
+                }
+                .toggleStyle(.bitwarden)
+                .padding(.vertical, 12)
+                .accessibilityIdentifier(accessibilityIdentifier ?? "")
+                .accessibilityLabel(accessibilityLabel ?? "")
+                .padding(.horizontal, 16)
             }
-            .toggleStyle(.bitwarden)
-            .padding(.vertical, 12)
-            .accessibilityIdentifier(accessibilityIdentifier ?? "")
-            .accessibilityLabel(accessibilityLabel ?? "")
-            .padding(.horizontal, 16)
 
             if footer != nil || footerContent != nil {
                 Divider()
@@ -71,10 +102,11 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
         _ title: String,
         isOn: Binding<Bool>,
         accessibilityIdentifier: String? = nil,
-    ) where TitleContent == Text, FooterContent == EmptyView {
+    ) where TitleContent == Text, FooterContent == EmptyView, AccessoryContent == EmptyView {
         self.accessibilityIdentifier = accessibilityIdentifier
         accessibilityLabel = title
         _isOn = isOn
+        accessoryContent = nil
         footer = nil
         footerContent = nil
         titleContent = Text(title)
@@ -93,10 +125,11 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
         footer: String,
         isOn: Binding<Bool>,
         accessibilityIdentifier: String? = nil,
-    ) where TitleContent == Text, FooterContent == EmptyView {
+    ) where TitleContent == Text, FooterContent == EmptyView, AccessoryContent == EmptyView {
         self.accessibilityIdentifier = accessibilityIdentifier
         accessibilityLabel = title
         _isOn = isOn
+        accessoryContent = nil
         self.footer = footer
         footerContent = nil
         titleContent = Text(title)
@@ -115,10 +148,11 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
         isOn: Binding<Bool>,
         accessibilityIdentifier: String? = nil,
         @ViewBuilder footerContent: () -> FooterContent,
-    ) where TitleContent == Text {
+    ) where TitleContent == Text, AccessoryContent == EmptyView {
         self.accessibilityIdentifier = accessibilityIdentifier
         accessibilityLabel = title
         _isOn = isOn
+        accessoryContent = nil
         footer = nil
         self.footerContent = footerContent()
         titleContent = Text(title)
@@ -139,11 +173,41 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
         accessibilityIdentifier: String? = nil,
         accessibilityLabel: String? = nil,
         @ViewBuilder title titleContent: () -> TitleContent,
+    ) where FooterContent == EmptyView, AccessoryContent == EmptyView {
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.accessibilityLabel = accessibilityLabel
+        self.titleContent = titleContent()
+        _isOn = isOn
+        accessoryContent = nil
+        self.footer = footer
+        footerContent = nil
+    }
+
+    /// Initialize a `BitwardenToggle` with accessory content displayed adjacent to the title,
+    /// outside of the toggle's own accessibility element. This is useful for elements like an
+    /// info button that need to remain independently reachable by VoiceOver.
+    ///
+    /// - Parameters:
+    ///   - footer: The footer text displayed below the toggle.
+    ///   - isOn: A binding for whether the toggle is on.
+    ///   - accessibilityIdentifier: The accessibility identifier for the toggle.
+    ///   - accessibilityLabel: The accessibility label for the toggle.
+    ///   - title: The content to display in the title of the toggle.
+    ///   - accessory: The accessory content displayed adjacent to the title.
+    ///
+    public init(
+        footer: String? = nil,
+        isOn: Binding<Bool>,
+        accessibilityIdentifier: String? = nil,
+        accessibilityLabel: String? = nil,
+        @ViewBuilder title titleContent: () -> TitleContent,
+        @ViewBuilder accessory accessoryContent: () -> AccessoryContent,
     ) where FooterContent == EmptyView {
         self.accessibilityIdentifier = accessibilityIdentifier
         self.accessibilityLabel = accessibilityLabel
         self.titleContent = titleContent()
         _isOn = isOn
+        self.accessoryContent = accessoryContent()
         self.footer = footer
         footerContent = nil
     }
@@ -160,16 +224,18 @@ public struct BitwardenToggle<TitleContent: View, FooterContent: View>: View {
         BitwardenToggle("Toggle", isOn: .constant(true))
             .contentBlock()
 
-        BitwardenToggle(isOn: .constant(true)) {
-            HStack(spacing: 8) {
+        BitwardenToggle(
+            isOn: .constant(true),
+            title: {
                 Text("Toggle")
-
+            },
+            accessory: {
                 Button {} label: {
                     SharedAsset.Icons.cog16.swiftUIImage
                 }
                 .buttonStyle(.fieldLabelIcon)
-            }
-        }
+            },
+        )
         .contentBlock()
 
         BitwardenToggle("Toggle", footer: "Footer text", isOn: .constant(false))

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView+ViewInspectorTests.swift
@@ -64,6 +64,24 @@ class AutoFillViewTests: BitwardenTestCase {
         _ = try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.turnOnFillAssist)
     }
 
+    /// Tapping the Fill Assist toggle sends the `.toggleFillAssist` action.
+    @MainActor
+    func test_fillAssistToggle_tap() throws {
+        processor.state.isFillAssistFeatureFlagEnabled = true
+        let toggle = try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.turnOnFillAssist)
+        try toggle.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .toggleFillAssist(true))
+    }
+
+    /// The Fill Assist info button is independently reachable by VoiceOver and is announced as
+    /// an external link.
+    @MainActor
+    func test_fillAssistToggle_learnMoreButton_accessibility() throws {
+        processor.state.isFillAssistFeatureFlagEnabled = true
+        let button = try subject.inspect().find(buttonWithAccessibilityLabel: Localizations.learnMore)
+        try XCTAssertEqual(button.accessibilityHint().string(), Localizations.externalLink)
+    }
+
     /// The action card is hidden if the autofill setup progress is complete.
     @MainActor
     func test_setUpUnlockActionCard_hidden_complete() {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView+ViewInspectorTests.swift
@@ -57,6 +57,13 @@ class AutoFillViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .passwordAutoFillTapped)
     }
 
+    /// The Fill Assist toggle announces its name to VoiceOver.
+    @MainActor
+    func test_fillAssistToggle_accessibilityLabel() throws {
+        processor.state.isFillAssistFeatureFlagEnabled = true
+        _ = try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.turnOnFillAssist)
+    }
+
     /// The action card is hidden if the autofill setup progress is complete.
     @MainActor
     func test_setUpUnlockActionCard_hidden_complete() {

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -105,7 +105,14 @@ struct AutoFillView: View {
                                 .accessibilityLabel(Localizations.learnMore)
                         }
                         .buttonStyle(.fieldLabelIcon)
+                        .accessibilityHint(Localizations.externalLink)
                     }
+                }
+                // The info button above is nested inside the toggle's custom label, which VoiceOver
+                // treats as part of the toggle's single accessibility element, so it can't be
+                // reached by swiping to it directly. Expose it as a custom action instead.
+                .accessibilityAction(named: "\(Localizations.learnMore), \(Localizations.externalLink)") {
+                    openURL(ExternalLinksConstants.fillAssistHelp)
                 }
                 .contentBlock()
             }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -94,26 +94,21 @@ struct AutoFillView: View {
                     ),
                     accessibilityIdentifier: "FillAssistSwitch",
                     accessibilityLabel: Localizations.turnOnFillAssist,
-                ) {
-                    HStack(spacing: 8) {
+                    title: {
                         Text(Localizations.turnOnFillAssist)
+                    },
+                    accessory: {
                         Button {
                             openURL(ExternalLinksConstants.fillAssistHelp)
                         } label: {
                             SharedAsset.Icons.questionCircle16.swiftUIImage
                                 .scaledFrame(width: 16, height: 16)
-                                .accessibilityLabel(Localizations.learnMore)
                         }
                         .buttonStyle(.fieldLabelIcon)
+                        .accessibilityLabel(Localizations.learnMore)
                         .accessibilityHint(Localizations.externalLink)
-                    }
-                }
-                // The info button above is nested inside the toggle's custom label, which VoiceOver
-                // treats as part of the toggle's single accessibility element, so it can't be
-                // reached by swiping to it directly. Expose it as a custom action instead.
-                .accessibilityAction(named: "\(Localizations.learnMore), \(Localizations.externalLink)") {
-                    openURL(ExternalLinksConstants.fillAssistHelp)
-                }
+                    },
+                )
                 .contentBlock()
             }
 

--- a/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AutoFill/AutoFillView.swift
@@ -93,6 +93,7 @@ struct AutoFillView: View {
                         send: AutoFillAction.toggleFillAssist,
                     ),
                     accessibilityIdentifier: "FillAssistSwitch",
+                    accessibilityLabel: Localizations.turnOnFillAssist,
                 ) {
                     HStack(spacing: 8) {
                         Text(Localizations.turnOnFillAssist)


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41097

## 📔 Objective

With VoiceOver enabled, the Fill Assist toggle in Settings > Auto-fill didn't announce its name, and the adjacent info button (which opens an external help article) wasn't independently reachable, VoiceOver read the entire row as a single element and only announced the on/off state.

This PR:
- Sets `accessibilityLabel` on the toggle so its name is announced.
- Extends `BitwardenToggle` with a new accessory content slot, so elements like the info button render as a true sibling next to the title instead of being nested inside the toggle's own label. This makes the info button an independently reachable VoiceOver element that announces "Learn more, External link".

## 📸 Screenshots

https://github.com/user-attachments/assets/7e3b6eaa-4ca9-40f7-b113-5d64baf5fa42


