### PR TITLE
[PM-41956] fix: Resolve data races and task leak causing flaky processor tests

### DIFF
--- a/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
+++ b/AuthenticatorShared/UI/Platform/Application/AppProcessorTests.swift
@@ -13,6 +13,7 @@ class AppProcessorTests: BitwardenTestCase {
     var coordinator: MockCoordinator<AppRoute, AppEvent>!
     var errorReporter: MockErrorReporter!
     var notificationCenter: MockNotificationCenterService!
+    var stateService: MockStateService!
     var subject: AppProcessor!
     var timeProvider: MockTimeProvider!
 
@@ -26,6 +27,7 @@ class AppProcessorTests: BitwardenTestCase {
         coordinator = MockCoordinator()
         errorReporter = MockErrorReporter()
         notificationCenter = MockNotificationCenterService()
+        stateService = MockStateService()
         timeProvider = MockTimeProvider(.mockTime(Date(year: 2024, month: 6, day: 1, hour: 2, minute: 30, second: 10)))
 
         subject = AppProcessor(
@@ -34,6 +36,7 @@ class AppProcessorTests: BitwardenTestCase {
                 appSettingsStore: appSettingsStore,
                 errorReporter: errorReporter,
                 notificationCenterService: notificationCenter,
+                stateService: stateService,
                 timeProvider: timeProvider,
             ),
         )
@@ -43,11 +46,19 @@ class AppProcessorTests: BitwardenTestCase {
     override func tearDown() {
         super.tearDown()
 
+        // Complete the notification and theme publishers so the long-lived listener tasks
+        // `AppProcessor` starts in `init`/`start` end cleanly instead of leaking (parked forever
+        // on a publisher that will never emit again) for the rest of the test run.
+        notificationCenter.willEnterForegroundSubject.send(completion: .finished)
+        notificationCenter.didEnterBackgroundSubject.send(completion: .finished)
+        stateService.appThemeSubject.send(completion: .finished)
+
         appModule = nil
         appSettingsStore = nil
         coordinator = nil
         errorReporter = nil
         notificationCenter = nil
+        stateService = nil
         subject = nil
         timeProvider = nil
     }

--- a/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
+++ b/BitwardenShared/Core/Platform/Services/TestHelpers/MockStateService.swift
@@ -674,6 +674,10 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
         clearClipboardValues[userId] = clearClipboardValue
     }
 
+    // `@MainActor` isolates the write below: callers await this from processor code that isn't
+    // itself actor-isolated, so without this the mutation runs on a background thread and races
+    // with tests polling `collapsedVaultListSectionIds` from the main thread via `waitFor`.
+    @MainActor
     func setCollapsedVaultListSectionIds(_ ids: [String], userId: String?) async throws {
         let userId = try unwrapUserId(userId)
         collapsedVaultListSectionIds[userId] = ids
@@ -710,6 +714,10 @@ class MockStateService: StateService, ActiveAccountStateProvider, AutofillStateS
         self.events[userId] = events
     }
 
+    // `@MainActor` isolates the write below for the same reason as `setCollapsedVaultListSectionIds`
+    // above: it keeps this mutation serialized with tests polling `fillAssistEnabledByUserId` from
+    // the main thread via `waitFor`, rather than racing with it from a background thread.
+    @MainActor
     func setFillAssistEnabled(_ fillAssistEnabled: Bool, userId: String?) async throws {
         if let setFillAssistEnabledError {
             throw setFillAssistEnabledError


### PR DESCRIPTION
## 🎟️ Tracking

[PM-41956](https://bitwarden.atlassian.net/browse/PM-41956)

## 📔 Objective

Fixes 3 faulty/flaky tests by resolving their real root causes (data races and a task leak in test infrastructure — no production code changed):

- `AutoFillProcessorTests.test_receive_toggleFillAssist_off()` and `VaultListProcessorTests.test_receive_sectionExpandToggled_expand()`: `MockStateService.setFillAssistEnabled` / `.setCollapsedVaultListSectionIds` are nonisolated async protocol methods. Callers await them from processor code that isn't itself actor-isolated, so the mutation runs on a background thread while the tests poll the same (non-thread-safe) dictionaries from the main thread via `waitFor` — a genuine data race, reproduced via crashes under stress testing. Fixed by marking both mock methods `@MainActor`, which serializes the write with the test's reads.
- `AppProcessorTests.test_vaultTimeout_oneMinute_noLastActive()`: `AppProcessor.init()`/`.start()` spin up long-lived `Task { for await ... }` listeners. Because the mock publishers they subscribe to never complete, those tasks (and everything they retain — the whole `ServiceContainer`) leak across test iterations. Under heavy same-process iteration this eventually causes real 10s `waitForAsync` timeouts. Fixed by completing the relevant mock publishers (`willEnterForegroundSubject`, `didEnterBackgroundSubject`, `appThemeSubject`) in `tearDown()`, which unblocks the leaked loops so they release their retained state instead of accumulating.

**Deferred** (documenting, not addressed here — pre-existing, not one of the reported flaky tests): two sibling tests in the same class (`test_vaultTimeout_oneMinute_timeout`, `test_vaultTimeout_oneHour_timeout`) still show rare residual flakiness under extreme same-process stress (100+ iterations in a single process), which is far beyond how CI actually runs tests (once per suite run). It's the same class of task leak; eliminating it completely would mean replacing `AppProcessor`'s `Task { for await ... }` listener pattern with Combine `.sink` + `AnyCancellable`, a production-code change judged out of scope for this test-only fix.

**Verification:** each root cause was reproduced and confirmed fixed via repeated stress runs (100–300 same-process iterations) on an isolated simulator, plus a full, realistic single-run pass of the `Bitwarden-Unit` and `Authenticator-Unit` test plans.

## 📸 Screenshots

N/A — test-infrastructure-only change, no UI impact.


[PM-41956]: https://bitwarden.atlassian.net/browse/PM-41956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