### PR TITLE
[PM-40519] feat: Add SDK-backed passkey registration and assertion services to TestHarness

### DIFF
--- a/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2CredentialStore.swift
+++ b/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2CredentialStore.swift
@@ -1,0 +1,78 @@
+import BitwardenKit
+import BitwardenSdk
+import Foundation
+
+// MARK: - DefaultFido2CredentialStore
+
+/// A `Fido2CredentialStore` for the SDK-backed passkey scenarios, backed by an injected
+/// `CipherStorageService` so credentials survive app relaunches as long as the same synthetic
+/// identity — and therefore the same crypto keys — is reconstructed alongside it.
+///
+actor DefaultFido2CredentialStore: Fido2CredentialStore {
+    // MARK: Private Properties
+
+    /// Used to persist ciphers across app relaunches.
+    private let cipherStorageService: CipherStorageService
+
+    /// The SDK-encrypted ciphers created for this session, in the order they were saved.
+    private var ciphers: [Cipher]
+
+    /// Used to decrypt stored ciphers' Fido2 credentials on read.
+    private let platformClientService: PlatformClientService
+
+    /// Used to decrypt stored ciphers on read.
+    private let vaultClientService: VaultClientService
+
+    // MARK: Initialization
+
+    /// Initializes an `DefaultFido2CredentialStore`.
+    ///
+    /// - Parameters:
+    ///   - cipherStorageService: Used to persist ciphers across app relaunches.
+    ///   - platformClientService: Used to decrypt stored ciphers' Fido2 credentials on read.
+    ///   - vaultClientService: Used to decrypt stored ciphers on read.
+    ///
+    init(
+        cipherStorageService: CipherStorageService,
+        platformClientService: PlatformClientService,
+        vaultClientService: VaultClientService,
+    ) {
+        self.cipherStorageService = cipherStorageService
+        self.platformClientService = platformClientService
+        self.vaultClientService = vaultClientService
+        ciphers = cipherStorageService.loadCiphers()
+    }
+
+    // MARK: Methods
+
+    func allCredentials() async throws -> [CipherListView] {
+        try await vaultClientService.ciphers().decryptList(ciphers: ciphers)
+    }
+
+    func findCredentials(ids: [Data]?, ripId: String, userHandle: Data?) async throws -> [CipherView] {
+        var matches: [CipherView] = []
+        for cipher in ciphers {
+            let cipherView = try await vaultClientService.ciphers().decrypt(cipher: cipher)
+            let autofillCredentials = try platformClientService.fido2()
+                .decryptFido2AutofillCredentials(cipherView: cipherView)
+            let isMatch = autofillCredentials.contains { credential in
+                guard credential.rpId == ripId else { return false }
+                if let ids, !ids.contains(credential.credentialId) { return false }
+                if let userHandle, credential.userHandle != userHandle { return false }
+                return true
+            }
+            guard isMatch else { continue }
+            matches.append(cipherView)
+        }
+        return matches
+    }
+
+    func saveCredential(cred: EncryptionContext) async throws {
+        if let id = cred.cipher.id, let index = ciphers.firstIndex(where: { $0.id == id }) {
+            ciphers[index] = cred.cipher
+        } else {
+            ciphers.append(cred.cipher)
+        }
+        cipherStorageService.save(ciphers: ciphers)
+    }
+}

