### PR TITLE
Auth/ PM-41503 & PM-41533 - Add openOrgInvite param to SDK registration finish call

### DIFF
--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -235,6 +235,7 @@ class CompleteRegistrationProcessor: StateProcessor<
                     acceptEmergencyAccessId: nil,
                     providerInviteToken: nil,
                     providerUserId: nil,
+                    openOrgInvite: nil,
                 ),
             )
 


### PR DESCRIPTION
## 🎟️ Tracking
<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-41503
https://bitwarden.atlassian.net/browse/PM-41533

Server PR: https://github.com/bitwarden/server/pull/8159
Server SDK Bindings Update PR: https://github.com/bitwarden/sdk-internal/pull/1372
SDK PR which wires up breaking changes: https://github.com/bitwarden/sdk-internal/pull/1363


## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->
The SDK's `UserMasterPasswordRegistrationRequest` will gain a new `openOrgInvite` field (`Option<RegistrationFinishOpenOrgInviteData>`) to support finishing registration via an open organization invite link once https://github.com/bitwarden/sdk-internal/pull/1363 merges. iOS does not use open-org-invite (that flow is web-only), so this passes `nil` at the sole call site to satisfy the new required constructor parameter.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
n/a