### PR TITLE
[PM-42523] fix: Restore AppIntents localization strings and detect their usage

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -877,6 +877,10 @@
 "Identification" = "Identification";
 "Owner" = "Owner";
 "VerifyYourIdentity" = "Verify your identity";
+"ThisOperationIsNotAllowedOnThisAccount" = "This operation is not allowed on this account";
+"AnErrorOccurredWhileTryingToLockTheCurrentUser" = "An error occurred while trying to lock the current user";
+"LockAllAccounts" = "Lock all accounts";
+"AllAccountsHaveBeenLocked" = "All accounts have been locked";
 "ShareErrorDetails" = "Share error details";
 "FlightRecorder" = "Flight recorder";
 "EnableFlightRecorder" = "Enable flight recorder";
@@ -905,7 +909,13 @@
 "ExpiresOnXDate" = "Expires on %1$@";
 "ExpiresTomorrow" = "Expires tomorrow";
 "DateRangeXToY" = "%1$@ to %2$@";
+"LogOutAllAccounts" = "Log out all accounts";
+"AllAccountsHaveBeenLoggedOut" = "All accounts have been logged out";
+"AnErrorOccurredWhileTryingToLogOutAllAccounts" = "An error occurred while trying to log out all accounts";
 "SelfHostServerURL" = "Self-host server URL";
+"OpenGenerator" = "Open generator";
+"OpenPasswordGenerator" = "Open password generator";
+"GeneratePassphrase" = "Generate passphrase";
 "AllowUniversalClipboard" = "Allow Universal Clipboard";
 "UseUniversalClipboardToCopyDescriptionLong" = "Use Universal Clipboard to copy here and paste on other devices signed in with the same Apple ID.";
 "RemoveMasterPasswordConfirmDomain" = "A master password is no longer required for members of the following organization. Please confirm the domain below with your organization administrator.";
@@ -925,6 +935,7 @@
 "GoToSettings" = "Go to settings";
 "SiriAndShortcutsAccess" = "Siri & Shortcuts access";
 "EnableToAllowTheAppToRespondToSiriAndShortcutsUsingAppIntents" = "Enable to allow the app to respond to Siri and Shortcuts using App Intents.";
+"ThereIsNoActiveAccount" = "There is no active account.";
 "NewFileSend" = "New file Send";
 "NewTextSend" = "New text Send";
 "EditFileSend" = "Edit file Send";

--- a/Scripts/fix-localizable-strings/delete_unused_strings.py
+++ b/Scripts/fix-localizable-strings/delete_unused_strings.py
@@ -2,10 +2,26 @@
 delete_unused_strings
 
 Finds and removes string entries from a Localizable.strings file whose keys are
-never referenced in Swift source code. Keys are assumed to be accessed via
+never referenced in Swift source code. Keys are usually accessed via
 ``Localizations.X``, where ``X`` is the SwiftGen-generated identifier for the
 key (first character lowercased). Any comment block immediately preceding a
 removed entry (with no blank lines between them) is also removed.