--- a/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2CredentialStoreTests.swift
+++ b/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2CredentialStoreTests.swift
@@ -1,0 +1,183 @@
+import BitwardenKit
+import BitwardenKitMocks
+import BitwardenSdk
+import TestHelpers
+import XCTest
+
+@testable import TestHarnessShared
+
+// MARK: - DefaultFido2CredentialStoreTests
+
+/// Tests for `DefaultFido2CredentialStore`.
+///
+class DefaultFido2CredentialStoreTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var cipherStorageService: MockCipherStorageService!
+    var clientFido2Service: MockClientFido2Service!
+    var platformClientService: MockPlatformClientService!
+    var subject: DefaultFido2CredentialStore!
+    var vaultClientService: MockVaultClientService!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        cipherStorageService = MockCipherStorageService()
+        cipherStorageService.loadCiphersReturnValue = []
+        clientFido2Service = MockClientFido2Service()
+        platformClientService = MockPlatformClientService()
+        platformClientService.fido2ReturnValue = clientFido2Service
+        vaultClientService = MockVaultClientService()
+        subject = DefaultFido2CredentialStore(
+            cipherStorageService: cipherStorageService,
+            platformClientService: platformClientService,
+            vaultClientService: vaultClientService,
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        cipherStorageService = nil
+        clientFido2Service = nil
+        platformClientService = nil
+        subject = nil
+        vaultClientService = nil
+    }
+
+    // MARK: Tests
+
+    /// `allCredentials()` returns an empty list when nothing has been saved.
+    func test_allCredentials_empty() async throws {
+        let result = try await subject.allCredentials()
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    /// `findCredentials(ids:ripId:userHandle:)` excludes ciphers whose Fido2 credentials don't
+    /// match the requested relying party.
+    func test_findCredentials_noMatch_returnsEmpty() async throws {
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "Other"))),
+        )
+        clientFido2Service.decryptFido2AutofillCredentialsClosure = { _ in [.fixture(rpId: "other.com")] }
+
+        let result = try await subject.findCredentials(ids: nil, ripId: "bitwarden.com", userHandle: nil)
+
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    /// `findCredentials(ids:ripId:userHandle:)` returns the decrypted cipher for a saved
+    /// credential whose Fido2 credential matches the requested relying party.
+    func test_findCredentials_match_returnsCipherView() async throws {
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "Match"))),
+        )
+        clientFido2Service.decryptFido2AutofillCredentialsClosure = { _ in [.fixture(rpId: "bitwarden.com")] }
+
+        let result = try await subject.findCredentials(ids: nil, ripId: "bitwarden.com", userHandle: nil)
+
+        XCTAssertEqual(result.map(\.name), ["Match"])
+    }
+
+    /// `findCredentials(ids:ripId:userHandle:)` only returns the credential whose ID is in
+    /// `ids`, ignoring other credentials registered for the same relying party.
+    func test_findCredentials_withIds_onlyReturnsMatchingCredential() async throws {
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "First"))),
+        )
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "Second"))),
+        )
+        let firstCredentialId = Data([0x01])
+        let secondCredentialId = Data([0x02])
+        clientFido2Service.decryptFido2AutofillCredentialsClosure = { cipherView in
+            let credentialId = cipherView.name == "First" ? firstCredentialId : secondCredentialId
+            return [.fixture(credentialId: credentialId, rpId: "bitwarden.com")]
+        }
+
+        let result = try await subject.findCredentials(
+            ids: [secondCredentialId],
+            ripId: "bitwarden.com",
+            userHandle: nil,
+        )
+
+        XCTAssertEqual(result.map(\.name), ["Second"])
+    }
+
+    /// `findCredentials(ids:ripId:userHandle:)` only returns the credential matching
+    /// `userHandle`, ignoring other credentials registered for the same relying party.
+    func test_findCredentials_withUserHandle_onlyReturnsMatchingCredential() async throws {
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "First"))),
+        )
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "Second"))),
+        )
+        let firstUserHandle = Data([0x01])
+        let secondUserHandle = Data([0x02])
+        clientFido2Service.decryptFido2AutofillCredentialsClosure = { cipherView in
+            let userHandle = cipherView.name == "First" ? firstUserHandle : secondUserHandle
+            return [.fixture(rpId: "bitwarden.com", userHandle: userHandle)]
+        }
+
+        let result = try await subject.findCredentials(
+            ids: nil,
+            ripId: "bitwarden.com",
+            userHandle: secondUserHandle,
+        )
+
+        XCTAssertEqual(result.map(\.name), ["Second"])
+    }
+
+    /// `saveCredential(cred:)` makes the credential visible to a subsequent `allCredentials()`
+    /// call.
+    func test_saveCredential_thenAllCredentials_returnsIt() async throws {
+        try await subject.saveCredential(
+            cred: EncryptionContext(encryptedFor: "1", cipher: Cipher(cipherView: .fixture(name: "Saved"))),
+        )
+
+        let result = try await subject.allCredentials()
+
+        XCTAssertEqual(result.map(\.name), ["Saved"])
+    }
+
+    /// `saveCredential(cred:)` persists the full, updated list of ciphers via the injected
+    /// `CipherStorageService`.
+    func test_saveCredential_persistsFullList() async throws {
+        let cipher = Cipher(cipherView: .fixture(name: "Saved"))
+
+        try await subject.saveCredential(cred: EncryptionContext(encryptedFor: "1", cipher: cipher))
+
+        XCTAssertEqual(cipherStorageService.saveReceivedCiphers, [cipher])
+    }
+
+    /// `saveCredential(cred:)` replaces the existing cipher with the same ID rather than
+    /// appending a duplicate, so a re-save (e.g. a signature-counter update) doesn't leave two
+    /// entries behind for the same credential.
+    func test_saveCredential_existingId_replacesExistingCipher() async throws {
+        let original = Cipher(cipherView: .fixture(id: "1", name: "Original"))
+        try await subject.saveCredential(cred: EncryptionContext(encryptedFor: "1", cipher: original))
+
+        let updated = Cipher(cipherView: .fixture(id: "1", name: "Updated"))
+        try await subject.saveCredential(cred: EncryptionContext(encryptedFor: "1", cipher: updated))
+
+        let result = try await subject.allCredentials()
+        XCTAssertEqual(result.map(\.name), ["Updated"])
+        XCTAssertEqual(cipherStorageService.saveReceivedCiphers, [updated])
+    }
+
+    /// Ciphers persisted from a previous session are loaded and visible on initialization.
+    func test_init_loadsPersistedCiphers() async throws {
+        let cipher = Cipher(cipherView: .fixture(name: "Persisted"))
+        cipherStorageService.loadCiphersReturnValue = [cipher]
+
+        subject = DefaultFido2CredentialStore(
+            cipherStorageService: cipherStorageService,
+            platformClientService: platformClientService,
+            vaultClientService: vaultClientService,
+        )
+        let result = try await subject.allCredentials()
+
+        XCTAssertEqual(result.map(\.name), ["Persisted"])
+    }
+}

--- a/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2UserInterface.swift
+++ b/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2UserInterface.swift
@@ -1,0 +1,80 @@
+import BitwardenSdk
+import Foundation
+
+// MARK: - DefaultFido2UserInterface
+
+/// A minimal `Fido2UserInterface` implementation for the SDK-backed passkey scenarios. There's
+/// no vault, biometrics, or master password reprompt to mediate here, so this always approves
+/// user checks and synthesizes a single throwaway login item for new credentials.
+///
+final class DefaultFido2UserInterface: Fido2UserInterface, Sendable {
+    // MARK: Methods
+
+    func checkUser(options: CheckUserOptions, hint: UiHint) async throws -> CheckUserResult {
+        CheckUserResult(userPresent: true, userVerified: true)
+    }
+
+    func checkUserAndPickCredentialForCreation(
+        options: CheckUserOptions,
+        newCredential: Fido2CredentialNewView,
+    ) async throws -> CheckUserAndPickCredentialForCreationResult {
+        let cipherView = CipherView(
+            id: UUID().uuidString,
+            organizationId: nil,
+            folderId: nil,
+            collectionIds: [],
+            key: nil,
+            name: newCredential.rpName ?? newCredential.rpId,
+            notes: nil,
+            type: .login,
+            login: LoginView(
+                username: newCredential.userName,
+                password: nil,
+                passwordRevisionDate: nil,
+                uris: nil,
+                totp: nil,
+                autofillOnPageLoad: nil,
+                fido2Credentials: nil,
+            ),
+            identity: nil,
+            card: nil,
+            secureNote: nil,
+            sshKey: nil,
+            bankAccount: nil,
+            driversLicense: nil,
+            passport: nil,
+            favorite: false,
+            reprompt: .none,
+            organizationUseTotp: false,
+            edit: true,
+            permissions: nil,
+            viewPassword: true,
+            localData: nil,
+            attachments: nil,
+            attachmentDecryptionFailures: nil,
+            fields: nil,
+            passwordHistory: nil,
+            creationDate: newCredential.creationDate,
+            deletedDate: nil,
+            revisionDate: newCredential.creationDate,
+            archivedDate: nil,
+        )
+        return CheckUserAndPickCredentialForCreationResult(
+            cipher: CipherViewWrapper(cipher: cipherView),
+            checkUserResult: CheckUserResult(userPresent: true, userVerified: true),
+        )
+    }
+
+    func isVerificationEnabled() -> Bool {
+        false
+    }
+
+    func pickCredentialForAuthentication(availableCredentials: [CipherView]) async throws -> CipherViewWrapper {
+        guard availableCredentials.count == 1, let onlyCredential = availableCredentials.first else {
+            throw availableCredentials.isEmpty
+                ? PasskeyError.noMatchingCredential
+                : PasskeyError.ambiguousCredential
+        }
+        return CipherViewWrapper(cipher: onlyCredential)
+    }
+}

