### PR TITLE
[PM-42025] fix: Show a toast after a vault item is saved

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1271,3 +1271,19 @@
 "ClearFieldName" = "Clear %1$@";
 "SelectDate" = "Select date";
 "PremiumRequiredTOTPDescriptionLong" = "Authenticator key (TOTP) is a Premium feature. Your current plan does not include access to this feature.";
+/* Toast shown after a login item is saved. */
+"LoginSaved" = "Login saved";
+/* Toast shown after a card item is saved. */
+"CardSaved" = "Card saved";
+/* Toast shown after an identity item is saved. */
+"IdentitySaved" = "Identity saved";
+/* Toast shown after a secure note item is saved. */
+"SecureNoteSaved" = "Secure note saved";
+/* Toast shown after an SSH key item is saved. */
+"SSHKeySaved" = "SSH key saved";
+/* Toast shown after a bank account item is saved. */
+"BankAccountSaved" = "Bank account saved";
+/* Toast shown after a driver's license item is saved. */
+"LicenseSaved" = "License saved";
+/* Toast shown after a passport item is saved. */
+"PassportSaved" = "Passport saved";

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
@@ -111,4 +111,18 @@ extension CipherType {
             [.text, .hidden, .boolean]
         }
     }
+
+    /// The title of the toast shown after an item of this type is saved.
+    var savedToastTitle: String {
+        switch self {
+        case .bankAccount: Localizations.bankAccountSaved
+        case .card: Localizations.cardSaved
+        case .driversLicense: Localizations.licenseSaved
+        case .identity: Localizations.identitySaved
+        case .login: Localizations.loginSaved
+        case .passport: Localizations.passportSaved
+        case .secureNote: Localizations.secureNoteSaved
+        case .sshKey: Localizations.sshKeySaved
+        }
+    }
 }

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
@@ -64,4 +64,16 @@ class CipherTypeTests: BitwardenTestCase {
         XCTAssertEqual(CipherType.passport.rawValue, 8)
         XCTAssertTrue(CipherType.allCases.contains(.passport))
     }
+
+    /// `savedToastTitle` returns the correct values.
+    func test_savedToastTitle() {
+        XCTAssertEqual(CipherType.bankAccount.savedToastTitle, Localizations.bankAccountSaved)
+        XCTAssertEqual(CipherType.card.savedToastTitle, Localizations.cardSaved)
+        XCTAssertEqual(CipherType.driversLicense.savedToastTitle, Localizations.licenseSaved)
+        XCTAssertEqual(CipherType.identity.savedToastTitle, Localizations.identitySaved)
+        XCTAssertEqual(CipherType.login.savedToastTitle, Localizations.loginSaved)
+        XCTAssertEqual(CipherType.passport.savedToastTitle, Localizations.passportSaved)
+        XCTAssertEqual(CipherType.secureNote.savedToastTitle, Localizations.secureNoteSaved)
+        XCTAssertEqual(CipherType.sshKey.savedToastTitle, Localizations.sshKeySaved)
+    }
 }

--- a/BitwardenShared/UI/Vault/Helpers/CipherSavedToastDelegate.swift
+++ b/BitwardenShared/UI/Vault/Helpers/CipherSavedToastDelegate.swift
@@ -1,0 +1,40 @@
+import BitwardenKit
+import Foundation
+
+// MARK: - CipherSavedToastDelegate
+
+/// A `CipherItemOperationDelegate` that reports a saved item by displaying a confirmation toast,
+/// leaving the presenting screen in place.
+///
+/// This is for screens whose own `CipherItemOperationDelegate` conformance does something other
+/// than show a toast on save, and which therefore can't pass themselves as the delegate for an
+/// edit started from the more options menu. `VaultItemSelectionProcessor` is one: it dismisses on
+/// save so the user is returned to the vault after adding an OTP key to an existing item.
+///
+/// Screens are expected to hold onto their instance, since `AddEditItemProcessor` references its
+/// delegate weakly.
+///
+@MainActor
+final class CipherSavedToastDelegate: CipherItemOperationDelegate {
+    // MARK: Private Properties
+
+    /// A closure called to display a toast.
+    private let handleDisplayToast: (Toast) -> Void
+
+    // MARK: Initialization
+
+    /// Initialize a `CipherSavedToastDelegate`.
+    ///
+    /// - Parameter handleDisplayToast: A closure called to display a toast.
+    ///
+    init(handleDisplayToast: @escaping (Toast) -> Void) {
+        self.handleDisplayToast = handleDisplayToast
+    }
+
+    // MARK: Methods
+
+    func itemUpdated(type: CipherType) -> Bool {
+        handleDisplayToast(Toast(title: type.savedToastTitle))
+        return true
+    }
+}

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -52,6 +52,10 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     /// The services used by this helper.
     private var services: Services
 
+    /// The closure used to display a toast, stored when navigating to the edit item screen so
+    /// that a confirmation toast can be displayed once the item has been saved.
+    private var handleDisplayToastAfterEdit: ((Toast) -> Void)?
+
     // MARK: Initialization
 
     /// Initialize a `VaultItemMoreOptionsHelper`.
@@ -227,6 +231,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             }
         case let .edit(cipherView):
             await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
+                self.handleDisplayToastAfterEdit = handleDisplayToast
                 self.coordinator.navigate(to: .editItem(cipherView), context: self)
             }
         case let .launch(url):
