### PR TITLE
[PM-32848] feat: Split master password authentication/unlock data in password requests

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/SetPasswordRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/SetPasswordRequestModel.swift
@@ -7,61 +7,18 @@ import Networking
 struct SetPasswordRequestModel: JSONRequestBody {
     // MARK: Properties
 
-    /// The type of KDF for this request.
-    let kdf: KdfType?
-
-    /// The number of KDF iterations performed in this request.
-    let kdfIterations: Int?
-
-    /// The KDF memory allocated for the computed password hash.
-    let kdfMemory: Int?
-
-    /// The number of threads upon which the KDF iterations are performed.
-    let kdfParallelism: Int?
-
-    /// The encrypted user key.
-    let key: String
-
     /// The user's encryption keys.
     let keys: KeysRequestModel?
 
-    /// The master password hash used to authenticate a user.
-    let masterPasswordHash: String
+    /// The user's master password authentication data.
+    let masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel
 
     /// The master password hint.
     let masterPasswordHint: String?
 
+    /// The user's master password unlock data.
+    let masterPasswordUnlock: MasterPasswordUnlockDataRequestModel
+
     /// The organization's identifier.
     let orgIdentifier: String
-
-    // MARK: Initialization
-
-    /// Initialize a `SetPasswordRequestModel`.
-    ///
-    /// - Parameters:
-    ///   - kdfConfig: The KDF configuration options.
-    ///   - key: The encrypted user key.
-    ///   - keys: The user's encryption keys.
-    ///   - masterPasswordHash: The master password hash used to authenticate a user.
-    ///   - masterPasswordHint: The master password hint.
-    ///   - orgIdentifier: The organization's identifier.
-    ///
-    init(
-        kdfConfig: KdfConfig,
-        key: String,
-        keys: KeysRequestModel?,
-        masterPasswordHash: String,
-        masterPasswordHint: String?,
-        orgIdentifier: String,
-    ) {
-        kdf = kdfConfig.kdf
-        kdfIterations = kdfConfig.kdfIterations
-        kdfMemory = kdfConfig.kdfMemory
-        kdfParallelism = kdfConfig.kdfParallelism
-        self.key = key
-        self.keys = keys
-        self.masterPasswordHash = masterPasswordHash
-        self.masterPasswordHint = masterPasswordHint
-        self.orgIdentifier = orgIdentifier
-    }
 }

--- a/BitwardenShared/Core/Auth/Models/Request/UpdatePasswordRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/UpdatePasswordRequestModel.swift
@@ -7,8 +7,8 @@ import Networking
 struct UpdatePasswordRequestModel: JSONRequestBody {
     // MARK: Properties
 
-    /// The user's key.
-    let key: String
+    /// The new password's authentication data.
+    let authenticationData: MasterPasswordAuthenticationDataRequestModel
 
     /// The hash of the user's current master password.
     let masterPasswordHash: String?
@@ -16,6 +16,6 @@ struct UpdatePasswordRequestModel: JSONRequestBody {
     /// The master password hint.
     let masterPasswordHint: String
 
-    /// The hash of the new master password.
-    let newMasterPasswordHash: String
+    /// The new password's unlock data.
+    let unlockData: MasterPasswordUnlockDataRequestModel
 }

--- a/BitwardenShared/Core/Auth/Models/Request/UpdateTempPasswordRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/UpdateTempPasswordRequestModel.swift
@@ -7,12 +7,12 @@ import Networking
 struct UpdateTempPasswordRequestModel: JSONRequestBody {
     // MARK: Properties
 
-    /// The user's key.
-    let key: String
+    /// The new password's authentication data.
+    let authenticationData: MasterPasswordAuthenticationDataRequestModel
 
     /// The master password hint.
     let masterPasswordHint: String
 
-    /// The hash of the new master password.
-    let newMasterPasswordHash: String
+    /// The new password's unlock data.
+    let unlockData: MasterPasswordUnlockDataRequestModel
 }

--- a/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
+++ b/BitwardenShared/Core/Auth/Repositories/AuthRepository.swift
@@ -996,11 +996,18 @@ extension DefaultAuthRepository: AuthRepository {
         }
 
         let requestModel = SetPasswordRequestModel(
-            kdfConfig: kdf,
-            key: requestUserKey,
             keys: requestKeys,
-            masterPasswordHash: requestPasswordHash,
+            masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                kdf: kdf,
+                masterPasswordAuthenticationHash: requestPasswordHash,
+                salt: email,
+            ),
             masterPasswordHint: masterPasswordHint,
+            masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                kdf: kdf,
+                masterKeyWrappedUserKey: requestUserKey,
+                salt: email,
+            ),
             orgIdentifier: organizationIdentifier,
         )
 