--- a/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2UserInterfaceTests.swift
+++ b/TestHarnessShared/Core/Autofill/Passkey/DefaultFido2UserInterfaceTests.swift
@@ -1,0 +1,94 @@
+import BitwardenSdk
+import TestHelpers
+import XCTest
+
+@testable import TestHarnessShared
+
+// MARK: - DefaultFido2UserInterfaceTests
+
+/// Tests for `DefaultFido2UserInterface`.
+///
+class DefaultFido2UserInterfaceTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var subject: DefaultFido2UserInterface!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        subject = DefaultFido2UserInterface()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// `checkUser(options:hint:)` always approves presence and verification.
+    func test_checkUser_approves() async throws {
+        let result = try await subject.checkUser(
+            options: CheckUserOptions(requirePresence: true, requireVerification: .required),
+            hint: .informNoCredentialsFound,
+        )
+        XCTAssertTrue(result.userPresent)
+        XCTAssertTrue(result.userVerified)
+    }
+
+    /// `checkUserAndPickCredentialForCreation(options:newCredential:)` synthesizes a new login
+    /// item using the new credential's relying party and username.
+    func test_checkUserAndPickCredentialForCreation() async throws {
+        let newCredential = Fido2CredentialNewView(
+            credentialId: "credential-id",
+            keyType: "public-key",
+            keyAlgorithm: "ECDSA",
+            keyCurve: "P-256",
+            rpId: "bitwarden.com",
+            userHandle: nil,
+            userName: "user@example.com",
+            counter: "0",
+            rpName: "Bitwarden",
+            userDisplayName: "User",
+            creationDate: Date(timeIntervalSince1970: 0),
+        )
+        let result = try await subject.checkUserAndPickCredentialForCreation(
+            options: CheckUserOptions(requirePresence: true, requireVerification: .preferred),
+            newCredential: newCredential,
+        )
+        XCTAssertEqual(result.cipher.cipher.name, "Bitwarden")
+        XCTAssertEqual(result.cipher.cipher.login?.username, "user@example.com")
+        XCTAssertTrue(result.checkUserResult.userPresent)
+        XCTAssertTrue(result.checkUserResult.userVerified)
+    }
+
+    /// `isVerificationEnabled()` returns `false` since there's no biometrics to back it.
+    func test_isVerificationEnabled() {
+        XCTAssertFalse(subject.isVerificationEnabled())
+    }
+
+    /// `pickCredentialForAuthentication(availableCredentials:)` throws when there are no
+    /// candidates.
+    func test_pickCredentialForAuthentication_empty_throwsNoMatchingCredential() async {
+        await assertAsyncThrows(error: PasskeyError.noMatchingCredential) {
+            _ = try await subject.pickCredentialForAuthentication(availableCredentials: [])
+        }
+    }
+
+    /// `pickCredentialForAuthentication(availableCredentials:)` throws when there's more than one
+    /// candidate, since picking between them isn't supported yet.
+    func test_pickCredentialForAuthentication_multiple_throwsAmbiguousCredential() async {
+        await assertAsyncThrows(error: PasskeyError.ambiguousCredential) {
+            _ = try await subject.pickCredentialForAuthentication(availableCredentials: [.fixture(), .fixture()])
+        }
+    }
+
+    /// `pickCredentialForAuthentication(availableCredentials:)` returns the only candidate when
+    /// there's exactly one.
+    func test_pickCredentialForAuthentication_single_returnsIt() async throws {
+        let cipherView = CipherView.fixture(name: "Only")
+        let result = try await subject.pickCredentialForAuthentication(availableCredentials: [cipherView])
+        XCTAssertEqual(result.cipher, cipherView)
+    }
+}

