### PR TITLE
[PM-42022] fix: Drivers License accessibility fixes

### DIFF
--- a/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
+++ b/BitwardenKit/UI/Platform/Application/Views/BitwardenTextField.swift
@@ -90,6 +90,11 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
     /// The accessibility identifier for the button to toggle password visibility.
     let passwordVisibilityAccessibilityId: String?
 
+    /// The name of the field to include in the password visibility toggle's accessibility label
+    /// (e.g. "License number"), so VoiceOver announces which field the toggle affects instead of
+    /// the generic "Password" wording. Defaults to `nil`, which falls back to the generic wording.
+    let passwordVisibilityFieldName: String?
+
     // MARK: View
 
     public var body: some View {
@@ -142,9 +147,9 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
                         asset: isPasswordVisible.wrappedValue
                             ? SharedAsset.Icons.eyeSlash24
                             : SharedAsset.Icons.eye24,
-                        accessibilityLabel: isPasswordVisible.wrappedValue
-                            ? Localizations.passwordIsVisibleTapToHide
-                            : Localizations.passwordIsNotVisibleTapToShow,
+                        accessibilityLabel: passwordVisibilityAccessibilityLabel(
+                            isVisible: isPasswordVisible.wrappedValue,
+                        ),
                     ) {
                         isPasswordVisible.wrappedValue.toggle()
                     }
@@ -243,6 +248,8 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
     ///   - footer: The footer text displayed below the text field.
     ///   - accessibilityIdentifier: The accessibility identifier for the text field.
     ///   - passwordVisibilityAccessibilityId: The accessibility ID for the button to toggle password visibility.
+    ///   - passwordVisibilityFieldName: The name of the field to include in the password visibility
+    ///     toggle's accessibility label, or `nil` to use the generic password wording.
     ///   - canViewPassword: Whether the password can be viewed.
     ///   - isPasswordAutoFocused: Whether the password field shows the keyboard initially.
     ///   - isPasswordVisible: Whether the password is visible.
@@ -255,6 +262,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         footer: String? = nil,
         accessibilityIdentifier: String? = nil,
         passwordVisibilityAccessibilityId: String? = nil,
+        passwordVisibilityFieldName: String? = nil,
         canViewPassword: Bool = true,
         isPasswordAutoFocused: Bool = false,
         isPasswordVisible: Binding<Bool>? = nil,
@@ -269,6 +277,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         footerContent = nil
         self.canViewPassword = canViewPassword
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
+        self.passwordVisibilityFieldName = passwordVisibilityFieldName
         _text = text
         _localText = State(initialValue: text.wrappedValue)
         self.title = title
@@ -282,6 +291,8 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
     ///   - text: The text entered into the text field.
     ///   - accessibilityIdentifier: The accessibility identifier for the text field.
     ///   - passwordVisibilityAccessibilityId: The accessibility ID for the button to toggle password visibility.
+    ///   - passwordVisibilityFieldName: The name of the field to include in the password visibility
+    ///     toggle's accessibility label, or `nil` to use the generic password wording.
     ///   - canViewPassword: Whether the password can be viewed.
     ///   - isPasswordAutoFocused: Whether the password field shows the keyboard initially.
     ///   - isPasswordVisible: Whether the password is visible.
@@ -294,6 +305,7 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         text: Binding<String>,
         accessibilityIdentifier: String? = nil,
         passwordVisibilityAccessibilityId: String? = nil,
+        passwordVisibilityFieldName: String? = nil,
         canViewPassword: Bool = true,
         isPasswordAutoFocused: Bool = false,
         isPasswordVisible: Binding<Bool>? = nil,
@@ -309,10 +321,28 @@ public struct BitwardenTextField<FooterContent: View, TrailingContent: View>: Vi
         self.footerContent = footerContent()
         self.canViewPassword = canViewPassword
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
+        self.passwordVisibilityFieldName = passwordVisibilityFieldName
         _text = text
         _localText = State(initialValue: text.wrappedValue)
         self.title = title
         self.trailingContent = trailingContent()
