### PR TITLE
[PM-41110] fix: Update device list date format, pending request matching, and activity display

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1217,8 +1217,8 @@
 /* Device display name. %1$@ = category (e.g. "Mobile"), %2$@ = platform (e.g. "iOS"). */
 "DeviceDisplayNameXHyphenY" = "%1$@ - %2$@";
 "Mobile" = "Mobile";
-"BrowserExtension" = "Browser extension";
-"WebVault2" = "Web vault";
+"BrowserExtension" = "Extension";
+"WebVault2" = "Web app";
 "Desktop" = "Desktop";
 "Cli" = "CLI";
 "Sdk" = "SDK";

--- a/BitwardenShared/Core/Auth/Models/Domain/DeviceListItem.swift
+++ b/BitwardenShared/Core/Auth/Models/Domain/DeviceListItem.swift
@@ -39,6 +39,10 @@ struct DeviceListItem: Comparable, Identifiable, Sendable {
     /// The date of the last activity on this device.
     let lastActivityDate: Date?
 
+    /// The unique identifier of this device's pending authentication request, as reported
+    /// directly by the server on the device record. Used to look up the matching `pendingRequest`.
+    let pendingAuthRequestId: String?
+
     /// The most recent pending login request for this device, if any.
     var pendingRequest: LoginRequest?
 }
@@ -93,6 +97,7 @@ extension DeviceListItem {
         isCurrentSession = false
         isTrusted = device.isTrusted
         lastActivityDate = device.lastActivityDate
+        pendingAuthRequestId = device.devicePendingAuthRequest?.id
         pendingRequest = nil
     }
 }

--- a/BitwardenShared/Core/Auth/Models/Domain/DeviceListItemTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Domain/DeviceListItemTests.swift
@@ -36,8 +36,22 @@ struct DeviceListItemTests {
         #expect(subject.isCurrentSession == false)
         #expect(subject.isTrusted == false)
         #expect(subject.lastActivityDate == device.lastActivityDate)
+        #expect(subject.pendingAuthRequestId == nil)
         #expect(subject.pendingRequest == nil)
         #expect(subject.hasPendingRequest == false)
+    }
+
+    /// `init(device:timeProvider:)` maps `pendingAuthRequestId` from the device's
+    /// `devicePendingAuthRequest`, when present.
+    @Test
+    func init_device_pendingAuthRequestId() {
+        let device = DeviceResponse.fixture(
+            devicePendingAuthRequest: .fixture(id: "auth-request-id"),
+        )
+
+        let subject = DeviceListItem(device: device, timeProvider: timeProvider)
+
+        #expect(subject.pendingAuthRequestId == "auth-request-id")
     }
 
     /// `init(device:timeProvider:)` computes `activityStatus` from the device's last activity

