### PR TITLE
[PM-33025] ci: Temporarily disable Test workflow cache restore

### DIFF
--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -120,15 +120,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mint-
 
-      - name: Restore SPM packages
-        id: restore-spm
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: build/DerivedData/SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
       - name: Restore DerivedData
         id: restore-deriveddata
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -137,6 +128,15 @@ jobs:
           key: ${{ runner.os }}-deriveddata-testbwa-${{ env._XCODE_VERSION }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-deriveddata-testbwa-${{ env._XCODE_VERSION }}-
+
+      - name: Restore SPM packages
+        id: restore-spm
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build/DerivedData/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       # src: https://stackoverflow.com/questions/53753511/is-it-possible-to-copy-an-xcode-derived-data-cache
       - name: Set IgnoreFileSystemDeviceInodeChanges flag

--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -138,6 +138,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
+      # On dependency updates SPM cache key won't match and it'll fallback to an older cache.
+      # Removing workspace-state.json forces SPM to reconcile against Package.resolved, preserving old dependencies and downloading new ones.
+      - name: Reconcile SPM after partial cache hit
+        if: steps.restore-spm.outputs.cache-hit != 'true' && steps.restore-spm.outputs.cache-matched-key != ''
+        run: rm -f build/DerivedData/SourcePackages/workspace-state.json
+
       # src: https://stackoverflow.com/questions/53753511/is-it-possible-to-copy-an-xcode-derived-data-cache
       - name: Set IgnoreFileSystemDeviceInodeChanges flag
         run: defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES

--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -122,6 +122,7 @@ jobs:
 
       - name: Restore DerivedData
         id: restore-deriveddata
+        if: false # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData
@@ -131,18 +132,13 @@ jobs:
 
       - name: Restore SPM packages
         id: restore-spm
+        if: false # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData/SourcePackages
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
-
-      # On dependency updates SPM cache key won't match and it'll fallback to an older cache.
-      # Removing workspace-state.json forces SPM to reconcile against Package.resolved, preserving old dependencies and downloading new ones.
-      - name: Reconcile SPM after partial cache hit
-        if: steps.restore-spm.outputs.cache-hit != 'true' && steps.restore-spm.outputs.cache-matched-key != ''
-        run: rm -f build/DerivedData/SourcePackages/workspace-state.json
 
       # src: https://stackoverflow.com/questions/53753511/is-it-possible-to-copy-an-xcode-derived-data-cache
       - name: Set IgnoreFileSystemDeviceInodeChanges flag

--- a/.github/workflows/test-bwa.yml
+++ b/.github/workflows/test-bwa.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Restore DerivedData
         id: restore-deriveddata
-        if: false # Disabled for now while we investigate build failures on partial cache hit
+        if: ${{ contains(env._GITHUB_ACTION_RUN_URL, 'temp_disable_cache') }} # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData
@@ -132,7 +132,7 @@ jobs:
 
       - name: Restore SPM packages
         id: restore-spm
-        if: false # Disabled for now while we investigate build failures on partial cache hit
+        if: ${{ contains(env._GITHUB_ACTION_RUN_URL, 'temp_disable_cache') }} # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData/SourcePackages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Restore DerivedData
         id: restore-deriveddata
-        if: false # Disabled for now while we investigate build failures on partial cache hit
+        if: ${{ contains(env._GITHUB_ACTION_RUN_URL, 'temp_disable_cache') }} # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData
@@ -126,7 +126,7 @@ jobs:
 
       - name: Restore SPM packages
         id: restore-spm
-        if: false # Disabled for now while we investigate build failures on partial cache hit
+        if: ${{ contains(env._GITHUB_ACTION_RUN_URL, 'temp_disable_cache') }} # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData/SourcePackages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -132,6 +132,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-spm-
 
+      # On dependency updates SPM cache key won't match and it'll fallback to an older cache.
+      # Removing workspace-state.json forces SPM to reconcile against Package.resolved, preserving old dependencies and downloading new ones.
+      - name: Reconcile SPM after partial cache hit
+        if: steps.restore-spm.outputs.cache-hit != 'true' && steps.restore-spm.outputs.cache-matched-key != ''
+        run: rm -f build/DerivedData/SourcePackages/workspace-state.json
+
       # src: https://stackoverflow.com/questions/53753511/is-it-possible-to-copy-an-xcode-derived-data-cache
       - name: Set IgnoreFileSystemDeviceInodeChanges flag
         run: defaults write com.apple.dt.XCBuild IgnoreFileSystemDeviceInodeChanges -bool YES

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,6 +116,7 @@ jobs:
 
       - name: Restore DerivedData
         id: restore-deriveddata
+        if: false # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData
@@ -125,18 +126,13 @@ jobs:
 
       - name: Restore SPM packages
         id: restore-spm
+        if: false # Disabled for now while we investigate build failures on partial cache hit
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build/DerivedData/SourcePackages
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
-
-      # On dependency updates SPM cache key won't match and it'll fallback to an older cache.
-      # Removing workspace-state.json forces SPM to reconcile against Package.resolved, preserving old dependencies and downloading new ones.
-      - name: Reconcile SPM after partial cache hit
-        if: steps.restore-spm.outputs.cache-hit != 'true' && steps.restore-spm.outputs.cache-matched-key != ''
-        run: rm -f build/DerivedData/SourcePackages/workspace-state.json
 
       # src: https://stackoverflow.com/questions/53753511/is-it-possible-to-copy-an-xcode-derived-data-cache
       - name: Set IgnoreFileSystemDeviceInodeChanges flag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,15 +114,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-mint-
 
-      - name: Restore SPM packages
-        id: restore-spm
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: build/DerivedData/SourcePackages
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
       - name: Restore DerivedData
         id: restore-deriveddata
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -131,6 +122,15 @@ jobs:
           key: ${{ runner.os }}-deriveddata-testbwpm-${{ env._XCODE_VERSION }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-deriveddata-testbwpm-${{ env._XCODE_VERSION }}-
+
+      - name: Restore SPM packages
+        id: restore-spm
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build/DerivedData/SourcePackages
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
 
       # src: https://stackoverflow.com/questions/53753511/is-it-possible-to-copy-an-xcode-derived-data-cache
       - name: Set IgnoreFileSystemDeviceInodeChanges flag


### PR DESCRIPTION
## 🎟️ Tracking

[PM-33025] 

## 📔 Objective

Disabling DerivedData and SPM cache restore while we troubleshoot SDK-Update build failures on a partial cache hit. E.g.  https://github.com/bitwarden/ios/actions/runs/30996138298/job/92273546428?pr=2894


[PM-33025]: https://bitwarden.atlassian.net/browse/PM-33025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