--- a/TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift
+++ b/TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift
@@ -1,0 +1,242 @@
+import BitwardenKit
+import BitwardenSdk
+import CryptoKit
+import Foundation
+
+// MARK: - PasskeyService
+
+// sourcery: AutoMockable
+/// A service that performs passkey registration and authentication directly through
+/// `BitwardenSdk`'s Fido2 client — the same way the main Bitwarden app and its AutoFill
+/// extension do — without going through the OS's passkey UI or a real vault.
+///
+public protocol PasskeyService: AnyObject {
+    /// Asserts a passkey for `rpId` against previously registered credentials.
+    ///
+    /// - Parameters:
+    ///   - credentialId: A specific credential to assert, e.g. one the user selected from
+    ///     `registeredCredentials()`. When provided, only this credential is considered,
+    ///     regardless of how many others are registered for `rpId`. When `nil`, the first
+    ///     unambiguous match for `rpId` is used.
+    ///   - rpId: The relying party identifier to assert a credential for.
+    /// - Returns: The SDK's assertion result.
+    ///
+    func assertPasskey(credentialId: Data?, rpId: String) async throws -> GetAssertionResult
+
+    /// Lists the credentials registered so far, across app launches.
+    ///
+    /// - Returns: The registered credentials' autofill-ready metadata.
+    ///
+    func registeredCredentials() async throws -> [Fido2CredentialAutofillView]
+
+    /// Registers a new passkey for `rpId`.
+    ///
+    /// - Parameters:
+    ///   - rpId: The relying party identifier the credential is scoped to.
+    ///   - userName: The username associated with the credential.
+    ///   - displayName: The display name associated with the credential.
+    /// - Returns: The SDK's registration result.
+    ///
+    func registerPasskey(rpId: String, userName: String, displayName: String) async throws -> MakeCredentialResult
+}
+
+// MARK: - HasPasskeyService
+
+/// A protocol for an object that provides an `PasskeyService`.
+protocol HasPasskeyService {
+    /// The service used to perform passkey registration and authentication through the
+    /// Bitwarden SDK.
+    var passkeyService: PasskeyService { get }
+}
+
+// MARK: - DefaultPasskeyService
+
+/// The default `PasskeyService` implementation. Bootstraps a single `BitwardenSdk.Client` per
+/// app session, backed by a synthetic identity — since this scenario has no real account or
+/// vault — that's persisted in the keychain so the same crypto keys, and therefore any
+/// previously-registered credentials, remain usable across app launches. Drives the client's
+/// Fido2 authenticator directly for registration, assertion, and listing registered credentials.
+///
+actor DefaultPasskeyService: PasskeyService {
+    // MARK: Private Properties
+
+    /// The number of PBKDF2 iterations used to derive this session's synthetic identity's keys.
+    private static let kdfIterations: UInt32 = 600_000
+
+    /// Used to persist ciphers across app relaunches.
+    private let cipherStorageService: CipherStorageService
+
+    /// Used to persist and reload the synthetic identity across app launches.
+    private let keychainServiceFacade: KeychainServiceFacade
+
+    /// The in-flight or completed session bootstrap, cached so concurrent callers share a single
+    /// client and credential store instead of each bootstrapping their own.
+    private var sessionTask: Task<(BitwardenSdk.Client, DefaultFido2CredentialStore), Error>?
+
+    /// The user interface driving `checkUser`/credential-picking callbacks from the SDK.
+    private let userInterface = DefaultFido2UserInterface()
+
+    // MARK: Initialization
+
+    /// Initializes a `DefaultPasskeyService`.
+    ///
+    /// - Parameters:
+    ///   - cipherStorageService: Used to persist ciphers across app relaunches.
+    ///   - keychainServiceFacade: Used to persist and reload the synthetic identity across app
+    ///     launches.
+    ///
+    init(
+        cipherStorageService: CipherStorageService = DefaultCipherStorageService(),
+        keychainServiceFacade: KeychainServiceFacade = DefaultKeychainServiceFacade(
+            appSecAttrAccessGroup: Bundle.main.groupIdentifier,
+            keychainService: DefaultKeychainService(),
+            namespacing: .shared,
+        ),
+    ) {
+        self.cipherStorageService = cipherStorageService
+        self.keychainServiceFacade = keychainServiceFacade
+    }
+
+    // MARK: Static Methods
+
+    /// Builds a synthetic WebAuthn `clientDataJSON` for `type`/`rpId` and returns its SHA-256
+    /// hash, since these scenarios simulate the relying party's browser step in-process rather
+    /// than delegating to a real one.
+    private static func clientDataHash(type: String, rpId: String) -> Data {
+        let challenge = SymmetricKey(size: .bits256).withUnsafeBytes { Data($0) }
+        let clientData = [
+            "type": type,
+            "challenge": challenge.base64EncodedString(),
+            "origin": "https://\(rpId)",
+        ]
+        let clientDataJSON = (try? JSONSerialization.data(withJSONObject: clientData, options: [.sortedKeys])) ?? Data()
+        return Data(SHA256.hash(data: clientDataJSON))
+    }
+
+    // MARK: Methods
+
+    func assertPasskey(credentialId: Data?, rpId: String) async throws -> GetAssertionResult {
+        let (client, credentialStore) = try await session()
+        let allowList = credentialId.map { [PublicKeyCredentialDescriptor(ty: "public-key", id: $0, transports: nil)] }
+        let request = GetAssertionRequest(
+            rpId: rpId,
+            clientDataHash: Self.clientDataHash(type: "webauthn.get", rpId: rpId),
+            allowList: allowList,
+            options: Options(rk: false, uv: .preferred),
+            extensions: nil,
+        )
+        return try await client.platform().fido2()
+            .vaultAuthenticator(userInterface: userInterface, credentialStore: credentialStore)
+            .getAssertion(request: request)
+    }
+
+    func registeredCredentials() async throws -> [Fido2CredentialAutofillView] {
+        let (client, credentialStore) = try await session()
+        return try await client.platform().fido2()
+            .vaultAuthenticator(userInterface: userInterface, credentialStore: credentialStore)
+            .credentialsForAutofill()
+    }
+
+    func registerPasskey(rpId: String, userName: String, displayName: String) async throws -> MakeCredentialResult {
+        let (client, credentialStore) = try await session()
+        let request = MakeCredentialRequest(
+            clientDataHash: Self.clientDataHash(type: "webauthn.create", rpId: rpId),
+            rp: PublicKeyCredentialRpEntity(id: rpId, name: rpId),
+            user: PublicKeyCredentialUserEntity(
+                id: Data(UUID().uuidString.utf8),
+                displayName: displayName.isEmpty ? userName : displayName,
+                name: userName,
+            ),
+            pubKeyCredParams: [PublicKeyCredentialParameters(ty: "public-key", alg: -7)],
+            excludeList: nil,
+            options: Options(rk: true, uv: .preferred),
+            extensions: nil,
+        )
+        return try await client.platform().fido2()
+            .vaultAuthenticator(userInterface: userInterface, credentialStore: credentialStore)
+            .makeCredential(request: request)
+    }
+
+    // MARK: Private
+
+    /// Loads the synthetic identity persisted from a previous launch, or generates and persists a
+    /// new one via the SDK's local-only key-generation primitive if none exists yet.
+    private func loadOrCreateIdentity() async throws -> SyntheticIdentity {
+        if let identity: SyntheticIdentity = try? await keychainServiceFacade.getValue(
+            for: PasskeyKeychainItem.syntheticIdentity,
+        ) {
+            return identity
+        }
+
+        let client = BitwardenSdk.Client(tokenProvider: ClientManagedTokensProvider(), settings: nil)
+        let email = "sdk-passkey-playground@bitwarden.com"
+        let password = UUID().uuidString
+        let keys = try client.auth().makeRegisterKeys(
+            email: email,
+            password: password,
+            kdf: Kdf.pbkdf2(iterations: Self.kdfIterations),
+        )
+        let identity = SyntheticIdentity(
+            email: email,
+            encryptedUserKey: keys.encryptedUserKey,
+            kdfIterations: Self.kdfIterations,
+            password: password,
+            privateKey: keys.keys.private,
+            userId: UUID().uuidString,
+        )
+        try await keychainServiceFacade.setValue(identity, for: PasskeyKeychainItem.syntheticIdentity)
+        // The new identity's key can't decrypt anything persisted under the previous one.
+        cipherStorageService.save(ciphers: [])
+        return identity
+    }
+
+    /// Lazily builds and crypto-initializes the SDK client and credential store for this session,
+    /// reusing them across calls so registered credentials remain visible to later assertions.
+    /// Caches the bootstrap as a `Task` so concurrent callers await the same work instead of each
+    /// racing their own bootstrap.
+    private func session() async throws -> (BitwardenSdk.Client, DefaultFido2CredentialStore) {
+        if let sessionTask {
+            return try await sessionTask.value
+        }
+
+        let task = Task { try await makeSession() }
+        sessionTask = task
+        do {
+            return try await task.value
+        } catch {
+            sessionTask = nil
+            throw error
+        }
+    }
+
+    /// Builds and crypto-initializes the SDK client and credential store for this session.
+    private func makeSession() async throws -> (BitwardenSdk.Client, DefaultFido2CredentialStore) {
+        let identity = try await loadOrCreateIdentity()
+        let client = BitwardenSdk.Client(tokenProvider: ClientManagedTokensProvider(), settings: nil)
+        let kdf = Kdf.pbkdf2(iterations: identity.kdfIterations)
+        try await client.crypto().initializeUserCrypto(
+            req: InitUserCryptoRequest(
+                userId: identity.userId,
+                kdfParams: kdf,
+                email: identity.email,
+                accountCryptographicState: .v1(privateKey: identity.privateKey),
+                method: .masterPasswordUnlock(
+                    password: identity.password,
+                    masterPasswordUnlock: MasterPasswordUnlockData(
+                        kdf: kdf,
+                        masterKeyWrappedUserKey: identity.encryptedUserKey,
+                        salt: identity.email,
+                    ),
+                ),
+                upgradeToken: nil,
+            ),
+        )
+
+        let credentialStore = DefaultFido2CredentialStore(
+            cipherStorageService: cipherStorageService,
+            platformClientService: client.platform(),
+            vaultClientService: client.vault(),
+        )
+        return (client, credentialStore)
+    }
+}