--- a/BitwardenShared/Core/Auth/Models/Domain/Fixtures/DeviceListItem+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Domain/Fixtures/DeviceListItem+Fixtures.swift
@@ -14,6 +14,7 @@ extension DeviceListItem {
         isCurrentSession: Bool = false,
         isTrusted: Bool = true,
         lastActivityDate: Date? = Date(timeIntervalSince1970: 1_718_452_200),
+        pendingAuthRequestId: String? = nil,
         pendingRequest: LoginRequest? = nil,
     ) -> DeviceListItem {
         DeviceListItem(
@@ -26,6 +27,7 @@ extension DeviceListItem {
             isCurrentSession: isCurrentSession,
             isTrusted: isTrusted,
             lastActivityDate: lastActivityDate,
+            pendingAuthRequestId: pendingAuthRequestId,
             pendingRequest: pendingRequest,
         )
     }

--- a/BitwardenShared/Core/Auth/Models/Response/DevicePendingAuthRequest.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/DevicePendingAuthRequest.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+// MARK: - DevicePendingAuthRequest
+
+/// The pending authentication request associated with a device, as reported directly by the
+/// `/devices` endpoint.
+///
+struct DevicePendingAuthRequest: Codable, Equatable, Hashable, Sendable {
+    // MARK: Properties
+
+    /// The date the pending authentication request was created.
+    let creationDate: Date
+
+    /// The unique identifier of the pending authentication request.
+    let id: String
+}

--- a/BitwardenShared/Core/Auth/Models/Response/DeviceResponse.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/DeviceResponse.swift
@@ -14,6 +14,9 @@ struct DeviceResponse: JSONResponse, Equatable, Sendable, Identifiable, Hashable
     /// The date the device was first registered.
     let creationDate: Date
 
+    /// The pending authentication request currently associated with this device, if any.
+    let devicePendingAuthRequest: DevicePendingAuthRequest?
+
     /// The unique identifier of the device.
     let id: String
 

--- a/BitwardenShared/Core/Auth/Models/Response/DeviceResponseTests.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/DeviceResponseTests.swift
@@ -22,6 +22,44 @@ class DeviceResponseTests: BitwardenTestCase {
         XCTAssertNotNil(subject.lastActivityDate)
     }
 
+    /// Validates decoding a `DeviceResponse`'s `devicePendingAuthRequest` when the server reports
+    /// a pending authentication request directly on the device record.
+    func test_decode_devicePendingAuthRequest() throws {
+        let json = Data("""
+        {
+            "id": "device-id-1",
+            "name": "chrome",
+            "identifier": "device-identifier-1",
+            "type": 9,
+            "creationDate": "2024-01-01T00:00:00.000Z",
+            "isTrusted": true,
+            "lastActivityDate": null,
+            "devicePendingAuthRequest": {
+                "id": "72b50b5a-13e1-4300-b966-b49b00a2b1e4",
+                "creationDate": "2026-08-03T09:52:21.240Z"
+            }
+        }
+        """.utf8)
+        let subject = try JSONDecoder.defaultDecoder.decode(DeviceResponse.self, from: json)
+
+        var dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let expectedCreationDate = try XCTUnwrap(dateFormatter.date(from: "2026-08-03T09:52:21.240Z"))
+
+        XCTAssertEqual(subject.devicePendingAuthRequest?.id, "72b50b5a-13e1-4300-b966-b49b00a2b1e4")
+        XCTAssertEqual(subject.devicePendingAuthRequest?.creationDate, expectedCreationDate)
+    }
+
+    /// Decoding a `DeviceResponse` defaults `devicePendingAuthRequest` to `nil` when the server
+    /// doesn't report a pending authentication request for the device.
+    func test_decode_devicePendingAuthRequest_nil() throws {
+        let subject = try JSONDecoder.defaultDecoder.decode(
+            DeviceResponse.self,
+            from: APITestData.currentDevice.data,
+        )
+        XCTAssertNil(subject.devicePendingAuthRequest)
+    }
+
     /// Decoding a `DeviceResponse` defaults `type` to `.unknownBrowser` when the server sends a
     /// raw value not yet recognized by the client.
     func test_decode_unknownType() throws {

--- a/BitwardenShared/Core/Auth/Models/Response/Fixtures/DevicePendingAuthRequest+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/Fixtures/DevicePendingAuthRequest+Fixtures.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@testable import BitwardenShared
+
+extension DevicePendingAuthRequest {
+    static func fixture(
+        creationDate: Date = Date(timeIntervalSince1970: 1_704_067_200),
+        id: String = "auth-request-id-1",
+    ) -> DevicePendingAuthRequest {
+        DevicePendingAuthRequest(
+            creationDate: creationDate,
+            id: id,
+        )
+    }
+}

--- a/BitwardenShared/Core/Auth/Models/Response/Fixtures/DeviceResponse+Fixtures.swift
+++ b/BitwardenShared/Core/Auth/Models/Response/Fixtures/DeviceResponse+Fixtures.swift
@@ -6,6 +6,7 @@ import Foundation
 extension DeviceResponse {
     static func fixture(
         creationDate: Date = Date(timeIntervalSince1970: 1_704_067_200),
+        devicePendingAuthRequest: DevicePendingAuthRequest? = nil,
         id: String = "device-id-1",
         identifier: String = "device-identifier-1",
         isTrusted: Bool = true,
@@ -15,6 +16,7 @@ extension DeviceResponse {
     ) -> DeviceResponse {
         DeviceResponse(
             creationDate: creationDate,
+            devicePendingAuthRequest: devicePendingAuthRequest,
             id: id,
             identifier: identifier,
             isTrusted: isTrusted,

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessor.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessor.swift
@@ -120,37 +120,23 @@ final class DeviceManagementProcessor: StateProcessor<
         }
     }
 
-    /// Matches the most recent pending login request to its corresponding device.
+    /// Matches each device's authoritative pending authentication request id (reported directly
+    /// by the `/devices` endpoint) to its corresponding login request.
     ///
     /// - Parameters:
     ///   - devices: The list of device items.
     ///   - pendingRequests: The list of pending login requests.
-    /// - Returns: The updated list of device items with the most recent pending request matched.
+    /// - Returns: The updated list of device items with their pending request matched by id.
     ///
     private func matchPendingRequestsToDevices(
         _ devices: [DeviceListItem],
         pendingRequests: [LoginRequest],
     ) -> [DeviceListItem] {
         var updatedDevices = devices
-
-        // Sort pending requests by creation date descending to get most recent first.
-        let sortedRequests = pendingRequests.sorted { $0.creationDate > $1.creationDate }
-
-        for request in sortedRequests {
-            guard !request.requestDeviceType.isEmpty else { continue }
-            // Match by platform name, skipping devices that already have a pending request
-            // assigned so that multiple requests for the same platform (e.g. browser and
-            // extension variants that both map to "Chrome") can match distinct devices.
-            if let index = updatedDevices.firstIndex(where: { device in
-                device.pendingRequest == nil &&
-                    !device.isCurrentSession &&
-                    !device.deviceType.platform.isEmpty &&
-                    device.deviceType.platform.caseInsensitiveCompare(request.requestDeviceType) == .orderedSame
-            }) {
-                updatedDevices[index].pendingRequest = request
-            }
+        for index in updatedDevices.indices {
+            guard let pendingAuthRequestId = updatedDevices[index].pendingAuthRequestId else { continue }
+            updatedDevices[index].pendingRequest = pendingRequests.first { $0.id == pendingAuthRequestId }
         }
-
         return updatedDevices
     }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementProcessorTests.swift
@@ -68,7 +68,9 @@ struct DeviceManagementProcessorTests {
             id: "current",
             lastActivityDate: Date(timeIntervalSince1970: 1_717_900_000),
         )
+        let pendingRequest = LoginRequest.fixture(requestDeviceType: "Chrome")
         let pendingDevice = DeviceResponse.fixture(
+            devicePendingAuthRequest: .fixture(creationDate: pendingRequest.creationDate, id: pendingRequest.id),
             id: "pending",
             isTrusted: false,
             lastActivityDate: Date(timeIntervalSince1970: 1_717_800_000),
@@ -80,7 +82,6 @@ struct DeviceManagementProcessorTests {
             lastActivityDate: Date(timeIntervalSince1970: 1_600_000_000),
             type: .macOsDesktop,
         )
-        let pendingRequest = LoginRequest.fixture(requestDeviceType: "Chrome")
 
         deviceAPIService.getDevicesReturnValue = [oldDevice, pendingDevice, currentDevice]
         deviceAPIService.getCurrentDeviceReturnValue = currentDevice
@@ -95,83 +96,75 @@ struct DeviceManagementProcessorTests {
         #expect(items[2].id == "old") // oldest last
     }
 
-    /// `perform(_:)` assigns the most recent pending request when multiple exist for the same platform.
+    /// `perform(_:)` matches a device's pending request by the id the server reports directly on
+    /// that device, not by a coarse platform-name heuristic.
     @Test
-    func perform_loadData_matchesMostRecentPendingRequest() async throws {
-        let chromeDevice = DeviceResponse.fixture(id: "chrome", type: .chromeExtension)
+    func perform_loadData_matchesPendingRequestById() async throws {
+        let otherRequest = LoginRequest.fixture(id: "other-request", requestDeviceType: "Chrome")
+        let matchingRequest = LoginRequest.fixture(id: "matching-request", requestDeviceType: "Chrome")
+        let chromeDevice = DeviceResponse.fixture(
+            devicePendingAuthRequest: .fixture(creationDate: matchingRequest.creationDate, id: matchingRequest.id),
+            id: "chrome",
+            type: .chromeExtension,
+        )
         let currentDevice = DeviceResponse.fixture(id: "current")
-        let olderRequest = LoginRequest.fixture(
-            creationDate: Date(timeIntervalSince1970: 1_000_000),
-            id: "older",
-            requestDeviceType: "Chrome",
-        )
-        let newerRequest = LoginRequest.fixture(
-            creationDate: Date(timeIntervalSince1970: 2_000_000),
-            id: "newer",
-            requestDeviceType: "Chrome",
-        )
 
         deviceAPIService.getDevicesReturnValue = [chromeDevice, currentDevice]
         deviceAPIService.getCurrentDeviceReturnValue = currentDevice
-        authService.getPendingLoginRequestResult = .success([olderRequest, newerRequest])
+        authService.getPendingLoginRequestResult = .success([otherRequest, matchingRequest])
 
         await subject.perform(.loadData)
 
         let items = try #require(subject.state.loadingState.data)
         let chromeItem = try #require(items.first(where: { $0.id == "chrome" }))
-        #expect(chromeItem.pendingRequest?.id == "newer")
+        #expect(chromeItem.pendingRequest?.id == "matching-request")
     }
 
-    /// `perform(_:)` matches a pending request to a device's platform regardless of case.
+    /// `perform(_:)` only flags the device the server marked with a pending auth request, even when
+    /// multiple devices share the same platform and multiple valid requests exist for that platform.
     @Test
-    func perform_loadData_matchesPendingRequestCaseInsensitively() async throws {
-        let chromeDevice = DeviceResponse.fixture(id: "chrome", type: .chromeExtension)
+    func perform_loadData_multipleDevicesSamePlatformOnlyMatchesFlaggedDevice() async throws {
+        let flaggedRequest = LoginRequest.fixture(id: "flagged-request", requestDeviceType: "Chrome")
+        let otherRequest1 = LoginRequest.fixture(id: "other-request-1", requestDeviceType: "Chrome")
+        let otherRequest2 = LoginRequest.fixture(id: "other-request-2", requestDeviceType: "Chrome")
+
+        let flaggedChromeDevice = DeviceResponse.fixture(
+            devicePendingAuthRequest: .fixture(creationDate: flaggedRequest.creationDate, id: flaggedRequest.id),
+            id: "chrome-1",
+            type: .chromeExtension,
+        )
+        let unflaggedChromeDevice1 = DeviceResponse.fixture(id: "chrome-2", type: .chromeExtension)
+        let unflaggedChromeDevice2 = DeviceResponse.fixture(id: "chrome-3", type: .chromeExtension)
         let currentDevice = DeviceResponse.fixture(id: "current")
-        let request = LoginRequest.fixture(requestDeviceType: "chrome")
+
+        deviceAPIService.getDevicesReturnValue = [
+            flaggedChromeDevice, unflaggedChromeDevice1, unflaggedChromeDevice2, currentDevice,
+        ]
+        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
+        authService.getPendingLoginRequestResult = .success([flaggedRequest, otherRequest1, otherRequest2])
+
+        await subject.perform(.loadData)
+
+        let items = try #require(subject.state.loadingState.data)
+        #expect(items.first(where: { $0.id == "chrome-1" })?.pendingRequest?.id == "flagged-request")
+        #expect(items.first(where: { $0.id == "chrome-2" })?.pendingRequest == nil)
+        #expect(items.first(where: { $0.id == "chrome-3" })?.pendingRequest == nil)
+    }
+
+    /// `perform(_:)` leaves a device unmatched when its pending auth request id isn't present in
+    /// the pending login requests list (e.g. it was answered or expired between the two calls).
+    @Test
+    func perform_loadData_pendingAuthRequestIdWithNoMatchingRequestLeavesUnmatched() async throws {
+        let chromeDevice = DeviceResponse.fixture(
+            devicePendingAuthRequest: .fixture(id: "missing-request"),
+            id: "chrome",
+            type: .chromeExtension,
+        )
+        let currentDevice = DeviceResponse.fixture(id: "current")
 
         deviceAPIService.getDevicesReturnValue = [chromeDevice, currentDevice]
         deviceAPIService.getCurrentDeviceReturnValue = currentDevice
-        authService.getPendingLoginRequestResult = .success([request])
-
-        await subject.perform(.loadData)
-
-        let items = try #require(subject.state.loadingState.data)
-        let chromeItem = try #require(items.first(where: { $0.id == "chrome" }))
-        #expect(chromeItem.pendingRequest?.id == request.id)
-    }
-
-    /// `perform(_:)` does not assign a pending request to the current session's device, even if
-    /// its platform matches, and instead matches another device with the same platform.
-    @Test
-    func perform_loadData_skipsCurrentSessionDeviceForPendingRequest() async throws {
-        let currentDevice = DeviceResponse.fixture(id: "current", type: .chromeExtension)
-        let otherChromeDevice = DeviceResponse.fixture(id: "other-chrome", type: .chromeExtension)
-        let request = LoginRequest.fixture(requestDeviceType: "Chrome")
-
-        deviceAPIService.getDevicesReturnValue = [currentDevice, otherChromeDevice]
-        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
-        authService.getPendingLoginRequestResult = .success([request])
-
-        await subject.perform(.loadData)
-
-        let items = try #require(subject.state.loadingState.data)
-        let currentItem = try #require(items.first(where: { $0.id == "current" }))
-        let otherItem = try #require(items.first(where: { $0.id == "other-chrome" }))
-        #expect(currentItem.pendingRequest == nil)
-        #expect(otherItem.pendingRequest?.id == request.id)
-    }
-
-    /// `perform(_:)` leaves a pending request unmatched when the current session's device is the
-    /// only one with a matching platform.
-    @Test
-    func perform_loadData_currentSessionOnlyMatch_leavesPendingRequestUnmatched() async throws {
-        let currentDevice = DeviceResponse.fixture(id: "current", type: .chromeExtension)
-        let otherDevice = DeviceResponse.fixture(id: "other", type: .macOsDesktop)
-        let request = LoginRequest.fixture(requestDeviceType: "Chrome")
-
-        deviceAPIService.getDevicesReturnValue = [currentDevice, otherDevice]
-        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
-        authService.getPendingLoginRequestResult = .success([request])
+        authService.getPendingLoginRequestResult = .success([])
 
         await subject.perform(.loadData)
 
@@ -179,30 +172,13 @@ struct DeviceManagementProcessorTests {
         #expect(items.allSatisfy { $0.pendingRequest == nil })
     }
 
-    /// `perform(_:)` leaves every device without a pending request when none of their platforms
-    /// match the request's device type.
+    /// `perform(_:)` leaves a device without a pending auth request id unmatched, even when
+    /// pending login requests exist for other devices.
     @Test
-    func perform_loadData_noMatchingDeviceForPendingRequest() async throws {
+    func perform_loadData_deviceWithoutPendingAuthRequestIdRemainsUnmatched() async throws {
         let chromeDevice = DeviceResponse.fixture(id: "chrome", type: .chromeExtension)
         let currentDevice = DeviceResponse.fixture(id: "current")
-        let request = LoginRequest.fixture(requestDeviceType: "Firefox")
-
-        deviceAPIService.getDevicesReturnValue = [chromeDevice, currentDevice]
-        deviceAPIService.getCurrentDeviceReturnValue = currentDevice
-        authService.getPendingLoginRequestResult = .success([request])
-
-        await subject.perform(.loadData)
-
-        let items = try #require(subject.state.loadingState.data)
-        #expect(items.allSatisfy { $0.pendingRequest == nil })
-    }
-
-    /// `perform(_:)` skips a pending request that has an empty device type.
-    @Test
-    func perform_loadData_skipsPendingRequestWithEmptyDeviceType() async throws {
-        let chromeDevice = DeviceResponse.fixture(id: "chrome", type: .chromeExtension)
-        let currentDevice = DeviceResponse.fixture(id: "current")
-        let request = LoginRequest.fixture(requestDeviceType: "")
+        let request = LoginRequest.fixture(requestDeviceType: "Chrome")
 
         deviceAPIService.getDevicesReturnValue = [chromeDevice, currentDevice]
         deviceAPIService.getCurrentDeviceReturnValue = currentDevice

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView+ViewInspectorTests.swift
@@ -55,4 +55,34 @@ class DeviceManagementViewTests: BitwardenTestCase {
 
         XCTAssertEqual(processor.dispatchedActions.last, .deviceRow(.rowTapped(device)))
     }
+
+    /// The recently active row is hidden for the current session's device, even when it has a
+    /// last activity date.
+    @MainActor
+    func test_deviceRow_recentlyActiveRow_hiddenForCurrentSession() throws {
+        let device = DeviceListItem.fixture(isCurrentSession: true, lastActivityDate: Date())
+        processor.state.loadingState = .data([device])
+
+        XCTAssertThrowsError(try subject.inspect().find(viewWithAccessibilityIdentifier: "RecentlyActiveRow"))
+    }
+
+    /// The recently active row is hidden for a device with a pending request, even when it has a
+    /// last activity date.
+    @MainActor
+    func test_deviceRow_recentlyActiveRow_hiddenForPendingRequest() throws {
+        var device = DeviceListItem.fixture(lastActivityDate: Date())
+        device.pendingRequest = .fixture()
+        processor.state.loadingState = .data([device])
+
+        XCTAssertThrowsError(try subject.inspect().find(viewWithAccessibilityIdentifier: "RecentlyActiveRow"))
+    }
+
+    /// The recently active row is shown for a regular device with a last activity date.
+    @MainActor
+    func test_deviceRow_recentlyActiveRow_shownForRegularDevice() throws {
+        let device = DeviceListItem.fixture(isCurrentSession: false, lastActivityDate: Date())
+        processor.state.loadingState = .data([device])
+
+        XCTAssertNoThrow(try subject.inspect().find(viewWithAccessibilityIdentifier: "RecentlyActiveRow"))
+    }
 }

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceManagementView.swift
@@ -94,6 +94,7 @@ struct DeviceManagementView: View {
                 isCurrentSession: true,
                 isTrusted: true,
                 lastActivityDate: Date(),
+                pendingAuthRequestId: nil,
                 pendingRequest: nil,
             ),
             DeviceListItem(
@@ -106,6 +107,7 @@ struct DeviceManagementView: View {
                 isCurrentSession: false,
                 isTrusted: false,
                 lastActivityDate: Date().addingTimeInterval(-86400 * 3),
+                pendingAuthRequestId: nil,
                 pendingRequest: nil,
             ),
             DeviceListItem(
@@ -118,6 +120,7 @@ struct DeviceManagementView: View {
                 isCurrentSession: false,
                 isTrusted: true,
                 lastActivityDate: Date().addingTimeInterval(-86400 * 45),
+                pendingAuthRequestId: nil,
                 pendingRequest: nil,
             ),
         ]),

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
@@ -13,18 +13,38 @@ struct DeviceRowState: Equatable {
 
     /// The formatted first-login date and time for display.
     var formattedFirstLogin: String {
-        DeviceRowState.dateTimeFormatter.string(from: device.firstLogin)
+        DeviceRowState.formattedDateTime(from: device.firstLogin)
     }
 }
 
 extension DeviceRowState {
-    /// Shared formatter for device activity dates.
-    private static let dateTimeFormatter: DateFormatter = {
+    /// Locale-aware formatter for the date portion of a first-login timestamp, e.g. "Apr 1, 2026".
+    private static let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
         return formatter
     }()
+
+    /// Locale-aware formatter for the time portion of a first-login timestamp, including seconds
+    /// and respecting the user's 12/24-hour preference, e.g. "5:29:54 PM".
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale.current
+        formatter.setLocalizedDateFormatFromTemplate("jj:mm:ss")
+        return formatter
+    }()
+
+    /// Formats a date as a localized "MMM d, yyyy, h:mm:ss a"-style string (e.g.
+    /// "Apr 1, 2026, 5:29:54 PM"), including seconds and respecting the user's 12/24-hour
+    /// preference.
+    ///
+    /// - Parameter date: The date to format.
+    /// - Returns: The formatted date and time string.
+    ///
+    private static func formattedDateTime(from date: Date) -> String {
+        "\(dateFormatter.string(from: date)), \(timeFormatter.string(from: date))"
+    }
 }
 
 // MARK: - DeviceRowAction

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
@@ -113,7 +113,7 @@ struct DeviceRow: View {
                 }
 
                 VStack(alignment: .leading, spacing: 0) {
-                    if store.state.device.lastActivityDate != nil {
+                    if shouldShowRecentlyActiveRow {
                         recentlyActiveRow
                     }
 
@@ -131,6 +131,15 @@ struct DeviceRow: View {
         }
         .padding(16)
         .contentShape(Rectangle())
+    }
+
+    /// Whether the recently active row should be shown. It's hidden for the current session and
+    /// for devices with a pending request, since those cases are already communicated by their
+    /// badge and don't need a separate activity timestamp.
+    private var shouldShowRecentlyActiveRow: Bool {
+        !store.state.device.isCurrentSession &&
+            !store.state.device.hasPendingRequest &&
+            store.state.device.lastActivityDate != nil
     }
 
     /// The recently active row with bold label and regular status.

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRow.swift
@@ -177,6 +177,7 @@ struct DeviceRow: View {
             isCurrentSession: true,
             isTrusted: true,
             lastActivityDate: Date(),
+            pendingAuthRequestId: nil,
             pendingRequest: nil,
         )))),
     )
@@ -197,6 +198,7 @@ struct DeviceRow: View {
             isCurrentSession: false,
             isTrusted: false,
             lastActivityDate: Date().addingTimeInterval(-86400 * 3),
+            pendingAuthRequestId: nil,
             pendingRequest: .fixture(),
         )))),
     )
@@ -217,6 +219,7 @@ struct DeviceRow: View {
             isCurrentSession: false,
             isTrusted: true,
             lastActivityDate: Date().addingTimeInterval(-86400 * 10),
+            pendingAuthRequestId: nil,
             pendingRequest: nil,
         )))),
     )

