### PR TITLE
[PM-37883] fix: Restrict card scanning region and stop guessing the expiration date

### DIFF
--- a/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
+++ b/BitwardenShared/Core/Platform/Services/ServiceContainer.swift
@@ -1197,7 +1197,7 @@ public class ServiceContainer: Services { // swiftlint:disable:this type_body_le
             biometricsRepository: biometricsRepository,
             biometricsService: biometricsService,
             cameraService: DefaultCameraService(),
-            cardTextParser: DefaultCardTextParser(),
+            cardTextParser: DefaultCardTextParser(timeProvider: timeProvider),
             changeKdfService: changeKdfService,
             cipherOwnershipHelper: cipherOwnershipHelper,
             clientCertificateService: clientCertificateService,

--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -16,6 +16,12 @@ extension Constants {
     /// tracks the card being scanned rather than a fraction of whatever view is hosting it.
     static let cardAspectRatio = 85.6 / 53.98
 
+    /// The number of years after the current year that a scanned card expiration year may be.
+    static let cardScanMaxExpiryYearsAhead = 20
+
+    /// The number of years before the current year that a scanned card expiration year may be.
+    static let cardScanMaxExpiryYearsPast = 1
+
     /// How much taller the card scanner's capture region is than an exactly proportioned card, so
     /// that a card held at a slight angle, or a little off center, still falls inside it.
     static let cardScanRegionHeightTolerance = 1.3

--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -11,6 +11,20 @@ extension Constants {
     /// The app review prompt delay in nanoseconds.
     static let appReviewPromptDelay: UInt64 = 3_000_000_000
 
+    /// The aspect ratio of a payment card: 85.60 mm wide by 53.98 mm high, the ID-1 (CR-80) format
+    /// defined by ISO/IEC 7810. The card scanner's capture region is shaped from this so that it
+    /// tracks the card being scanned rather than a fraction of whatever view is hosting it.
+    static let cardAspectRatio = 85.6 / 53.98
+
+    /// How much taller the card scanner's capture region is than an exactly proportioned card, so
+    /// that a card held at a slight angle, or a little off center, still falls inside it.
+    static let cardScanRegionHeightTolerance = 1.3
+
+    /// The proportion of the card scanner's width that text is recognized within. Nearly the full
+    /// width, since a card held landscape spans it; the height is derived from the card's aspect
+    /// ratio, and is what excludes unrelated text above and below the card.
+    static let cardScanRegionWidthProportion = 0.96
+
     /// The size of the slice to decrypt ciphers in batch using the SDK.
     static let decryptCiphersBatchSize: Int = 100
 

--- a/BitwardenShared/Core/Platform/Utilities/Constants.swift
+++ b/BitwardenShared/Core/Platform/Utilities/Constants.swift
@@ -11,9 +11,8 @@ extension Constants {
     /// The app review prompt delay in nanoseconds.
     static let appReviewPromptDelay: UInt64 = 3_000_000_000
 
-    /// The aspect ratio of a payment card: 85.60 mm wide by 53.98 mm high, the ID-1 (CR-80) format
-    /// defined by ISO/IEC 7810. The card scanner's capture region is shaped from this so that it
-    /// tracks the card being scanned rather than a fraction of whatever view is hosting it.
+    /// The aspect ratio of a payment card, per the ISO/IEC 7810 ID-1 (CR-80) format: 85.60 mm by
+    /// 53.98 mm.
     static let cardAspectRatio = 85.6 / 53.98
 
     /// The number of years after the current year that a scanned card expiration year may be.
@@ -22,13 +21,11 @@ extension Constants {
     /// The number of years before the current year that a scanned card expiration year may be.
     static let cardScanMaxExpiryYearsPast = 1
 
-    /// How much taller the card scanner's capture region is than an exactly proportioned card, so
-    /// that a card held at a slight angle, or a little off center, still falls inside it.
+    /// How much taller the card scanner's capture region is than an exactly proportioned card, to
+    /// allow for a card held at an angle or off center.
     static let cardScanRegionHeightTolerance = 1.3
 
-    /// The proportion of the card scanner's width that text is recognized within. Nearly the full
-    /// width, since a card held landscape spans it; the height is derived from the card's aspect
-    /// ratio, and is what excludes unrelated text above and below the card.
+    /// The proportion of the card scanner's width that text is recognized within.
     static let cardScanRegionWidthProportion = 0.96
 
     /// The size of the slice to decrypt ciphers in batch using the SDK.

--- a/BitwardenShared/Core/Vault/Models/Fixtures/ScannedCardData+Fixtures.swift
+++ b/BitwardenShared/Core/Vault/Models/Fixtures/ScannedCardData+Fixtures.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@testable import BitwardenShared
+
+extension ScannedCardData {
+    static func fixture(
+        cardNumber: String? = "4111111111111111",
+        expirationMonth: Int? = 12,
+        expirationYear: String? = "2028",
+    ) -> ScannedCardData {
+        self.init(
+            cardNumber: cardNumber,
+            expirationMonth: expirationMonth,
+            expirationYear: expirationYear,
+        )
+    }
+}

--- a/BitwardenShared/Core/Vault/Services/CardTextParser.swift
+++ b/BitwardenShared/Core/Vault/Services/CardTextParser.swift
@@ -25,8 +25,8 @@ final class DefaultCardTextParser: CardTextParser {
         pattern: #"(?<!\d)(\d[ \-]?){12,18}\d(?!\d)"#,
     )
 
-    /// Regex that matches an expiry date in MM/YY or MM/YYYY format. The year is either two or four
-    /// digits — a three digit run is OCR noise rather than a year, and must not be accepted.
+    /// Regex that matches an expiry date in MM/YY or MM/YYYY format. A three digit year is rejected
+    /// as OCR noise.
     private static let expiryRegex = try? NSRegularExpression(
         pattern: #"\b(0?[1-9]|1[0-2])\s*/\s*(\d{2}|\d{4})\b"#,
     )
@@ -34,8 +34,8 @@ final class DefaultCardTextParser: CardTextParser {
     /// The most digits a payment card number can have.
     private static let maximumCardNumberDigits = 19
 
-    /// The fewest digits a payment card number can have. Doubles as the threshold that separates a
-    /// card number from an expiration date, since an expiry carries only four to six digits.
+    /// The fewest digits a payment card number can have. Also separates a card number from an
+    /// expiry, which carries at most six digits.
     private static let minimumCardNumberDigits = 13
 
     // MARK: Properties
@@ -47,8 +47,7 @@ final class DefaultCardTextParser: CardTextParser {
 
     /// Initializes a `DefaultCardTextParser`.
     ///
-    /// - Parameter timeProvider: Provides the present time, used to bound a scanned expiration year
-    ///     to a plausible range.
+    /// - Parameter timeProvider: Provides the present time, used to bound the expiration year.
     ///
     init(timeProvider: TimeProvider) {
         self.timeProvider = timeProvider
@@ -124,15 +123,10 @@ final class DefaultCardTextParser: CardTextParser {
 
     /// Extracts an expiry month (1–12) and 4-digit year from a line of text.
     ///
-    /// A line carrying as many digits as a card number is skipped entirely. OCR routinely reads a
-    /// digit, or a group separator, inside a card number as `/`, which leaves behind something shaped
-    /// exactly like an expiry — `"5/33 6195 0371 5702"` parses as May 2033 despite no date being
-    /// printed on the card. A card number carries at least 13 digits and an expiry carries four to
-    /// six, so the digit count tells them apart. A genuine expiry that OCR merged onto the same line
-    /// as the card number is skipped too; leaving the field empty is the safer of the two failures.
-    ///
-    /// Of the remaining matches the last plausible one wins, so a card printing both a "valid from"
-    /// and a "valid thru" date yields the expiry rather than the start date.
+    /// Lines carrying a card number's worth of digits are skipped: OCR often reads a digit or a
+    /// group separator within a card number as `/`, so `"5/33 6195 0371 5702"` would otherwise parse
+    /// as May 2033. Of the remaining matches the last plausible one wins, so a card printing both a
+    /// "valid from" and a "valid thru" date yields the expiry.
     private func extractExpiry(from line: String) -> (month: Int, year: String)? {
         guard let regex = Self.expiryRegex,
               line.filter(\.isNumber).count < Self.minimumCardNumberDigits

--- a/BitwardenShared/Core/Vault/Services/CardTextParser.swift
+++ b/BitwardenShared/Core/Vault/Services/CardTextParser.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import Foundation
 
 // MARK: - CardTextParser
@@ -24,10 +25,34 @@ final class DefaultCardTextParser: CardTextParser {
         pattern: #"(?<!\d)(\d[ \-]?){12,18}\d(?!\d)"#,
     )
 
-    /// Regex that matches an expiry date in MM/YY or MM/YYYY format.
+    /// Regex that matches an expiry date in MM/YY or MM/YYYY format. The year is either two or four
+    /// digits — a three digit run is OCR noise rather than a year, and must not be accepted.
     private static let expiryRegex = try? NSRegularExpression(
-        pattern: #"\b(0?[1-9]|1[0-2])\s*/\s*(\d{2,4})\b"#,
+        pattern: #"\b(0?[1-9]|1[0-2])\s*/\s*(\d{2}|\d{4})\b"#,
     )
+
+    /// The most digits a payment card number can have.
+    private static let maximumCardNumberDigits = 19
+
+    /// The fewest digits a payment card number can have. Doubles as the threshold that separates a
+    /// card number from an expiration date, since an expiry carries only four to six digits.
+    private static let minimumCardNumberDigits = 13
+
+    // MARK: Properties
+
+    /// Provides the present time, used to bound a scanned expiration year to a plausible range.
+    private let timeProvider: TimeProvider
+
+    // MARK: Initialization
+
+    /// Initializes a `DefaultCardTextParser`.
+    ///
+    /// - Parameter timeProvider: Provides the present time, used to bound a scanned expiration year
+    ///     to a plausible range.
+    ///
+    init(timeProvider: TimeProvider) {
+        self.timeProvider = timeProvider
+    }
 
     // MARK: CardTextParser
 
@@ -89,7 +114,8 @@ final class DefaultCardTextParser: CardTextParser {
         let matchRange = Range(match.range, in: line)!
         let raw = String(line[matchRange])
         let digits = raw.filter(\.isNumber)
-        guard digits.count >= 13, digits.count <= 19 else { return nil }
+        guard digits.count >= Self.minimumCardNumberDigits,
+              digits.count <= Self.maximumCardNumberDigits else { return nil }
         // Reject sequences that look like dates or years (e.g. 8-digit numbers that match no Luhn prefix)
         guard !looksLikeDateOrYear(digits) else { return nil }
         guard isLuhnValid(digits), hasValidLength(digits) else { return nil }
@@ -97,23 +123,51 @@ final class DefaultCardTextParser: CardTextParser {
     }
 
     /// Extracts an expiry month (1–12) and 4-digit year from a line of text.
+    ///
+    /// A line carrying as many digits as a card number is skipped entirely. OCR routinely reads a
+    /// digit, or a group separator, inside a card number as `/`, which leaves behind something shaped
+    /// exactly like an expiry — `"5/33 6195 0371 5702"` parses as May 2033 despite no date being
+    /// printed on the card. A card number carries at least 13 digits and an expiry carries four to
+    /// six, so the digit count tells them apart. A genuine expiry that OCR merged onto the same line
+    /// as the card number is skipped too; leaving the field empty is the safer of the two failures.
+    ///
+    /// Of the remaining matches the last plausible one wins, so a card printing both a "valid from"
+    /// and a "valid thru" date yields the expiry rather than the start date.
     private func extractExpiry(from line: String) -> (month: Int, year: String)? {
-        guard let regex = Self.expiryRegex else { return nil }
-        let range = NSRange(line.startIndex..., in: line)
-        let allMatches = regex.matches(in: line, range: range)
-        guard let match = allMatches.last,
-              match.numberOfRanges == 3 else { return nil }
-        guard
-            let monthRange = Range(match.range(at: 1), in: line),
-            let yearRange = Range(match.range(at: 2), in: line),
-            let month = Int(String(line[monthRange]))
+        guard let regex = Self.expiryRegex,
+              line.filter(\.isNumber).count < Self.minimumCardNumberDigits
         else { return nil }
 
-        var yearString = String(line[yearRange])
-        if yearString.count == 2 {
-            yearString = "20\(yearString)"
+        let range = NSRange(line.startIndex..., in: line)
+        var result: (month: Int, year: String)?
+
+        for match in regex.matches(in: line, range: range) {
+            guard match.numberOfRanges == 3,
+                  let monthRange = Range(match.range(at: 1), in: line),
+                  let yearRange = Range(match.range(at: 2), in: line),
+                  let month = Int(String(line[monthRange]))
+            else { continue }
+
+            var yearString = String(line[yearRange])
+            if yearString.count == 2 {
+                yearString = "20\(yearString)"
+            }
+
+            // Skip rather than stop: a later match on the line may still be a genuine expiry.
+            guard isPlausibleExpiryYear(yearString) else { continue }
+
+            result = (month, yearString)
         }
-        return (month, yearString)
+
+        return result
+    }
+
+    /// Returns `true` if `yearString` falls within the plausible range for a card expiration year.
+    private func isPlausibleExpiryYear(_ yearString: String) -> Bool {
+        guard let year = Int(yearString) else { return false }
+        let currentYear = Calendar.current.component(.year, from: timeProvider.presentTime)
+        return year >= currentYear - Constants.cardScanMaxExpiryYearsPast
+            && year <= currentYear + Constants.cardScanMaxExpiryYearsAhead
     }
 
     /// Merges adjacent lines that look like split card-number digit groups into a single line.

--- a/BitwardenShared/Core/Vault/Services/CardTextParserTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CardTextParserTests.swift
@@ -1,3 +1,6 @@
+import BitwardenKit
+import BitwardenKitMocks
+import Foundation
 import Testing
 
 @testable import BitwardenShared
@@ -9,10 +12,14 @@ struct CardTextParserTests {
 
     let subject: DefaultCardTextParser
 
+    /// A fixed present time, so the plausible expiration year range the parser applies stays stable
+    /// and the fixtures below never rot. Mid-year, so the calendar year is 2025 in every time zone.
+    let timeProvider = MockTimeProvider(.mockTime(Date(timeIntervalSince1970: 1_751_328_000)))
+
     // MARK: Setup
 
     init() {
-        subject = DefaultCardTextParser()
+        subject = DefaultCardTextParser(timeProvider: timeProvider)
     }
 
     // MARK: Tests – Card Number
@@ -72,6 +79,54 @@ struct CardTextParserTests {
         let result = subject.parseCard(lines: lines)
         #expect(result.expirationMonth == expectedMonth)
         #expect(result.expirationYear == expectedYear)
+    }
+
+    /// `parseCard(lines:)` does not read an expiry off a line carrying a card number's worth of
+    /// digits. OCR reading a digit or a group separator as `/` leaves a card number looking exactly
+    /// like a date, which is how a card with no printed expiry ends up with one.
+    @Test(arguments: [
+        ["5/33 6195 0371 5702"],
+        ["5333 6/95 0371 5702"],
+        ["5333 6195 0371 5/02"],
+        ["1234 5/2035 6789"],
+        ["4342 5620 3/2035 3456"],
+    ])
+    func parseCard_rejectsExpiryOnCardNumberLine(lines: [String]) {
+        let result = subject.parseCard(lines: lines)
+        #expect(result.expirationMonth == nil)
+        #expect(result.expirationYear == nil)
+    }
+
+    /// `parseCard(lines:)` rejects an expiry whose year falls outside the plausible range, and a
+    /// three digit run that is not a year at all.
+    @Test(arguments: [["03/999"], ["03/9999"], ["01/20"], ["12/99"]])
+    func parseCard_rejectsImplausibleExpiryYear(lines: [String]) {
+        let result = subject.parseCard(lines: lines)
+        #expect(result.expirationMonth == nil)
+        #expect(result.expirationYear == nil)
+    }
+
+    /// `parseCard(lines:)` still reads an expiry printed alongside its label, which is how a card
+    /// presents it.
+    @Test(arguments: zip(
+        [["VALID THRU 12/28"], ["GOOD THRU 10/27"], ["EXP 09/27"]],
+        [(12, "2028"), (10, "2027"), (9, "2027")],
+    ))
+    func parseCard_extractsLabelledExpiry(lines: [String], expected: (Int, String)) {
+        let (expectedMonth, expectedYear) = expected
+        let result = subject.parseCard(lines: lines)
+        #expect(result.expirationMonth == expectedMonth)
+        #expect(result.expirationYear == expectedYear)
+    }
+
+    /// `parseCard(lines:)` reads the card number and the expiry when the sample card from PM-37883 is
+    /// scanned with a misread slash in its number, leaving the expiry empty because the card has none.
+    @Test
+    func parseCard_sampleCardWithMisreadSlash_hasNoExpiry() {
+        let result = subject.parseCard(lines: ["5333 6195 0371 5702", "5/33 6195 0371 5702"])
+        #expect(result.cardNumber == "5333619503715702")
+        #expect(result.expirationMonth == nil)
+        #expect(result.expirationYear == nil)
     }
 
     /// `parseCard(lines:)` returns nil for both expiry fields when input contains no expiry date.

--- a/BitwardenShared/Core/Vault/Services/CardTextParserTests.swift
+++ b/BitwardenShared/Core/Vault/Services/CardTextParserTests.swift
@@ -12,8 +12,8 @@ struct CardTextParserTests {
 
     let subject: DefaultCardTextParser
 
-    /// A fixed present time, so the plausible expiration year range the parser applies stays stable
-    /// and the fixtures below never rot. Mid-year, so the calendar year is 2025 in every time zone.
+    /// A fixed present time, so the parser's plausible expiration year range stays stable. Mid-year,
+    /// so the calendar year is 2025 in every time zone.
     let timeProvider = MockTimeProvider(.mockTime(Date(timeIntervalSince1970: 1_751_328_000)))
 
     // MARK: Setup
@@ -82,8 +82,7 @@ struct CardTextParserTests {
     }
 
     /// `parseCard(lines:)` does not read an expiry off a line carrying a card number's worth of
-    /// digits. OCR reading a digit or a group separator as `/` leaves a card number looking exactly
-    /// like a date, which is how a card with no printed expiry ends up with one.
+    /// digits, since OCR reading a digit or separator as `/` makes a card number look like a date.
     @Test(arguments: [
         ["5/33 6195 0371 5702"],
         ["5333 6/95 0371 5702"],
@@ -119,8 +118,8 @@ struct CardTextParserTests {
         #expect(result.expirationYear == expectedYear)
     }
 
-    /// `parseCard(lines:)` reads the card number and the expiry when the sample card from PM-37883 is
-    /// scanned with a misread slash in its number, leaving the expiry empty because the card has none.
+    /// `parseCard(lines:)` reads the card number from the PM-37883 sample card scanned with a
+    /// misread slash in it, leaving the expiry empty because the card has none.
     @Test
     func parseCard_sampleCardWithMisreadSlash_hasNoExpiry() {
         let result = subject.parseCard(lines: ["5333 6195 0371 5702", "5/33 6195 0371 5702"])

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerView.swift
@@ -28,9 +28,8 @@ struct CardScannerWrapperView: View {
     /// resets on each `.onAppear`. Foreground-triggered restarts do not count against this budget.
     @SwiftUI.State private var scannerRetryCount = 0
 
-    /// The scanner's laid-out size, measured by a background `GeometryReader`. Passed down so that a
-    /// size change — a rotation, most importantly — re-invokes `updateUIViewController` and the
-    /// region of interest is re-derived instead of going stale.
+    /// The scanner's laid-out size, measured by a background `GeometryReader`. Passed down so that
+    /// a size change, a rotation most importantly, re-derives the region of interest.
     @SwiftUI.State private var scannerViewSize: CGSize = .zero
 
     /// Dismisses the sheet when the scanner gives up after exhausting retries.
@@ -52,8 +51,8 @@ struct CardScannerWrapperView: View {
                     onScannerUnavailable: restartScanning,
                 )
                 .background {
-                    // Measures the scanner itself, before the padding below is applied. A background
-                    // is used rather than wrapping the scanner so that measuring cannot affect layout.
+                    // A background measures the scanner before the padding below is applied,
+                    // without affecting layout.
                     GeometryReader { proxy in
                         Color.clear
                             .onAppear { scannerViewSize = proxy.size }
@@ -124,9 +123,8 @@ struct CardScannerWrapperView: View {
 ///
 /// - `isScanning` drives `startScanning()`/`stopScanning()` via `updateUIViewController`,
 ///   toggled by the wrapper's `.onAppear`/`.onDisappear`.
-/// - `viewSize` drives the scanner's region of interest, so that it is re-derived whenever the view
-///   is resized rather than only when scanning starts. Scanning also waits on it, so that no frame is
-///   ever recognized before the region is in place.
+/// - `viewSize` drives the region of interest, re-deriving it whenever the view is resized. Scanning
+///   waits on it, so no frame is recognized before the region is in place.
 ///
 @available(iOS 16.0, *)
 struct CardScannerView: UIViewControllerRepresentable {
@@ -142,9 +140,8 @@ struct CardScannerView: UIViewControllerRepresentable {
     /// When `true`, scanning is active; when `false`, scanning is stopped.
     @Binding var isScanning: Bool
 
-    /// The scanner's laid-out size, supplied by the wrapper. The region of interest is derived from
-    /// this rather than read from the view controller, because SwiftUI has finished laying out by the
-    /// time it changes, whereas the view controller's own bounds may not have been updated yet.
+    /// The scanner's laid-out size, supplied by the wrapper. Used to derive the region of interest,
+    /// since the view controller's own bounds may not have been updated yet.
     let viewSize: CGSize
 
     /// Called when `startScanning()` throws or the scanner becomes unavailable at runtime
@@ -162,20 +159,15 @@ struct CardScannerView: UIViewControllerRepresentable {
 
     /// Returns the region of the scanner's view that text should be recognized within.
     ///
-    /// `DataScannerViewController` recognizes text across its whole view by default, which means a
-    /// card scanned from a screen also picks up any other text on that screen — a date in a calendar
-    /// or a spreadsheet is read as the card's expiration date just as readily as one printed on the
-    /// card. Restricting recognition to a card-shaped region centered in the view keeps text above
-    /// and below the card out of the scan.
-    ///
-    /// The region spans most of the view's width, since that is how a card is held, and takes its
-    /// height from the card's own aspect ratio rather than a proportion of the view — the view's
-    /// height varies by device and by how the sheet is laid out, whereas a card's shape does not.
-    /// The height is clamped to the view so that a short view still yields a valid region.
+    /// `DataScannerViewController` recognizes text across its whole view by default, so a card
+    /// scanned from a screen also picks up unrelated text, such as a date in a calendar. A
+    /// card-shaped region centered in the view keeps that text out of the scan. It spans most of the
+    /// view's width, takes its height from the card's aspect ratio, and clamps that height to the
+    /// view so a short view still yields a valid region.
     ///
     /// - Parameter bounds: The bounds of the scanner's view.
-    /// - Returns: The region to recognize text within, or `nil` to recognize text across the whole
-    ///     view when `bounds` is empty and no meaningful region can be derived.
+    /// - Returns: The region to recognize text within, or `nil` when `bounds` is empty and text
+    ///     should be recognized across the whole view.
     ///
     static func regionOfInterest(in bounds: CGRect) -> CGRect? {
         guard !bounds.isEmpty else { return nil }
@@ -227,10 +219,8 @@ struct CardScannerView: UIViewControllerRepresentable {
             uiViewController.regionOfInterest = region
         }
 
-        // Scanning waits until a region has been derived. Starting before then would recognize text
-        // across the whole view for the first frames — precisely what the region exists to prevent.
-        // The wrapper's `GeometryReader` reports a size as soon as the scanner is laid out, which
-        // re-invokes this method, so the wait lasts a single layout pass.
+        // Wait for a region before scanning, otherwise the first frames recognize text across the
+        // whole view. The wrapper reports a size once laid out, so the wait is a single layout pass.
         guard isScanning, region != nil else {
             uiViewController.stopScanning()
             return

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerView.swift
@@ -1,3 +1,4 @@
+import BitwardenKit
 import BitwardenResources
 import SwiftUI
 import UIKit
@@ -27,6 +28,11 @@ struct CardScannerWrapperView: View {
     /// resets on each `.onAppear`. Foreground-triggered restarts do not count against this budget.
     @SwiftUI.State private var scannerRetryCount = 0
 
+    /// The scanner's laid-out size, measured by a background `GeometryReader`. Passed down so that a
+    /// size change — a rotation, most importantly — re-invokes `updateUIViewController` and the
+    /// region of interest is re-derived instead of going stale.
+    @SwiftUI.State private var scannerViewSize: CGSize = .zero
+
     /// Dismisses the sheet when the scanner gives up after exhausting retries.
     @Environment(\.dismiss) private var dismiss
 
@@ -42,8 +48,18 @@ struct CardScannerWrapperView: View {
                     scanner: scanner,
                     onLinesUpdated: onLinesUpdated,
                     isScanning: $isScanning,
+                    viewSize: scannerViewSize,
                     onScannerUnavailable: restartScanning,
                 )
+                .background {
+                    // Measures the scanner itself, before the padding below is applied. A background
+                    // is used rather than wrapping the scanner so that measuring cannot affect layout.
+                    GeometryReader { proxy in
+                        Color.clear
+                            .onAppear { scannerViewSize = proxy.size }
+                            .onChange(of: proxy.size) { scannerViewSize = $0 }
+                    }
+                }
                 .padding(.horizontal, 12)
                 .padding(.top, 12)
                 .padding(.bottom, 35)
@@ -108,6 +124,9 @@ struct CardScannerWrapperView: View {
 ///
 /// - `isScanning` drives `startScanning()`/`stopScanning()` via `updateUIViewController`,
 ///   toggled by the wrapper's `.onAppear`/`.onDisappear`.
+/// - `viewSize` drives the scanner's region of interest, so that it is re-derived whenever the view
+///   is resized rather than only when scanning starts. Scanning also waits on it, so that no frame is
+///   ever recognized before the region is in place.
 ///
 @available(iOS 16.0, *)
 struct CardScannerView: UIViewControllerRepresentable {
@@ -123,6 +142,11 @@ struct CardScannerView: UIViewControllerRepresentable {
     /// When `true`, scanning is active; when `false`, scanning is stopped.
     @Binding var isScanning: Bool
 
+    /// The scanner's laid-out size, supplied by the wrapper. The region of interest is derived from
+    /// this rather than read from the view controller, because SwiftUI has finished laying out by the
+    /// time it changes, whereas the view controller's own bounds may not have been updated yet.
+    let viewSize: CGSize
+
     /// Called when `startScanning()` throws or the scanner becomes unavailable at runtime
     /// (e.g. camera interrupted). The wrapper uses this to schedule a stop-then-restart cycle.
     var onScannerUnavailable: (() -> Void)?
@@ -134,6 +158,38 @@ struct CardScannerView: UIViewControllerRepresentable {
     static func dismantleUIViewController(_ uiViewController: DataScannerViewController, coordinator: Coordinator) {
         uiViewController.stopScanning()
         uiViewController.delegate = nil
+    }
+
+    /// Returns the region of the scanner's view that text should be recognized within.
+    ///
+    /// `DataScannerViewController` recognizes text across its whole view by default, which means a
+    /// card scanned from a screen also picks up any other text on that screen — a date in a calendar
+    /// or a spreadsheet is read as the card's expiration date just as readily as one printed on the
+    /// card. Restricting recognition to a card-shaped region centered in the view keeps text above
+    /// and below the card out of the scan.
+    ///
+    /// The region spans most of the view's width, since that is how a card is held, and takes its
+    /// height from the card's own aspect ratio rather than a proportion of the view — the view's
+    /// height varies by device and by how the sheet is laid out, whereas a card's shape does not.
+    /// The height is clamped to the view so that a short view still yields a valid region.
+    ///
+    /// - Parameter bounds: The bounds of the scanner's view.
+    /// - Returns: The region to recognize text within, or `nil` to recognize text across the whole
+    ///     view when `bounds` is empty and no meaningful region can be derived.
+    ///
+    static func regionOfInterest(in bounds: CGRect) -> CGRect? {
+        guard !bounds.isEmpty else { return nil }
+        let width = bounds.width * Constants.cardScanRegionWidthProportion
+        let height = min(
+            (width / Constants.cardAspectRatio) * Constants.cardScanRegionHeightTolerance,
+            bounds.height,
+        )
+        return CGRect(
+            x: bounds.midX - width / 2,
+            y: bounds.midY - height / 2,
+            width: width,
+            height: height,
+        )
     }
 
     // MARK: Factory
@@ -165,14 +221,25 @@ struct CardScannerView: UIViewControllerRepresentable {
     }
 
     func updateUIViewController(_ uiViewController: DataScannerViewController, context: Context) {
-        if isScanning {
-            do {
-                try uiViewController.startScanning()
-            } catch {
-                DispatchQueue.main.async { context.coordinator.onScannerUnavailable?() }
-            }
-        } else {
+        // Assigning reconfigures a running scanner, so only assign when the region has changed.
+        let region = Self.regionOfInterest(in: CGRect(origin: .zero, size: viewSize))
+        if uiViewController.regionOfInterest != region {
+            uiViewController.regionOfInterest = region
+        }
+
+        // Scanning waits until a region has been derived. Starting before then would recognize text
+        // across the whole view for the first frames — precisely what the region exists to prevent.
+        // The wrapper's `GeometryReader` reports a size as soon as the scanner is laid out, which
+        // re-invokes this method, so the wait lasts a single layout pass.
+        guard isScanning, region != nil else {
             uiViewController.stopScanning()
+            return
+        }
+
+        do {
+            try uiViewController.startScanning()
+        } catch {
+            DispatchQueue.main.async { context.coordinator.onScannerUnavailable?() }
         }
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerViewTests.swift
@@ -8,9 +8,8 @@ import XCTest
 /// Tests for `CardScannerView` and its `Coordinator`.
 ///
 /// `CardScannerWrapperView`'s retry/foreground-resume logic and its `GeometryReader` size measurement
-/// are driven by SwiftUI `@State` and cannot be meaningfully exercised without a live view host, so
-/// they are not covered here. Neither is `updateUIViewController` applying the region of interest,
-/// which needs a representable `Context` that cannot be constructed in a test.
+/// need a live view host, so they are not covered here. Neither is `updateUIViewController`, which
+/// needs a representable `Context` that a test cannot construct.
 ///
 @available(iOS 16.0, *)
 class CardScannerViewTests: BitwardenTestCase {
@@ -70,8 +69,7 @@ class CardScannerViewTests: BitwardenTestCase {
     }
 
     /// `regionOfInterest(in:)` centers the region on the bounds it is given rather than assuming an
-    /// origin of zero. The only production caller passes a zero origin, so this covers the general
-    /// contract of the function rather than a path the app exercises today.
+    /// origin of zero.
     @MainActor
     func test_regionOfInterest_nonZeroOrigin_centersOnBounds() throws {
         let region = try XCTUnwrap(CardScannerView.regionOfInterest(in: CGRect(x: 20, y: 50, width: 400, height: 800)))
@@ -82,8 +80,8 @@ class CardScannerViewTests: BitwardenTestCase {
         XCTAssertEqual(region.height, 314.799, accuracy: 0.001)
     }
 
-    /// `regionOfInterest(in:)` clamps the region's height to the bounds, so that a view too short to
-    /// contain a card-shaped region still yields a region that fits inside it.
+    /// `regionOfInterest(in:)` clamps the region's height to bounds too short to contain a
+    /// card-shaped region.
     @MainActor
     func test_regionOfInterest_boundsShorterThanCard_clampsHeight() throws {
         let region = try XCTUnwrap(CardScannerView.regionOfInterest(in: CGRect(x: 0, y: 0, width: 400, height: 200)))
@@ -94,8 +92,8 @@ class CardScannerViewTests: BitwardenTestCase {
         XCTAssertEqual(region.height, 200, accuracy: 0.001)
     }
 
-    /// `regionOfInterest(in:)` returns `nil` for empty bounds, so that text is recognized across the
-    /// whole view rather than within a degenerate region while the view is still being laid out.
+    /// `regionOfInterest(in:)` returns `nil` for empty bounds, so no region is applied while the
+    /// view is still being laid out.
     @MainActor
     func test_regionOfInterest_emptyBounds_returnsNil() {
         XCTAssertNil(CardScannerView.regionOfInterest(in: .zero))

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerViewTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardScannerViewTests.swift
@@ -5,10 +5,12 @@ import XCTest
 
 // MARK: - CardScannerViewTests
 
-/// Tests for `CardScannerView.Coordinator`.
+/// Tests for `CardScannerView` and its `Coordinator`.
 ///
-/// `CardScannerWrapperView`'s retry/foreground-resume logic is driven by SwiftUI `@State` and cannot
-/// be meaningfully exercised without a live view host, so it is not covered here.
+/// `CardScannerWrapperView`'s retry/foreground-resume logic and its `GeometryReader` size measurement
+/// are driven by SwiftUI `@State` and cannot be meaningfully exercised without a live view host, so
+/// they are not covered here. Neither is `updateUIViewController` applying the region of interest,
+/// which needs a representable `Context` that cannot be constructed in a test.
 ///
 @available(iOS 16.0, *)
 class CardScannerViewTests: BitwardenTestCase {
@@ -53,5 +55,51 @@ class CardScannerViewTests: BitwardenTestCase {
         )
 
         subject.dataScanner(CardScannerView.makeScanner(), becameUnavailableWithError: .unsupported)
+    }
+
+    /// `regionOfInterest(in:)` returns a card-shaped region centered in the bounds, spanning 96% of
+    /// their width with a height derived from the card's aspect ratio.
+    @MainActor
+    func test_regionOfInterest_centersCardShapedRegionWithinBounds() throws {
+        let region = try XCTUnwrap(CardScannerView.regionOfInterest(in: CGRect(x: 0, y: 0, width: 400, height: 800)))
+
+        XCTAssertEqual(region.minX, 8, accuracy: 0.001)
+        XCTAssertEqual(region.minY, 242.6, accuracy: 0.001)
+        XCTAssertEqual(region.width, 384, accuracy: 0.001)
+        XCTAssertEqual(region.height, 314.799, accuracy: 0.001)
+    }
+
+    /// `regionOfInterest(in:)` centers the region on the bounds it is given rather than assuming an
+    /// origin of zero. The only production caller passes a zero origin, so this covers the general
+    /// contract of the function rather than a path the app exercises today.
+    @MainActor
+    func test_regionOfInterest_nonZeroOrigin_centersOnBounds() throws {
+        let region = try XCTUnwrap(CardScannerView.regionOfInterest(in: CGRect(x: 20, y: 50, width: 400, height: 800)))
+
+        XCTAssertEqual(region.minX, 28, accuracy: 0.001)
+        XCTAssertEqual(region.minY, 292.6, accuracy: 0.001)
+        XCTAssertEqual(region.width, 384, accuracy: 0.001)
+        XCTAssertEqual(region.height, 314.799, accuracy: 0.001)
+    }
+
+    /// `regionOfInterest(in:)` clamps the region's height to the bounds, so that a view too short to
+    /// contain a card-shaped region still yields a region that fits inside it.
+    @MainActor
+    func test_regionOfInterest_boundsShorterThanCard_clampsHeight() throws {
+        let region = try XCTUnwrap(CardScannerView.regionOfInterest(in: CGRect(x: 0, y: 0, width: 400, height: 200)))
+
+        XCTAssertEqual(region.minX, 8, accuracy: 0.001)
+        XCTAssertEqual(region.minY, 0, accuracy: 0.001)
+        XCTAssertEqual(region.width, 384, accuracy: 0.001)
+        XCTAssertEqual(region.height, 200, accuracy: 0.001)
+    }
+
+    /// `regionOfInterest(in:)` returns `nil` for empty bounds, so that text is recognized across the
+    /// whole view rather than within a degenerate region while the view is still being laid out.
+    @MainActor
+    func test_regionOfInterest_emptyBounds_returnsNil() {
+        XCTAssertNil(CardScannerView.regionOfInterest(in: .zero))
+        XCTAssertNil(CardScannerView.regionOfInterest(in: CGRect(x: 0, y: 0, width: 400, height: 0)))
+        XCTAssertNil(CardScannerView.regionOfInterest(in: CGRect(x: 0, y: 0, width: 0, height: 800)))
     }
 }

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -299,9 +299,8 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     // MARK: Private Methods
 
     /// Applies a parsed card scan result to the item state, dismissing the scanner on success.
-    /// Only applies if a card number was detected; the expiration month and year are each applied
-    /// only when the scan found them, so a card with no printed expiration date leaves those fields
-    /// empty rather than filled with a value the scan never actually read.
+    /// Requires a card number; the expiration month and year are applied only when the scan found
+    /// them, so a card with no printed expiration date leaves those fields empty.
     ///
     /// - Parameters:
     ///   - state: The item state to update.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -299,23 +299,20 @@ final class AddEditItemProcessor: StateProcessor<// swiftlint:disable:this type_
     // MARK: Private Methods
 
     /// Applies a parsed card scan result to the item state, dismissing the scanner on success.
-    /// Only applies if both a card number and expiration month were detected.
+    /// Only applies if a card number was detected; the expiration month and year are each applied
+    /// only when the scan found them, so a card with no printed expiration date leaves those fields
+    /// empty rather than filled with a value the scan never actually read.
     ///
     /// - Parameters:
     ///   - state: The item state to update.
     ///   - data: The parsed card data returned by the card text parser.
     private func applyCardScanResult(_ state: inout AddEditItemState, data: ScannedCardData) {
-        guard data.cardNumber != nil,
-              data.expirationMonth != nil else {
-            return
-        }
+        guard let number = data.cardNumber else { return }
 
         state.cardItemState.isCardScannerPresented = false
         state.cardItemState.shouldFocusCardholderNameAfterScan = true
-        if let number = data.cardNumber {
-            state.cardItemState.cardNumber = number
-            state.cardItemState.brand = .custom(CardComponent.Brand.detect(from: number))
-        }
+        state.cardItemState.cardNumber = number
+        state.cardItemState.brand = .custom(CardComponent.Brand.detect(from: number))
         if let month = data.expirationMonth,
            let cardMonth = CardComponent.Month(rawValue: month) {
             state.cardItemState.expirationMonth = .custom(cardMonth)

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -2323,9 +2323,8 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.cardItemState.brand, .custom(.visa))
     }
 
-    /// `receive(_:)` with `.cardFieldChanged(.cardScannerLinesUpdated)` for a card that has no
-    /// printed expiration date dismisses the scanner and populates the card number and brand, while
-    /// leaving the expiration fields empty rather than filling them with a date the scan never read.
+    /// `receive(_:)` with `.cardFieldChanged(.cardScannerLinesUpdated)` for a card with no printed
+    /// expiration date populates the card number and brand, leaving the expiration fields empty.
     @MainActor
     func test_receive_cardFieldChanged_cardScannerLinesUpdated_noExpiration() {
         cardTextParser.parseCardReturnValue = .fixture(

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -2286,11 +2286,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     /// dismisses the scanner and populates card state.
     @MainActor
     func test_receive_cardFieldChanged_cardScannerLinesUpdated_sufficientData() {
-        cardTextParser.parseCardReturnValue = ScannedCardData(
-            cardNumber: "4111111111111111",
-            expirationMonth: 12,
-            expirationYear: "2028",
-        )
+        cardTextParser.parseCardReturnValue = .fixture()
         subject.state.cardItemState.isCardScannerPresented = true
 
         subject.receive(.cardFieldChanged(.cardScannerLinesUpdated(["4111111111111111", "JANE DOE", "12/28"])))
@@ -2306,11 +2302,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     /// leaves the scanner open and does not update card state.
     @MainActor
     func test_receive_cardFieldChanged_cardScannerLinesUpdated_insufficientData() {
-        cardTextParser.parseCardReturnValue = ScannedCardData(
-            cardNumber: nil,
-            expirationMonth: 12,
-            expirationYear: "2028",
-        )
+        cardTextParser.parseCardReturnValue = .fixture(cardNumber: nil)
         subject.state.cardItemState.isCardScannerPresented = true
 
         subject.receive(.cardFieldChanged(.cardScannerLinesUpdated(["JANE DOE", "12/28"])))
@@ -2323,16 +2315,48 @@ class AddEditItemProcessorTests: BitwardenTestCase {
     /// inferred from the detected card number.
     @MainActor
     func test_receive_cardFieldChanged_cardScannerLinesUpdated_setsCardBrand() {
-        cardTextParser.parseCardReturnValue = ScannedCardData(
-            cardNumber: "4111111111111111",
-            expirationMonth: 12,
-            expirationYear: "2028",
-        )
+        cardTextParser.parseCardReturnValue = .fixture()
         subject.state.cardItemState.isCardScannerPresented = true
 
         subject.receive(.cardFieldChanged(.cardScannerLinesUpdated(["4111111111111111", "JANE DOE", "12/28"])))
 
         XCTAssertEqual(subject.state.cardItemState.brand, .custom(.visa))
+    }
+
+    /// `receive(_:)` with `.cardFieldChanged(.cardScannerLinesUpdated)` for a card that has no
+    /// printed expiration date dismisses the scanner and populates the card number and brand, while
+    /// leaving the expiration fields empty rather than filling them with a date the scan never read.
+    @MainActor
+    func test_receive_cardFieldChanged_cardScannerLinesUpdated_noExpiration() {
+        cardTextParser.parseCardReturnValue = .fixture(
+            cardNumber: "5333619503715702",
+            expirationMonth: nil,
+            expirationYear: nil,
+        )
+        subject.state.cardItemState.isCardScannerPresented = true
+
+        subject.receive(.cardFieldChanged(.cardScannerLinesUpdated(["5333 6195 0371 5702"])))
+
+        XCTAssertFalse(subject.state.cardItemState.isCardScannerPresented)
+        XCTAssertTrue(subject.state.cardItemState.shouldFocusCardholderNameAfterScan)
+        XCTAssertEqual(subject.state.cardItemState.cardNumber, "5333619503715702")
+        XCTAssertEqual(subject.state.cardItemState.brand, .custom(.mastercard))
+        XCTAssertEqual(subject.state.cardItemState.expirationMonth, .default)
+        XCTAssertEqual(subject.state.cardItemState.expirationYear, "")
+    }
+
+    /// `receive(_:)` with `.cardFieldChanged(.cardScannerLinesUpdated)` applies an expiration year
+    /// that was detected without a month, leaving the month unset.
+    @MainActor
+    func test_receive_cardFieldChanged_cardScannerLinesUpdated_expirationYearWithoutMonth() {
+        cardTextParser.parseCardReturnValue = .fixture(expirationMonth: nil, expirationYear: "2028")
+        subject.state.cardItemState.isCardScannerPresented = true
+
+        subject.receive(.cardFieldChanged(.cardScannerLinesUpdated(["4111111111111111", "2028"])))
+
+        XCTAssertFalse(subject.state.cardItemState.isCardScannerPresented)
+        XCTAssertEqual(subject.state.cardItemState.expirationMonth, .default)
+        XCTAssertEqual(subject.state.cardItemState.expirationYear, "2028")
     }
 
     /// `receive(_:)` with `.cardFieldChanged(.cardScannerDismissed)` hides the card scanner and


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-37883

## 📔 Objective

- Scanning a card with no expiry printed on it was filling in a made-up date — 05/2035, 03/2035, 07/2028 depending on the card. Turned out there were two separate causes.
- The camera was reading text from anywhere in the frame, so a date sitting behind the card or elsewhere on the screen got picked up. It now only reads inside a card-shaped box in the middle of the frame, sized from real card dimensions (85.60 × 53.98 mm, ISO/IEC 7810) and recalculated on rotation. Scanning waits for that box before reading a single frame.
- The card's own number could produce a date too. OCR reads a digit or a space as `/` often enough that `5333 6195 0371 5702` comes through as `5/33 6195 0371 5702`, which looks exactly like May 2033. The parser now skips any line carrying a card number's worth of digits — an expiry has four to six, a card number has at least 13.
- Expiry years well outside a sensible range are rejected as well, and `03/999` no longer slips through with "999" as the year.
- A scan that genuinely can't find an expiry now leaves those fields blank, instead of refusing to finish until it finds one.