@@ -270,5 +275,20 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
+    }
+}
+
+// MARK: - CipherItemOperationDelegate
+
+extension DefaultVaultItemMoreOptionsHelper: CipherItemOperationDelegate {
+    func itemDismissed() -> Bool {
+        handleDisplayToastAfterEdit = nil
+        return true
+    }
+
+    func itemUpdated(type: CipherType) -> Bool {
+        handleDisplayToastAfterEdit?(Toast(title: type.savedToastTitle))
+        handleDisplayToastAfterEdit = nil
+        return true
     }
 }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -13,12 +13,15 @@ protocol VaultItemMoreOptionsHelper {
     ///
     /// - Parameters
     ///   - item: The selected item to show the options for.
+    ///   - delegate: The delegate notified of operations performed on the item from within the
+    ///     add/edit item view, used when the edit option is selected.
     ///   - handleDisplayToast: A closure called to handle displaying a toast.
     ///   - handleNavigateToPremiumUpgrade: A closure called to navigate to the Premium upgrade flow.
     ///   - handleOpenURL: A closure called to open a URL.
     ///
     func showMoreOptionsAlert(
         for item: VaultListItem,
+        delegate: CipherItemOperationDelegate?,
         handleDisplayToast: @escaping (Toast) -> Void,
         handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         handleOpenURL: @escaping (URL) -> Void,
@@ -52,10 +55,6 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     /// The services used by this helper.
     private var services: Services
 
-    /// The closure used to display a toast, stored when navigating to the edit item screen so
-    /// that a confirmation toast can be displayed once the item has been saved.
-    private var handleDisplayToastAfterEdit: ((Toast) -> Void)?
-
     // MARK: Initialization
 
     /// Initialize a `VaultItemMoreOptionsHelper`.
@@ -79,6 +78,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
 
     func showMoreOptionsAlert(
         for item: VaultListItem,
+        delegate: CipherItemOperationDelegate?,
         handleDisplayToast: @escaping (Toast) -> Void,
         handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         handleOpenURL: @escaping (URL) -> Void,
@@ -107,6 +107,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
                 await self.handleMoreOptionsAction(
                     action,
                     cipherView: cipherView,
+                    delegate: delegate,
                     handleDisplayToast: handleDisplayToast,
                     handleNavigateToPremiumUpgrade: handleNavigateToPremiumUpgrade,
                     handleOpenURL: handleOpenURL,
@@ -186,12 +187,15 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     /// - Parameters:
     ///   - action: The selected action.
     ///   - cipherView: The cipher to act upon.
+    ///   - delegate: The delegate notified of operations performed on the item from within the
+    ///     add/edit item view, used when the edit option is selected.
     ///   - handleDisplayToast: A closure to display a toast.
     ///   - handleOpenURL: A closure to open an URL.
     ///   - hasPremium: Whether the user has Premium account.
     private func handleMoreOptionsAction( // swiftlint:disable:this function_body_length function_parameter_count
         _ action: MoreOptionsAction,
         cipherView: CipherView,
+        delegate: CipherItemOperationDelegate?,
         handleDisplayToast: @escaping (Toast) -> Void,
         handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         handleOpenURL: @escaping (URL) -> Void,
@@ -231,8 +235,7 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             }
         case let .edit(cipherView):
             await masterPasswordRepromptHelper.repromptForMasterPasswordIfNeeded(cipherView: cipherView) {
-                self.handleDisplayToastAfterEdit = handleDisplayToast
-                self.coordinator.navigate(to: .editItem(cipherView), context: self)
+                self.coordinator.navigate(to: .editItem(cipherView), context: delegate)
             }
         case let .launch(url):
             handleOpenURL(url.sanitized)
@@ -275,20 +278,5 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
             await coordinator.showErrorAlert(error: error)
             services.errorReporter.log(error: error)
         }
-    }
-}
-
-// MARK: - CipherItemOperationDelegate
-
-extension DefaultVaultItemMoreOptionsHelper: CipherItemOperationDelegate {
-    func itemDismissed() -> Bool {
-        handleDisplayToastAfterEdit = nil
-        return true
-    }
-
-    func itemUpdated(type: CipherType) -> Bool {
-        handleDisplayToastAfterEdit?(Toast(title: type.savedToastTitle))
-        handleDisplayToastAfterEdit = nil
-        return true
     }
 }

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -522,6 +522,64 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(coordinator.routes, [.editItem(cipherView)])
     }
 
+    /// `showMoreOptionsAlert()` and press `edit` passes the helper as the navigation context, so
+    /// that it's notified when the item is saved and can show a confirmation toast.
+    @MainActor
+    func test_showMoreOptionsAlert_edit_showsToastAfterSave() async throws {
+        stateService.activeAccount = .fixture()
+
+        let cipherView = CipherView.fixture(type: .identity)
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        var displayedToast: Toast?
+        await subject.showMoreOptionsAlert(
+            for: item,
+            handleDisplayToast: { displayedToast = $0 },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.edit)
+
+        // The helper is the delegate, so the add/edit screen can report the save back to it.
+        let delegate = try XCTUnwrap(coordinator.contexts.last as? CipherItemOperationDelegate)
+        XCTAssertIdentical(delegate, subject as AnyObject)
+
+        let shouldDismiss = delegate.itemUpdated(type: .driversLicense)
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(displayedToast, Toast(title: Localizations.licenseSaved))
+    }
+
+    /// `showMoreOptionsAlert()` and press `edit` doesn't show a toast when the edit screen is
+    /// dismissed without saving.
+    @MainActor
+    func test_showMoreOptionsAlert_edit_noToastWhenDismissed() async throws {
+        stateService.activeAccount = .fixture()
+
+        vaultRepository.fetchCipherResult = .success(.fixture(type: .identity))
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        var displayedToast: Toast?
+        await subject.showMoreOptionsAlert(
+            for: item,
+            handleDisplayToast: { displayedToast = $0 },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
+        try await optionsAlert.tapAction(title: Localizations.edit)
+
+        let delegate = try XCTUnwrap(coordinator.contexts.last as? CipherItemOperationDelegate)
+        let shouldDismiss = delegate.itemDismissed()
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertNil(displayedToast)
+    }
+
     /// `showMoreOptionsAlert()` shows the appropriate more options alert for an identity cipher.
     @MainActor
     func test_showMoreOptionsAlert_identity() async throws {

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -86,6 +86,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -122,6 +123,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -155,6 +157,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -204,6 +207,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var navigatedToPremiumUpgrade = false
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: { navigatedToPremiumUpgrade = true },
             handleOpenURL: { _ in },
@@ -228,48 +232,54 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertTrue(navigatedToPremiumUpgrade)
     }
 
-    /// `showMoreOptionsAlert()` shows the appropriate more options alert for a card cipher.
+    /// `showMoreOptionsAlert()` shows only the view, edit and archive options for a card cipher
+    /// with no number or security code.
     @MainActor
     func test_showMoreOptionsAlert_card() async throws {
-        let account = Account.fixture()
-        stateService.activeAccount = account
+        stateService.activeAccount = .fixture()
 
-        var item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(type: .card(.init(brand: nil)))))
-
-        // If the card item has no number or code, only the view and add buttons should display.
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(type: .card(.init(brand: nil)))))
         vaultRepository.fetchCipherResult = .success(.cardFixture())
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
         )
 
-        var alert = try XCTUnwrap(coordinator.alertShown.last)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, "Bitwarden")
         XCTAssertEqual(alert.alertActions.count, 4)
         XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
         XCTAssertEqual(alert.alertActions[1].title, Localizations.edit)
         XCTAssertEqual(alert.alertActions[2].title, Localizations.archive)
         XCTAssertEqual(alert.alertActions[3].title, Localizations.cancel)
+    }
 
