### PR TITLE
[PM-41479] fix: Correct manageDevices feature flag raw value to match LaunchDarkly

### DIFF
--- a/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
+++ b/BitwardenShared/Core/Platform/Models/Enum/FeatureFlag.swift
@@ -42,7 +42,7 @@ extension FeatureFlag: @retroactive CaseIterable {
     static let fillAssistTargetingRules = FeatureFlag(rawValue: "fill-assist-targeting-rules")
 
     /// Feature flag for device management screen.
-    static let manageDevices = FeatureFlag(rawValue: "pm-4516-manage-devices")
+    static let manageDevices = FeatureFlag(rawValue: "pm-4516-devices-add-last-activity-date")
 
     /// Flag to enable/disable migration from My Vault Items to My Items.
     static let migrateMyVaultToMyItems = FeatureFlag(rawValue: "pm-20558-migrate-myvault-to-myitems")


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41479

## 📔 Objective

The `manageDevices` feature flag was defined in the iOS codebase as `pm-4516-manage-devices`, but the actual flag key in LaunchDarkly is `pm-4516-devices-add-last-activity-date`. Since the raw values didn't match, toggling the flag remotely had no effect — the Device Table could only be shown by flipping the local client-side flag, not through LaunchDarkly/the server like every other flag.

Fixed the raw value to match LaunchDarkly so QA and eng can control the rollout remotely as intended.