@@ -1340,22 +1347,33 @@ extension DefaultAuthRepository: AuthRepository {
             purpose: .serverAuthorization,
         )
 
+        let authenticationData = MasterPasswordAuthenticationDataRequestModel(
+            kdf: account.kdf,
+            masterPasswordAuthenticationHash: updatePasswordResponse.passwordHash,
+            salt: account.profile.email,
+        )
+        let unlockData = MasterPasswordUnlockDataRequestModel(
+            kdf: account.kdf,
+            masterKeyWrappedUserKey: updatePasswordResponse.newKey,
+            salt: account.profile.email,
+        )
+
         switch reason {
         case .adminForcePasswordReset:
             try await accountAPIService.updateTempPassword(
                 UpdateTempPasswordRequestModel(
-                    key: updatePasswordResponse.newKey,
+                    authenticationData: authenticationData,
                     masterPasswordHint: passwordHint,
-                    newMasterPasswordHash: updatePasswordResponse.passwordHash,
+                    unlockData: unlockData,
                 ),
             )
         case .weakMasterPasswordOnLogin:
             try await accountAPIService.updatePassword(
                 UpdatePasswordRequestModel(
-                    key: updatePasswordResponse.newKey,
+                    authenticationData: authenticationData,
                     masterPasswordHash: masterPasswordHash,
                     masterPasswordHint: passwordHint,
-                    newMasterPasswordHash: updatePasswordResponse.passwordHash,
+                    unlockData: unlockData,
                 ),
             )
         }

--- a/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
@@ -355,11 +355,18 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
         client.result = .httpSuccess(testData: .emptyResponse)
 
         let requestModel = SetPasswordRequestModel(
-            kdfConfig: KdfConfig(),
-            key: "KEY",
             keys: KeysRequestModel(encryptedPrivateKey: "ENCRYPTED_PRIVATE_KEY", publicKey: "PUBLIC_KEY"),
-            masterPasswordHash: "MASTER_PASSWORD_HASH",
+            masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                kdf: KdfConfig(),
+                masterPasswordAuthenticationHash: "MASTER_PASSWORD_HASH",
+                salt: "AUTHENTICATION_SALT",
+            ),
             masterPasswordHint: "MASTER_PASSWORD_HINT",
+            masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                kdf: KdfConfig(),
+                masterKeyWrappedUserKey: "KEY",
+                salt: "UNLOCK_SALT",
+            ),
             orgIdentifier: "ORG_ID",
         )
         try await subject.setPassword(requestModel)
@@ -402,10 +409,18 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
         client.result = .httpSuccess(testData: .emptyResponse)
 
         let requestModel = UpdatePasswordRequestModel(
-            key: "KEY",
+            authenticationData: MasterPasswordAuthenticationDataRequestModel(
+                kdf: KdfConfig(),
+                masterPasswordAuthenticationHash: "NEW_MASTER_PASSWORD_HASH",
+                salt: "AUTHENTICATION_SALT",
+            ),
             masterPasswordHash: "MASTER_PASSWORD_HASH",
             masterPasswordHint: "MASTER_PASSWORD_HINT",
-            newMasterPasswordHash: "NEW_MASTER_PASSWORD_HASH",
+            unlockData: MasterPasswordUnlockDataRequestModel(
+                kdf: KdfConfig(),
+                masterKeyWrappedUserKey: "KEY",
+                salt: "UNLOCK_SALT",
+            ),
         )
         try await subject.updatePassword(requestModel)
 
@@ -420,9 +435,17 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
         client.result = .httpSuccess(testData: .emptyResponse)
 
         let requestModel = UpdateTempPasswordRequestModel(
-            key: "KEY",
+            authenticationData: MasterPasswordAuthenticationDataRequestModel(
+                kdf: KdfConfig(),
+                masterPasswordAuthenticationHash: "NEW_MASTER_PASSWORD_HASH",
+                salt: "AUTHENTICATION_SALT",
+            ),
             masterPasswordHint: "MASTER_PASSWORD_HINT",
-            newMasterPasswordHash: "NEW_MASTER_PASSWORD_HASH",
+            unlockData: MasterPasswordUnlockDataRequestModel(
+                kdf: KdfConfig(),
+                masterKeyWrappedUserKey: "KEY",
+                salt: "UNLOCK_SALT",
+            ),
         )
         try await subject.updateTempPassword(requestModel)
 

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/UpdatePasswordRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/UpdatePasswordRequestTests.swift
@@ -15,10 +15,18 @@ class UpdatePasswordRequestTests: BitwardenTestCase {
 
         subject = UpdatePasswordRequest(
             requestModel: UpdatePasswordRequestModel(
-                key: "KEY",
+                authenticationData: MasterPasswordAuthenticationDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterPasswordAuthenticationHash: "NEW_MASTER_PASSWORD_HASH",
+                    salt: "AUTHENTICATION_SALT",
+                ),
                 masterPasswordHash: "MASTER_PASSWORD_HASH",
                 masterPasswordHint: "MASTER_PASSWORD_HINT",
-                newMasterPasswordHash: "NEW_MASTER_PASSWORD_HASH",
+                unlockData: MasterPasswordUnlockDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterKeyWrappedUserKey: "KEY",
+                    salt: "UNLOCK_SALT",
+                ),
             ),
         )
     }