--- a/TestHarnessShared/Core/Autofill/Passkey/PasskeyServiceTests.swift
+++ b/TestHarnessShared/Core/Autofill/Passkey/PasskeyServiceTests.swift
@@ -1,0 +1,179 @@
+import BitwardenKit
+import BitwardenKitMocks
+import BitwardenSdk
+import TestHelpers
+import XCTest
+
+@testable import TestHarnessShared
+
+// MARK: - PasskeyServiceTests
+
+/// Tests for `DefaultPasskeyService`. These exercise the real, local-only `BitwardenSdk`
+/// client rather than a mock, since the whole point of this service is driving the actual SDK
+/// Fido2 authenticator.
+///
+class PasskeyServiceTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var cipherStorageService: DefaultCipherStorageService!
+    var keychainServiceFacade: MockKeychainServiceFacade!
+    var subject: DefaultPasskeyService!
+    var userDefaults: UserDefaults!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+        userDefaults = UserDefaults(suiteName: "PasskeyServiceTests")
+        userDefaults.removePersistentDomain(forName: "PasskeyServiceTests")
+        cipherStorageService = DefaultCipherStorageService(userDefaults: userDefaults)
+        keychainServiceFacade = MockKeychainServiceFacade()
+
+        var storedIdentity: String?
+        keychainServiceFacade.getValueClosure = { item in
+            guard let storedIdentity else { throw KeychainServiceError.keyNotFound(item) }
+            return storedIdentity
+        }
+        keychainServiceFacade.setValueClosure = { value, _ in storedIdentity = value }
+
+        subject = makeSubject()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        userDefaults.removePersistentDomain(forName: "PasskeyServiceTests")
+        cipherStorageService = nil
+        keychainServiceFacade = nil
+        subject = nil
+        userDefaults = nil
+    }
+
+    // MARK: Tests
+
+    /// `assertPasskey(credentialId:rpId:)` throws when there's no credential registered for the
+    /// relying party.
+    func test_assertPasskey_noRegisteredCredential_throws() async {
+        await assertAsyncThrows {
+            _ = try await subject.assertPasskey(credentialId: nil, rpId: "nobody-registered-here.example.com")
+        }
+    }
+
+    /// `assertPasskey(credentialId:rpId:)` selects the specific credential passed in, even when
+    /// multiple credentials are registered for the same relying party.
+    func test_assertPasskey_specificCredentialId_selectsThatCredential() async throws {
+        _ = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user1@example.com",
+            displayName: "User One",
+        )
+        let second = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user2@example.com",
+            displayName: "User Two",
+        )
+
+        let assertion = try await subject.assertPasskey(credentialId: second.credentialId, rpId: "bitwarden.com")
+
+        XCTAssertEqual(assertion.selectedCredential.credential.userName, "user2@example.com")
+    }
+
+    /// `registerPasskey(rpId:userName:displayName:)` returns a non-empty credential ID and
+    /// attestation object.
+    func test_registerPasskey_returnsCredential() async throws {
+        let result = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user@example.com",
+            displayName: "User",
+        )
+
+        XCTAssertFalse(result.credentialId.isEmpty)
+        XCTAssertFalse(result.attestationObject.isEmpty)
+    }
+
+    /// A credential registered by one service instance remains registered and assertable by a
+    /// fresh instance sharing the same persisted identity and cipher storage — simulating an app
+    /// relaunch.
+    func test_registerPasskey_persistsAcrossServiceInstances() async throws {
+        _ = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user@example.com",
+            displayName: "User",
+        )
+
+        let relaunchedSubject = makeSubject()
+        let assertion = try await relaunchedSubject.assertPasskey(credentialId: nil, rpId: "bitwarden.com")
+
+        XCTAssertEqual(assertion.selectedCredential.credential.userName, "user@example.com")
+    }
+
+    /// A credential registered via `registerPasskey` can subsequently be asserted via
+    /// `assertPasskey`, and the assertion resolves back to the same username.
+    func test_registerPasskey_thenAssertPasskey_matchesRegisteredUser() async throws {
+        _ = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user@example.com",
+            displayName: "User",
+        )
+
+        let assertion = try await subject.assertPasskey(credentialId: nil, rpId: "bitwarden.com")
+
+        XCTAssertEqual(assertion.selectedCredential.credential.userName, "user@example.com")
+    }
+
+    /// `registeredCredentials()` reflects a credential registered via `registerPasskey`.
+    func test_registeredCredentials_returnsRegisteredCredential() async throws {
+        let registration = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user@example.com",
+            displayName: "User",
+        )
+
+        let credentials = try await subject.registeredCredentials()
+
+        XCTAssertEqual(credentials.map(\.credentialId), [registration.credentialId])
+        XCTAssertEqual(credentials.map(\.rpId), ["bitwarden.com"])
+    }
+
+    /// When the persisted identity can't be loaded on a later launch — e.g. a backup restored the
+    /// `UserDefaults`-backed ciphers to a new device without the `ThisDeviceOnly`-scoped keychain
+    /// identity — the newly-minted identity discards those now-undecryptable orphaned ciphers,
+    /// rather than leaving the store permanently wedged trying to decrypt them under the wrong key.
+    func test_registerPasskey_identityLost_discardsOrphanedCiphers() async throws {
+        _ = try await subject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user@example.com",
+            displayName: "User",
+        )
+
+        let identityLostKeychainServiceFacade = MockKeychainServiceFacade()
+        identityLostKeychainServiceFacade.getValueClosure = { item in throw KeychainServiceError.keyNotFound(item) }
+        identityLostKeychainServiceFacade.setValueClosure = { _, _ in }
+        let relaunchedSubject = DefaultPasskeyService(
+            cipherStorageService: cipherStorageService,
+            keychainServiceFacade: identityLostKeychainServiceFacade,
+        )
+
+        // Without discarding the orphaned cipher above, this cipher — encrypted under the new
+        // identity's key — would sit alongside the undecryptable one, and any read touching the
+        // old cipher would throw rather than merely returning an empty list.
+        let registration = try await relaunchedSubject.registerPasskey(
+            rpId: "bitwarden.com",
+            userName: "user2@example.com",
+            displayName: "User Two",
+        )
+        let assertion = try await relaunchedSubject.assertPasskey(credentialId: nil, rpId: "bitwarden.com")
+
+        XCTAssertEqual(assertion.credentialId, registration.credentialId)
+    }
+
+    // MARK: Private
+
+    /// Builds a new `DefaultPasskeyService` sharing this test's persisted identity and cipher
+    /// storage, to simulate a fresh instance picking up state from a previous app launch.
+    private func makeSubject() -> DefaultPasskeyService {
+        DefaultPasskeyService(
+            cipherStorageService: cipherStorageService,
+            keychainServiceFacade: keychainServiceFacade,
+        )
+    }
+}