+    }
+
+    /// The accessibility label for the password visibility toggle button, announcing the
+    /// specific field name if one was provided, or falling back to generic password wording.
+    ///
+    /// - Parameter isVisible: Whether the password is currently visible.
+    /// - Returns: The accessibility label to use for the toggle button.
+    ///
+    private func passwordVisibilityAccessibilityLabel(isVisible: Bool) -> String {
+        guard let passwordVisibilityFieldName else {
+            return isVisible
+                ? Localizations.passwordIsVisibleTapToHide
+                : Localizations.passwordIsNotVisibleTapToShow
+        }
+        return isVisible
+            ? Localizations.fieldValueIsVisibleTapToHide(passwordVisibilityFieldName)
+            : Localizations.fieldValueIsNotVisibleTapToShow(passwordVisibilityFieldName)
     }
 }
 
@@ -325,6 +355,8 @@ public extension BitwardenTextField where TrailingContent == EmptyView {
     ///   - text: The text entered into the text field.
     ///   - accessibilityIdentifier: The accessibility identifier for the text field.
     ///   - passwordVisibilityAccessibilityId: The accessibility ID for the button to toggle password visibility.
+    ///   - passwordVisibilityFieldName: The name of the field to include in the password visibility
+    ///     toggle's accessibility label, or `nil` to use the generic password wording.
     ///   - canViewPassword: Whether the password can be viewed.
     ///   - isPasswordAutoFocused: Whether the password field shows the keyboard initially.
     ///   - isPasswordVisible: Whether the password is visible.
@@ -337,6 +369,7 @@ public extension BitwardenTextField where TrailingContent == EmptyView {
         text: Binding<String>,
         accessibilityIdentifier: String? = nil,
         passwordVisibilityAccessibilityId: String? = nil,
+        passwordVisibilityFieldName: String? = nil,
         canViewPassword: Bool = true,
         isPasswordAutoFocused: Bool = false,
         isPasswordVisible: Binding<Bool>? = nil,
@@ -351,6 +384,7 @@ public extension BitwardenTextField where TrailingContent == EmptyView {
         self.isPasswordVisible = isPasswordVisible
         self.isTextFieldDisabled = isTextFieldDisabled
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
+        self.passwordVisibilityFieldName = passwordVisibilityFieldName
         _text = text
         _localText = State(initialValue: text.wrappedValue)
         self.title = title
@@ -367,6 +401,8 @@ public extension BitwardenTextField where FooterContent == EmptyView, TrailingCo
     ///   - text: The text entered into the text field.
     ///   - accessibilityIdentifier: The accessibility identifier for the text field.
     ///   - passwordVisibilityAccessibilityId: The accessibility ID for the button to toggle password visibility.
+    ///   - passwordVisibilityFieldName: The name of the field to include in the password visibility
+    ///     toggle's accessibility label, or `nil` to use the generic password wording.
     ///   - canViewPassword: Whether the password can be viewed.
     ///   - isPasswordAutoFocused: Whether the password field shows the keyboard initially.
     ///   - isPasswordVisible: Whether the password is visible.
@@ -378,6 +414,7 @@ public extension BitwardenTextField where FooterContent == EmptyView, TrailingCo
         footer: String? = nil,
         accessibilityIdentifier: String? = nil,
         passwordVisibilityAccessibilityId: String? = nil,
+        passwordVisibilityFieldName: String? = nil,
         canViewPassword: Bool = true,
         isPasswordAutoFocused: Bool = false,
         isPasswordVisible: Binding<Bool>? = nil,
@@ -391,6 +428,7 @@ public extension BitwardenTextField where FooterContent == EmptyView, TrailingCo
         self.isPasswordVisible = isPasswordVisible
         self.isTextFieldDisabled = isTextFieldDisabled
         self.passwordVisibilityAccessibilityId = passwordVisibilityAccessibilityId
+        self.passwordVisibilityFieldName = passwordVisibilityFieldName
         _text = text
         _localText = State(initialValue: text.wrappedValue)
         self.title = title

--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -497,6 +497,8 @@
 "SpecialCharacters" = "Special characters (!@#$%^&*)";
 "PasswordIsVisibleTapToHide" = "Password is visible, tap to hide.";
 "PasswordIsNotVisibleTapToShow" = "Password is not visible, tap to show.";
+"FieldValueIsVisibleTapToHide" = "%1$@ is visible, tap to hide.";
+"FieldValueIsNotVisibleTapToShow" = "%1$@ is not visible, tap to show.";
 "FilterByVault" = "Filter items by vault";
 "AllVaults" = "All vaults";
 "Vaults" = "Vaults";

--- a/BitwardenShared/UI/Platform/Application/Views/PasswordText.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/PasswordText.swift
@@ -14,6 +14,11 @@ struct PasswordText: View {
     /// A flag indicating if the password is visible or not.
     let isPasswordVisible: Bool
 
+    /// A flag indicating whether VoiceOver should announce the password's characters
+    /// individually (e.g. "1 2 3 4" instead of "one thousand two hundred thirty-four") rather
+    /// than using its default heuristics for the rendered text.
+    var spellOutAccessibilityValue = false
+
     var body: some View {
         (
             isPasswordVisible
@@ -21,6 +26,7 @@ struct PasswordText: View {
                 : Text(String(repeating: "•", count: Constants.hiddenPasswordLength)),
         )
         .styleGuide(.bodyMonospaced)
+        .speechSpellsOutCharacters(spellOutAccessibilityValue && isPasswordVisible)
     }
 
     // MARK: Private Properties

--- a/BitwardenShared/UI/Platform/Application/Views/PasswordVisibilityButton.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/PasswordVisibilityButton.swift
@@ -32,6 +32,7 @@ struct PasswordVisibilityButton: View {
             .resizable()
             .frame(width: size, height: size)
         }
+        .accessibilityLabel(accessibilityLabel)
         .accessibilityIdentifier(accessibilityIdentifier)
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditDriversLicenseItem/AddEditDriversLicenseItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditDriversLicenseItem/AddEditDriversLicenseItemView.swift
@@ -54,6 +54,7 @@ struct AddEditDriversLicenseItemView: View {
                     ),
                     accessibilityIdentifier: "DriversLicenseNumberEntry",
                     passwordVisibilityAccessibilityId: "ShowDriversLicenseNumberButton",
+                    passwordVisibilityFieldName: Localizations.licenseNumber,
                     isPasswordVisible: store.binding(
                         get: \.isLicenseNumberVisible,
                         send: AddEditDriversLicenseItemAction.toggleLicenseNumberVisibilityChanged,

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView+ViewInspectorTests.swift
@@ -193,10 +193,22 @@ class AddEditItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_b
         if #available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, *) {
             throw XCTSkip("Unable to run test in iOS 16, keep an eye on ViewInspector to see if it gets updated.")
         }
+        processor.state.isAdditionalOptionsExpanded = true
         processor.state.isMasterPasswordRePromptOn = false
-        let toggle = try subject.inspect().find(ViewType.Toggle.self, containing: Localizations.passwordPrompt)
+        let toggle = try subject.inspect().find(toggleWithAccessibilityLabel: Localizations.passwordPrompt)
         try toggle.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .masterPasswordRePromptChanged(true))
+    }
+
+    /// The master password re-prompt info button is independently reachable by VoiceOver and is
+    /// announced as an external link.
+    @MainActor
+    func test_masterPasswordRePromptToggle_infoButton_accessibility() throws {
+        processor.state.isAdditionalOptionsExpanded = true
+        let button = try subject.inspect().find(
+            buttonWithAccessibilityLabel: Localizations.masterPasswordRePromptHelp,
+        )
+        try XCTAssertEqual(button.accessibilityHint().string(), Localizations.externalLink)
     }
 
     /// Updating the name text field dispatches the `.nameChanged()` action.

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView+ViewInspectorTests.swift
@@ -636,7 +636,9 @@ class AddEditItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_b
         processor.state.driversLicenseItemState.isLicenseNumberVisible = false
         let button = try subject.inspect()
             .find(bitwardenTextField: Localizations.licenseNumber)
-            .find(buttonWithAccessibilityLabel: Localizations.passwordIsNotVisibleTapToShow)
+            .find(buttonWithAccessibilityLabel: Localizations.fieldValueIsNotVisibleTapToShow(
+                Localizations.licenseNumber,
+            ))
         try button.tap()
         XCTAssertEqual(
             processor.dispatchedActions.last,
@@ -652,7 +654,9 @@ class AddEditItemViewTests: BitwardenTestCase { // swiftlint:disable:this type_b
         processor.state.driversLicenseItemState.isLicenseNumberVisible = true
         let button = try subject.inspect()
             .find(bitwardenTextField: Localizations.licenseNumber)
-            .find(buttonWithAccessibilityLabel: Localizations.passwordIsVisibleTapToHide)
+            .find(buttonWithAccessibilityLabel: Localizations.fieldValueIsVisibleTapToHide(
+                Localizations.licenseNumber,
+            ))
         try button.tap()
         XCTAssertEqual(
             processor.dispatchedActions.last,

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemView.swift
@@ -245,25 +245,28 @@ private extension AddEditItemView {
             }
 
             if store.state.showMasterPasswordReprompt {
-                BitwardenToggle(isOn: store.binding(
-                    get: \.isMasterPasswordRePromptOn,
-                    send: AddEditItemAction.masterPasswordRePromptChanged,
-                )) {
-                    HStack(alignment: .center, spacing: 8) {
+                BitwardenToggle(
+                    isOn: store.binding(
+                        get: \.isMasterPasswordRePromptOn,
+                        send: AddEditItemAction.masterPasswordRePromptChanged,
+                    ),
+                    accessibilityIdentifier: "MasterPasswordRepromptToggle",
+                    accessibilityLabel: Localizations.passwordPrompt,
+                    title: {
                         Text(Localizations.passwordPrompt)
-
+                    },
+                    accessory: {
                         Button {
                             openURL(ExternalLinksConstants.protectIndividualItems)
                         } label: {
                             SharedAsset.Icons.questionCircle16.swiftUIImage
                         }
-                        .accessibilityLabel(Localizations.masterPasswordRePromptHelp)
                         .buttonStyle(.fieldLabelIcon)
-                    }
-                }
+                        .accessibilityLabel(Localizations.masterPasswordRePromptHelp)
+                        .accessibilityHint(Localizations.externalLink)
+                    },
+                )
                 .toggleStyle(.bitwarden)
-                .accessibilityIdentifier("MasterPasswordRepromptToggle")
-                .accessibilityLabel(Localizations.passwordPrompt)
                 .contentBlock()
             }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView+ViewInspectorTests.swift
@@ -1,6 +1,7 @@
 // swiftlint:disable:this file_name
 import BitwardenKit
 import BitwardenKitMocks
+import BitwardenResources
 import XCTest
 
 @testable import BitwardenShared
@@ -78,6 +79,24 @@ class ViewDriversLicenseItemViewTests: BitwardenTestCase {
         XCTAssertEqual(
             processor.dispatchedActions.last,
             .driversLicenseItemAction(.toggleLicenseNumberVisibilityChanged),
+        )
+    }
+
+    /// The license number visibility toggle announces the field name and current state to
+    /// VoiceOver.
+    @MainActor
+    func test_licenseNumberVisibilityToggle_accessibilityLabel() throws {
+        var state = populatedState()
+        state.isLicenseNumberVisible = false
+        initSubject(state: state)
+        _ = try subject.inspect().find(
+            buttonWithAccessibilityLabel: Localizations.fieldValueIsNotVisibleTapToShow(Localizations.licenseNumber),
+        )
+
+        state.isLicenseNumberVisible = true
+        initSubject(state: state)
+        _ = try subject.inspect().find(
+            buttonWithAccessibilityLabel: Localizations.fieldValueIsVisibleTapToHide(Localizations.licenseNumber),
         )
     }
 

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView+ViewInspectorTests.swift
@@ -100,6 +100,23 @@ class ViewDriversLicenseItemViewTests: BitwardenTestCase {
         )
     }
 
+    /// The license number field asks VoiceOver to spell out its characters individually when
+    /// visible.
+    ///
+    /// - Note: ViewInspector doesn't support inspecting `speechSpellsOutCharacters`, so this
+    ///   verifies the flag is passed through to `PasswordText` rather than the final VoiceOver
+    ///   announcement, which should be confirmed with on-device VoiceOver testing.
+    @MainActor
+    func test_licenseNumber_spellsOutCharacters() throws {
+        var state = populatedState()
+        state.isLicenseNumberVisible = true
+        initSubject(state: state)
+        let passwordText = try subject.inspect().find(PasswordText.self) { view in
+            try view.actualView().password == "D1234567"
+        }.actualView()
+        XCTAssertTrue(passwordText.spellOutAccessibilityValue)
+    }
+
     /// An empty state renders no fields, so the copy buttons are absent.
     @MainActor
     func test_emptyState_hidesFields() throws {

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView.swift
@@ -106,6 +106,9 @@ struct ViewDriversLicenseItemView: View {
             } accessoryContent: {
                 PasswordVisibilityButton(
                     accessibilityIdentifier: "ShowDriversLicenseNumberButton",
+                    accessibilityLabel: isVisible
+                        ? Localizations.fieldValueIsVisibleTapToHide(Localizations.licenseNumber)
+                        : Localizations.fieldValueIsNotVisibleTapToShow(Localizations.licenseNumber),
                     isPasswordVisible: isVisible,
                 ) {
                     store.send(.driversLicenseItemAction(.toggleLicenseNumberVisibilityChanged))

--- a/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/ViewItem/ViewDriversLicenseItem/ViewDriversLicenseItemView.swift
@@ -99,7 +99,7 @@ struct ViewDriversLicenseItemView: View {
         let isVisible = store.state.isLicenseNumberVisible
         if !licenseNumber.isEmpty {
             BitwardenField(title: Localizations.licenseNumber) {
-                PasswordText(password: licenseNumber, isPasswordVisible: isVisible)
+                PasswordText(password: licenseNumber, isPasswordVisible: isVisible, spellOutAccessibilityValue: true)
                     .styleGuide(.body)
                     .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
                     .accessibilityIdentifier("DriversLicenseNumberEntry")


### PR DESCRIPTION
## 🎟️ Tracking

- [PM-42022](https://bitwarden.atlassian.net/browse/PM-42022) - View screen show/hide toggle has a generic button announcement
- [PM-42020](https://bitwarden.atlassian.net/browse/PM-42020) - Add & Edit Screen: show/hide toggle name announcement is not custom by line item
- [PM-42027](https://bitwarden.atlassian.net/browse/PM-42027) - Entered characters are not announced individually
- [PM-42021](https://bitwarden.atlassian.net/browse/PM-42021) - MP Re-prompt information icon is not announced and can't be accessed

## 📔 Objective

Adds a batch of VoiceOver accessibility fixes under the Drivers License item type, mirroring the same batch of fixes already implemented for Bank Account in #2985:

- View/Add-Edit screen toggles now announce which field they control instead of generic "Password"/"Toggle Visibility" wording
- The license number spells out its characters individually to VoiceOver when visible, instead of being read as a whole number/word
- The Master Password Re-prompt info icon is independently announced and reachable instead of being swallowed by the toggle row

The overflow ("more options") menu fix (PM-42026) is stacked on top in #3013, since it grew into a larger shared-component rework and made sense to track as its own PR.

## 📸 Screenshots




[PM-42022]: https://bitwarden.atlassian.net/browse/PM-42022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-42020]: https://bitwarden.atlassian.net/browse/PM-42020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-42027]: https://bitwarden.atlassian.net/browse/PM-42027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-42021]: https://bitwarden.atlassian.net/browse/PM-42021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