@@ -38,10 +46,24 @@ class UpdatePasswordRequestTests: BitwardenTestCase {
             bodyData.prettyPrintedJson,
             """
             {
-              "key" : "KEY",
+              "authenticationData" : {
+                "kdf" : {
+                  "iterations" : 600000,
+                  "kdfType" : 0
+                },
+                "masterPasswordAuthenticationHash" : "NEW_MASTER_PASSWORD_HASH",
+                "salt" : "AUTHENTICATION_SALT"
+              },
               "masterPasswordHash" : "MASTER_PASSWORD_HASH",
               "masterPasswordHint" : "MASTER_PASSWORD_HINT",
-              "newMasterPasswordHash" : "NEW_MASTER_PASSWORD_HASH"
+              "unlockData" : {
+                "kdf" : {
+                  "iterations" : 600000,
+                  "kdfType" : 0
+                },
+                "masterKeyWrappedUserKey" : "KEY",
+                "salt" : "UNLOCK_SALT"
+              }
             }
             """,
         )

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/UpdateTempPasswordRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/UpdateTempPasswordRequestTests.swift
@@ -14,9 +14,17 @@ class UpdateTempPasswordRequestTests: BitwardenTestCase {
 
         subject = UpdateTempPasswordRequest(
             requestModel: UpdateTempPasswordRequestModel(
-                key: "KEY",
+                authenticationData: MasterPasswordAuthenticationDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterPasswordAuthenticationHash: "NEW_MASTER_PASSWORD_HASH",
+                    salt: "AUTHENTICATION_SALT",
+                ),
                 masterPasswordHint: "MASTER_PASSWORD_HINT",
-                newMasterPasswordHash: "NEW_MASTER_PASSWORD_HASH",
+                unlockData: MasterPasswordUnlockDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterKeyWrappedUserKey: "KEY",
+                    salt: "UNLOCK_SALT",
+                ),
             ),
         )
     }
@@ -36,9 +44,23 @@ class UpdateTempPasswordRequestTests: BitwardenTestCase {
             bodyData.prettyPrintedJson,
             """
             {
-              "key" : "KEY",
+              "authenticationData" : {
+                "kdf" : {
+                  "iterations" : 600000,
+                  "kdfType" : 0
+                },
+                "masterPasswordAuthenticationHash" : "NEW_MASTER_PASSWORD_HASH",
+                "salt" : "AUTHENTICATION_SALT"
+              },
               "masterPasswordHint" : "MASTER_PASSWORD_HINT",
-              "newMasterPasswordHash" : "NEW_MASTER_PASSWORD_HASH"
+              "unlockData" : {
+                "kdf" : {
+                  "iterations" : 600000,
+                  "kdfType" : 0
+                },
+                "masterKeyWrappedUserKey" : "KEY",
+                "salt" : "UNLOCK_SALT"
+              }
             }
             """,
         )


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-32848](https://bitwarden.atlassian.net/browse/PM-32848)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Splits master password authentication and unlock data in password requests and passes master password salt through all set/change/rotation flows.

- Replace legacy `masterPasswordHash`/`key`/`kdf*` fields with `masterPasswordAuthentication` + `masterPasswordUnlock` in `SetPasswordRequestModel` (`/accounts/set-password`)
- Replace legacy `key`/`newMasterPasswordHash` with `authenticationData` + `unlockData` in `UpdatePasswordRequestModel` (`/accounts/password`) and `UpdateTempPasswordRequestModel` (`/accounts/update-temp-password`), preserving `masterPasswordHash` as the current-password auth field on `/accounts/password`
- Update `AuthRepository.setMasterPassword` (TDE + V1-JIT paths) and `AuthRepository.updateMasterPassword` (both reset reasons) to build the new request shapes, using account email as salt per existing codebase convention

[PM-32848]: https://bitwarden.atlassian.net/browse/PM-32848?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