-        // A card with data should show the copy actions.
+    /// `showMoreOptionsAlert()` shows the copy options for a card cipher with a number and
+    /// security code, and each option performs the expected operation.
+    @MainActor
+    func test_showMoreOptionsAlert_card_withData() async throws {
+        stateService.activeAccount = .fixture()
+
         let cardWithData = CipherView.cardFixture(card: .fixture(
             code: "123",
             number: "123456789",
         ))
         vaultRepository.fetchCipherResult = .success(cardWithData)
-        item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
         )
 
-        alert = try XCTUnwrap(coordinator.alertShown.last)
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, "Bitwarden")
         XCTAssertEqual(alert.alertActions.count, 6)
         XCTAssertEqual(alert.alertActions[0].title, Localizations.view)
@@ -278,8 +288,6 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(alert.alertActions[3].title, Localizations.copySecurityCode)
         XCTAssertEqual(alert.alertActions[4].title, Localizations.archive)
         XCTAssertEqual(alert.alertActions[5].title, Localizations.cancel)
-
-        // Test the functionality of the buttons.
 
         // View navigates to the view item view.
         let viewAction = try XCTUnwrap(alert.alertActions[0])
@@ -323,6 +331,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -379,6 +388,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -424,6 +434,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -454,6 +465,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -478,6 +490,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -503,6 +516,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -522,20 +536,21 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(coordinator.routes, [.editItem(cipherView)])
     }
 
-    /// `showMoreOptionsAlert()` and press `edit` passes the helper as the navigation context, so
-    /// that it's notified when the item is saved and can show a confirmation toast.
+    /// `showMoreOptionsAlert()` and press `edit` passes the delegate it was given as the
+    /// navigation context, so that the caller is notified when the item is saved.
     @MainActor
