### PR TITLE
[PM-33025] ci: Fix linting step CI check

### DIFF
--- a/project-bwa.yml
+++ b/project-bwa.yml
@@ -113,7 +113,8 @@ targets:
           - $(SRCROOT)/Authenticator/Application/Support/Settings.bundle/Acknowledgements
     postCompileScripts:
       - script: |
-          if [[ -z "$CI" ]]; then
+          if [[ -n "$CI" ]]; then
+            echo "[Lint Changes] skipping, CI detected"
             exit 0
           fi
           if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then

--- a/project-bwth.yml
+++ b/project-bwth.yml
@@ -79,7 +79,8 @@ targets:
       - target: BitwardenKit/Networking
     postCompileScripts:
       - script: |
-          if [[ -z "$CI" ]]; then
+          if [[ -n "$CI" ]]; then
+            echo "[Lint Changes] skipping, CI detected"
             exit 0
           fi
           if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then

--- a/project-pm.yml
+++ b/project-pm.yml
@@ -193,7 +193,8 @@ targets:
           - $(SRCROOT)/Bitwarden/Application/Support/Settings.bundle/Acknowledgements
     postCompileScripts:
       - script: |
-          if [[ -z "$CI" ]]; then
+          if [[ -n "$CI" ]]; then
+            echo "[Lint Changes] skipping, CI detected"
             exit 0
           fi
           if [[ ! "$PATH" =~ "/opt/homebrew/bin" ]]; then


### PR DESCRIPTION
## 🎟️ Tracking

PM-33025

## 📔 Objective

Fixes the project setup level linting CI check, ensuring post-build linting only runs for local builds. Introduced by https://github.com/bitwarden/ios/pull/2739.

Test run: https://github.com/bitwarden/ios/actions/runs/30920935027
Root cause for: https://github.com/bitwarden/ios/actions/runs/30896949855

