### PR TITLE
[PM-41957] fix: Remove new folder snackbar from add/edit item flow and trailing period

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -21,7 +21,7 @@
 "EnterPIN" = "Enter your PIN code.";
 "Favorites" = "Favorites";
 "Folder" = "Folder";
-"FolderCreated" = "New folder created.";
+"FolderCreated" = "New folder created";
 "FolderDeleted" = "Folder deleted.";
 "FolderNone" = "No Folder";
 "Folders" = "Folders";

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessor.swift
@@ -1149,8 +1149,9 @@ extension AddEditItemProcessor: GeneratorCoordinatorDelegate {
 
 extension AddEditItemProcessor: AddEditFolderDelegate {
     func folderAdded(_ folderView: FolderView) {
+        // The new folder is selected for the item, so no toast is shown to avoid it covering the
+        // folder field in the add/edit item view.
         state.folder = .custom(folderView)
-        state.toast = Toast(title: Localizations.folderCreated)
     }
 
     func folderDeleted() {

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -619,8 +619,8 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         XCTAssertEqual(subject.state.toast, Toast(title: Localizations.itemUpdated))
     }
 
-    /// `folderAdded(_:)` sets the selected folder to the folder that was added and shows the
-    /// folder created toast.
+    /// `folderAdded(_:)` sets the selected folder to the folder that was added without showing a
+    /// toast.
     @MainActor
     func test_folderAdded() {
         let newFolder = FolderView.fixture(name: "New folder")
@@ -630,7 +630,7 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         subject.folderAdded(newFolder)
 
         XCTAssertEqual(subject.state.folder, .custom(newFolder))
-        XCTAssertEqual(subject.state.toast, Toast(title: Localizations.folderCreated))
+        XCTAssertNil(subject.state.toast)
     }
 
     /// `init(appExtensionDelegate:coordinator:delegate:services:state:)` with adding configuration


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-41957

## 📔 Objective

- New requirement. The "New folder created" snackbar showing up when you add a folder from inside the add/edit item screen. It doesn't belong there since the new folder already gets selected in the folder field, so it's just noise covering the field you were looking at.
- Dropped the trailing period from the snackbar text so it reads like the rest of our snackbars.