-    func test_showMoreOptionsAlert_edit_showsToastAfterSave() async throws {
+    func test_showMoreOptionsAlert_edit_passesDelegateAsContext() async throws {
         stateService.activeAccount = .fixture()
 
         let cipherView = CipherView.fixture(type: .identity)
         vaultRepository.fetchCipherResult = .success(cipherView)
         let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
 
-        var displayedToast: Toast?
+        let delegate = MockCipherItemOperationDelegate()
         await subject.showMoreOptionsAlert(
             for: item,
-            handleDisplayToast: { displayedToast = $0 },
+            delegate: delegate,
+            handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
         )
@@ -543,28 +558,24 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
         try await optionsAlert.tapAction(title: Localizations.edit)
 
-        // The helper is the delegate, so the add/edit screen can report the save back to it.
-        let delegate = try XCTUnwrap(coordinator.contexts.last as? CipherItemOperationDelegate)
-        XCTAssertIdentical(delegate, subject as AnyObject)
-
-        let shouldDismiss = delegate.itemUpdated(type: .driversLicense)
-
-        XCTAssertTrue(shouldDismiss)
-        XCTAssertEqual(displayedToast, Toast(title: Localizations.licenseSaved))
+        XCTAssertEqual(coordinator.routes.last, .editItem(cipherView))
+        XCTAssertIdentical(coordinator.contexts.last as AnyObject, delegate)
     }
 
-    /// `showMoreOptionsAlert()` and press `edit` doesn't show a toast when the edit screen is
-    /// dismissed without saving.
+    /// `showMoreOptionsAlert()` and press `edit` routes the saved confirmation through the
+    /// caller's delegate rather than a toast closure held by the helper.
     @MainActor
-    func test_showMoreOptionsAlert_edit_noToastWhenDismissed() async throws {
+    func test_showMoreOptionsAlert_edit_savedToastComesFromDelegate() async throws {
         stateService.activeAccount = .fixture()
 
         vaultRepository.fetchCipherResult = .success(.fixture(type: .identity))
         let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
 
         var displayedToast: Toast?
+        let delegate = MockCipherItemOperationDelegate()
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: delegate,
             handleDisplayToast: { displayedToast = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -573,11 +584,13 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         let optionsAlert = try XCTUnwrap(coordinator.alertShown.last)
         try await optionsAlert.tapAction(title: Localizations.edit)
 
-        let delegate = try XCTUnwrap(coordinator.contexts.last as? CipherItemOperationDelegate)
-        let shouldDismiss = delegate.itemDismissed()
+        let context = try XCTUnwrap(coordinator.contexts.last as? CipherItemOperationDelegate)
+        XCTAssertTrue(context.itemUpdated(type: .driversLicense))
 
-        XCTAssertTrue(shouldDismiss)
+        // The helper doesn't display the toast itself, the delegate is left to do it.
         XCTAssertNil(displayedToast)
+        XCTAssertTrue(delegate.itemUpdatedCalled)
+        XCTAssertEqual(delegate.itemUpdatedType, .driversLicense)
     }
 
     /// `showMoreOptionsAlert()` shows the appropriate more options alert for an identity cipher.
@@ -594,6 +607,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -632,6 +646,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -658,6 +673,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -698,6 +714,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var urlToOpen: URL?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { urlToOpen = $0 },
@@ -762,6 +779,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -795,6 +813,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -815,6 +834,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -855,6 +875,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -871,6 +892,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { _ in },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -895,6 +917,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -928,6 +951,7 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         var toastToDisplay: Toast?
         await subject.showMoreOptionsAlert(
             for: item,
+            delegate: nil,
             handleDisplayToast: { toastToDisplay = $0 },
             handleNavigateToPremiumUpgrade: {},
             handleOpenURL: { _ in },
@@ -959,17 +983,20 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
 
 class MockVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
     var showMoreOptionsAlertCalled = false
+    var showMoreOptionsAlertDelegate: CipherItemOperationDelegate?
     var showMoreOptionsAlertHandleDisplayToast: ((Toast) -> Void)?
     var showMoreOptionsAlertHandlePremiumUpgrade: (() async -> Void)?
     var showMoreOptionsAlertHandleOpenURL: ((URL) -> Void)?
 
     func showMoreOptionsAlert(
         for item: VaultListItem,
+        delegate: CipherItemOperationDelegate?,
         handleDisplayToast: @escaping (Toast) -> Void,
         handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         handleOpenURL: @escaping (URL) -> Void,
     ) async {
         showMoreOptionsAlertCalled = true
+        showMoreOptionsAlertDelegate = delegate
         showMoreOptionsAlertHandleDisplayToast = handleDisplayToast
         showMoreOptionsAlertHandlePremiumUpgrade = handleNavigateToPremiumUpgrade
         showMoreOptionsAlertHandleOpenURL = handleOpenURL

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -384,6 +384,10 @@ extension VaultGroupProcessor: CipherItemOperationDelegate {
         displayToastAndRefresh(toastTitle: Localizations.itemDeleted)
     }
 
+    func itemSaved(type: CipherType) {
+        displayToastAndRefresh(toastTitle: type.savedToastTitle)
+    }
+
     func itemSoftDeleted() {
         displayToastAndRefresh(toastTitle: Localizations.itemSoftDeleted)
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -376,16 +376,17 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
 extension VaultGroupProcessor: CipherItemOperationDelegate {
     // MARK: Methods
 
+    func itemAdded(type: CipherType) -> Bool {
+        displayToastAndRefresh(toastTitle: type.savedToastTitle)
+        return true
+    }
+
     func itemArchived() {
         displayToastAndRefresh(toastTitle: Localizations.itemMovedToArchive)
     }
 
     func itemDeleted() {
         displayToastAndRefresh(toastTitle: Localizations.itemDeleted)
-    }
-
-    func itemSaved(type: CipherType) {
-        displayToastAndRefresh(toastTitle: type.savedToastTitle)
     }
 
     func itemSoftDeleted() {

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -131,6 +131,7 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
         case let .morePressed(item):
             await vaultItemMoreOptionsHelper.showMoreOptionsAlert(
                 for: item,
+                delegate: self,
                 handleDisplayToast: { [weak self] toast in
                     self?.state.toast = toast
                 },
@@ -399,6 +400,11 @@ extension VaultGroupProcessor: CipherItemOperationDelegate {
 
     func itemUnarchived() {
         displayToastAndRefresh(toastTitle: Localizations.itemMovedToVault)
+    }
+
+    func itemUpdated(type: CipherType) -> Bool {
+        displayToastAndRefresh(toastTitle: type.savedToastTitle)
+        return true
     }
 
     // MARK: Private methods

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -132,14 +132,25 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         waitFor(vaultRepository.fetchSyncCalled)
     }
 
-    /// `itemSaved(type:)` delegate method shows the toast for the saved item's type.
+    /// `itemAdded(type:)` delegate method shows the toast for the added item's type.
     @MainActor
-    func test_delegate_itemSaved() {
+    func test_delegate_itemAdded() {
         XCTAssertNil(subject.state.toast)
 
-        subject.itemSaved(type: .driversLicense)
+        let shouldDismiss = subject.itemAdded(type: .driversLicense)
+        XCTAssertTrue(shouldDismiss)
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
         waitFor(vaultRepository.fetchSyncCalled)
+    }
+
+    /// `itemDismissed()` delegate method doesn't show a toast when the editor is dismissed
+    /// without saving.
+    @MainActor
+    func test_delegate_itemDismissed() {
+        let shouldDismiss = subject.itemDismissed()
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertNil(subject.state.toast)
     }
 
     /// `itemSoftDeleted()` delegate method shows the expected toast.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -132,6 +132,16 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         waitFor(vaultRepository.fetchSyncCalled)
     }
 
+    /// `itemSaved(type:)` delegate method shows the toast for the saved item's type.
+    @MainActor
+    func test_delegate_itemSaved() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.itemSaved(type: .driversLicense)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+        waitFor(vaultRepository.fetchSyncCalled)
+    }
+
     /// `itemSoftDeleted()` delegate method shows the expected toast.
     @MainActor
     func test_delegate_itemSoftDeleted() {

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -143,6 +143,18 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         waitFor(vaultRepository.fetchSyncCalled)
     }
 
+    /// `itemUpdated(type:)` delegate method shows the toast for the updated item's type, which
+    /// covers saving an edit started from the item's more options menu.
+    @MainActor
+    func test_delegate_itemUpdated() {
+        XCTAssertNil(subject.state.toast)
+
+        let shouldDismiss = subject.itemUpdated(type: .driversLicense)
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+        waitFor(vaultRepository.fetchSyncCalled)
+    }
+
     /// `itemDismissed()` delegate method doesn't show a toast when the editor is dismissed
     /// without saving.
     @MainActor

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -287,7 +287,7 @@ class VaultItemSelectionProcessor: StateProcessor<
 // MARK: - CipherItemOperationDelegate
 
 extension VaultItemSelectionProcessor: CipherItemOperationDelegate {
-    func itemAdded() -> Bool {
+    func itemAdded(type _: CipherType) -> Bool {
         coordinator.navigate(to: .dismiss())
         // Return false to notify the calling processor that the dismissal occurs here.
         return false
@@ -297,11 +297,17 @@ extension VaultItemSelectionProcessor: CipherItemOperationDelegate {
         coordinator.navigate(to: .dismiss())
     }
 
+    func itemDismissed() -> Bool {
+        coordinator.navigate(to: .dismiss())
+        // Return false to notify the calling processor that the dismissal occurs here.
+        return false
+    }
+
     func itemUnarchived() {
         coordinator.navigate(to: .dismiss())
     }
 
-    func itemUpdated() -> Bool {
+    func itemUpdated(type _: CipherType) -> Bool {
         coordinator.navigate(to: .dismiss())
         // Return false to notify the calling processor that the dismissal occurs here.
         return false

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -50,6 +50,14 @@ class VaultItemSelectionProcessor: StateProcessor<
     /// The helper to handle the more options menu for a vault item.
     private let vaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper
 
+    /// The delegate used when editing an item from the more options menu. This screen's own
+    /// delegate conformance dismisses on save, which is correct for the OTP key flow but not for
+    /// a plain edit, which should stay put and show a confirmation toast. Retained here because
+    /// `AddEditItemProcessor` holds its delegate weakly.
+    private lazy var moreOptionsEditDelegate = CipherSavedToastDelegate { [weak self] toast in
+        self?.state.toast = toast
+    }
+
     // MARK: Initialization
 
     /// Initialize a `VaultItemSelectionProcessor`.
@@ -87,6 +95,7 @@ class VaultItemSelectionProcessor: StateProcessor<
         case let .morePressed(item):
             await vaultItemMoreOptionsHelper.showMoreOptionsAlert(
                 for: item,
+                delegate: moreOptionsEditDelegate,
                 handleDisplayToast: { [weak self] toast in
                     self?.state.toast = toast
                 },

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -106,10 +106,20 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertTrue(searchProcessorMediatorFactory.makeCalled)
     }
 
-    /// `itemAdded()` requests the coordinator dismiss the view.
+    /// `itemAdded(type:)` requests the coordinator dismiss the view.
     @MainActor
     func test_itemAdded() {
-        let shouldDismiss = subject.itemAdded()
+        let shouldDismiss = subject.itemAdded(type: .login)
+
+        XCTAssertEqual(coordinator.routes, [.dismiss()])
+        XCTAssertFalse(shouldDismiss)
+    }
+
+    /// `itemDismissed()` requests the coordinator dismiss the view, so that cancelling the add
+    /// item screen also tears down the item selection screen presented beneath it.
+    @MainActor
+    func test_itemDismissed() {
+        let shouldDismiss = subject.itemDismissed()
 
         XCTAssertEqual(coordinator.routes, [.dismiss()])
         XCTAssertFalse(shouldDismiss)
@@ -131,10 +141,10 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertEqual(coordinator.routes, [.dismiss()])
     }
 
-    /// `itemUpdated()` requests the coordinator dismiss the view.
+    /// `itemUpdated(type:)` requests the coordinator dismiss the view.
     @MainActor
     func test_itemUpdated() {
-        let shouldDismiss = subject.itemUpdated()
+        let shouldDismiss = subject.itemUpdated(type: .login)
 
         XCTAssertEqual(coordinator.routes, [.dismiss()])
         XCTAssertFalse(shouldDismiss)

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -201,6 +201,23 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertEqual(subject.state.url, url)
     }
 
+    /// `perform(_:)` with `.morePressed` passes a delegate that shows a confirmation toast once
+    /// the item is saved and leaves this screen in place, rather than this screen's own delegate
+    /// conformance, which dismisses on save for the OTP key flow.
+    @MainActor
+    func test_perform_morePressed_editShowsToastWithoutDismissing() async throws {
+        await subject.perform(.morePressed(.fixture()))
+
+        let delegate = try XCTUnwrap(vaultItemMoreOptionsHelper.showMoreOptionsAlertDelegate)
+        XCTAssertNotIdentical(delegate as AnyObject, subject)
+
+        let shouldDismiss = delegate.itemUpdated(type: .driversLicense)
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+        XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+
     /// `perform(_:)` with `.morePressed` delegates to the Premium upgrade helper when the
     /// upgrade action is triggered.
     @MainActor

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -851,16 +851,17 @@ extension VaultListProcessor: AddEditFolderDelegate {
 // MARK: - CipherItemOperationDelegate
 
 extension VaultListProcessor: CipherItemOperationDelegate {
+    func itemAdded(type: CipherType) -> Bool {
+        state.toast = Toast(title: type.savedToastTitle)
+        return true
+    }
+
     func itemArchived() {
         state.toast = Toast(title: Localizations.itemMovedToArchive)
     }
 
     func itemDeleted() {
         state.toast = Toast(title: Localizations.itemDeleted)
-    }
-
-    func itemSaved(type: CipherType) {
-        state.toast = Toast(title: type.savedToastTitle)
     }
 
     func itemSoftDeleted() {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -859,6 +859,10 @@ extension VaultListProcessor: CipherItemOperationDelegate {
         state.toast = Toast(title: Localizations.itemDeleted)
     }
 
+    func itemSaved(type: CipherType) {
+        state.toast = Toast(title: type.savedToastTitle)
+    }
+
     func itemSoftDeleted() {
         state.toast = Toast(title: Localizations.itemSoftDeleted)
     }

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -679,6 +679,7 @@ extension VaultListProcessor {
     private func morePressed(item: VaultListItem) async {
         await vaultItemMoreOptionsHelper.showMoreOptionsAlert(
             for: item,
+            delegate: self,
             handleDisplayToast: { [weak self] toast in
                 self?.state.toast = toast
             },
@@ -874,6 +875,11 @@ extension VaultListProcessor: CipherItemOperationDelegate {
 
     func itemUnarchived() {
         state.toast = Toast(title: Localizations.itemMovedToVault)
+    }
+
+    func itemUpdated(type: CipherType) -> Bool {
+        state.toast = Toast(title: type.savedToastTitle)
+        return true
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -232,13 +232,24 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemDeleted))
     }
 
-    /// `itemSaved(type:)` delegate method shows the toast for the saved item's type.
+    /// `itemAdded(type:)` delegate method shows the toast for the added item's type.
     @MainActor
-    func test_delegate_itemSaved() {
+    func test_delegate_itemAdded() {
         XCTAssertNil(subject.state.toast)
 
-        subject.itemSaved(type: .driversLicense)
+        let shouldDismiss = subject.itemAdded(type: .driversLicense)
+        XCTAssertTrue(shouldDismiss)
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+    }
+
+    /// `itemDismissed()` delegate method doesn't show a toast when the editor is dismissed
+    /// without saving.
+    @MainActor
+    func test_delegate_itemDismissed() {
+        let shouldDismiss = subject.itemDismissed()
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertNil(subject.state.toast)
     }
 
     /// `itemSoftDeleted()` delegate method shows the expected toast.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -232,6 +232,15 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemDeleted))
     }
 
+    /// `itemSaved(type:)` delegate method shows the toast for the saved item's type.
+    @MainActor
+    func test_delegate_itemSaved() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.itemSaved(type: .driversLicense)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+    }
+
     /// `itemSoftDeleted()` delegate method shows the expected toast.
     @MainActor
     func test_delegate_itemSoftDeleted() {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -242,6 +242,17 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
     }
 
+    /// `itemUpdated(type:)` delegate method shows the toast for the updated item's type, which
+    /// covers saving an edit started from the item's more options menu.
+    @MainActor
+    func test_delegate_itemUpdated() {
+        XCTAssertNil(subject.state.toast)
+
+        let shouldDismiss = subject.itemUpdated(type: .driversLicense)
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+    }
+
     /// `itemDismissed()` delegate method doesn't show a toast when the editor is dismissed
     /// without saving.
     @MainActor

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -26,6 +26,12 @@ protocol CipherItemOperationDelegate: AnyObject {
     /// Called when the cipher item has been successfully restored.
     func itemRestored()
 
+    /// Called when the cipher item has been successfully saved, whether it was added or updated.
+    ///
+    /// - Parameter type: The type of the cipher item that was saved.
+    ///
+    func itemSaved(type: CipherType)
+
     /// Called when the cipher item has been successfully soft deleted.
     func itemSoftDeleted()
 
@@ -48,6 +54,8 @@ extension CipherItemOperationDelegate {
     func itemDeleted() {}
 
     func itemRestored() {}
+
+    func itemSaved(type _: CipherType) {}
 
     func itemSoftDeleted() {}
 
@@ -917,6 +925,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
         try await services.vaultRepository.addCipher(state.cipher)
         coordinator.hideLoadingOverlay()
 
+        delegate?.itemSaved(type: state.type)
         handleDismiss(didAddItem: true)
         await services.reviewPromptService.trackUserAction(.addedNewItem)
     }
@@ -1081,6 +1090,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     private func updateItem(cipherView: CipherView) async throws {
         try await services.vaultRepository.updateCipher(cipherView.updatedView(with: state))
         coordinator.hideLoadingOverlay()
+        delegate?.itemSaved(type: state.type)
         let shouldDismissed = delegate?.itemUpdated() ?? true
         if shouldDismissed {
             coordinator.navigate(to: .dismiss())

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -12,10 +12,11 @@ import UIKit
 protocol CipherItemOperationDelegate: AnyObject {
     /// Called when a new cipher item has been successfully added.
     ///
+    /// - Parameter type: The type of the cipher item that was added.
     /// - Returns: A boolean indicating whether the view should be dismissed. Defaults to `true`.
     ///     If `false` is returned the delegate is responsible for dismissing the view.
     ///
-    func itemAdded() -> Bool
+    func itemAdded(type: CipherType) -> Bool
 
     /// Called when the cipher item has been successfully archived.
     func itemArchived()
@@ -23,14 +24,15 @@ protocol CipherItemOperationDelegate: AnyObject {
     /// Called when the cipher item has been successfully permanently deleted.
     func itemDeleted()
 
+    /// Called when the add/edit item view is being dismissed without the item having been saved.
+    ///
+    /// - Returns: A boolean indicating whether the view should be dismissed. Defaults to `true`.
+    ///     If `false` is returned the delegate is responsible for dismissing the view.
+    ///
+    func itemDismissed() -> Bool
+
     /// Called when the cipher item has been successfully restored.
     func itemRestored()
-
-    /// Called when the cipher item has been successfully saved, whether it was added or updated.
-    ///
-    /// - Parameter type: The type of the cipher item that was saved.
-    ///
-    func itemSaved(type: CipherType)
 
     /// Called when the cipher item has been successfully soft deleted.
     func itemSoftDeleted()
@@ -40,28 +42,29 @@ protocol CipherItemOperationDelegate: AnyObject {
 
     /// Called when a cipher item has been successfully updated.
     ///
+    /// - Parameter type: The type of the cipher item that was updated.
     /// - Returns: A boolean indicating whether the view should be dismissed. Defaults to `true`.
     ///     If `false` is returned the delegate is responsible for dismissing the view.
     ///
-    func itemUpdated() -> Bool
+    func itemUpdated(type: CipherType) -> Bool
 }
 
 extension CipherItemOperationDelegate {
-    func itemAdded() -> Bool { true }
+    func itemAdded(type _: CipherType) -> Bool { true }
 
     func itemArchived() {}
 
     func itemDeleted() {}
 
-    func itemRestored() {}
+    func itemDismissed() -> Bool { true }
 
-    func itemSaved(type _: CipherType) {}
+    func itemRestored() {}
 
     func itemSoftDeleted() {}
 
     func itemUnarchived() {}
 
-    func itemUpdated() -> Bool { true }
+    func itemUpdated(type _: CipherType) -> Bool { true }
 }
 
 // MARK: - AddEditItemProcessor
@@ -381,7 +384,11 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
             return
         }
 
-        let shouldDismiss = delegate?.itemAdded() ?? true
+        let shouldDismiss = if didAddItem {
+            delegate?.itemAdded(type: state.type) ?? true
+        } else {
+            delegate?.itemDismissed() ?? true
+        }
         if shouldDismiss {
             coordinator.navigate(to: .dismiss())
         }
@@ -925,7 +932,6 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
         try await services.vaultRepository.addCipher(state.cipher)
         coordinator.hideLoadingOverlay()
 
-        delegate?.itemSaved(type: state.type)
         handleDismiss(didAddItem: true)
         await services.reviewPromptService.trackUserAction(.addedNewItem)
     }
@@ -1090,8 +1096,7 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     private func updateItem(cipherView: CipherView) async throws {
         try await services.vaultRepository.updateCipher(cipherView.updatedView(with: state))
         coordinator.hideLoadingOverlay()
-        delegate?.itemSaved(type: state.type)
-        let shouldDismissed = delegate?.itemUpdated() ?? true
+        let shouldDismissed = delegate?.itemUpdated(type: state.type) ?? true
         if shouldDismissed {
             coordinator.navigate(to: .dismiss())
         }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -1228,7 +1228,7 @@ extension AddEditItemProcessor: AuthenticatorKeyCaptureDelegate {
 
 extension AddEditItemProcessor: EditCollectionsProcessorDelegate {
     func didUpdateCipher() {
-        state.toast = Toast(title: Localizations.itemUpdated)
+        state.toast = Toast(title: state.type.savedToastTitle)
     }
 }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -1685,13 +1685,14 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.savePressed` notifies the delegate of the type of the item that was
     /// added, so that a confirmation toast can be shown.
     @MainActor
-    func test_perform_savePressed_new_notifiesDelegateItemSaved() async throws {
+    func test_perform_savePressed_new_notifiesDelegateItemAdded() async throws {
         subject.state.type = .driversLicense
         subject.state.name = "Bitwarden"
 
         await subject.perform(.savePressed)
 
-        XCTAssertEqual(delegate.itemSavedType, .driversLicense)
+        XCTAssertEqual(delegate.itemAddedType, .driversLicense)
+        XCTAssertFalse(delegate.itemDismissedCalled)
     }
 
     /// `perform(_:)` with `.savePressed` forwards errors to the error reporter.
@@ -1717,7 +1718,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     /// `perform(_:)` with `.savePressed` notifies the delegate of the type of the item that was
     /// updated, so that a confirmation toast can be shown.
     @MainActor
-    func test_perform_savePressed_existing_notifiesDelegateItemSaved() async throws {
+    func test_perform_savePressed_existing_notifiesDelegateItemUpdated() async throws {
         subject.state = try XCTUnwrap(
             CipherItemState(existing: .fixture(type: .identity), hasPremium: true),
         ).addEditState
@@ -1726,7 +1727,8 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 
         await subject.perform(.savePressed)
 
-        XCTAssertEqual(delegate.itemSavedType, .identity)
+        XCTAssertEqual(delegate.itemUpdatedType, .identity)
+        XCTAssertFalse(delegate.itemDismissedCalled)
     }
 
     /// `perform(_:)` with `.savePressed` notifies the delegate that the item was updated and
@@ -2464,14 +2466,30 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.guidedTourViewState.showGuidedTour)
     }
 
-    /// `receive(_:)` with `.dismiss()` navigates to the `.dismiss()` route without notifying the
-    /// delegate that the item was saved, so that cancelling doesn't show a confirmation toast.
+    /// `receive(_:)` with `.dismissPressed` notifies the delegate that the view was dismissed
+    /// without saving, so that cancelling doesn't show a confirmation toast.
     @MainActor
     func test_receive_dismiss() {
         subject.receive(.dismissPressed)
 
         XCTAssertEqual(coordinator.routes.last, .dismiss())
-        XCTAssertNil(delegate.itemSavedType)
+        XCTAssertTrue(delegate.itemDismissedCalled)
+        XCTAssertFalse(delegate.itemAddedCalled)
+        XCTAssertFalse(delegate.itemUpdatedCalled)
+        XCTAssertNil(delegate.itemAddedType)
+        XCTAssertNil(delegate.itemUpdatedType)
+    }
+
+    /// `receive(_:)` with `.dismissPressed` doesn't dismiss the view if the delegate returns
+    /// `false` from `itemDismissed()`, indicating it handles the dismissal itself.
+    @MainActor
+    func test_receive_dismiss_shouldNotDismiss() {
+        delegate.itemDismissedShouldDismiss = false
+
+        subject.receive(.dismissPressed)
+
+        XCTAssertTrue(delegate.itemDismissedCalled)
+        XCTAssertTrue(coordinator.routes.isEmpty)
     }
 
     /// `receive(_:)` with `.guidedTourViewAction(.doneTapped)` completes the guided tour.
@@ -3551,17 +3569,21 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 class MockCipherItemOperationDelegate: CipherItemOperationDelegate {
     var itemAddedCalled = false
     var itemAddedShouldDismiss = true
+    var itemAddedType: BitwardenShared.CipherType?
     var itemArchivedCalled = false
     var itemDeletedCalled = false
+    var itemDismissedCalled = false
+    var itemDismissedShouldDismiss = true
     var itemRestoredCalled = false
-    var itemSavedType: BitwardenShared.CipherType?
     var itemSoftDeletedCalled = false
     var itemUpdatedCalled = false
     var itemUpdatedShouldDismiss = true
+    var itemUpdatedType: BitwardenShared.CipherType?
     var itemUnarchivedCalled = false
 
-    func itemAdded() -> Bool {
+    func itemAdded(type: BitwardenShared.CipherType) -> Bool {
         itemAddedCalled = true
+        itemAddedType = type
         return itemAddedShouldDismiss
     }
 
@@ -3573,20 +3595,22 @@ class MockCipherItemOperationDelegate: CipherItemOperationDelegate {
         itemDeletedCalled = true
     }
 
-    func itemRestored() {
-        itemRestoredCalled = true
+    func itemDismissed() -> Bool {
+        itemDismissedCalled = true
+        return itemDismissedShouldDismiss
     }
 
-    func itemSaved(type: BitwardenShared.CipherType) {
-        itemSavedType = type
+    func itemRestored() {
+        itemRestoredCalled = true
     }
 
     func itemSoftDeleted() {
         itemSoftDeletedCalled = true
     }
 
-    func itemUpdated() -> Bool {
+    func itemUpdated(type: BitwardenShared.CipherType) -> Bool {
         itemUpdatedCalled = true
+        itemUpdatedType = type
         return itemUpdatedShouldDismiss
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -609,14 +609,16 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         )
     }
 
-    /// `didUpdateCipher()` displays a toast after the cipher is updated.
+    /// `didUpdateCipher()` displays the toast for the item's type after the cipher is updated.
     @MainActor
     func test_didUpdateCipher() {
+        subject.state.type = .driversLicense
+
         subject.didUpdateCipher()
 
         waitFor { subject.state.toast != nil }
 
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemUpdated))
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
     }
 
     /// `folderAdded(_:)` sets the selected folder to the folder that was added without showing a

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -1680,6 +1680,18 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertTrue(coordinator.routes.isEmpty)
     }
 
+    /// `perform(_:)` with `.savePressed` notifies the delegate of the type of the item that was
+    /// added, so that a confirmation toast can be shown.
+    @MainActor
+    func test_perform_savePressed_new_notifiesDelegateItemSaved() async throws {
+        subject.state.type = .driversLicense
+        subject.state.name = "Bitwarden"
+
+        await subject.perform(.savePressed)
+
+        XCTAssertEqual(delegate.itemSavedType, .driversLicense)
+    }
+
     /// `perform(_:)` with `.savePressed` forwards errors to the error reporter.
     @MainActor
     func test_perform_savePressed_existing_error() async throws {
@@ -1698,6 +1710,21 @@ class AddEditItemProcessorTests: BitwardenTestCase {
 
         XCTAssertEqual(errorReporter.errors.first as? EncryptError, EncryptError())
         XCTAssertTrue(reviewPromptService.userActions.isEmpty)
+    }
+
+    /// `perform(_:)` with `.savePressed` notifies the delegate of the type of the item that was
+    /// updated, so that a confirmation toast can be shown.
+    @MainActor
+    func test_perform_savePressed_existing_notifiesDelegateItemSaved() async throws {
+        subject.state = try XCTUnwrap(
+            CipherItemState(existing: .fixture(type: .identity), hasPremium: true),
+        ).addEditState
+        subject.state.name = "vault item"
+        vaultRepository.updateCipherResult = .success(())
+
+        await subject.perform(.savePressed)
+
+        XCTAssertEqual(delegate.itemSavedType, .identity)
     }
 
     /// `perform(_:)` with `.savePressed` notifies the delegate that the item was updated and
@@ -2435,12 +2462,14 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertFalse(subject.state.guidedTourViewState.showGuidedTour)
     }
 
-    /// `receive(_:)` with `.dismiss()` navigates to the `.dismiss()` route.
+    /// `receive(_:)` with `.dismiss()` navigates to the `.dismiss()` route without notifying the
+    /// delegate that the item was saved, so that cancelling doesn't show a confirmation toast.
     @MainActor
     func test_receive_dismiss() {
         subject.receive(.dismissPressed)
 
         XCTAssertEqual(coordinator.routes.last, .dismiss())
+        XCTAssertNil(delegate.itemSavedType)
     }
 
     /// `receive(_:)` with `.guidedTourViewAction(.doneTapped)` completes the guided tour.
@@ -3523,6 +3552,7 @@ class MockCipherItemOperationDelegate: CipherItemOperationDelegate {
     var itemArchivedCalled = false
     var itemDeletedCalled = false
     var itemRestoredCalled = false
+    var itemSavedType: BitwardenShared.CipherType?
     var itemSoftDeletedCalled = false
     var itemUpdatedCalled = false
     var itemUpdatedShouldDismiss = true
@@ -3543,6 +3573,10 @@ class MockCipherItemOperationDelegate: CipherItemOperationDelegate {
 
     func itemRestored() {
         itemRestoredCalled = true
+    }
+
+    func itemSaved(type: BitwardenShared.CipherType) {
+        itemSavedType = type
     }
 
     func itemSoftDeleted() {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -700,6 +700,10 @@ private extension ViewItemProcessor {
 
                     newState.loadingState = .data(itemState)
                 }
+
+                // Carry over any toast, so that a toast shown in response to saving the item isn't
+                // cleared out from under the user by the cipher update that the save triggers.
+                newState.toast = state.toast
                 state = newState
             }
         } catch {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -775,6 +775,10 @@ extension ViewItemProcessor: CipherItemOperationDelegate {
         delegate?.itemRestored()
     }
 
+    func itemSaved(type: CipherType) {
+        state.toast = Toast(title: type.savedToastTitle)
+    }
+
     func itemSoftDeleted() {
         coordinator.navigate(to: .dismiss(DismissAction(action: { [delegate] in delegate?.itemSoftDeleted() })))
     }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -796,7 +796,8 @@ extension ViewItemProcessor: CipherItemOperationDelegate {
 
 extension ViewItemProcessor: EditCollectionsProcessorDelegate {
     func didUpdateCipher() {
-        state.toast = Toast(title: Localizations.itemUpdated)
+        let title = state.loadingState.data?.type.savedToastTitle ?? Localizations.itemUpdated
+        state.toast = Toast(title: title)
     }
 }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessor.swift
@@ -767,6 +767,11 @@ private extension ViewItemProcessor {
 // MARK: - CipherItemOperationDelegate
 
 extension ViewItemProcessor: CipherItemOperationDelegate {
+    func itemAdded(type: CipherType) -> Bool {
+        state.toast = Toast(title: type.savedToastTitle)
+        return true
+    }
+
     func itemArchived() {
         coordinator.navigate(to: .dismiss(DismissAction(action: { [delegate] in delegate?.itemArchived() })))
     }
@@ -779,16 +784,17 @@ extension ViewItemProcessor: CipherItemOperationDelegate {
         delegate?.itemRestored()
     }
 
-    func itemSaved(type: CipherType) {
-        state.toast = Toast(title: type.savedToastTitle)
-    }
-
     func itemSoftDeleted() {
         coordinator.navigate(to: .dismiss(DismissAction(action: { [delegate] in delegate?.itemSoftDeleted() })))
     }
 
     func itemUnarchived() {
         coordinator.navigate(to: .dismiss(DismissAction(action: { [delegate] in delegate?.itemUnarchived() })))
+    }
+
+    func itemUpdated(type: CipherType) -> Bool {
+        state.toast = Toast(title: type.savedToastTitle)
+        return true
     }
 }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -210,6 +210,23 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(delegate.itemUnarchivedCalled)
     }
 
+    /// `perform(_:)` with `.appeared` keeps a toast that was already displayed, so that saving the
+    /// item doesn't clear its own confirmation toast when the cipher update streams in.
+    @MainActor
+    func test_perform_appeared_keepsToast() {
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+        subject.state.toast = Toast(title: Localizations.licenseSaved)
+        vaultRepository.cipherDetailsSubject.send(.fixture(id: "id", type: .identity))
+
+        let task = Task {
+            await subject.perform(.appeared)
+        }
+        waitFor(subject.state.loadingState != .loading(nil))
+        task.cancel()
+
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+    }
+
     /// `perform(_:)` with `.appeared` starts listening for updates with the vault repository.
     @MainActor
     func test_perform_appeared() { // swiftlint:disable:this function_body_length

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -105,9 +105,24 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         )
     }
 
-    /// `didUpdateCipher()` displays a toast after the cipher is updated.
+    /// `didUpdateCipher()` displays the toast for the item's type after the cipher is updated.
     @MainActor
-    func test_didUpdateCipher() {
+    func test_didUpdateCipher() throws {
+        let cipherState = try XCTUnwrap(
+            CipherItemState(existing: .fixture(type: .identity), hasPremium: true),
+        )
+        subject.state.loadingState = .data(cipherState)
+
+        subject.didUpdateCipher()
+
+        waitFor { subject.state.toast != nil }
+
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.identitySaved))
+    }
+
+    /// `didUpdateCipher()` falls back to the generic toast if the item hasn't loaded yet.
+    @MainActor
+    func test_didUpdateCipher_notLoaded() {
         subject.didUpdateCipher()
 
         waitFor { subject.state.toast != nil }

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -173,6 +173,15 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(delegate.itemDeletedCalled)
     }
 
+    /// `itemSaved(type:)` shows the toast for the saved item's type.
+    @MainActor
+    func test_itemSaved() {
+        XCTAssertNil(subject.state.toast)
+
+        subject.itemSaved(type: .driversLicense)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+    }
+
     /// `itemSoftDeleted()` presents the dismiss action and calls the delegate.
     @MainActor
     func test_itemSoftDeleted() async throws {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewItemProcessorTests.swift
@@ -188,12 +188,32 @@ class ViewItemProcessorTests: BitwardenTestCase { // swiftlint:disable:this type
         XCTAssertTrue(delegate.itemDeletedCalled)
     }
 
-    /// `itemSaved(type:)` shows the toast for the saved item's type.
+    /// `itemAdded(type:)` shows the toast for the added item's type and dismisses the view.
     @MainActor
-    func test_itemSaved() {
+    func test_itemAdded() {
         XCTAssertNil(subject.state.toast)
 
-        subject.itemSaved(type: .driversLicense)
+        let shouldDismiss = subject.itemAdded(type: .driversLicense)
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
+    }
+
+    /// `itemDismissed()` doesn't show a toast when the editor is dismissed without saving.
+    @MainActor
+    func test_itemDismissed() {
+        let shouldDismiss = subject.itemDismissed()
+
+        XCTAssertTrue(shouldDismiss)
+        XCTAssertNil(subject.state.toast)
+    }
+
+    /// `itemUpdated(type:)` shows the toast for the updated item's type and dismisses the view.
+    @MainActor
+    func test_itemUpdated() {
+        XCTAssertNil(subject.state.toast)
+
+        let shouldDismiss = subject.itemUpdated(type: .driversLicense)
+        XCTAssertTrue(shouldDismiss)
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.licenseSaved))
     }
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42025

## 📔 Objective

- Saving a license showed no "License saved" toast. Turns out no item type showed one; QA just happened to catch it on the license.
- Nothing was wired up for it. `itemAdded()` also fires when you cancel out of the editor, so the toast couldn't just hang off the existing delegate methods.
- Added an `itemSaved(type:)` delegate call that only fires after the item actually saves, plus a per-type title so each type gets its own wording.
- The vault list, group list, and item view screens all show it now.
- Found a second problem while testing: the item view rebuilds its whole state whenever the cipher changes, so saving wiped its own toast. That's fixed too, which also steadies the existing "Item saved" toast on that screen.

## 📸 Screenshots

# Before 

https://github.com/user-attachments/assets/5fbcbe6d-2367-4748-80b8-dd4af8d1909e

# After

https://github.com/user-attachments/assets/8629dbbc-31d1-407d-b3c0-d6cda9fdd33a


