### PR TITLE
[PM-41109] feat: Update pending login requests UI screen

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Appearance/StyleGuideFont.swift
+++ b/BitwardenKit/UI/Platform/Application/Appearance/StyleGuideFont.swift
@@ -115,6 +115,13 @@ public extension StyleGuideFont {
     /// The font for the bold semibody style.
     static let bodySemibold = body.with(font: FontFamily.DMSans.semiBold)
 
+    /// The font for the small sensitive info style (e.g. fingerprint phrases).
+    static let sensitiveInfoSmall = StyleGuideFont(
+        font: .system(size: 14, design: .monospaced),
+        lineHeight: 18,
+        size: 14,
+    )
+
     /// The font for the callout style.
     static let callout = StyleGuideFont.dmSans(lineHeight: 18, size: 13, textStyle: .callout)
 

--- a/BitwardenKit/UI/Platform/Application/Appearance/StyleGuideFont.swift
+++ b/BitwardenKit/UI/Platform/Application/Appearance/StyleGuideFont.swift
@@ -117,9 +117,10 @@ public extension StyleGuideFont {
 
     /// The font for the small sensitive info style (e.g. fingerprint phrases).
     static let sensitiveInfoSmall = StyleGuideFont(
-        font: .system(size: 14, design: .monospaced),
+        font: .custom("Menlo", size: 14, relativeTo: .footnote),
         lineHeight: 18,
         size: 14,
+        textStyle: .footnote,
     )
 
     /// The font for the callout style.

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestView.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestView.swift
@@ -16,17 +16,23 @@ struct LoginRequestView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 24) {
-            titleText
+            VStack(alignment: .center, spacing: 12) {
+                titleText
 
-            explanationText
+                explanationText
+            }
+            .frame(maxWidth: .infinity, alignment: .center)
+            .multilineTextAlignment(.center)
 
-            fingerprintView
+            ContentBlock(dividerLeadingPadding: 16) {
+                fingerprintView
 
-            deviceTypeView
+                deviceTypeView
 
-            ipAddressView
+                ipAddressView
 
-            timeView
+                timeView
+            }
 
             VStack(spacing: 12) {
                 confirmButton
@@ -73,15 +79,17 @@ struct LoginRequestView: View {
     private var deviceTypeView: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(Localizations.deviceType)
-                .styleGuide(.body, weight: .semibold)
+                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
                 .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
 
             Text(store.state.request.requestDeviceType)
                 .styleGuide(.body)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
                 .multilineTextAlignment(.leading)
                 .accessibilityIdentifier("DeviceTypeValueLabel")
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     /// The explanation text.
@@ -94,60 +102,64 @@ struct LoginRequestView: View {
         )
         .styleGuide(.body)
         .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-        .multilineTextAlignment(.leading)
         .accessibilityIdentifier("LogInAttemptByLabel")
     }
 
     /// The fingerprint phrase title and display.
     private var fingerprintView: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 0) {
             Text(Localizations.fingerprintPhrase)
-                .styleGuide(.body, weight: .semibold)
+                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
                 .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
                 .accessibilityIdentifier("FingerprintValueLabel")
 
             Text(store.state.request.fingerprintPhrase ?? "")
-                .styleGuide(.bodyMonospaced)
+                .styleGuide(.sensitiveInfoSmall)
                 .foregroundStyle(SharedAsset.Colors.textCodePink.swiftUIColor)
                 .multilineTextAlignment(.leading)
                 .accessibilityIdentifier("FingerprintPhraseValue")
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     /// The IP address title and details.
     private var ipAddressView: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(Localizations.ipAddress)
-                .styleGuide(.body, weight: .semibold)
+                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
                 .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
 
             Text(store.state.request.requestIpAddress)
                 .styleGuide(.body)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
                 .multilineTextAlignment(.leading)
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     /// The time title and details.
     private var timeView: some View {
         VStack(alignment: .leading, spacing: 0) {
             Text(Localizations.time)
-                .styleGuide(.body, weight: .semibold)
+                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
                 .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
 
             Text(RelativeDateTimeFormatter().localizedString(for: store.state.request.creationDate, relativeTo: Date()))
                 .styleGuide(.body)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
                 .multilineTextAlignment(.leading)
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 
     /// The title text.
     private var titleText: some View {
         Text(Localizations.areYouTryingToLogIn)
-            .styleGuide(.title, weight: .bold)
+            .styleGuide(.title2, weight: .semibold)
             .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-            .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestView.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestView.swift
@@ -144,13 +144,13 @@ struct LoginRequestView: View {
             Text(title)
                 .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
                 .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-                .if(titleAccessibilityIdentifier != nil) { $0.accessibilityIdentifier(titleAccessibilityIdentifier!) }
+                .accessibilityIdentifier(titleAccessibilityIdentifier ?? "")
 
             Text(value)
                 .styleGuide(valueStyle)
                 .foregroundStyle(valueColor)
                 .multilineTextAlignment(.leading)
-                .if(valueAccessibilityIdentifier != nil) { $0.accessibilityIdentifier(valueAccessibilityIdentifier!) }
+                .accessibilityIdentifier(valueAccessibilityIdentifier ?? "")
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 12)

--- a/BitwardenShared/UI/Platform/LoginRequest/LoginRequestView.swift
+++ b/BitwardenShared/UI/Platform/LoginRequest/LoginRequestView.swift
@@ -7,6 +7,11 @@ import SwiftUI
 /// A view that shows the information of the login request to allow the user to confirm or deny the request.
 ///
 struct LoginRequestView: View {
+    // MARK: Static Properties
+
+    /// The formatter used to display the relative time of the login request.
+    private static let relativeDateTimeFormatter = RelativeDateTimeFormatter()
+
     // MARK: Properties
 
     /// The `Store` for this view.
@@ -25,13 +30,33 @@ struct LoginRequestView: View {
             .multilineTextAlignment(.center)
 
             ContentBlock(dividerLeadingPadding: 16) {
-                fingerprintView
+                detailRow(
+                    title: Localizations.fingerprintPhrase,
+                    titleAccessibilityIdentifier: "FingerprintValueLabel",
+                    value: store.state.request.fingerprintPhrase ?? "",
+                    valueAccessibilityIdentifier: "FingerprintPhraseValue",
+                    valueColor: SharedAsset.Colors.textCodePink.swiftUIColor,
+                    valueStyle: .sensitiveInfoSmall,
+                )
 
-                deviceTypeView
+                detailRow(
+                    title: Localizations.deviceType,
+                    value: store.state.request.requestDeviceType,
+                    valueAccessibilityIdentifier: "DeviceTypeValueLabel",
+                )
 
-                ipAddressView
+                detailRow(
+                    title: Localizations.ipAddress,
+                    value: store.state.request.requestIpAddress,
+                )
 
-                timeView
+                detailRow(
+                    title: Localizations.time,
+                    value: Self.relativeDateTimeFormatter.localizedString(
+                        for: store.state.request.creationDate,
+                        relativeTo: Date(),
+                    ),
+                )
             }
 
             VStack(spacing: 12) {
@@ -75,23 +100,6 @@ struct LoginRequestView: View {
         .accessibilityIdentifier("DenyLoginButton")
     }
 
-    /// The device type title and details.
-    private var deviceTypeView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(Localizations.deviceType)
-                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-
-            Text(store.state.request.requestDeviceType)
-                .styleGuide(.body)
-                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
-                .multilineTextAlignment(.leading)
-                .accessibilityIdentifier("DeviceTypeValueLabel")
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
     /// The explanation text.
     private var explanationText: some View {
         Text(
@@ -105,61 +113,47 @@ struct LoginRequestView: View {
         .accessibilityIdentifier("LogInAttemptByLabel")
     }
 
-    /// The fingerprint phrase title and display.
-    private var fingerprintView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(Localizations.fingerprintPhrase)
-                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-                .accessibilityIdentifier("FingerprintValueLabel")
-
-            Text(store.state.request.fingerprintPhrase ?? "")
-                .styleGuide(.sensitiveInfoSmall)
-                .foregroundStyle(SharedAsset.Colors.textCodePink.swiftUIColor)
-                .multilineTextAlignment(.leading)
-                .accessibilityIdentifier("FingerprintPhraseValue")
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
-    /// The IP address title and details.
-    private var ipAddressView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(Localizations.ipAddress)
-                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-
-            Text(store.state.request.requestIpAddress)
-                .styleGuide(.body)
-                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
-                .multilineTextAlignment(.leading)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
-    /// The time title and details.
-    private var timeView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(Localizations.time)
-                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
-                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
-
-            Text(RelativeDateTimeFormatter().localizedString(for: store.state.request.creationDate, relativeTo: Date()))
-                .styleGuide(.body)
-                .foregroundStyle(SharedAsset.Colors.textSecondary.swiftUIColor)
-                .multilineTextAlignment(.leading)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 12)
-    }
-
     /// The title text.
     private var titleText: some View {
         Text(Localizations.areYouTryingToLogIn)
             .styleGuide(.title2, weight: .semibold)
             .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+    }
+
+    // MARK: Private Methods
+
+    /// Builds a titled row of details for display within the details `ContentBlock`.
+    ///
+    /// - Parameters:
+    ///   - title: The title displayed above the value.
+    ///   - titleAccessibilityIdentifier: The accessibility identifier applied to the title, if any.
+    ///   - value: The value displayed below the title.
+    ///   - valueAccessibilityIdentifier: The accessibility identifier applied to the value, if any.
+    ///   - valueColor: The foreground color applied to the value.
+    ///   - valueStyle: The style guide font applied to the value.
+    ///
+    private func detailRow(
+        title: String,
+        titleAccessibilityIdentifier: String? = nil,
+        value: String,
+        valueAccessibilityIdentifier: String? = nil,
+        valueColor: Color = SharedAsset.Colors.textSecondary.swiftUIColor,
+        valueStyle: StyleGuideFont = .body,
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(title)
+                .styleGuide(.headline, weight: .semibold, includeLinePadding: false, includeLineSpacing: false)
+                .foregroundStyle(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .if(titleAccessibilityIdentifier != nil) { $0.accessibilityIdentifier(titleAccessibilityIdentifier!) }
+
+            Text(value)
+                .styleGuide(valueStyle)
+                .foregroundStyle(valueColor)
+                .multilineTextAlignment(.leading)
+                .if(valueAccessibilityIdentifier != nil) { $0.accessibilityIdentifier(valueAccessibilityIdentifier!) }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
     }
 }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41109

## 📔 Objective

The pending login requests screen didn't match Figma. The header wasn't centered, the fonts and colors were off on the title, row titles, row values, and the fingerprint phrase, and the rows weren't grouped into a card like the design shows.

This PR fixes that:
- Adds a `sensitiveInfoSmall` font token for the fingerprint phrase (Menlo, Regular, 14px), matching Figma's "Sensitive info/Small" style.
- Centers the header title and description, and wraps the fingerprint/device type/IP address/time rows in a single card (`ContentBlock`) with dividers between them.
- Fixes the fonts and row value color so they match the spec.
- Cleans up the four nearly-identical row views by pulling them into one shared helper.

## 📸 Screenshots 
| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/802ce643-d521-4479-b188-aaa484c2095d" /> | <img width="365" src="https://github.com/user-attachments/assets/a9620da0-077b-4b97-85b9-9bfc1ca180a2" /> |