+
+AppIntents are an exception to the ``Localizations.X`` convention: Apple's
+AppIntents framework requires ``title``/``description``/``shortTitle``/
+``dialog`` values to be string literals (compile-time constants), so those
+intents reference Localizable.strings keys directly as raw string literals
+rather than through the generated ``Localizations`` enum, e.g.
+``static var title: LocalizedStringResource = "OpenGenerator"``. Those
+literal-key patterns are also treated as usages so that entries backing
+``AppIntents/`` and ``ShortcutsProvider.swift`` aren't deleted as unused.
+
+The same applies to types conforming to ``CustomLocalizedStringResourceConvertible``
+(e.g. error enums surfaced by AppIntents), where the ``localizedStringResource``
+computed property returns a bare string literal per case, e.g.:
+``var localizedStringResource: LocalizedStringResource { switch self { case
+.foo: "Key" } }``. Any bare string literal inside such a block is also
+treated as a key usage.
 """
 
 import os
@@ -17,8 +33,69 @@ from strings_file_utils import filter_entries
 # cases where the identifier is on the next line (e.g. `Localizations\n    .foo`).
 _LOCALIZATIONS_RE = re.compile(r'Localizations\s*\.([a-zA-Z_][a-zA-Z0-9_]*)')
 
+# Matches string-literal keys in the handful of AppIntents/ShortcutsProvider
+# positions that require compile-time string literals rather than
+# `Localizations.X` references:
+#   - `static var title: LocalizedStringResource = "Key"` (AppIntent title)
+#   - `IntentDescription("Key")` (AppIntent description)
+#   - `shortTitle: "Key"` (AppShortcut in ShortcutsProvider)
+#   - `dialog: "Key"` (IntentResult dialog, e.g. `.result(dialog: "Key")`)
+# The captured value is only treated as a key when it's a plain literal (no
+# string interpolation), since interpolated dialogs (e.g. `"Value: \(x)"`)
+# aren't Localizable.strings keys.
+_APPINTENT_LITERAL_KEY_RE = re.compile(
+    r'(?:'
+    r'static\s+var\s+title\s*:\s*LocalizedStringResource\s*=\s*'
+    r'|IntentDescription\(\s*'
+    r'|shortTitle\s*:\s*'
+    r'|dialog\s*:\s*'
+    r')"([^"\\]*)"'
+)
+
+# Matches the opening of a `... LocalizedStringResource { ... }` computed
+# property or function body (e.g. `var localizedStringResource:
+# LocalizedStringResource { switch self { ... } }`, as used by
+# `CustomLocalizedStringResourceConvertible` conformances). The body is
+# extracted separately via `_extract_localized_string_resource_blocks` since
+# it may contain nested braces (e.g. a `switch`).
+_LOCALIZED_STRING_RESOURCE_BLOCK_START_RE = re.compile(r'LocalizedStringResource\s*\{')
+
+# Matches any plain (non-interpolated) string literal.
+_STRING_LITERAL_RE = re.compile(r'"([^"\\]*)"')
+
 # Matches any character that is not valid in a Swift identifier.
 _NON_IDENTIFIER_RE = re.compile(r'[^a-zA-Z0-9_]')
+
+
+def _extract_localized_string_resource_blocks(content: str) -> list[str]:
+    """Extract the bodies of ``LocalizedStringResource { ... }`` blocks.
+
+    Finds every place where a property or function returning
+    ``LocalizedStringResource`` opens a brace, then walks forward counting
+    nested braces to find the matching close, so that any `switch` inside the
+    block doesn't prematurely truncate the extracted body.
+
+    Args:
+        content: The full text of a Swift source file.
+
+    Returns:
+        A list of block bodies (text between the outermost matching braces),
+        one per `LocalizedStringResource { ... }` occurrence found.
+    """
+    blocks: list[str] = []
+    for match in _LOCALIZED_STRING_RESOURCE_BLOCK_START_RE.finditer(content):
+        depth = 1
+        pos = match.end()
+        start = pos
+        while pos < len(content) and depth > 0:
+            char = content[pos]
+            if char == '{':
+                depth += 1
+            elif char == '}':
+                depth -= 1
+            pos += 1
+        blocks.append(content[start:pos - 1])
+    return blocks
 
 
 def _normalize_key(key: str) -> str:
@@ -40,13 +117,14 @@ def _normalize_key(key: str) -> str:
 
 
 def find_used_keys(swift_sources: list[str]) -> set[str]:
-    """Scan Swift file contents for ``Localizations.X`` references.
+    """Scan Swift file contents for ``Localizations.X`` references and AppIntents
+    string-literal key usages.
 
-    Returns a set of identifiers found in the sources, converted to lowercase
-    for comparison with the keys from the strings file. While this does mean
-    that keys differing only in case (e.g. ``"OK"`` vs. ``"Ok"``) will be
-    treated as the same key, in practice we're not likely to have keys that
-    only differ by case.
+    Returns a set of identifiers found in the sources, normalized (non-identifier
+    characters stripped, then lowercased) for comparison with the keys from the
+    strings file. While this does mean that keys differing only in case (e.g.
+    ``"OK"`` vs. ``"Ok"``) will be treated as the same key, in practice we're not
+    likely to have keys that only differ by case.
 
     The internal helper ``Localizations.tr(...)`` is excluded.
 
@@ -55,8 +133,8 @@ def find_used_keys(swift_sources: list[str]) -> set[str]:
             source file.
 
     Returns:
-        A set of lowercased identifiers referenced in the given sources,
-        e.g. ``{"about", "ok", "valuehasbeencopied"}``.
+        A set of normalized, lowercased identifiers referenced in the given
+        sources, e.g. ``{"about", "ok", "valuehasbeencopied", "opengenerator"}``.
     """
     result: set[str] = set()
     for content in swift_sources:
@@ -64,6 +142,11 @@ def find_used_keys(swift_sources: list[str]) -> set[str]:
             if identifier == "tr":
                 continue
             result.add(identifier.lower())
+        for key in _APPINTENT_LITERAL_KEY_RE.findall(content):
+            result.add(_normalize_key(key))
+        for block in _extract_localized_string_resource_blocks(content):
+            for key in _STRING_LITERAL_RE.findall(block):
+                result.add(_normalize_key(key))
     return result
 
 

--- a/Scripts/fix-localizable-strings/tests/test_delete_unused_strings.py
+++ b/Scripts/fix-localizable-strings/tests/test_delete_unused_strings.py
@@ -77,6 +77,111 @@ class TestFindUsedKeysParameterizedCalls(unittest.TestCase):
         self.assertEqual(result, {"alpha", "beta"})
 
 
+class TestFindUsedKeysAppIntentLiterals(unittest.TestCase):
+    """AppIntents/ShortcutsProvider reference Localizable.strings keys as
+    string literals instead of `Localizations.X`, since Apple's AppIntents
+    framework requires compile-time string literals for these properties."""
+
+    def test_intent_title_literal_is_matched(self):
+        source = 'static var title: LocalizedStringResource = "OpenGenerator"'
+        result = find_used_keys([source])
+        self.assertEqual(result, {"opengenerator"})
+
+    def test_intent_description_literal_is_matched(self):
+        source = 'static var description = IntentDescription("OpenGenerator")'
+        result = find_used_keys([source])
+        self.assertEqual(result, {"opengenerator"})
+
+    def test_shortcuts_provider_short_title_literal_is_matched(self):
+        source = 'shortTitle: "LockAllAccounts",'
+        result = find_used_keys([source])
+        self.assertEqual(result, {"lockallaccounts"})
+
+    def test_result_dialog_literal_is_matched(self):
+        source = 'return .result(dialog: "AllAccountsHaveBeenLocked")'
+        result = find_used_keys([source])
+        self.assertEqual(result, {"allaccountshavebeenlocked"})
+
+    def test_result_dialog_with_interpolation_is_not_matched_as_a_key(self):
+        # Interpolated dialogs aren't Localizable.strings keys.
+        source = 'return .result(value: passphrase, dialog: "Passphrase: \\(passphrase)")'
+        result = find_used_keys([source])
+        self.assertEqual(result, set())
+
+    def test_full_appintent_file_all_literals_matched(self):
+        source = (
+            'struct LockAllAccountsIntent: AppIntent {\n'
+            '    static var title: LocalizedStringResource = "LockAllAccounts"\n'
+            '    static var description = IntentDescription("LockAllAccounts")\n'
+            '    func perform() async throws -> some IntentResult {\n'
+            '        return .result(dialog: "AllAccountsHaveBeenLocked")\n'
+            '    }\n'
+            '}\n'
+        )
+        result = find_used_keys([source])
+        self.assertEqual(result, {"lockallaccounts", "allaccountshavebeenlocked"})
+
+
+class TestFindUsedKeysCustomLocalizedStringResourceConvertible(unittest.TestCase):
+    """`CustomLocalizedStringResourceConvertible` conformances (e.g. AppIntent
+    error enums) return bare string literals per switch case rather than
+    `Localizations.X` references, since the property type is
+    `LocalizedStringResource`."""
+
+    def test_bare_literal_in_switch_case_is_matched(self):
+        source = (
+            'public var localizedStringResource: LocalizedStringResource {\n'
+            '    switch self {\n'
+            '    case .noActiveAccount:\n'
+            '        "ThereIsNoActiveAccount"\n'
+            '    case .notAllowed:\n'
+            '        "ThisOperationIsNotAllowedOnThisAccount"\n'
+            '    }\n'
+            '}\n'
+        )
+        result = find_used_keys([source])
+        self.assertEqual(
+            result, {"thereisnoactiveaccount", "thisoperationisnotallowedonthisaccount"}
+        )
+
+    def test_full_appintent_error_enum_matched(self):
+        # Mirrors BitwardenShared/UI/Platform/Application/AppIntentMediator.swift.
+        source = (
+            '@available(iOS 16, *)\n'
+            'public enum AppIntentError: Error, CustomLocalizedStringResourceConvertible {\n'
+            '    case noActiveAccount\n'
+            '    case notAllowed\n'
+            '\n'
+            '    public var localizedStringResource: LocalizedStringResource {\n'
+            '        switch self {\n'
+            '        case .noActiveAccount:\n'
+            '            "ThereIsNoActiveAccount"\n'
+            '        case .notAllowed:\n'
+            '            "ThisOperationIsNotAllowedOnThisAccount"\n'
+            '        }\n'
+            '    }\n'
+            '}\n'
+        )
+        result = find_used_keys([source])
+        self.assertEqual(
+            result, {"thereisnoactiveaccount", "thisoperationisnotallowedonthisaccount"}
+        )
+
+    def test_unrelated_switch_outside_block_is_not_matched(self):
+        # A bare string literal in a switch that has nothing to do with
+        # LocalizedStringResource must not be treated as a key.
+        source = (
+            'var body: String {\n'
+            '    switch self {\n'
+            '    case .foo:\n'
+            '        "NotAKey"\n'
+            '    }\n'
+            '}\n'
+        )
+        result = find_used_keys([source])
+        self.assertEqual(result, set())
+
+
 class TestFindUsedKeysMultipleFiles(unittest.TestCase):
     """Identifiers are unioned across all provided file contents."""
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-42523

