### PR TITLE
[PM-42462] fix: Show None as the vault item picker placeholder

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Enum/BankAccountTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/BankAccountTypeTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import Foundation
 import Testing
 
@@ -5,6 +6,13 @@ import Testing
 
 struct BankAccountTypeTests {
     // MARK: Tests
+
+    /// `defaultValueLocalizedName` is the localized `None` placeholder shown when no account
+    /// type is selected.
+    @Test
+    func defaultValueLocalizedName_isNone() {
+        #expect(BankAccountType.defaultValueLocalizedName == Localizations.none)
+    }
 
     /// Raw values match the server contract.
     @Test

--- a/BitwardenShared/Core/Vault/Models/Enum/TitleType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/TitleType.swift
@@ -26,9 +26,9 @@ enum TitleType: String, Codable, Equatable, Hashable, Menuable {
 
     // MARK: Type Properties
 
-    /// default state title for title type
+    /// The default placeholder shown when no title is selected.
     static var defaultValueLocalizedName: String {
-        "--\(Localizations.select)--"
+        Localizations.none
     }
 
     var localizedName: String {

--- a/BitwardenShared/Core/Vault/Models/Enum/TitleTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/TitleTypeTests.swift
@@ -1,0 +1,15 @@
+import BitwardenResources
+import Testing
+
+@testable import BitwardenShared
+
+struct TitleTypeTests {
+    // MARK: Tests
+
+    /// `defaultValueLocalizedName` is the localized `None` placeholder shown when no title is
+    /// selected.
+    @Test
+    func defaultValueLocalizedName_isNone() {
+        #expect(TitleType.defaultValueLocalizedName == Localizations.none)
+    }
+}

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditBankAccountItem/AddEditBankAccountItemState.swift
@@ -51,7 +51,7 @@ protocol AddEditBankAccountItemState: Equatable, Sendable {
 extension BankAccountType: Menuable {
     /// The default placeholder shown when no account type is selected.
     public static var defaultValueLocalizedName: String {
-        "--\(Localizations.select)--"
+        Localizations.none
     }
 
     /// A localized string representation of the account type.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardComponent.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardComponent.swift
@@ -162,9 +162,9 @@ extension CardComponent.Brand {
 
 extension CardComponent.Brand: CaseIterable {}
 extension CardComponent.Brand: Menuable {
-    /// default state title for title type
+    /// The default placeholder shown when no card brand is selected.
     static var defaultValueLocalizedName: String {
-        "--\(Localizations.select)--"
+        Localizations.none
     }
 
     /// Provides a localized string representation of the card brand.
@@ -290,9 +290,9 @@ extension CardComponent.Brand {
 
 extension CardComponent.Month: CaseIterable {}
 extension CardComponent.Month: Menuable {
-    /// default state title for title type
+    /// The default placeholder shown when no expiration month is selected.
     static var defaultValueLocalizedName: String {
-        "--\(Localizations.select)--"
+        Localizations.none
     }
 
     var localizedName: String {

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardComponentTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardComponentTests.swift
@@ -10,6 +10,12 @@ import XCTest
 class CardComponentBrandTests: BitwardenTestCase {
     // MARK: Tests
 
+    /// `defaultValueLocalizedName` is the localized `None` placeholder shown when no brand is
+    /// selected.
+    func test_defaultValueLocalizedName() {
+        XCTAssertEqual(CardComponent.Brand.defaultValueLocalizedName, Localizations.none)
+    }
+
     /// `getter:icon` returns the appropriate icon for each card brand.
     func test_icon() {
         XCTAssertEqual(CardComponent.Brand.americanExpress.icon.name, SharedAsset.Icons.Cards.amex.name)
@@ -278,5 +284,17 @@ class CardComponentBrandTests: BitwardenTestCase {
     /// `validDigitLengths` returns `[13, 16, 19]` for Visa.
     func test_validDigitLengths_visa() {
         XCTAssertEqual(CardComponent.Brand.visa.validDigitLengths, [13, 16, 19])
+    }
+}
+
+// MARK: - CardComponentMonthTests
+
+class CardComponentMonthTests: BitwardenTestCase {
+    // MARK: Tests
+
+    /// `defaultValueLocalizedName` is the localized `None` placeholder shown when no expiration
+    /// month is selected.
+    func test_defaultValueLocalizedName() {
+        XCTAssertEqual(CardComponent.Month.defaultValueLocalizedName, Localizations.none)
     }
 }


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42462

## 📔 Objective

- The card brand picker showed `--Select--` as its placeholder. Per the design discussion on this PR, the placeholder is now `None`.
- Card expiration month, identity title, and bank account type used the same `--Select--` format, so I fixed all four. Fixing only the brand would leave two placeholder styles on the same screen.
- Uses the existing `None` localization, so no new string was added.
- Tidied up the doc comments on those four so they match. A couple said "default state title for title type" even on the card brand.
- Added a test per type so the dashes don't come back.

## 📸 Screenshots

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/e981eccb-ba17-4829-93bb-f818cdc7c4be" /> | <img width="365" src="https://github.com/user-attachments/assets/0e2fe419-d6fc-4928-8bce-572f8084d39d" /> |
