### PR TITLE
[PM-42029] fix: Match the add item menu order to the designs

### DIFF
--- a/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherType.swift
@@ -95,7 +95,7 @@ extension CipherType: Menuable {
 extension CipherType {
     /// These are the cases of `CipherType` that the user can use to create a cipher.
     static let canCreateCases: [CipherType] = [
-        .login, .card, .identity, .secureNote, .bankAccount, .driversLicense, .passport,
+        .login, .card, .bankAccount, .identity, .driversLicense, .passport, .secureNote,
     ]
 
     /// The cases of `CipherType` that are gated behind the `.newItemTypes` feature flag.

--- a/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
+++ b/BitwardenShared/Core/Vault/Models/Enum/CipherTypeTests.swift
@@ -50,7 +50,7 @@ class CipherTypeTests: BitwardenTestCase {
     func test_canCreateCases() {
         XCTAssertEqual(
             CipherType.canCreateCases,
-            [.login, .card, .identity, .secureNote, .bankAccount, .driversLicense, .passport],
+            [.login, .card, .bankAccount, .identity, .driversLicense, .passport, .secureNote],
         )
     }
 

--- a/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
+++ b/BitwardenShared/Core/Vault/Repositories/TestHelpers/MockVaultRepository.swift
@@ -75,7 +75,7 @@ class MockVaultRepository: VaultRepository { // swiftlint:disable:this type_body
 
     var getTOTPKeyIfAllowedToCopyResult: Result<String?, Error> = .success(nil)
 
-    var getItemTypesUserCanCreateResult: [BitwardenShared.CipherType] = CipherType.canCreateCases
+    var getItemTypesUserCanCreateResult: [BitwardenShared.CipherType] = CipherType.canCreateCases.reversed()
 
     var hasMinimumCipherCountResult: Result<Bool, Error> = .success(false)
 

--- a/BitwardenShared/UI/Platform/Application/Extensions/View.swift
+++ b/BitwardenShared/UI/Platform/Application/Extensions/View.swift
@@ -90,7 +90,7 @@ extension View {
     ///
     func addVaultItemFloatingActionMenu(
         hidden: Bool = false,
-        availableItemTypes: [CipherType] = CipherType.canCreateCases,
+        availableItemTypes: [CipherType] = CipherType.canCreateCases.reversed(),
         addItem: @escaping (CipherType) -> Void,
         addFolder: (() -> Void)? = nil,
     ) -> some View {

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupState.swift
@@ -78,7 +78,7 @@ struct VaultGroupState: Equatable, Sendable {
     var iconBaseURL: URL?
 
     /// List of available item type for creation.
-    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCases
+    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCases.reversed()
 
     /// Whether the policy is enforced to disable personal vault ownership.
     var isPersonalOwnershipDisabled: Bool = false

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupStateTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupStateTests.swift
@@ -20,6 +20,13 @@ class VaultGroupStateTests: BitwardenTestCase {
         XCTAssertEqual(subject.addItemButtonTitle, Localizations.addLicense)
     }
 
+    /// `itemTypesUserCanCreate` defaults to the same order the vault repository provides, since
+    /// the floating action menu renders the list bottom-up.
+    func test_itemTypesUserCanCreate_defaultsToMenuOrder() {
+        let subject = VaultGroupState(group: .login, vaultFilterType: .myVault)
+        XCTAssertEqual(subject.itemTypesUserCanCreate, CipherType.canCreateCases.reversed())
+    }
+
     /// `newItemButtonType` returns the new item button type based on the group.
     func test_newItemButtonType() {
         let subjectBankAccount = VaultGroupState(group: .bankAccount, vaultFilterType: .myVault)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListState.swift
@@ -38,7 +38,7 @@ struct VaultListState: Equatable {
     var isVfo1FoundationFeatureFlagEnabled = false
 
     /// List of available item type for creation.
-    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCases
+    var itemTypesUserCanCreate: [CipherType] = CipherType.canCreateCases.reversed()
 
     /// The loading state of the My Vault screen.
     var loadingState: LoadingState<[VaultListSection]> = .loading(nil)

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListStateTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListStateTests.swift
@@ -71,6 +71,13 @@ struct VaultListStateTests {
         #expect(state.activeActionCard == nil)
     }
 
+    /// `itemTypesUserCanCreate` defaults to the same order the vault repository provides, since
+    /// the floating action menu renders the list bottom-up.
+    @Test
+    func itemTypesUserCanCreate_defaultsToMenuOrder() {
+        #expect(subject.itemTypesUserCanCreate == CipherType.canCreateCases.reversed())
+    }
+
     /// `navigationTitle` returns "My Vault" when no organizations are present, and "Vaults"
     /// when the user belongs to at least one organization.
     @Test


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42029

## 📔 Objective

- The add item menu listed the types in the wrong order: Identity and Secure note came before Bank account, License and Passport.
- Order now matches the designs: Login, Card, Bank account, Identity, License, Passport, Secure note, then Folder at the bottom.
- The list gets reversed on its way to the menu, since iOS draws it bottom-up when it opens above the button. So `canCreateCases` reads the same way you see it on screen.
- Also reversed the two state defaults and the view's default parameter. They were feeding the menu an unreversed list, so tapping the button before the vault list finished loading showed everything upside-down.

## 📸 Screenshots 

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/e555e981-cb63-4465-bb47-d9e3ae68761e" /> | <img width="365" src="https://github.com/user-attachments/assets/049eac2b-91ca-42b7-8bf2-ea4f6af09579" /> |