--- a/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRowStateTests.swift
+++ b/BitwardenShared/UI/Platform/Settings/Settings/AccountSecurity/DeviceManagement/DeviceRowStateTests.swift
@@ -9,17 +9,23 @@ import Testing
 struct DeviceRowStateTests {
     // MARK: Tests
 
-    /// `formattedFirstLogin` formats the device's first-login date with medium date and short
-    /// time styles.
+    /// `formattedFirstLogin` formats the device's first-login date as "MMM d, yyyy, h:mm:ss a",
+    /// including seconds.
     @Test
     func formattedFirstLogin() {
         let firstLogin = Date(timeIntervalSince1970: 1_718_020_800)
         let subject = DeviceRowState(device: .fixture(firstLogin: firstLogin))
 
-        let expectedFormatter = DateFormatter()
-        expectedFormatter.dateStyle = .medium
-        expectedFormatter.timeStyle = .short
+        let expectedDateFormatter = DateFormatter()
+        expectedDateFormatter.locale = Locale.current
+        expectedDateFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
 
-        #expect(subject.formattedFirstLogin == expectedFormatter.string(from: firstLogin))
+        let expectedTimeFormatter = DateFormatter()
+        expectedTimeFormatter.locale = Locale.current
+        expectedTimeFormatter.setLocalizedDateFormatFromTemplate("jj:mm:ss")
+
+        let expected = "\(expectedDateFormatter.string(from: firstLogin)), " +
+            "\(expectedTimeFormatter.string(from: firstLogin))"
+        #expect(subject.formattedFirstLogin == expected)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41110
https://bitwarden.atlassian.net/browse/PM-41111
https://bitwarden.atlassian.net/browse/PM-41112

## 📔 Objective

Three bugs on the device list screen, all found while testing PM-33981:

- The date and time on each device row didn't match Figma — it was missing seconds and used "at" instead of a comma between the date and time.
- Login requests from a browser extension weren't showing up as pending requests on their device. Turned out we were matching a pending request to a device by comparing platform names (like "Chrome"), which breaks as soon as you have more than one device on the same platform. Now we match by the actual id the server reports on the device record, so it's always the right one.
- The "Recently active" line was showing up on the current session and on pending-request rows, which doesn't make sense since those already have their own badge telling you what's going on. It's now hidden in both cases.

Also renamed "Web vault" to "Web app" and "Browser extension" to "Extension" to match the current naming.

## 📸 Screenshots 

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/10b1c7a2-260e-4404-afd4-ce81588f5882" /> | <img width="365" src="https://github.com/user-attachments/assets/d69c9935-e4ad-486e-8326-4133fa1bb9bf" /> |