### PR TITLE
[PM-42176] ci: Exclude ViewInspectorTestHelpers from Codecov coverage

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -6,5 +6,6 @@ ignore:
   - "GlobalTestHelpers/**"
   - "GlobalTestHelpers-bwa/**"
   - "GlobalTestHelpers-bwth/**"
+  - "ViewInspectorTestHelpers/**"
   - "**/Mocks/**"
   - "**/*Mock*.swift"


### PR DESCRIPTION
## 🎟️ Tracking

PM-42176

## 📔 Objective

Exclude `ViewInspectorTestHelpers/**` from Codecov, matching how `TestHelpers/` and `Mocks/` are already ignored. This is test infrastructure with generic, partially-exercised helpers — not application code — so it shouldn't count toward coverage.