--- a/TestHarnessShared/Core/Platform/ServiceContainer.swift
+++ b/TestHarnessShared/Core/Platform/ServiceContainer.swift
@@ -3,6 +3,7 @@ import Foundation
 
 /// The services provided by the `ServiceContainer`.
 typealias Services = HasErrorReportBuilder
+    & HasPasskeyService
 
 /// The default implementation of a container that provides the services used by the application.
 ///
@@ -12,16 +13,25 @@ public class ServiceContainer: Services {
     /// A helper for building an error report containing the details of an error that occurred.
     public let errorReportBuilder: ErrorReportBuilder
 
+    /// The service used to perform passkey registration and authentication through the
+    /// Bitwarden SDK.
+    public let passkeyService: PasskeyService
+
     // MARK: Initialization
 
     /// Initialize a `ServiceContainer`.
     ///
     /// - Parameters:
     ///   - errorReportBuilder: A helper for building an error report containing the details of an
+    ///     error that occurred.
+    ///   - passkeyService: The service used to perform passkey registration and
+    ///     authentication through the Bitwarden SDK.
     public init(
         errorReportBuilder: ErrorReportBuilder,
+        passkeyService: PasskeyService,
     ) {
         self.errorReportBuilder = errorReportBuilder
+        self.passkeyService = passkeyService
     }
 
     public convenience init() {
@@ -37,6 +47,7 @@ public class ServiceContainer: Services {
 
         self.init(
             errorReportBuilder: errorReportBuilder,
+            passkeyService: DefaultPasskeyService(),
         )
     }
 }

--- a/project-bwth.yml
+++ b/project-bwth.yml
@@ -77,6 +77,7 @@ targets:
       - target: BitwardenKit/BitwardenKit
       - target: BitwardenKit/BitwardenResources
       - target: BitwardenKit/Networking
+      - package: BitwardenSdk
     postCompileScripts:
       - script: |
           if [[ -n "$CI" ]]; then
@@ -174,6 +175,7 @@ targets:
       - target: TestHarness
       - target: TestHarnessShared
       - target: BitwardenKit/BitwardenKitMocks
+      - target: BitwardenKit/BitwardenSdkMocks
       - target: BitwardenKit/TestHelpers
       - package: BitwardenSdk
     randomExecutionOrder: true


### PR DESCRIPTION
## 🎟️ Tracking

[PM-40519](https://bitwarden.atlassian.net/browse/PM-40519)

## 📔 Objective

Adds SDK-backed passkey test scenarios to TestHarness, on top of the cipher storage/identity foundation in #2977.

- Updates the `Core/Autofill` layer, which drives `BitwardenSdk`'s Fido2 client directly (`makeCredential`/`getAssertion`) the same way the main app and AutoFill extension do, instead of delegating to the OS passkey UI.
- `PasskeyService` lazily bootstraps a `BitwardenSdk.Client` backed by the synthetic identity persisted in the Keychain, so registered credentials survive relaunches.
- `DefaultFido2CredentialStore`/`DefaultFido2UserInterface` satisfy the SDK's `Fido2CredentialStore`/`Fido2UserInterface` protocols.
- No UI wiring yet — this PR lands the service layer standalone, fully covered by its own test suite. The next PR in the stack adds the "Register Passkey" screen that consumes it.


https://github.com/user-attachments/assets/f0c50736-53b9-4015-8215-7d3ad34e6079


## 🔐  Security Review

<details>
<summary>Click to reveal</summary>

# 🤖 Claude Security Code Review 🤖

PR: (#2945) - [PM-40519] feat: Add SDK-backed passkey registration and assertion services to TestHarness — 2026-08-27

**Date:** 2026-08-27

<details>
<summary><strong>Commits reviewed:</strong> c419835..c4f80a68f · 2 commits · TestHarnessShared/Core/Autofill/Passkey/</summary>

| SHA       | Title                                                                   |
| --------- | ------------------------------------------------------------------------ |
| `f4b8cb4b6` | [PM-40519] feat: Add passkey cipher storage and identity foundation     |
| `c4f80a68f` | [PM-40519] feat: Add SDK-backed passkey registration and assertion services |

</details>

## Summary

| Category        | Count |
| --------------- | ----- |
| 🚨 Blockers     | 0     |
| ⚠️ Improvements | 0     |
| 📝 Notes        | 14    |
| ✅ Strengths    | 13    |
| ❌ Dismissed    | 5     |

- This PR is entirely confined to `TestHarnessShared`, a non-shipping internal developer tool with a bundle ID, app group, and keychain access group fully disjoint from the production Password Manager and Authenticator apps — no production trust boundary is touched.
- The zero-knowledge invariant holds: all four independent agents and the verifier confirmed, field-by-field against the pinned SDK, that only `EncString`-typed ciphertext is ever persisted to `UserDefaults`; key material stays exclusively in the Keychain.
- No hardcoded secrets, no new third-party dependencies, and the SDK remains pinned to a committed full commit SHA — supply-chain posture is unchanged.
- The two Dependabot alerts (excon, faraday) are pre-existing Ruby/fastlane CI-tooling transitives with zero reachability from this Swift diff and were dismissed by all reviewers.
- All findings clustered around hardening of a synthetic, throwaway identity (a `try?` that conflates keychain errors, a self-contradictory UV flag, salt/password co-location) — none reach real user data because there is no real account, no network path, and no verifier consuming these ceremonies today.
- The most valuable single fix, despite being rated LOW, is narrowing the `try?` in `PasskeyService.loadOrCreateIdentity()` to only treat `keyNotFound` as "create new" — it's cheap, removes a real failure-mode ambiguity, and is exactly the kind of pattern that could get copy-pasted into shipping code later.

## 📝 Notes

<details>
<summary>Expand for details on (14) notes</summary>


- - `try?` on the keychain identity read conflates "not found" with "read failed" (locked device, missing entitlement, decode failure), causing an unconditional overwrite of the identity and a full wipe of stored passkeys on any of those errors.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:165-190`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Verified destructive-on-any-error behavior, but the asset destroyed is synthetic, throwaway test state in a non-shipping harness — no attacker, no vault data, no real user secret at risk.

- - `isVerificationEnabled()` returns `false` while every check-user ceremony unconditionally returns `userVerified: true`, so emitted authenticator data always claims UV was satisfied.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/DefaultFido2UserInterface.swift:14, 64, 68-70`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Real internal contradiction, but no relying party ever consumes these assertions today (self-generated challenge, discarded `clientDataJSON`), so there's no live exploit path — forward-risk only, and it's documented as intentional.

- - The synthetic identity's master password is JSON-encoded into the same keychain item as the key material it unwraps, defeating the purpose of the 600k-iteration KDF for anyone who can read the item.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/SyntheticIdentity.swift:21-23`, `PasskeyService.swift:173,187`, `PasskeyKeychainItem.swift:14-21`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Confirmed pattern, but the password is a per-install ~122-bit CSPRNG UUID guarding synthetic identity material with no real security value.

- - The WebAuthn challenge is self-generated and its `clientDataJSON` is discarded before reaching the SDK; `rpId` is interpolated into an `origin` string with no validation.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:105-114, 123, 143-144`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: `clientDataJSON` never leaves the process today, so nothing is forgeable against a real verifier; documented by design, but the unvalidated `rpId`→origin interpolation is exactly what would need hardening if this is ever extended to accept external challenges.

- - The synthetic identity's keychain item uses `.shared` namespacing and the app-group access group, deviating from the codebase's established `.appScoped` convention for private, non-cross-app secrets.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:90-94`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Concrete, verifiable deviation with no cross-app consumer today; worth fixing because it chains with the `try?` finding above — a future app extension would compute a different, non-entitled group and trigger silent destruction.

- - The KDF salt is a hardcoded constant email (`sdk-passkey-playground@bitwarden.com`), identical across every install.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:172, 228`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Precomputation attacks are infeasible against the paired 122-bit CSPRNG password; hygiene-only finding.

- - `clientDataHash` silently falls back to `SHA256("")` — a fixed, publicly known constant — if `JSONSerialization` fails.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:112`
  - Severity: ⚪ INFO
  - Confidence: 🟢 HIGH
  - Rationale: Unreachable in practice since a `[String: String]` dictionary cannot fail to serialize, but silently substituting a predictable constant for signed input is a smell worth removing (`throws` instead of `try? ?? Data()`).

- - Duplicate registration attempts for the same `rpId` are unbounded (`excludeList: nil`), and multiple credentials for one RP later throw `.ambiguousCredential` during assertion.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:146, 151`, `DefaultFido2UserInterface.swift:72-79`
  - Severity: 🔵 LOW
  - Confidence: 🟡 MEDIUM
  - Rationale: A documented disambiguation path exists via explicit `credentialId` / `registeredCredentials()`, so this is a functionality rough edge rather than a security gap.

- - `BitwardenSdk.Client(tokenProvider:settings: nil)` defaults to production `identity.bitwarden.com` / `api.bitwarden.com` rather than an explicit non-production endpoint.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:171, 215`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Harmless today only because none of the called SDK methods make network requests; the client is *configured* to reach production and is safe purely by call-site discipline, not by structural guarantee.

- - The SDK client and its decrypted user key are cached for the full process lifetime with no lock, timeout, or backgrounding teardown.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:74, 197-209, 662-675`
  - Severity: ⚪ INFO
  - Confidence: 🟢 HIGH
  - Rationale: There is no real vault or user secret behind this key, so the usual "locked vault" concern doesn't meaningfully apply; noted so the pattern isn't lifted into a shipping service.

- - `StoredCipher` drops the SDK's `Cipher.data` (blob-format) field, and `init?(cipher:)` silently returns `nil` for any unrecognized cipher shape via `compactMap`, with no error surfaced.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/StoredCipher.swift:129, 138-141`, `CipherStorageService.swift:61`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: The SDK's own docs indicate blob-format ciphers set `name: nil`; a future SDK revision to that format would make every cipher fail to reconstruct and silently empty storage on the next save.

- - The 600,000 PBKDF2 iteration count is hardcoded locally rather than sourced from a shared `Constants` file.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/PasskeyService.swift:64`
  - Severity: ⚪ INFO
  - Confidence: 🟢 HIGH
  - Rationale: Partly unavoidable since `TestHarnessShared` doesn't link `BitwardenShared` (where the existing constant lives); the durable fix is promoting the shared constant into `BitwardenKit`.

- - `CipherStorageService` silently returns `[]` on `JSONDecoder` failure and silently drops the entire save on `JSONEncoder` failure.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/CipherStorageService.swift:52-64`
  - Severity: 🔵 LOW
  - Confidence: 🟢 HIGH
  - Rationale: Confirmed in code — storage corruption is currently indistinguishable from "no credentials registered," which would mask a real bug during test harness use.

- - `StoredCipher.cipher` reconstructs security-relevant fields (`reprompt`, `edit`, `viewPassword`, `organizationUseTotp`) from hardcoded defaults rather than persisting them; a persist/reload round-trip silently resets `reprompt` to `.none`.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/StoredCipher.swift:71-131`
  - Severity: ⚪ INFO
  - Confidence: 🟢 HIGH
  - Rationale: Unreachable today since `DefaultFido2UserInterface` only ever creates ciphers with `reprompt: .none`, but the same silent-attribute-loss class as the `Cipher.data` finding — worth a doc comment so a future cipher shape doesn't lose protection flags on round-trip.

</details>

## ✅ Strengths

<details>
<summary>Expand for details on (13) strengths</summary>

- - No hardcoded secrets across 1,431 added lines; the only credential-shaped value is `UUID().uuidString`, a CSPRNG-backed identifier.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/` (all files)
  - Rationale: Grepped for credential-shaped literals; every test value is an obvious placeholder.
- - Ciphertext-only persistence verified field-by-field against the pinned SDK checkout — `Fido2Credential`'s `keyValue`, `credentialId`, `rpId`, `userHandle`, `userName`, etc. are all `EncString`, as is `Cipher.name`/`Cipher.key`.
  - Location: `CipherStorageService.swift:31-65`, `StoredCipher.swift`
  - Rationale: No plaintext vault-shaped data is ever written outside the Keychain; the zero-knowledge invariant holds. (Minor caveat: `EncString` is a naming convention, `typealias EncString = String`, not a compiler-enforced type.)
- - The SDK dependency remains pinned to a full commit SHA, unchanged and untouched by this PR, with a matching committed `Package.resolved`.
  - Location: `project-common.yml` (unchanged)
  - Rationale: Integrity control for the SPM git dependency is intact.
- - Zero new third-party dependencies; this PR only links the already-resolved `BitwardenSdk` package and an in-repo mocks target.
  - Location: `project-bwth.yml:80, 178`
  - Rationale: No new attack surface introduced to the dependency graph.
- - Ambiguous credential selection fails closed, throwing `.ambiguousCredential` rather than defaulting to the first match.
  - Location: `DefaultFido2UserInterface.swift:71-79`
  - Rationale: Avoids the common "fail open on uncertainty" anti-pattern; both empty and multiple-match cases are tested.
- - Signature-counter updates correctly replace the existing credential by cipher ID rather than forking divergent counter states.
  - Location: `DefaultFido2CredentialStore.swift:71-76`
  - Rationale: Matches correct WebAuthn semantics for credential re-registration.
- - Complete isolation from production apps — verified via `project-bwth.yml`, `TestHarness.entitlements`, and the xcconfig files: disjoint bundle ID, app group, and keychain access group from both Password Manager and Authenticator.
  - Location: `TestHarness.entitlements`, `Configs/Common-bwth.xcconfig`
  - Rationale: No path exists for this harness's synthetic key material to reach or collide with real vault data.
- - PBKDF2 at 600,000 iterations meets current OWASP guidance for PBKDF2-HMAC-SHA256.
  - Location: `PasskeyService.swift:64`
  - Rationale: Correct algorithm choice, even though the constant should eventually be shared (see Notes).
- - Actor-based concurrency isolation with single-flight session-task caching prevents concurrent callers from bootstrapping divergent identities.
  - Location: `PasskeyService.swift:74`, `DefaultFido2CredentialStore.swift`
  - Rationale: Identity creation is destructive, so preventing concurrent creation is a real safety property (narrowed slightly by the fact the shared `CipherStorageService` beneath both actors is non-`Sendable` — harmless today since `UserDefaults` is thread-safe).
- - `clientData` is built via `JSONSerialization`, not string concatenation, so `rpId` cannot alter the JSON structure.
  - Location: `PasskeyService.swift:107-112`
  - Rationale: Closes the injection variant of the origin-string finding; only the semantic (unvalidated origin) risk remains, tracked as a Note.
- - No sensitive material (identity, keys, `GetAssertionResult`) reaches any logging or `ErrorReporter` call site anywhere in the diff.
  - Location: `TestHarnessShared/Core/Autofill/Passkey/` (all files)
  - Rationale: Verified stronger than initially claimed — there are no logging or `ErrorReporter` calls at all in the added files.
- - Exact-string `rpId` matching in credential lookup is the spec-correct authenticator-level WebAuthn behavior, not merely a lucky safe default.
  - Location: `DefaultFido2CredentialStore.swift:59`
  - Rationale: Prevents cross-relying-party credential disclosure; registrable-domain-suffix logic correctly belongs to the browser/client layer, not the authenticator.
- - Backup/restore key-mismatch is explicitly reasoned about and tested: a restored `UserDefaults` backup without the matching `ThisDeviceOnly` Keychain item correctly discards the now-undecryptable ciphers instead of wedging.
  - Location: `PasskeyServiceTests.swift:854-880`
  - Rationale: Confirms deliberate handling of a real state-mismatch scenario — this is the same code path as the LOW `try?` finding above, so narrowing that catch to `keyNotFound` will preserve this tested behavior while removing the over-trigger.

</details>

## ❌ Dismissed

<details>
<summary>Expand for details on (5) dismissed findings</summary>

- - Real WebAuthn private keys could be exposed with only device-unlock gating if the harness were used against a real account.
  - Location: `CipherStorageService.swift:46, 60-64`, `PasskeyKeychainItem.swift:18`
  - Severity: 🔵 LOW
  - Confidence: 🔵 LOW
  - Rationale: Premise unreachable — no code path in this PR imports, accepts, or targets a real account; fully subsumed by the master-password co-location Note above.
- - Non-`Sendable` `DefaultCipherStorageService` is written from two different actor isolation domains.
  - Location: `PasskeyService.swift:189`, `DefaultFido2CredentialStore.swift:82`
  - Severity: ⚪ INFO
  - Confidence: 🟡 MEDIUM
  - Rationale: `UserDefaults` is thread-safe; no memory-safety or security consequence.
- - Two live `DefaultFido2CredentialStore` instances could clobber each other's registrations (last-writer-wins).
  - Location: `DefaultFido2CredentialStore.swift:43, 70-77`
  - Severity: ⚪ INFO
  - Confidence: 🟡 MEDIUM
  - Rationale: Hypothetical — the single-flight `sessionTask` cache guarantees one live instance today.
- - No registrable-domain-suffix validation in `findCredentials`, only exact `rpId` match.
  - Location: `DefaultFido2CredentialStore.swift:59-62`
  - Severity: ⚪ INFO
  - Confidence: 🟢 HIGH
  - Rationale: Not a defect — exact match is the correct authenticator-level behavior; recategorized as a Strength above.
- - Dependabot alerts: excon CVE-2026-54171 (MEDIUM) and faraday CVE-2026-54297 (HIGH).
  - Location: `Gemfile.lock:45-46` (fastlane transitive dependencies)
  - Severity: 🟠 HIGH
  - Confidence: 🔵 LOW
  - Rationale: Dev-only Ruby CI toolchain, never shipped in the app binary, no Ruby files touched by this PR; track separately as a `fastlane`/`Gemfile.lock` bump rather than blocking here.

</details>

---

Net result: **0 Blockers, 0 Improvements** — nothing here should hold up the PR. The 14 Notes are all low-cost hardening opportunities around the synthetic identity's error handling, keychain namespacing, and defensive serialization; worth a follow-up cleanup pass but not urgent given the complete isolation from production trust boundaries.


</details>

---
**Stack:** #2977 → #2945 → #2946 → #2947 → #2948

[PM-40519]: https://bitwarden.atlassian.net/browse/PM-40519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