### PR TITLE
[PM-41332] [BWA-260] fix: Recover from missing biometric key on Authenticator unlock

### DIFF
--- a/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
+++ b/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockProcessor.swift
@@ -92,13 +92,24 @@ class VaultUnlockProcessor: StateProcessor<
         do {
             _ = try await services.biometricsRepository.getUserAuthKey()
             await coordinator.handleEvent(.didCompleteAuth)
-        } catch let error as BiometricsServiceError {
-            Logger.processor.error("BiometricsServiceError unlocking vault with biometrics: \(error)")
-            if case .biometryCancelled = error {
-                // Do nothing if the user cancels.
-                return
-            }
-            await loadData()
+        } catch BiometricsServiceError.biometryCancelled {
+            // Do nothing if the user cancels.
+            Logger.processor.error("Biometric unlock cancelled.")
+        } catch BiometricsServiceError.getAuthKeyFailed {
+            // Biometric unlock is enabled, but the key is missing from the keychain. This happens
+            // when the app is reinstalled or the device is restored from a backup, either of which
+            // preserves the user's preference but not the biometric key.
+            //
+            // The key can never be recovered, so leaving the preference enabled strands the user on
+            // the unlock screen behind a button that cannot succeed. Clear the stale preference so
+            // the app returns to its unlocked state, matching what the user gets today by manually
+            // revoking the app's biometrics permission in the Settings app.
+            services.errorReporter.log(error: BitwardenError.generalError(
+                type: "VaultUnlock: Get Biometrics Auth Key Failed",
+                message: "Biometrics auth is enabled but key was unable to be found. Disabling biometric unlock.",
+            ))
+            try? await services.biometricsRepository.setBiometricUnlockKey(authKey: nil)
+            await coordinator.handleEvent(.didCompleteAuth)
         } catch {
             Logger.processor.error("Error unlocking vault with biometrics: \(error)")
             await loadData()

--- a/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
+++ b/AuthenticatorShared/UI/Auth/VaultUnlock/VaultUnlockProcessorTests.swift
@@ -1,0 +1,118 @@
+import BitwardenKit
+import BitwardenKitMocks
+import Testing
+
+@testable import AuthenticatorShared
+
+// MARK: - VaultUnlockProcessorTests
+
+@MainActor
+struct VaultUnlockProcessorTests {
+    // MARK: Properties
+
+    let biometricsRepository: MockBiometricsRepository
+    let coordinator: MockCoordinator<AuthRoute, AuthEvent>
+    let errorReporter: MockErrorReporter
+    let subject: VaultUnlockProcessor
+
+    // MARK: Initialization
+
+    init() {
+        biometricsRepository = MockBiometricsRepository()
+        coordinator = MockCoordinator()
+        errorReporter = MockErrorReporter()
+
+        subject = VaultUnlockProcessor(
+            coordinator: coordinator.asAnyCoordinator(),
+            services: ServiceContainer.withMocks(
+                biometricsRepository: biometricsRepository,
+                errorReporter: errorReporter,
+            ),
+            state: VaultUnlockState(),
+        )
+    }
+
+    // MARK: Tests
+
+    /// `perform(.appeared)` unlocks the vault when biometrics are enabled and the auth key is available.
+    @Test
+    func perform_appeared_biometricsEnabled_unlocksVault() async {
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        biometricsRepository.getUserAuthKeyReturnValue = "auth key"
+
+        await subject.perform(.appeared)
+
+        #expect(coordinator.events == [.didCompleteAuth])
+    }
+
+    /// `perform(.appeared)` doesn't attempt an unlock when biometrics aren't available.
+    @Test
+    func perform_appeared_biometricsNotAvailable_doesNotAttemptUnlock() async {
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .notAvailable
+
+        await subject.perform(.appeared)
+
+        #expect(subject.state.biometricUnlockStatus == .notAvailable)
+        #expect(biometricsRepository.getUserAuthKeyCalled == false)
+        #expect(coordinator.events.isEmpty)
+    }
+
+    /// `perform(.unlockWithBiometrics)` disables biometric unlock and lets the user into the app when
+    /// biometrics are enabled but the auth key is missing from the keychain.
+    ///
+    /// The key is unrecoverable once it's gone — it's lost when the app is reinstalled or the device
+    /// is restored from a backup, neither of which clears the user's stored preference. Leaving the
+    /// preference enabled would strand the user on the unlock screen behind a button that can never
+    /// succeed.
+    @Test
+    func perform_unlockWithBiometrics_getAuthKeyFailed_disablesBiometricsAndCompletesAuth() async {
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        biometricsRepository.getUserAuthKeyThrowableError = BiometricsServiceError.getAuthKeyFailed
+
+        await subject.perform(.unlockWithBiometrics)
+
+        #expect(biometricsRepository.setBiometricUnlockKeyCalled)
+        #expect(biometricsRepository.setBiometricUnlockKeyReceivedArguments?.authKey == nil)
+        #expect(errorReporter.errors.count == 1)
+        #expect(coordinator.events == [.didCompleteAuth])
+    }
+
+    /// `perform(.unlockWithBiometrics)` still lets the user into the app when clearing the stale
+    /// biometric unlock preference fails.
+    @Test
+    func perform_unlockWithBiometrics_getAuthKeyFailed_completesAuthWhenDisablingThrows() async {
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        biometricsRepository.getUserAuthKeyThrowableError = BiometricsServiceError.getAuthKeyFailed
+        biometricsRepository.setBiometricUnlockKeyThrowableError = BiometricsServiceError.setAuthKeyFailed
+
+        await subject.perform(.unlockWithBiometrics)
+
+        #expect(coordinator.events == [.didCompleteAuth])
+    }
+
+    /// `perform(.unlockWithBiometrics)` leaves the vault locked when the user cancels the prompt.
+    @Test
+    func perform_unlockWithBiometrics_cancelled_remainsLocked() async {
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        biometricsRepository.getUserAuthKeyThrowableError = BiometricsServiceError.biometryCancelled
+
+        await subject.perform(.unlockWithBiometrics)
+
+        #expect(biometricsRepository.setBiometricUnlockKeyCalled == false)
+        #expect(coordinator.events.isEmpty)
+    }
+
+    /// `perform(.unlockWithBiometrics)` leaves biometric unlock enabled for errors that a retry can
+    /// recover from.
+    @Test
+    func perform_unlockWithBiometrics_recoverableError_remainsLocked() async {
+        biometricsRepository.getBiometricUnlockStatusReturnValue = .available(.faceID, enabled: true)
+        biometricsRepository.getUserAuthKeyThrowableError = BiometricsServiceError.biometryFailed
+
+        await subject.perform(.unlockWithBiometrics)
+
+        #expect(biometricsRepository.setBiometricUnlockKeyCalled == false)
+        #expect(coordinator.events.isEmpty)
+        #expect(subject.state.biometricUnlockStatus == .available(.faceID, enabled: true))
+    }
+}


### PR DESCRIPTION
## 🎟️ Tracking

Fixes #2732 (BWA-260)

## 📔 Objective

The Authenticator app can end up permanently locked behind a "Use Face ID to Unlock" button that does nothing when tapped.

**Cause**

`getBiometricUnlockStatus()` reports `.available(_, enabled: true)` from two independent sources: the device's biometry status, and the user's stored preference. Those can disagree. The stored preference survives an app reinstall and an iCloud restore; the biometric key in the keychain does not.

When the preference says enabled but the key is gone, `AppCoordinator` routes to the unlock screen, and `VaultUnlockProcessor.unlockWithBiometrics()` calls `getUserAuthKey()`, which throws `BiometricsServiceError.getAuthKeyFailed`. That error was funnelled into `loadData()`, which re-reads the same two unchanged sources and produces the same enabled status. Nothing in the state changes and no error surfaces.

The keychain lookup fails on a missing item, so iOS never presents a biometric prompt — which is why the button reads as completely unresponsive rather than as a failed scan. The key cannot be recovered, so every subsequent tap and every relaunch repeats the same dead end.

The reported workaround — revoking the app's biometrics permission in the Settings app — works because it flips the *device* half of the status to unavailable, so `AppCoordinator` skips the unlock screen entirely. It depends on iOS showing a Face ID toggle for the app, and iOS only shows that toggle once the app has evaluated a biometric policy at least once. A user who reinstalled before ever granting the permission has no toggle and no way back in ([#2732 comment](https://github.com/bitwarden/ios/issues/2732#issuecomment-4804253545)).

**Fix**

Handle `BiometricsServiceError.getAuthKeyFailed` explicitly: log it, clear the stale preference via `setBiometricUnlockKey(authKey: nil)`, and complete auth.

This mirrors the recovery `BitwardenShared`'s `VaultUnlockProcessor` already performs for the same error — the Authenticator's copy of that processor was simply missing the case. The end state is identical to what the Settings-app workaround produces today, so it grants no access the user cannot already obtain, and it reaches the users who currently have no workaround at all. Re-enabling biometric unlock from the app's own settings then goes through `evaluateBiometricPolicy()`, which requests the permission and writes a fresh key, so the toggle recovers properly instead of resurrecting the broken state.

Other error cases are unchanged: cancellation is still a no-op, and recoverable failures still fall through to `loadData()` so a retry stays possible.

**Tests**

Adds `VaultUnlockProcessorTests`, which did not previously exist for the Authenticator. It covers the lockout regression, the successful-unlock path, cancellation, a recoverable error, and the case where clearing the preference itself fails.

## 📸 Screenshots

Not applicable — no UI changes. The existing unlock screen is unchanged; it is now reached only when biometric unlock can actually succeed.