## 📔 Objective

PM-26292 ("chore: Remove unused strings", #2003) removed 10 `Localizable.strings` entries that are actually referenced by `Bitwarden/Application/AppIntents/*.swift` and `ShortcutsProvider.swift` — but only as raw string literals (`title`, `description`, `shortTitle`, `dialog`, and a `CustomLocalizedStringResourceConvertible.localizedStringResource` switch), not via the generated `Localizations.X` enum. Without a matching entry, Siri/Shortcuts falls back to showing the raw key text instead of the intended English string.

This PR:

1. Restores the 10 missing entries in `BitwardenResources/Localizations/en.lproj/Localizable.strings`, at their original positions, with values matching what was deleted.
2. Fixes the root cause in `Scripts/fix-localizable-strings/delete_unused_strings.py` (used by the weekly `cron-fix-localizable-strings` GitHub Action) so its `delete-unused` detector recognizes these AppIntents literal-key usage patterns as "used" — otherwise the bot would silently delete them again on its next run. Adds test coverage for each pattern, including the actual `AppIntentError` shape in `AppIntentMediator.swift`.

Verified via `bash Scripts/fix-localizable-strings.sh --dry-run`, which now reports no unused strings in `Localizable.strings`, and the full Python test suite (`Scripts/test-fix-localizable-strings.sh`, 88/88 passing).
