### PR TITLE
[PM-42026] fix:  Overflow menu is not announced and can't be accessed via VoiceOver

### DIFF
--- a/BitwardenKit/Core/Platform/Extensions/String.swift
+++ b/BitwardenKit/Core/Platform/Extensions/String.swift
@@ -115,6 +115,16 @@ public extension String {
         return result
     }
 
+    /// Returns a copy of the string with each character separated by a space so that VoiceOver
+    /// announces the characters individually instead of interpreting the string as a whole word
+    /// or number.
+    ///
+    /// - Returns: A copy of the string with each character separated by a space.
+    ///
+    func spellingOutCharacters() -> String {
+        map { String($0) }.joined(separator: " ")
+    }
+
     /// Validates whether the string is a valid email address.
     ///
     /// - Parameter useStrictValidation: If `true`, validates against a regex pattern requiring

--- a/BitwardenShared/Core/Vault/Extensions/CipherListView+Extensions.swift
+++ b/BitwardenShared/Core/Vault/Extensions/CipherListView+Extensions.swift
@@ -1,5 +1,6 @@
 import BitwardenResources
 import BitwardenSdk
+import Foundation
 
 extension CipherListView {
     // MARK: Properties
@@ -31,7 +32,74 @@ extension CipherListView {
         archivedDate != nil || deletedDate != nil
     }
 
+    /// Whether this cipher can be archived. Mirrors `CipherView.canBeArchived`.
+    var canBeArchived: Bool {
+        archivedDate == nil && deletedDate == nil
+    }
+
+    /// Whether this cipher can be unarchived. Mirrors `CipherView.canBeUnarchived`.
+    var canBeUnarchived: Bool {
+        archivedDate != nil && deletedDate == nil
+    }
+
     // MARK: Methods
+
+    /// Computes, synchronously and without decrypting anything beyond what's already in this
+    /// list view, the set of more-options actions applicable to this cipher. Used to populate the
+    /// vault list row's VoiceOver custom accessibility actions without a `fetchCipher` round trip.
+    ///
+    /// Scope note: intentionally matches `Alert.moreOptions`'s scope exactly (e.g. no Identity
+    /// fields, no bank IBAN/SWIFT/PIN/branch number), even though `copyableFields` exposes more
+    /// than the sheet currently surfaces.
+    ///
+    /// - Parameter hasPremium: Whether the active account has Premium, used to gate the Copy TOTP
+    ///   action.
+    /// - Returns: The list of applicable more-options action kinds, in the order they should be
+    ///   presented.
+    func applicableMoreOptionsActionKinds( // swiftlint:disable:this cyclomatic_complexity
+        hasPremium: Bool,
+    ) -> [MoreOptionsActionKind] {
+        guard !isDecryptionFailure else { return [] }
+
+        var kinds: [MoreOptionsActionKind] = [.view]
+        if deletedDate == nil { kinds.append(.edit) }
+
+        switch type {
+        case .card:
+            if copyableFields.contains(.cardNumber) { kinds.append(.copyCardNumber) }
+            if copyableFields.contains(.cardSecurityCode) { kinds.append(.copySecurityCode) }
+        case let .login(loginListView):
+            if copyableFields.contains(.loginUsername) { kinds.append(.copyUsername) }
+            if copyableFields.contains(.loginPassword) { kinds.append(.copyPassword) }
+            if copyableFields.contains(.loginTotp), hasPremium || organizationUseTotp {
+                kinds.append(.copyTotp)
+            }
+            if let uri = loginListView.uris?.first?.uri, URL(string: uri) != nil {
+                kinds.append(.launch)
+            }
+        case .identity:
+            break
+        case .secureNote:
+            if copyableFields.contains(.secureNotes) { kinds.append(.copyNotes) }
+        case .sshKey:
+            if copyableFields.contains(.sshKey) {
+                kinds.append(.copyPublicKey)
+                if viewPassword { kinds.append(.copyPrivateKey) }
+                kinds.append(.copyFingerprint)
+            }
+        case .bankAccount:
+            if copyableFields.contains(.bankAccountAccountNumber) { kinds.append(.copyAccountNumber) }
+            if copyableFields.contains(.bankAccountRoutingNumber) { kinds.append(.copyRoutingNumber) }
+        case .driversLicense:
+            if copyableFields.contains(.driversLicenseLicenseNumber) { kinds.append(.copyLicenseNumber) }
+        case .passport:
+            if copyableFields.contains(.passportPassportNumber) { kinds.append(.copyPassportNumber) }
+        }
+
+        if canBeArchived { kinds.append(.archive) }
+        if canBeUnarchived { kinds.append(.unarchive) }
+        return kinds
+    }
 
     /// Whether the cipher belongs to a group.
     /// - Parameter group: The group to filter.

--- a/BitwardenShared/Core/Vault/Extensions/CipherListViewExtensionsTests.swift
+++ b/BitwardenShared/Core/Vault/Extensions/CipherListViewExtensionsTests.swift
@@ -469,4 +469,150 @@ class CipherListViewExtensionsTests: BitwardenTestCase { // swiftlint:disable:th
                 .passesRestrictItemTypesPolicy(["1", "2", "3"]),
         )
     }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` returns an empty list for a
+    /// decryption-failure cipher.
+    func test_applicableMoreOptionsActionKinds_decryptionFailure() {
+        let cipher = CipherListView(cipherDecryptFailure: .fixture())
+        XCTAssertEqual(cipher.applicableMoreOptionsActionKinds(hasPremium: true), [])
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` excludes `.edit` for a trashed cipher.
+    func test_applicableMoreOptionsActionKinds_trashed() {
+        let cipher = CipherListView.fixture(type: .identity, deletedDate: .now)
+        XCTAssertEqual(cipher.applicableMoreOptionsActionKinds(hasPremium: false), [.view])
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` returns only view/edit/archive for an identity cipher.
+    func test_applicableMoreOptionsActionKinds_identity() {
+        let cipher = CipherListView.fixture(type: .identity)
+        XCTAssertEqual(cipher.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .archive])
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates card copy actions on `copyableFields`.
+    func test_applicableMoreOptionsActionKinds_card() {
+        let noData = CipherListView.fixture(type: .card(.fixture()))
+        XCTAssertEqual(noData.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .archive])
+
+        let withData = CipherListView.fixture(
+            type: .card(.fixture()),
+            copyableFields: [.cardNumber, .cardSecurityCode],
+        )
+        XCTAssertEqual(
+            withData.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyCardNumber, .copySecurityCode, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates login copy/launch actions on
+    /// `copyableFields`, Premium/organization TOTP, and a parseable URI.
+    func test_applicableMoreOptionsActionKinds_login() {
+        let noData = CipherListView.fixture(type: .login(.fixture()))
+        XCTAssertEqual(noData.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .archive])
+
+        let withData = CipherListView.fixture(
+            type: .login(.fixture(uris: [.fixture(uri: URL.example.relativeString)])),
+            copyableFields: [.loginUsername, .loginPassword, .loginTotp],
+        )
+        XCTAssertEqual(
+            withData.applicableMoreOptionsActionKinds(hasPremium: true),
+            [.view, .edit, .copyUsername, .copyPassword, .copyTotp, .launch, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` excludes `.copyTotp` when the account has no
+    /// Premium and the organization doesn't use TOTP.
+    func test_applicableMoreOptionsActionKinds_login_copyTotp_noPremium() {
+        let cipher = CipherListView.fixture(type: .login(.fixture()), copyableFields: [.loginTotp])
+        XCTAssertEqual(cipher.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .archive])
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` includes `.copyTotp` when the organization
+    /// uses TOTP even without Premium.
+    func test_applicableMoreOptionsActionKinds_login_copyTotp_organizationUseTotp() {
+        let cipher = CipherListView.fixture(
+            type: .login(.fixture()),
+            organizationUseTotp: true,
+            copyableFields: [.loginTotp],
+        )
+        XCTAssertEqual(
+            cipher.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyTotp, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates secure note copy action on `copyableFields`.
+    func test_applicableMoreOptionsActionKinds_secureNote() {
+        let noData = CipherListView.fixture(type: .secureNote)
+        XCTAssertEqual(noData.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .archive])
+
+        let withData = CipherListView.fixture(type: .secureNote, copyableFields: [.secureNotes])
+        XCTAssertEqual(
+            withData.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyNotes, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates SSH key copy actions on `copyableFields`
+    /// and `viewPassword` for the private key.
+    func test_applicableMoreOptionsActionKinds_sshKey() {
+        let noViewPassword = CipherListView.fixture(type: .sshKey, copyableFields: [.sshKey])
+        XCTAssertEqual(
+            noViewPassword.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyPublicKey, .copyFingerprint, .archive],
+        )
+
+        let withViewPassword = CipherListView.fixture(
+            type: .sshKey,
+            viewPassword: true,
+            copyableFields: [.sshKey],
+        )
+        XCTAssertEqual(
+            withViewPassword.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyPublicKey, .copyPrivateKey, .copyFingerprint, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates bank account copy actions on `copyableFields`.
+    func test_applicableMoreOptionsActionKinds_bankAccount() {
+        let cipher = CipherListView.fixture(
+            type: .bankAccount(.init(accountNumber: nil, accountType: nil)),
+            copyableFields: [.bankAccountAccountNumber, .bankAccountRoutingNumber],
+        )
+        XCTAssertEqual(
+            cipher.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyAccountNumber, .copyRoutingNumber, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates drivers license copy action on `copyableFields`.
+    func test_applicableMoreOptionsActionKinds_driversLicense() {
+        let cipher = CipherListView.fixture(type: .driversLicense, copyableFields: [.driversLicenseLicenseNumber])
+        XCTAssertEqual(
+            cipher.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyLicenseNumber, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` gates passport copy action on `copyableFields`.
+    func test_applicableMoreOptionsActionKinds_passport() {
+        let cipher = CipherListView.fixture(type: .passport, copyableFields: [.passportPassportNumber])
+        XCTAssertEqual(
+            cipher.applicableMoreOptionsActionKinds(hasPremium: false),
+            [.view, .edit, .copyPassportNumber, .archive],
+        )
+    }
+
+    /// `applicableMoreOptionsActionKinds(hasPremium:)` includes `.archive` for a non-archived,
+    /// non-deleted cipher, and `.unarchive` for an archived cipher.
+    func test_applicableMoreOptionsActionKinds_archiveUnarchive() {
+        let archivable = CipherListView.fixture(type: .identity, deletedDate: nil, archivedDate: nil)
+        XCTAssertEqual(archivable.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .archive])
+
+        let archived = CipherListView.fixture(type: .identity, deletedDate: nil, archivedDate: .now)
+        XCTAssertEqual(archived.applicableMoreOptionsActionKinds(hasPremium: false), [.view, .edit, .unarchive])
+
+        let trashed = CipherListView.fixture(type: .identity, deletedDate: .now)
+        XCTAssertEqual(trashed.applicableMoreOptionsActionKinds(hasPremium: false), [.view])
+    }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Platform/Application/Views/PasswordText.swift
+++ b/BitwardenShared/UI/Platform/Application/Views/PasswordText.swift
@@ -26,6 +26,9 @@ struct PasswordText: View {
                 : Text(String(repeating: "•", count: Constants.hiddenPasswordLength)),
         )
         .styleGuide(.bodyMonospaced)
+        .if(spellOutAccessibilityValue && isPasswordVisible) { textView in
+            textView.accessibilityValue(password.spellingOutCharacters())
+        }
         .speechSpellsOutCharacters(spellOutAccessibilityValue && isPasswordVisible)
     }
 

--- a/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
+++ b/BitwardenShared/UI/Vault/Extensions/Alert+Vault.swift
@@ -637,6 +637,237 @@ extension Alert {
     }
 }
 
+// MARK: - MoreOptionsActionKind
+
+/// The kind of an individual more-options action for a vault list item, independent of the
+/// concrete cipher values needed to actually perform it.
+///
+/// Used both to decide which options are available (from a `CipherListView`, synchronously, for
+/// VoiceOver custom accessibility actions on the vault list row) and to build the more-options
+/// action sheet's `AlertAction`s (from a full `CipherView`, in `Alert.moreOptions`). If you
+/// add/remove a case here, also update `CipherListView.applicableMoreOptionsActionKinds` and
+/// `Alert.moreOptions` so the two stay in sync.
+///
+enum MoreOptionsActionKind: CaseIterable, Equatable {
+    /// Archive the cipher.
+    case archive
+
+    /// Copy the cipher's bank account number.
+    case copyAccountNumber
+
+    /// Copy the cipher's card number.
+    case copyCardNumber
+
+    /// Copy the cipher's SSH key fingerprint.
+    case copyFingerprint
+
+    /// Copy the cipher's drivers license number.
+    case copyLicenseNumber
+
+    /// Copy the cipher's notes.
+    case copyNotes
+
+    /// Copy the cipher's password.
+    case copyPassword
+
+    /// Copy the cipher's passport number.
+    case copyPassportNumber
+
+    /// Copy the cipher's SSH private key.
+    case copyPrivateKey
+
+    /// Copy the cipher's SSH public key.
+    case copyPublicKey
+
+    /// Copy the cipher's bank account routing number.
+    case copyRoutingNumber
+
+    /// Copy the cipher's security code.
+    case copySecurityCode
+
+    /// Copy the cipher's TOTP code.
+    case copyTotp
+
+    /// Copy the cipher's username.
+    case copyUsername
+
+    /// Navigate to edit the cipher.
+    case edit
+
+    /// Launch the cipher's URI.
+    case launch
+
+    /// Unarchive the cipher.
+    case unarchive
+
+    /// Navigate to view the cipher.
+    case view
+
+    /// The localized display name for this action. Used both as the action sheet's `AlertAction`
+    /// title and as the row's `.accessibilityAction` name, so VoiceOver announces the same words
+    /// a sighted user reads in the sheet.
+    var localizedName: String {
+        switch self {
+        case .archive: Localizations.archive
+        case .copyAccountNumber: Localizations.copyAccountNumber
+        case .copyCardNumber: Localizations.copyNumber
+        case .copyFingerprint: Localizations.copyFingerprint
+        case .copyLicenseNumber: Localizations.copyLicenseNumber
+        case .copyNotes: Localizations.copyNotes
+        case .copyPassword: Localizations.copyPassword
+        case .copyPassportNumber: Localizations.copyPassportNumber
+        case .copyPrivateKey: Localizations.copyPrivateKey
+        case .copyPublicKey: Localizations.copyPublicKey
+        case .copyRoutingNumber: Localizations.copyRoutingNumber
+        case .copySecurityCode: Localizations.copySecurityCode
+        case .copyTotp: Localizations.copyTotp
+        case .copyUsername: Localizations.copyUsername
+        case .edit: Localizations.edit
+        case .launch: Localizations.launch
+        case .unarchive: Localizations.unarchive
+        case .view: Localizations.view
+        }
+    }
+
+    /// Maps this kind and a concrete cipher to the fully-parameterized `MoreOptionsAction` to
+    /// execute.
+    ///
+    /// - Parameters:
+    ///   - cipherView: The cipher to act upon.
+    ///   - itemId: The id of the vault list item, used for the `.view` action.
+    /// - Returns: The action to execute, or `nil` if the expected field is unexpectedly missing
+    ///   (defensive only — the action shouldn't have been offered in that case).
+    func moreOptionsAction( // swiftlint:disable:this cyclomatic_complexity function_body_length
+        cipherView: CipherView,
+        itemId: String,
+    ) -> MoreOptionsAction? {
+        switch self {
+        case .archive:
+            return .archive(cipherView: cipherView)
+        case .copyAccountNumber:
+            guard let accountNumber = cipherView.bankAccount?.accountNumber else { return nil }
+            return .copy(
+                toast: Localizations.accountNumber,
+                value: accountNumber,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: nil,
+            )
+        case .copyCardNumber:
+            guard let number = cipherView.card?.number else { return nil }
+            return .copy(
+                toast: Localizations.number,
+                value: number,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: nil,
+            )
+        case .copyFingerprint:
+            guard let sshKey = cipherView.sshKey else { return nil }
+            return .copy(
+                toast: Localizations.fingerprint,
+                value: sshKey.fingerprint,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: cipherView.id,
+            )
+        case .copyLicenseNumber:
+            guard let licenseNumber = cipherView.driversLicense?.licenseNumber else { return nil }
+            return .copy(
+                toast: Localizations.licenseNumber,
+                value: licenseNumber,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: cipherView.id,
+            )
+        case .copyNotes:
+            guard let notes = cipherView.notes else { return nil }
+            return .copy(
+                toast: Localizations.notes,
+                value: notes,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: nil,
+            )
+        case .copyPassword:
+            guard let password = cipherView.login?.password else { return nil }
+            return .copy(
+                toast: Localizations.password,
+                value: password,
+                requiresMasterPasswordReprompt: true,
+                logEvent: .cipherClientCopiedPassword,
+                cipherId: cipherView.id,
+            )
+        case .copyPassportNumber:
+            guard let passportNumber = cipherView.passport?.passportNumber else { return nil }
+            return .copy(
+                toast: Localizations.passportNumber,
+                value: passportNumber,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: cipherView.id,
+            )
+        case .copyPrivateKey:
+            guard let sshKey = cipherView.sshKey else { return nil }
+            return .copy(
+                toast: Localizations.privateKey,
+                value: sshKey.privateKey,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: cipherView.id,
+            )
+        case .copyPublicKey:
+            guard let sshKey = cipherView.sshKey else { return nil }
+            return .copy(
+                toast: Localizations.publicKey,
+                value: sshKey.publicKey,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: cipherView.id,
+            )
+        case .copyRoutingNumber:
+            guard let routingNumber = cipherView.bankAccount?.routingNumber else { return nil }
+            return .copy(
+                toast: Localizations.routingNumber,
+                value: routingNumber,
+                requiresMasterPasswordReprompt: true,
+                logEvent: nil,
+                cipherId: nil,
+            )
+        case .copySecurityCode:
+            guard let code = cipherView.card?.code else { return nil }
+            return .copy(
+                toast: Localizations.securityCode,
+                value: code,
+                requiresMasterPasswordReprompt: true,
+                logEvent: .cipherClientCopiedCardCode,
+                cipherId: cipherView.id,
+            )
+        case .copyTotp:
+            guard let totp = cipherView.login?.totp else { return nil }
+            return .copyTotp(totpKey: TOTPKeyModel(authenticatorKey: totp))
+        case .copyUsername:
+            guard let username = cipherView.login?.username else { return nil }
+            return .copy(
+                toast: Localizations.username,
+                value: username,
+                requiresMasterPasswordReprompt: false,
+                logEvent: nil,
+                cipherId: nil,
+            )
+        case .edit:
+            return .edit(cipherView: cipherView)
+        case .launch:
+            guard let uri = cipherView.login?.uris?.first?.uri, let url = URL(string: uri) else { return nil }
+            return .launch(url: url)
+        case .unarchive:
+            return .unarchive(cipherView: cipherView)
+        case .view:
+            return .view(id: itemId)
+        }
+    }
+}
+
 // MARK: - MoreOptionsAlertContext
 
 /// Context for displaying a more options alert for a vault item.

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelper.swift
@@ -23,6 +23,24 @@ protocol VaultItemMoreOptionsHelper {
         handleNavigateToPremiumUpgrade: @escaping () async -> Void,
         handleOpenURL: @escaping (URL) -> Void,
     ) async
+
+    /// Performs the more-options action identified by `kind` for `item` directly, without
+    /// presenting the action sheet. Used by the vault list row's VoiceOver accessibility actions.
+    ///
+    /// - Parameters
+    ///   - kind: The kind of more-options action to perform.
+    ///   - item: The selected item to perform the action on.
+    ///   - handleDisplayToast: A closure called to handle displaying a toast.
+    ///   - handleNavigateToPremiumUpgrade: A closure called to navigate to the Premium upgrade flow.
+    ///   - handleOpenURL: A closure called to open a URL.
+    ///
+    func performMoreOptionsAction(
+        _ kind: MoreOptionsActionKind,
+        for item: VaultListItem,
+        handleDisplayToast: @escaping (Toast) -> Void,
+        handleNavigateToPremiumUpgrade: @escaping () async -> Void,
+        handleOpenURL: @escaping (URL) -> Void,
+    ) async
 }
 
 // MARK: - DefaultVaultItemMoreOptionsHelper
@@ -109,6 +127,37 @@ class DefaultVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
                     hasPremium: hasPremium,
                 )
             })
+        } catch {
+            services.errorReporter.log(error: error)
+            coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))
+        }
+    }
+
+    func performMoreOptionsAction(
+        _ kind: MoreOptionsActionKind,
+        for item: VaultListItem,
+        handleDisplayToast: @escaping (Toast) -> Void,
+        handleNavigateToPremiumUpgrade: @escaping () async -> Void,
+        handleOpenURL: @escaping (URL) -> Void,
+    ) async {
+        do {
+            guard case let .cipher(cipherListView, _) = item.itemType,
+                  let cipherId = cipherListView.id,
+                  let cipherView = try await services.vaultRepository.fetchCipher(withId: cipherId) else {
+                return
+            }
+
+            let hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
+            guard let action = kind.moreOptionsAction(cipherView: cipherView, itemId: item.id) else { return }
+
+            await handleMoreOptionsAction(
+                action,
+                cipherView: cipherView,
+                handleDisplayToast: handleDisplayToast,
+                handleNavigateToPremiumUpgrade: handleNavigateToPremiumUpgrade,
+                handleOpenURL: handleOpenURL,
+                hasPremium: hasPremium,
+            )
         } catch {
             services.errorReporter.log(error: error)
             coordinator.showAlert(.defaultAlert(title: Localizations.anErrorHasOccurred))

--- a/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
+++ b/BitwardenShared/UI/Vault/Helpers/VaultItemMoreOptionsHelperTests.swift
@@ -897,13 +897,271 @@ class VaultItemMoreOptionsHelperTests: BitwardenTestCase { // swiftlint:disable:
         XCTAssertEqual(vaultRepository.unarchiveCipher, [cipherView])
         XCTAssertEqual(toastToDisplay, Toast(title: Localizations.itemMovedToVault))
     }
+
+    // MARK: performMoreOptionsAction Tests
+
+    /// `performMoreOptionsAction(_:for:...)` with `.view` navigates to the `.viewItem` route.
+    @MainActor
+    func test_performMoreOptionsAction_view() async throws {
+        stateService.activeAccount = .fixture()
+        let cipherView = CipherView.fixture(id: "id")
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture(id: "id")))
+
+        await subject.performMoreOptionsAction(
+            .view,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.edit` navigates to the `.editItem` route.
+    @MainActor
+    func test_performMoreOptionsAction_edit() async throws {
+        stateService.activeAccount = .fixture()
+        let cipherView = CipherView.fixture()
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .edit,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(coordinator.routes.last, .editItem(cipherView))
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.copyUsername` copies the cipher's username.
+    @MainActor
+    func test_performMoreOptionsAction_copyUsername() async throws {
+        stateService.activeAccount = .fixture()
+        let cipherView = CipherView.loginFixture(login: .fixture(username: "username"))
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .copyUsername,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(pasteboardService.copiedString, "username")
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.copyPassword` presents the master password
+    /// re-prompt alert and copies the password once confirmed.
+    @MainActor
+    func test_performMoreOptionsAction_copyPassword_passwordReprompt() async throws {
+        stateService.activeAccount = .fixture()
+        masterPasswordRepromptHelper.repromptForMasterPasswordAutoComplete = false
+        let cipherView = CipherView.loginFixture(login: .fixture(password: "secretPassword"), reprompt: .password)
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .copyPassword,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherView, cipherView)
+        XCTAssertNil(pasteboardService.copiedString)
+
+        await masterPasswordRepromptHelper.repromptForMasterPasswordCompletion?()
+        XCTAssertEqual(pasteboardService.copiedString, "secretPassword")
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.copyPassword` does nothing if the cipher has no password.
+    @MainActor
+    func test_performMoreOptionsAction_copyPassword_noPassword() async throws {
+        stateService.activeAccount = .fixture()
+        let cipherView = CipherView.loginFixture()
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .copyPassword,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertNil(pasteboardService.copiedString)
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.copyTotp` generates and copies the TOTP code.
+    @MainActor
+    func test_performMoreOptionsAction_copyTotp() async throws {
+        stateService.activeAccount = .fixture()
+        vaultRepository.refreshTOTPCodeResult = .success(
+            LoginTOTPState(
+                authKeyModel: TOTPKeyModel(authenticatorKey: .standardTotpKey),
+                codeModel: TOTPCodeModel(code: "123321", codeGenerationDate: Date(), period: 30),
+            ),
+        )
+        let cipherView = CipherView.fixture(login: .fixture(totp: "totpKey"))
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .copyTotp,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(pasteboardService.copiedString, "123321")
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.launch` opens the cipher's URI.
+    @MainActor
+    func test_performMoreOptionsAction_launch() async throws {
+        stateService.activeAccount = .fixture()
+        let cipherView = CipherView.loginFixture(
+            login: .fixture(uris: [.fixture(uri: URL.example.relativeString, match: nil)]),
+        )
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        var urlToOpen: URL?
+        await subject.performMoreOptionsAction(
+            .launch,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { urlToOpen = $0 },
+        )
+
+        XCTAssertEqual(urlToOpen, .example)
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.archive` archives the cipher.
+    @MainActor
+    func test_performMoreOptionsAction_archive() async throws {
+        stateService.activeAccount = .fixture()
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+        vaultRepository.archiveCipherResult = .success(())
+        let cipherView = CipherView.loginFixture(archivedDate: nil, deletedDate: nil)
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        var toastToDisplay: Toast?
+        await subject.performMoreOptionsAction(
+            .archive,
+            for: item,
+            handleDisplayToast: { toastToDisplay = $0 },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        let confirmAlert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(confirmAlert.title, Localizations.archiveItem)
+        try await confirmAlert.tapAction(title: Localizations.archive)
+
+        XCTAssertEqual(vaultRepository.archiveCipher, [cipherView])
+        XCTAssertEqual(toastToDisplay, Toast(title: Localizations.itemMovedToArchive))
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` with `.unarchive` unarchives the cipher.
+    @MainActor
+    func test_performMoreOptionsAction_unarchive() async throws {
+        stateService.activeAccount = .fixture()
+        vaultRepository.unarchiveCipherResult = .success(())
+        let cipherView = CipherView.loginFixture(archivedDate: .now, deletedDate: nil)
+        vaultRepository.fetchCipherResult = .success(cipherView)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        var toastToDisplay: Toast?
+        await subject.performMoreOptionsAction(
+            .unarchive,
+            for: item,
+            handleDisplayToast: { toastToDisplay = $0 },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(vaultRepository.unarchiveCipher, [cipherView])
+        XCTAssertEqual(toastToDisplay, Toast(title: Localizations.itemMovedToVault))
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` does nothing when the cipher fetched is `nil`.
+    @MainActor
+    func test_performMoreOptionsAction_noCipher() async throws {
+        vaultRepository.fetchCipherResult = .success(nil)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .view,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertTrue(coordinator.alertShown.isEmpty)
+        XCTAssertTrue(coordinator.routes.isEmpty)
+    }
+
+    /// `performMoreOptionsAction(_:for:...)` logs an error and shows an alert when fetching the cipher throws.
+    @MainActor
+    func test_performMoreOptionsAction_fetchCipherThrows() async throws {
+        vaultRepository.fetchCipherResult = .failure(BitwardenTestError.example)
+        let item = try XCTUnwrap(VaultListItem(cipherListView: .fixture()))
+
+        await subject.performMoreOptionsAction(
+            .view,
+            for: item,
+            handleDisplayToast: { _ in },
+            handleNavigateToPremiumUpgrade: {},
+            handleOpenURL: { _ in },
+        )
+
+        XCTAssertEqual(errorReporter.errors as? [BitwardenTestError], [.example])
+        let alert = try XCTUnwrap(coordinator.alertShown.last)
+        XCTAssertEqual(alert.title, Localizations.anErrorHasOccurred)
+    }
 }
 
 class MockVaultItemMoreOptionsHelper: VaultItemMoreOptionsHelper {
+    var performActionCalled = false
+    var performActionKind: MoreOptionsActionKind?
+    var performActionItem: VaultListItem?
+    var performActionHandleDisplayToast: ((Toast) -> Void)?
+    var performActionHandlePremiumUpgrade: (() async -> Void)?
+    var performActionHandleOpenURL: ((URL) -> Void)?
+
     var showMoreOptionsAlertCalled = false
     var showMoreOptionsAlertHandleDisplayToast: ((Toast) -> Void)?
     var showMoreOptionsAlertHandlePremiumUpgrade: (() async -> Void)?
     var showMoreOptionsAlertHandleOpenURL: ((URL) -> Void)?
+
+    func performMoreOptionsAction(
+        _ kind: MoreOptionsActionKind,
+        for item: VaultListItem,
+        handleDisplayToast: @escaping (Toast) -> Void,
+        handleNavigateToPremiumUpgrade: @escaping () async -> Void,
+        handleOpenURL: @escaping (URL) -> Void,
+    ) async {
+        performActionCalled = true
+        performActionKind = kind
+        performActionItem = item
+        performActionHandleDisplayToast = handleDisplayToast
+        performActionHandlePremiumUpgrade = handleNavigateToPremiumUpgrade
+        performActionHandleOpenURL = handleOpenURL
+    }
 
     func showMoreOptionsAlert(
         for item: VaultListItem,

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView+ViewInspectorTests.swift
@@ -5,6 +5,7 @@ import BitwardenResources
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
 class VaultAutofillListViewTests: BitwardenTestCase {
     // MARK: Properties
@@ -73,5 +74,15 @@ class VaultAutofillListViewTests: BitwardenTestCase {
         let button = try subject.inspect().find(asyncButton: Localizations.tryAgain)
         try await button.tap()
         XCTAssertEqual(processor.effects.last, .loadData)
+    }
+
+    /// Tapping a vault item row performs the `.vaultItemTapped` effect.
+    @MainActor
+    func test_vaultItem_tap() async throws {
+        let item = VaultListItem.fixture(cipherListView: .fixture(name: "Item"))
+        processor.state.loadingState = .data([VaultListSection(id: "Items", items: [item], name: Localizations.items)])
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityIdentifier: "VaultListItemRowButton")
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .vaultItemTapped(item))
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -362,6 +362,9 @@ private struct VaultAutofillListSearchableView: View {
                 mapAction: nil,
                 mapEffect: { effect in
                     switch effect {
+                    case .accessibilityMoreOptionsActionPressed:
+                        // Unreachable: `isFromExtension: true` always hides the accessibility actions.
+                        .vaultItemTapped(item)
                     case .morePressed:
                         // Unreachable: `isFromExtension: true` always hides `CipherOptionsButton`.
                         .vaultItemTapped(item)

--- a/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/AutofillList/VaultAutofillListView.swift
@@ -267,11 +267,7 @@ private struct VaultAutofillListSearchableView: View {
                     section: section,
                     showCount: !store.state.isCreatingFido2Credential,
                 ) { item in
-                    AsyncButton {
-                        await store.perform(.vaultItemTapped(item))
-                    } label: {
-                        vaultItemRow(for: item, isLastInSection: section.items.last == item)
-                    }
+                    vaultItemRow(for: item, isLastInSection: section.items.last == item)
                 }
             }
         }
@@ -282,11 +278,7 @@ private struct VaultAutofillListSearchableView: View {
     private func cipherSimpleListView(_ items: [VaultListItem]) -> some View {
         LazyVStack(spacing: 0) {
             ForEach(items) { item in
-                AsyncButton {
-                    await store.perform(.vaultItemTapped(item))
-                } label: {
-                    vaultItemRow(for: item, isLastInSection: items.last == item)
-                }
+                vaultItemRow(for: item, isLastInSection: items.last == item)
             }
         }
         .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
@@ -368,7 +360,15 @@ private struct VaultAutofillListSearchableView: View {
                     )
                 },
                 mapAction: nil,
-                mapEffect: nil,
+                mapEffect: { effect in
+                    switch effect {
+                    case .morePressed:
+                        // Unreachable: `isFromExtension: true` always hides `CipherOptionsButton`.
+                        .vaultItemTapped(item)
+                    case .pressed:
+                        .vaultItemTapped(item)
+                    }
+                },
             ),
             timeProvider: timeProvider,
         )

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupAction.swift
@@ -18,12 +18,6 @@ enum VaultGroupAction: Equatable, Sendable {
     ///
     case copyTOTPCode(_ code: String)
 
-    /// An item in the vault group was tapped.
-    ///
-    /// - Parameter item: The item that was tapped.
-    ///
-    case itemPressed(_ item: VaultListItem)
-
     /// The user tapped in "Restart Premium" subscription for archive.
     case restartPremiumSubscription
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
@@ -2,6 +2,14 @@
 
 /// Effects that can be handled by a `VaultGroupProcessor`.
 enum VaultGroupEffect: Equatable {
+    /// A VoiceOver custom accessibility action for one of the more-options actions was activated.
+    ///
+    /// - Parameters:
+    ///   - item: The item associated with the action.
+    ///   - kind: The kind of more-options action that was activated.
+    ///
+    case accessibilityMoreOptionsActionPressed(_ item: VaultListItem, _ kind: MoreOptionsActionKind)
+
     /// The vault group view appeared on screen.
     case appeared
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupEffect.swift
@@ -5,6 +5,12 @@ enum VaultGroupEffect: Equatable {
     /// The vault group view appeared on screen.
     case appeared
 
+    /// An item in the vault group was tapped to be opened.
+    ///
+    /// - Parameter item: The item that was tapped.
+    ///
+    case itemPressed(_ item: VaultListItem)
+
     /// The more button on an item in the vault group was tapped.
     ///
     /// - Parameter item: The item associated with the more button that was tapped.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -128,6 +128,8 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
             await checkPersonalOwnershipPolicy()
             await loadItemTypesUserCanCreate()
             await streamVaultList()
+        case let .itemPressed(item):
+            handleItemTapped(item)
         case let .morePressed(item):
             await vaultItemMoreOptionsHelper.showMoreOptionsAlert(
                 for: item,
@@ -167,21 +169,6 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
         case let .copyTOTPCode(code):
             services.pasteboardService.copy(code)
             state.toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.verificationCode))
-        case let .itemPressed(item):
-            switch item.itemType {
-            case let .cipher(cipherListView, _):
-                if cipherListView.isDecryptionFailure, let cipherId = cipherListView.id {
-                    coordinator.showAlert(.cipherDecryptionFailure(cipherIds: [cipherId]) { stringToCopy in
-                        self.services.pasteboardService.copy(stringToCopy)
-                    })
-                } else {
-                    navigateToViewItem(cipherListView: cipherListView, id: item.id)
-                }
-            case let .group(group, _):
-                coordinator.navigate(to: .group(group, filter: state.vaultFilterType))
-            case let .totp(_, model):
-                navigateToViewItem(cipherListView: model.cipherListView, id: model.id)
-            }
         case .restartPremiumSubscription:
             state.url = services.environmentService.upgradeToPremiumURL
         case let .searchStateChanged(isSearching):
@@ -238,6 +225,27 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
             try await services.stateService.setPremiumUpgradeBannerDismissed(true)
         } catch {
             services.errorReporter.log(error: error)
+        }
+    }
+
+    /// Handles the user tapping a vault list item to open it.
+    ///
+    /// - Parameter item: The item that was tapped.
+    ///
+    private func handleItemTapped(_ item: VaultListItem) {
+        switch item.itemType {
+        case let .cipher(cipherListView, _):
+            if cipherListView.isDecryptionFailure, let cipherId = cipherListView.id {
+                coordinator.showAlert(.cipherDecryptionFailure(cipherIds: [cipherId]) { stringToCopy in
+                    self.services.pasteboardService.copy(stringToCopy)
+                })
+            } else {
+                navigateToViewItem(cipherListView: cipherListView, id: item.id)
+            }
+        case let .group(group, _):
+            coordinator.navigate(to: .group(group, filter: state.vaultFilterType))
+        case let .totp(_, model):
+            navigateToViewItem(cipherListView: model.cipherListView, id: model.id)
         }
     }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessor.swift
@@ -122,6 +122,8 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
 
     override func perform(_ effect: VaultGroupEffect) async {
         switch effect {
+        case let .accessibilityMoreOptionsActionPressed(item, kind):
+            await performMoreOptionsAction(kind, for: item)
         case .appeared:
             await loadFeatureFlags()
             await loadHasPremiumAccount()
@@ -256,6 +258,29 @@ final class VaultGroupProcessor: StateProcessor<// swiftlint:disable:this type_b
         await premiumUpgradeHelper.navigateToPremiumUpgrade(onConfirmed: { [weak self] in
             await self?.refreshVaultGroup()
         })
+    }
+
+    /// Performs the more-options action identified by `kind` for the given vault item, activated
+    /// via a VoiceOver custom accessibility action.
+    ///
+    /// - Parameters:
+    ///   - kind: The kind of more-options action to perform.
+    ///   - item: The vault list item to perform the action on.
+    ///
+    private func performMoreOptionsAction(_ kind: MoreOptionsActionKind, for item: VaultListItem) async {
+        await vaultItemMoreOptionsHelper.performMoreOptionsAction(
+            kind,
+            for: item,
+            handleDisplayToast: { [weak self] toast in
+                self?.state.toast = toast
+            },
+            handleNavigateToPremiumUpgrade: { [weak self] in
+                await self?.navigateToPremiumUpgrade()
+            },
+            handleOpenURL: { [weak self] url in
+                self?.state.url = url
+            },
+        )
     }
 
     /// Navigates to the view item view for the specified cipher. If the cipher requires master

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -292,6 +292,28 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         )
     }
 
+    /// `perform(_:)` with `.accessibilityMoreOptionsActionPressed` has the vault item more options
+    /// helper perform the action directly.
+    @MainActor
+    func test_perform_accessibilityMoreOptionsActionPressed() async throws {
+        let item = VaultListItem.fixture()
+        await subject.perform(.accessibilityMoreOptionsActionPressed(item, .copyUsername))
+
+        XCTAssertTrue(vaultItemMoreOptionsHelper.performActionCalled)
+        XCTAssertEqual(vaultItemMoreOptionsHelper.performActionKind, .copyUsername)
+        XCTAssertEqual(vaultItemMoreOptionsHelper.performActionItem, item)
+        XCTAssertNotNil(vaultItemMoreOptionsHelper.performActionHandleDisplayToast)
+        XCTAssertNotNil(vaultItemMoreOptionsHelper.performActionHandleOpenURL)
+
+        let toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.username))
+        vaultItemMoreOptionsHelper.performActionHandleDisplayToast?(toast)
+        XCTAssertEqual(subject.state.toast, toast)
+
+        let url = URL.example
+        vaultItemMoreOptionsHelper.performActionHandleOpenURL?(url)
+        XCTAssertEqual(subject.state.url, url)
+    }
+
     /// `perform(_:)` with `.morePressed` has the vault item more options helper display the alert.
     @MainActor
     func test_perform_morePressed() async throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupProcessorTests.swift
@@ -871,12 +871,12 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         )
     }
 
-    /// `receive(_:)` with `.itemPressed` on a cipher navigates to the `.viewItem` route.
+    /// `perform(_:)` with `.itemPressed` on a cipher navigates to the `.viewItem` route.
     @MainActor
-    func test_receive_itemPressed_cipher() async throws {
+    func test_perform_itemPressed_cipher() async throws {
         let cipherListView = CipherListView.fixture(id: "id")
 
-        subject.receive(.itemPressed(.fixture(cipherListView: cipherListView)))
+        await subject.perform(.itemPressed(.fixture(cipherListView: cipherListView)))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: "id", masterPasswordRepromptCheckCompleted: true))
@@ -884,13 +884,13 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherListView, cipherListView)
     }
 
-    /// `receive(_:)` with `.itemPressed` shows an alert when tapping on a cipher which failed to decrypt.
+    /// `perform(_:)` with `.itemPressed` shows an alert when tapping on a cipher which failed to decrypt.
     @MainActor
-    func test_receive_itemPressed_cipherDecryptionFailure() async throws {
+    func test_perform_itemPressed_cipherDecryptionFailure() async throws {
         let cipherListView = CipherListView.fixture(name: Localizations.errorCannotDecrypt)
         let item = VaultListItem.fixture(cipherListView: cipherListView)
 
-        subject.receive(.itemPressed(item))
+        await subject.perform(.itemPressed(item))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert, .cipherDecryptionFailure(cipherIds: ["1"]) { _ in })
@@ -907,20 +907,20 @@ class VaultGroupProcessorTests: BitwardenTestCase { // swiftlint:disable:this ty
         )
     }
 
-    /// `receive(_:)` with `.itemPressed` on a group navigates to the `.group` route.
+    /// `perform(_:)` with `.itemPressed` on a group navigates to the `.group` route.
     @MainActor
-    func test_receive_itemPressed_group() {
-        subject.receive(.itemPressed(VaultListItem(id: "1", itemType: .group(.card, 2))))
+    func test_perform_itemPressed_group() async {
+        await subject.perform(.itemPressed(VaultListItem(id: "1", itemType: .group(.card, 2))))
         XCTAssertEqual(coordinator.routes.last, .group(.card, filter: .allVaults))
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to the `.viewItem` route.
+    /// `perform(_:)` with `.itemPressed` navigates to the `.viewItem` route.
     @MainActor
-    func test_receive_itemPressed_totp() async throws {
+    func test_perform_itemPressed_totp() async throws {
         let cipherListView = CipherListView.fixture()
         let totpItem = VaultListItem.fixtureTOTP(totp: .fixture(cipherListView: cipherListView))
 
-        subject.receive(.itemPressed(totpItem))
+        await subject.perform(.itemPressed(totpItem))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: totpItem.id, masterPasswordRepromptCheckCompleted: true))

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView+ViewInspectorTests.swift
@@ -106,15 +106,15 @@ class VaultGroupViewTests: BitwardenTestCase {
         XCTAssertEqual(processor.dispatchedActions.last, .addItemPressed(.card))
     }
 
-    /// Tapping a vault item dispatches the `.itemPressed` action.
+    /// Tapping a vault item dispatches the `.itemPressed` effect.
     @MainActor
-    func test_vaultItem_tap() throws {
+    func test_vaultItem_tap() async throws {
         let item = VaultListItem.fixture(cipherListView: .fixture(name: "Item"))
         let section = VaultListSection(id: "Items", items: [item], name: Localizations.items)
         processor.state.loadingState = .data([section])
-        let button = try subject.inspect().find(button: "Item")
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .itemPressed(item))
+        let button = try subject.inspect().find(asyncButton: "Item")
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .itemPressed(item))
     }
 
     /// Tapping the vault item copy totp button dispatches the `.copyTOTPCode` action.

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -165,15 +165,11 @@ struct VaultGroupView: View {
                     searchVaultFilterRow
 
                     ForEach(store.state.searchResults) { item in
-                        Button {
-                            store.send(.itemPressed(item))
-                        } label: {
-                            vaultItemRow(
-                                for: item,
-                                isLastInSection: store.state.searchResults.last == item,
-                            )
-                            .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
-                        }
+                        vaultItemRow(
+                            for: item,
+                            isLastInSection: store.state.searchResults.last == item,
+                        )
+                        .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
                     }
                 }
             }
@@ -225,11 +221,7 @@ struct VaultGroupView: View {
 
             ForEach(sections) { section in
                 VaultListSectionView(section: section) { item in
-                    Button {
-                        store.send(.itemPressed(item))
-                    } label: {
-                        vaultItemRow(for: item, isLastInSection: section.items.last == item)
-                    }
+                    vaultItemRow(for: item, isLastInSection: section.items.last == item)
                 }
             }
         }
@@ -266,6 +258,8 @@ struct VaultGroupView: View {
                     switch effect {
                     case .morePressed:
                         .morePressed(item)
+                    case .pressed:
+                        .itemPressed(item)
                     }
                 },
             ),

--- a/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultGroup/VaultGroupView.swift
@@ -242,6 +242,7 @@ struct VaultGroupView: View {
                 state: { state in
                     VaultListItemRowState(
                         iconBaseURL: state.iconBaseURL,
+                        hasPremium: state.hasPremium,
                         isVfo1FoundationFeatureFlagEnabled: state.isVfo1FoundationFeatureFlagEnabled,
                         item: item,
                         hasDivider: !isLastInSection,
@@ -256,6 +257,8 @@ struct VaultGroupView: View {
                 },
                 mapEffect: { effect in
                     switch effect {
+                    case let .accessibilityMoreOptionsActionPressed(kind):
+                        .accessibilityMoreOptionsActionPressed(item, kind)
                     case .morePressed:
                         .morePressed(item)
                     case .pressed:

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionEffect.swift
@@ -5,6 +5,14 @@ import BitwardenSdk
 /// Actions that can be processed by a `VaultItemSelectionProcessor`.
 ///
 enum VaultItemSelectionEffect: Equatable {
+    /// A VoiceOver custom accessibility action for one of the more-options actions was activated.
+    ///
+    /// - Parameters:
+    ///   - item: The item associated with the action.
+    ///   - kind: The kind of more-options action that was activated.
+    ///
+    case accessibilityMoreOptionsActionPressed(_ item: VaultListItem, _ kind: MoreOptionsActionKind)
+
     /// Any initial data for the view should be loaded.
     case loadData
 

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessor.swift
@@ -81,8 +81,23 @@ class VaultItemSelectionProcessor: StateProcessor<
 
     override func perform(_ effect: VaultItemSelectionEffect) async {
         switch effect {
+        case let .accessibilityMoreOptionsActionPressed(item, kind):
+            await vaultItemMoreOptionsHelper.performMoreOptionsAction(
+                kind,
+                for: item,
+                handleDisplayToast: { [weak self] toast in
+                    self?.state.toast = toast
+                },
+                handleNavigateToPremiumUpgrade: { [weak self] in
+                    await self?.navigateToPremiumUpgrade()
+                },
+                handleOpenURL: { [weak self] url in
+                    self?.state.url = url
+                },
+            )
         case .loadData:
             state.isVfo1FoundationFeatureFlagEnabled = await services.configService.getFeatureFlag(.vfo1Foundation)
+            state.hasPremium = await services.vaultRepository.doesActiveAccountHavePremium()
             await refreshProfileState()
         case let .morePressed(item):
             await vaultItemMoreOptionsHelper.showMoreOptionsAlert(

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionProcessorTests.swift
@@ -173,6 +173,38 @@ class VaultItemSelectionProcessorTests: BitwardenTestCase { // swiftlint:disable
         XCTAssertEqual(subject.state.profileSwitcherState, .empty(shouldAlwaysHideAddAccount: true))
     }
 
+    /// `perform(_:)` with `.loadData` loads whether the active account has Premium.
+    @MainActor
+    func test_perform_loadData_hasPremium() async {
+        vaultRepository.doesActiveAccountHavePremiumResult = true
+
+        await subject.perform(.loadData)
+
+        XCTAssertTrue(subject.state.hasPremium)
+    }
+
+    /// `perform(_:)` with `.accessibilityMoreOptionsActionPressed` has the vault item more options
+    /// helper perform the action directly.
+    @MainActor
+    func test_perform_accessibilityMoreOptionsActionPressed() async throws {
+        let item = VaultListItem.fixture()
+        await subject.perform(.accessibilityMoreOptionsActionPressed(item, .copyUsername))
+
+        XCTAssertTrue(vaultItemMoreOptionsHelper.performActionCalled)
+        XCTAssertEqual(vaultItemMoreOptionsHelper.performActionKind, .copyUsername)
+        XCTAssertEqual(vaultItemMoreOptionsHelper.performActionItem, item)
+        XCTAssertNotNil(vaultItemMoreOptionsHelper.performActionHandleDisplayToast)
+        XCTAssertNotNil(vaultItemMoreOptionsHelper.performActionHandleOpenURL)
+
+        let toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.username))
+        vaultItemMoreOptionsHelper.performActionHandleDisplayToast?(toast)
+        XCTAssertEqual(subject.state.toast, toast)
+
+        let url = URL.example
+        vaultItemMoreOptionsHelper.performActionHandleOpenURL?(url)
+        XCTAssertEqual(subject.state.url, url)
+    }
+
     /// `perform(_:)` with `.morePressed` has the vault item more options helper display the alert.
     @MainActor
     func test_perform_morePressed() async throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionState.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionState.swift
@@ -12,6 +12,9 @@ struct VaultItemSelectionState: Equatable {
     /// The base url used to fetch icons.
     let iconBaseURL: URL?
 
+    /// Whether the active account has Premium, used to gate the Copy TOTP accessibility action.
+    var hasPremium: Bool = false
+
     /// Whether the `vfo1-foundation` feature flag is enabled.
     var isVfo1FoundationFeatureFlagEnabled = false
 

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView+ViewInspectorTests.swift
@@ -6,6 +6,7 @@ import BitwardenSdk
 import XCTest
 
 @testable import BitwardenShared
+@testable import BitwardenSharedMocks
 
 class VaultItemSelectionViewTests: BitwardenTestCase {
     // MARK: Properties
@@ -60,5 +61,17 @@ class VaultItemSelectionViewTests: BitwardenTestCase {
         let button = try subject.inspect().find(button: Localizations.addItem)
         try button.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .addTapped)
+    }
+
+    /// Tapping a vault item row performs the `.vaultListItemTapped` effect.
+    @MainActor
+    func test_vaultListItem_tap() async throws {
+        let item = VaultListItem.fixture(cipherListView: .fixture(name: "Item"))
+        processor.state.vaultListSections = [
+            VaultListSection(id: "Items", items: [item], name: Localizations.items),
+        ]
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityIdentifier: "VaultListItemRowButton")
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .vaultListItemTapped(item))
     }
 }

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
@@ -219,31 +219,29 @@ private struct VaultItemSelectionSearchableView: View {
     /// A view for displaying a `VaultListItem`.
     @ViewBuilder
     private func vaultListItemView(_ item: VaultListItem, hasDivider: Bool) -> some View {
-        AsyncButton {
-            await store.perform(.vaultListItemTapped(item))
-        } label: {
-            VaultListItemRowView(
-                store: store.child(
-                    state: { state in
-                        VaultListItemRowState(
-                            iconBaseURL: state.iconBaseURL,
-                            isVfo1FoundationFeatureFlagEnabled: state.isVfo1FoundationFeatureFlagEnabled,
-                            item: item,
-                            hasDivider: hasDivider,
-                            showWebIcons: state.showWebIcons,
-                        )
-                    },
-                    mapAction: nil, // No actions are supported (TOTP copy is handled by the more pressed effect).
-                    mapEffect: { effect in
-                        switch effect {
-                        case .morePressed:
-                            .morePressed(item)
-                        }
-                    },
-                ),
-                timeProvider: CurrentTime(),
-            )
-        }
+        VaultListItemRowView(
+            store: store.child(
+                state: { state in
+                    VaultListItemRowState(
+                        iconBaseURL: state.iconBaseURL,
+                        isVfo1FoundationFeatureFlagEnabled: state.isVfo1FoundationFeatureFlagEnabled,
+                        item: item,
+                        hasDivider: hasDivider,
+                        showWebIcons: state.showWebIcons,
+                    )
+                },
+                mapAction: nil, // No actions are supported (TOTP copy is handled by the more pressed effect).
+                mapEffect: { effect in
+                    switch effect {
+                    case .morePressed:
+                        .morePressed(item)
+                    case .pressed:
+                        .vaultListItemTapped(item)
+                    }
+                },
+            ),
+            timeProvider: CurrentTime(),
+        )
     }
 }
 

--- a/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultItemSelection/VaultItemSelectionView.swift
@@ -224,6 +224,7 @@ private struct VaultItemSelectionSearchableView: View {
                 state: { state in
                     VaultListItemRowState(
                         iconBaseURL: state.iconBaseURL,
+                        hasPremium: state.hasPremium,
                         isVfo1FoundationFeatureFlagEnabled: state.isVfo1FoundationFeatureFlagEnabled,
                         item: item,
                         hasDivider: hasDivider,
@@ -233,6 +234,8 @@ private struct VaultItemSelectionSearchableView: View {
                 mapAction: nil, // No actions are supported (TOTP copy is handled by the more pressed effect).
                 mapEffect: { effect in
                     switch effect {
+                    case let .accessibilityMoreOptionsActionPressed(kind):
+                        .accessibilityMoreOptionsActionPressed(item, kind)
                     case .morePressed:
                         .morePressed(item)
                     case .pressed:

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListAction.swift
@@ -27,9 +27,6 @@ enum VaultListAction: Equatable {
     /// The user tapped the button to go to archive.
     case goToArchive
 
-    /// An item in the vault was pressed.
-    case itemPressed(item: VaultListItem)
-
     /// The "Learn more" button on the upgraded to Premium action card was tapped.
     case learnMoreAboutPremium
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
@@ -2,6 +2,14 @@
 
 /// Effects that can be processed by a `VaultListProcessor`.
 enum VaultListEffect: Equatable {
+    /// A VoiceOver custom accessibility action for one of the more-options actions was activated.
+    ///
+    /// - Parameters:
+    ///   - item: The item associated with the action.
+    ///   - kind: The kind of more-options action that was activated.
+    ///
+    case accessibilityMoreOptionsActionPressed(_ item: VaultListItem, _ kind: MoreOptionsActionKind)
+
     /// The vault list appeared on screen.
     case appeared
 

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListEffect.swift
@@ -30,6 +30,12 @@ enum VaultListEffect: Equatable {
     /// The user tapped the dismiss button on the Upgraded to Premium action card.
     case dismissUpgradedToPremiumActionCard
 
+    /// An item in the vault list was tapped to be opened.
+    ///
+    /// - Parameter item: The item that was tapped.
+    ///
+    case itemPressed(_ item: VaultListItem)
+
     /// The more button on an item in the vault group was tapped.
     ///
     /// - Parameter item: The item associated with the more button that was tapped.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -132,6 +132,8 @@ final class VaultListProcessor: StateProcessor<
         case .dismissUpgradedToPremiumActionCard:
             state.shouldShowUpgradedToPremiumActionCard = false
             await services.billingService.setUpgradedToPremiumActionCardDismissed()
+        case let .itemPressed(item):
+            handleItemTapped(item)
         case let .morePressed(item):
             await morePressed(item: item)
         case let .profileSwitcher(profileEffect):
@@ -173,8 +175,6 @@ final class VaultListProcessor: StateProcessor<
             reviewPromptTask?.cancel()
         case .goToArchive:
             coordinator.navigate(to: .group(.archive, filter: state.vaultFilterType))
-        case let .itemPressed(item):
-            handleItemTapped(item)
         case .learnMoreAboutPremium:
             state.url = ExternalLinksConstants.learnMoreAboutPremium
             state.shouldShowUpgradedToPremiumActionCard = false

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessor.swift
@@ -117,6 +117,8 @@ final class VaultListProcessor: StateProcessor<
         switch effect {
         case .appeared:
             await appeared()
+        case let .accessibilityMoreOptionsActionPressed(item, kind):
+            await performMoreOptionsAction(kind, for: item)
         case .checkAppReviewEligibility:
             await checkAppReviewEligibility()
         case .dismissArchiveOnboardingActionCard:
@@ -678,6 +680,29 @@ extension VaultListProcessor {
     ///
     private func morePressed(item: VaultListItem) async {
         await vaultItemMoreOptionsHelper.showMoreOptionsAlert(
+            for: item,
+            handleDisplayToast: { [weak self] toast in
+                self?.state.toast = toast
+            },
+            handleNavigateToPremiumUpgrade: { [weak self] in
+                await self?.navigateToPremiumUpgrade()
+            },
+            handleOpenURL: { [weak self] url in
+                self?.state.url = url
+            },
+        )
+    }
+
+    /// Performs the more-options action identified by `kind` for the given vault item, activated
+    /// via a VoiceOver custom accessibility action.
+    ///
+    /// - Parameters:
+    ///   - kind: The kind of more-options action to perform.
+    ///   - item: The vault list item to perform the action on.
+    ///
+    private func performMoreOptionsAction(_ kind: MoreOptionsActionKind, for item: VaultListItem) async {
+        await vaultItemMoreOptionsHelper.performMoreOptionsAction(
+            kind,
             for: item,
             handleDisplayToast: { [weak self] toast in
                 self?.state.toast = toast

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -2159,13 +2159,13 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(coordinator.routes.last, .group(.archive, filter: .allVaults))
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to the `.viewItem` route for a cipher.
+    /// `perform(_:)` with `.itemPressed` navigates to the `.viewItem` route for a cipher.
     @MainActor
-    func test_receive_itemPressed_cipher() async throws {
+    func test_perform_itemPressed_cipher() async throws {
         let cipherListView = CipherListView.fixture()
         let item = VaultListItem.fixture(cipherListView: cipherListView)
 
-        subject.receive(.itemPressed(item: item))
+        await subject.perform(.itemPressed(item))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: item.id, masterPasswordRepromptCheckCompleted: true))
@@ -2173,13 +2173,13 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(masterPasswordRepromptHelper.repromptForMasterPasswordCipherListView, cipherListView)
     }
 
-    /// `receive(_:)` with `.itemPressed` shows an alert when tapping on a cipher which failed to decrypt.
+    /// `perform(_:)` with `.itemPressed` shows an alert when tapping on a cipher which failed to decrypt.
     @MainActor
-    func test_receive_itemPressed_cipherDecryptionFailure() async throws {
+    func test_perform_itemPressed_cipherDecryptionFailure() async throws {
         let cipherListView = CipherListView.fixture(name: Localizations.errorCannotDecrypt)
         let item = VaultListItem.fixture(cipherListView: cipherListView)
 
-        subject.receive(.itemPressed(item: item))
+        await subject.perform(.itemPressed(item))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert, .cipherDecryptionFailure(cipherIds: ["1"]) { _ in })
@@ -2196,35 +2196,35 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         )
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to the `.group` route for a group.
+    /// `perform(_:)` with `.itemPressed` navigates to the `.group` route for a group.
     @MainActor
-    func test_receive_itemPressed_group() {
-        subject.receive(.itemPressed(item: VaultListItem(id: "1", itemType: .group(.card, 1))))
+    func test_perform_itemPressed_group() async {
+        await subject.perform(.itemPressed(VaultListItem(id: "1", itemType: .group(.card, 1))))
 
         XCTAssertEqual(coordinator.routes.last, .group(.card, filter: .allVaults))
     }
 
-    /// `receive(_:)` with `.itemPressed` shows archive unavailable alert when user doesn't have Premium
+    /// `perform(_:)` with `.itemPressed` shows archive unavailable alert when user doesn't have Premium
     /// and archive has no items.
     @MainActor
-    func test_receive_itemPressed_archiveGroup_noPremium_noItems() {
+    func test_perform_itemPressed_archiveGroup_noPremium_noItems() async {
         subject.state.hasPremium = false
         let archiveItem = VaultListItem(id: "Archive", hasPremium: false, itemType: .group(.archive, 0))
 
-        subject.receive(.itemPressed(item: archiveItem))
+        await subject.perform(.itemPressed(archiveItem))
 
         XCTAssertEqual(coordinator.alertShown.last, .archiveUnavailable(action: {}))
         XCTAssertTrue(coordinator.routes.isEmpty)
     }
 
-    /// `receive(_:)` with `.itemPressed` shows archive unavailable alert and delegates to the
+    /// `perform(_:)` with `.itemPressed` shows archive unavailable alert and delegates to the
     /// Premium upgrade helper when the action is tapped.
     @MainActor
-    func test_receive_itemPressed_archiveGroup_noPremium_noItems_actionTapped() async throws {
+    func test_perform_itemPressed_archiveGroup_noPremium_noItems_actionTapped() async throws {
         subject.state.hasPremium = false
         let archiveItem = VaultListItem(id: "Archive", hasPremium: false, itemType: .group(.archive, 0))
 
-        subject.receive(.itemPressed(item: archiveItem))
+        await subject.perform(.itemPressed(archiveItem))
 
         let alert = try XCTUnwrap(coordinator.alertShown.last)
         XCTAssertEqual(alert.title, Localizations.premiumSubscriptionRequired)
@@ -2236,38 +2236,38 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertTrue(premiumUpgradeHelper.navigateToPremiumUpgradeCalled)
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to archive when user has Premium.
+    /// `perform(_:)` with `.itemPressed` navigates to archive when user has Premium.
     @MainActor
-    func test_receive_itemPressed_archiveGroup_hasPremium() {
+    func test_perform_itemPressed_archiveGroup_hasPremium() async {
         subject.state.hasPremium = true
         let archiveItem = VaultListItem(id: "Archive", hasPremium: true, itemType: .group(.archive, 5))
 
-        subject.receive(.itemPressed(item: archiveItem))
+        await subject.perform(.itemPressed(archiveItem))
 
         XCTAssertEqual(coordinator.routes.last, .group(.archive, filter: .allVaults))
         XCTAssertTrue(coordinator.alertShown.isEmpty)
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to archive when user doesn't have Premium
+    /// `perform(_:)` with `.itemPressed` navigates to archive when user doesn't have Premium
     /// but has archived items.
     @MainActor
-    func test_receive_itemPressed_archiveGroup_noPremium_hasItems() {
+    func test_perform_itemPressed_archiveGroup_noPremium_hasItems() async {
         subject.state.hasPremium = false
         let archiveItem = VaultListItem(id: "Archive", hasPremium: false, itemType: .group(.archive, 3))
 
-        subject.receive(.itemPressed(item: archiveItem))
+        await subject.perform(.itemPressed(archiveItem))
 
         XCTAssertEqual(coordinator.routes.last, .group(.archive, filter: .allVaults))
         XCTAssertTrue(coordinator.alertShown.isEmpty)
     }
 
-    /// `receive(_:)` with `.itemPressed` navigates to the `.totp` route for a totp code.
+    /// `perform(_:)` with `.itemPressed` navigates to the `.totp` route for a totp code.
     @MainActor
-    func test_receive_itemPressed_totp() async throws {
+    func test_perform_itemPressed_totp() async throws {
         let cipherListView = CipherListView.fixture()
         let totpItem = VaultListItem.fixtureTOTP(totp: .fixture(cipherListView: cipherListView))
 
-        subject.receive(.itemPressed(item: totpItem))
+        await subject.perform(.itemPressed(totpItem))
         try await waitForAsync { !self.coordinator.routes.isEmpty }
 
         XCTAssertEqual(coordinator.routes.last, .viewItem(id: "123", masterPasswordRepromptCheckCompleted: true))

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListProcessorTests.swift
@@ -826,6 +826,28 @@ class VaultListProcessorTests: BitwardenTestCase { // swiftlint:disable:this typ
         XCTAssertEqual(errorReporter.errors as? [StateServiceError], [.noActiveAccount])
     }
 
+    /// `perform(_:)` with `.accessibilityMoreOptionsActionPressed` has the vault item more options
+    /// helper perform the action directly.
+    @MainActor
+    func test_perform_accessibilityMoreOptionsActionPressed() async throws {
+        let item = VaultListItem.fixture()
+        await subject.perform(.accessibilityMoreOptionsActionPressed(item, .copyUsername))
+
+        XCTAssertTrue(vaultItemMoreOptionsHelper.performActionCalled)
+        XCTAssertEqual(vaultItemMoreOptionsHelper.performActionKind, .copyUsername)
+        XCTAssertEqual(vaultItemMoreOptionsHelper.performActionItem, item)
+        XCTAssertNotNil(vaultItemMoreOptionsHelper.performActionHandleDisplayToast)
+        XCTAssertNotNil(vaultItemMoreOptionsHelper.performActionHandleOpenURL)
+
+        let toast = Toast(title: Localizations.valueHasBeenCopied(Localizations.username))
+        vaultItemMoreOptionsHelper.performActionHandleDisplayToast?(toast)
+        XCTAssertEqual(subject.state.toast, toast)
+
+        let url = URL.example
+        vaultItemMoreOptionsHelper.performActionHandleOpenURL?(url)
+        XCTAssertEqual(subject.state.url, url)
+    }
+
     /// `perform(_:)` with `.morePressed` has the vault item more options helper display the alert.
     @MainActor
     func test_perform_morePressed() async throws {

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView+ViewInspectorTests.swift
@@ -333,14 +333,14 @@ class VaultListViewTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         )
     }
 
-    /// Tapping the search result dispatches the `.itemPressed` action.
+    /// Tapping the search result dispatches the `.itemPressed` effect.
     @MainActor
-    func test_searchResult_tap() throws {
+    func test_searchResult_tap() async throws {
         let result = VaultListItem.fixture()
         processor.state.searchResults = [result]
-        let button = try subject.inspect().find(button: "Bitwarden")
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .itemPressed(item: result))
+        let button = try subject.inspect().find(asyncButton: "Bitwarden")
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .itemPressed(result))
     }
 
     /// Tapping the go to settings button in the flight recorder toast banner dispatches the
@@ -367,18 +367,14 @@ class VaultListViewTests: BitwardenTestCase { // swiftlint:disable:this type_bod
         XCTAssertEqual(processor.effects, [.tryAgainTapped])
     }
 
-    /// Tapping the vault item dispatches the `.itemPressed` action.
+    /// Tapping the vault item dispatches the `.itemPressed` effect.
     @MainActor
-    func test_vaultItem_tap() throws {
+    func test_vaultItem_tap() async throws {
         let item = VaultListItem(id: "1", itemType: .group(.login, 123))
         processor.state.loadingState = .data([VaultListSection(id: "1", items: [item], name: "Group")])
-        let button = try subject.inspect().find(LoadingViewType.self)
-            .find(ViewType.Button.self) { view in
-                _ = try view.find { try $0.accessibilityIdentifier() == "LoginCell" }
-                return true
-            }
-        try button.tap()
-        XCTAssertEqual(processor.dispatchedActions.last, .itemPressed(item: item))
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityIdentifier: "VaultListItemRowButton")
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .itemPressed(item))
     }
 
     /// Tapping the vault item copy totp button dispatches the `.copyTOTPCode` action.

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -125,15 +125,11 @@ private struct SearchableVaultListView: View {
                     searchVaultFilterRow
 
                     ForEach(store.state.searchResults) { item in
-                        Button {
-                            store.send(.itemPressed(item: item))
-                        } label: {
-                            vaultItemRow(
-                                for: item,
-                                isLastInSection: store.state.searchResults.last == item,
-                            )
-                            .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
-                        }
+                        vaultItemRow(
+                            for: item,
+                            isLastInSection: store.state.searchResults.last == item,
+                        )
+                        .background(SharedAsset.Colors.backgroundSecondary.swiftUIColor)
                     }
                 }
             }
@@ -251,11 +247,7 @@ private struct SearchableVaultListView: View {
                         send: { .sectionExpandToggled(sectionId: section.id, isExpanded: $0) },
                     ),
                 ) { item in
-                    Button {
-                        store.send(.itemPressed(item: item))
-                    } label: {
-                        vaultItemRow(for: item, isLastInSection: section.items.last == item)
-                    }
+                    vaultItemRow(for: item, isLastInSection: section.items.last == item)
                 }
             }
         }
@@ -293,6 +285,8 @@ private struct SearchableVaultListView: View {
                     switch effect {
                     case .morePressed:
                         .morePressed(item)
+                    case .pressed:
+                        .itemPressed(item)
                     }
                 },
             ),

--- a/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
+++ b/BitwardenShared/UI/Vault/Vault/VaultList/VaultListView.swift
@@ -268,6 +268,7 @@ private struct SearchableVaultListView: View {
                 state: { state in
                     VaultListItemRowState(
                         iconBaseURL: state.iconBaseURL,
+                        hasPremium: state.hasPremium,
                         isFromExtension: false,
                         isVfo1FoundationFeatureFlagEnabled: state.isVfo1FoundationFeatureFlagEnabled,
                         item: item,
@@ -283,6 +284,8 @@ private struct SearchableVaultListView: View {
                 },
                 mapEffect: { effect in
                     switch effect {
+                    case let .accessibilityMoreOptionsActionPressed(kind):
+                        .accessibilityMoreOptionsActionPressed(item, kind)
                     case .morePressed:
                         .morePressed(item)
                     case .pressed:

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowEffect.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowEffect.swift
@@ -4,4 +4,7 @@
 enum VaultListItemRowEffect: Equatable {
     /// The more button was pressed.
     case morePressed
+
+    /// The row was pressed to open the item.
+    case pressed
 }

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowEffect.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowEffect.swift
@@ -2,6 +2,9 @@
 
 /// Effects that can be performed from a `VaultListItemRowView`.
 enum VaultListItemRowEffect: Equatable {
+    /// A VoiceOver custom accessibility action for one of the more-options actions was activated.
+    case accessibilityMoreOptionsActionPressed(MoreOptionsActionKind)
+
     /// The more button was pressed.
     case morePressed
 

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowState.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowState.swift
@@ -9,6 +9,9 @@ struct VaultListItemRowState {
     /// The base url used to fetch icons.
     var iconBaseURL: URL?
 
+    /// Whether the active account has Premium, used to gate the Copy TOTP accessibility action.
+    var hasPremium: Bool = false
+
     /// Whether we are in an extension context.
     var isFromExtension: Bool = false
 

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView+ViewInspectorTests.swift
@@ -36,12 +36,34 @@ class VaultListItemRowViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
+    /// Test that tapping the row dispatches the `.pressed` effect.
+    @MainActor
+    func test_pressed_tap() async throws {
+        let button = try subject.inspect().find(asyncButtonWithAccessibilityIdentifier: "VaultListItemRowButton")
+        try await button.tap()
+        XCTAssertEqual(processor.effects.last, .pressed)
+    }
+
     /// Test that tapping the more button dispatches the `.morePressed` action.
     @MainActor
     func test_moreButton_tap() async throws {
         let button = try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.moreOptions)
         try await button.tap()
         XCTAssertEqual(processor.effects.last, .morePressed)
+    }
+
+    /// Test that the more options button isn't shown when displayed from an extension.
+    @MainActor
+    func test_moreButton_notShownFromExtension() throws {
+        processor.state = VaultListItemRowState(
+            isFromExtension: true,
+            item: .fixture(),
+            hasDivider: false,
+            showWebIcons: true,
+        )
+        XCTAssertThrowsError(
+            try subject.inspect().find(asyncButtonWithAccessibilityLabel: Localizations.moreOptions),
+        )
     }
 
     /// Test that tapping the totp copy button dispatches the `.copyTOTPCode` action.

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
@@ -3,6 +3,32 @@ import BitwardenResources
 import BitwardenSdk
 import SwiftUI
 
+// MARK: - View+MoreOptionsAccessibilityActions
+
+private extension View {
+    /// Adds a named `.accessibilityAction` for each of the provided more-options action kinds.
+    /// The number of kinds is data-driven (it depends on the cipher's `copyableFields`), so this
+    /// folds over the list at runtime rather than statically chaining a fixed set of conditional
+    /// modifiers; `AnyView` erasure is used so the accumulator type stays fixed across the fold.
+    ///
+    /// - Parameters:
+    ///   - kinds: The more-options action kinds to expose as accessibility actions.
+    ///   - onSelect: Called with the selected kind when its accessibility action is activated.
+    ///
+    func accessibilityMoreOptionsActions(
+        _ kinds: [MoreOptionsActionKind],
+        onSelect: @escaping (MoreOptionsActionKind) async -> Void,
+    ) -> AnyView {
+        kinds.reduce(AnyView(self)) { view, kind in
+            AnyView(
+                view.accessibilityAsyncAction(named: kind.localizedName) {
+                    await onSelect(kind)
+                },
+            )
+        }
+    }
+}
+
 // MARK: - VaultListItemRowView
 
 /// A view that displays information about a `VaultListItem` as a row in a list.
@@ -76,8 +102,39 @@ struct VaultListItemRowView: View {
                     .padding(.leading, 22 + 16 + 16)
             }
         }
-        .accessibilityElement(children: .contain)
+        .accessibilityElement(children: .combine)
         .accessibilityIdentifier(store.state.item.vaultItemAccessibilityId)
+        .accessibilityAction {
+            Task { await store.perform(.pressed) }
+        }
+        .accessibilityMoreOptionsActions(accessibilityMoreOptionsActionKinds) { kind in
+            await store.perform(.accessibilityMoreOptionsActionPressed(kind))
+        }
+        .conditionalAccessibilityAction(
+            if: {
+                if case let .totp(_, model) = store.state.item.itemType {
+                    !model.requiresMasterPassword && store.state.showTotpCopyButton
+                } else {
+                    false
+                }
+            }(),
+            named: Localizations.copyTotp,
+        ) {
+            if case let .totp(_, model) = store.state.item.itemType {
+                store.send(.copyTOTPCode(model.totpCode.code))
+            }
+        }
+    }
+
+    /// The more-options accessibility action kinds applicable to this row, empty for non-cipher
+    /// items, decryption-failure ciphers, or when running in an extension (matching the ellipsis
+    /// button's own visibility gate).
+    private var accessibilityMoreOptionsActionKinds: [MoreOptionsActionKind] {
+        guard case let .cipher(cipherItem, _) = store.state.item.itemType,
+              !store.state.isFromExtension, !cipherItem.isDecryptionFailure else {
+            return []
+        }
+        return cipherItem.applicableMoreOptionsActionKinds(hasPremium: store.state.hasPremium)
     }
 
     // MARK: - Private Views

--- a/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
+++ b/BitwardenShared/UI/Vault/Views/VaultListItemRow/VaultListItemRowView.swift
@@ -18,115 +18,55 @@ struct VaultListItemRowView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 16) {
-                VaultItemDecorativeImageView(
-                    item: store.state.item,
-                    iconBaseURL: store.state.iconBaseURL,
-                    showWebIcons: store.state.showWebIcons,
-                )
-                .imageStyle(.rowIcon)
-                .padding(.vertical, 19)
+                AsyncButton {
+                    await store.perform(.pressed)
+                } label: {
+                    HStack(spacing: 16) {
+                        VaultItemDecorativeImageView(
+                            item: store.state.item,
+                            iconBaseURL: store.state.iconBaseURL,
+                            showWebIcons: store.state.showWebIcons,
+                        )
+                        .imageStyle(.rowIcon)
+                        .padding(.vertical, 19)
 
-                HStack {
-                    switch store.state.item.itemType {
-                    case let .cipher(cipherItem, _):
-                        VStack(alignment: .leading, spacing: 0) {
-                            HStack(spacing: 8) {
-                                Text(cipherItem.name)
-                                    .styleGuide(.body)
-                                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
-                                    .lineLimit(1)
-                                    .accessibilityIdentifier("CipherNameLabel")
-
-                                if cipherItem.organizationId != nil {
-                                    (store.state.isVfo1FoundationFeatureFlagEnabled
-                                        ? SharedAsset.Icons.sharedFolder16
-                                        : SharedAsset.Icons.collections16).swiftUIImage
-                                        .imageStyle(.accessoryIcon16(
-                                            color: SharedAsset.Colors.textSecondary.swiftUIColor,
-                                            scaleWithFont: true,
-                                        ))
-                                        .accessibilityLabel(Localizations.shared)
-                                        .accessibilityIdentifier("CipherInCollectionIcon")
-                                }
-
-                                if cipherItem.attachments > 0 {
-                                    SharedAsset.Icons.paperclip16.swiftUIImage
-                                        .imageStyle(.accessoryIcon16(
-                                            color: SharedAsset.Colors.textSecondary.swiftUIColor,
-                                            scaleWithFont: true,
-                                        ))
-                                        .accessibilityLabel(Localizations.attachments)
-                                        .accessibilityIdentifier("CipherWithAttachmentsIcon")
-                                }
-                            }
-
-                            if store.state.item.shouldShowFido2CredentialRpId,
-                               let fido2CredentialRpId = store.state.item.fido2CredentialRpId {
-                                Text(fido2CredentialRpId)
-                                    .styleGuide(.subheadline)
-                                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                                    .lineLimit(1)
-                                    .accessibilityIdentifier("CipherFido2CredentialRpIdLabel")
-                            }
-
-                            if let subTitle = store.state.item.subtitle, !subTitle.isEmpty {
-                                Text(subTitle)
-                                    .styleGuide(.subheadline)
-                                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                                    .lineLimit(1)
-                                    .accessibilityIdentifier("CipherSubTitleLabel")
+                        HStack {
+                            switch store.state.item.itemType {
+                            case let .cipher(cipherItem, _):
+                                cipherRowLabel(cipherItem)
+                            case let .group(group, count):
+                                groupRowLabel(group, count)
+                            case let .totp(name, model):
+                                totpRowLabel(name, model)
                             }
                         }
-                        .accessibilityElement(children: .combine)
-
-                        Spacer()
-
-                        if !store.state.isFromExtension, !cipherItem.isDecryptionFailure {
-                            AsyncButton {
-                                await store.perform(.morePressed)
-                            } label: {
-                                SharedAsset.Icons.ellipsisHorizontal24.swiftUIImage
-                                    .imageStyle(.rowIcon)
-                            }
-                            .accessibilityLabel(Localizations.moreOptions)
-                            .accessibilityIdentifier("CipherOptionsButton")
-                        }
-
-                    case let .group(group, count):
-                        VStack(alignment: .leading, spacing: 0) {
-                            Text(group.name)
-                                .styleGuide(.body)
-                                .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
-                                .accessibilityIdentifier("GroupNameLabel")
-
-                            if let subTitle = store.state.item.subtitle, !subTitle.isEmpty {
-                                Text(subTitle)
-                                    .styleGuide(.subheadline)
-                                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                                    .lineLimit(1)
-                                    .accessibilityIdentifier("GroupSubTitleLabel")
-                            }
-                        }
-                        .accessibilityElement(children: .combine)
-
-                        Spacer()
-
-                        if let accessoryIcon = store.state.item.accessoryIcon {
-                            Image(decorative: accessoryIcon)
-                                .imageStyle(.rowIcon)
-                                .accessibilityHidden(true)
-                        } else {
-                            Text("\(count)")
-                                .styleGuide(.body)
-                                .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                                .accessibilityIdentifier("GroupCountLabel")
-                        }
-
-                    case let .totp(name, model):
-                        totpCodeRow(name, model)
+                        .padding(.vertical, 9)
                     }
                 }
-                .padding(.vertical, 9)
+                .accessibilityIdentifier("VaultListItemRowButton")
+
+                if case let .cipher(cipherItem, _) = store.state.item.itemType,
+                   !store.state.isFromExtension, !cipherItem.isDecryptionFailure {
+                    AsyncButton {
+                        await store.perform(.morePressed)
+                    } label: {
+                        SharedAsset.Icons.ellipsisHorizontal24.swiftUIImage
+                            .imageStyle(.rowIcon)
+                    }
+                    .accessibilityLabel(Localizations.moreOptions)
+                    .accessibilityIdentifier("CipherOptionsButton")
+                }
+
+                if case let .totp(_, model) = store.state.item.itemType,
+                   !model.requiresMasterPassword, store.state.showTotpCopyButton {
+                    Button {
+                        store.send(.copyTOTPCode(model.totpCode.code))
+                    } label: {
+                        SharedAsset.Icons.copy24.swiftUIImage
+                    }
+                    .foregroundColor(SharedAsset.Colors.iconPrimary.swiftUIColor)
+                    .accessibilityLabel(Localizations.copyTotp)
+                }
             }
             .multilineTextAlignment(.leading)
             .padding(.horizontal, 16)
@@ -136,15 +76,104 @@ struct VaultListItemRowView: View {
                     .padding(.leading, 22 + 16 + 16)
             }
         }
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier(store.state.item.vaultItemAccessibilityId)
     }
 
     // MARK: - Private Views
 
-    /// The row showing the totp code.
+    /// The label content for a cipher row, excluding the more-options button.
     @ViewBuilder
-    private func totpCodeRow(
+    private func cipherRowLabel(_ cipherItem: CipherListView) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                Text(cipherItem.name)
+                    .styleGuide(.body)
+                    .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("CipherNameLabel")
+
+                if cipherItem.organizationId != nil {
+                    (store.state.isVfo1FoundationFeatureFlagEnabled
+                        ? SharedAsset.Icons.sharedFolder16
+                        : SharedAsset.Icons.collections16).swiftUIImage
+                        .imageStyle(.accessoryIcon16(
+                            color: SharedAsset.Colors.textSecondary.swiftUIColor,
+                            scaleWithFont: true,
+                        ))
+                        .accessibilityLabel(Localizations.shared)
+                        .accessibilityIdentifier("CipherInCollectionIcon")
+                }
+
+                if cipherItem.attachments > 0 {
+                    SharedAsset.Icons.paperclip16.swiftUIImage
+                        .imageStyle(.accessoryIcon16(
+                            color: SharedAsset.Colors.textSecondary.swiftUIColor,
+                            scaleWithFont: true,
+                        ))
+                        .accessibilityLabel(Localizations.attachments)
+                        .accessibilityIdentifier("CipherWithAttachmentsIcon")
+                }
+            }
+
+            if store.state.item.shouldShowFido2CredentialRpId,
+               let fido2CredentialRpId = store.state.item.fido2CredentialRpId {
+                Text(fido2CredentialRpId)
+                    .styleGuide(.subheadline)
+                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("CipherFido2CredentialRpIdLabel")
+            }
+
+            if let subTitle = store.state.item.subtitle, !subTitle.isEmpty {
+                Text(subTitle)
+                    .styleGuide(.subheadline)
+                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("CipherSubTitleLabel")
+            }
+        }
+        .accessibilityElement(children: .combine)
+
+        Spacer()
+    }
+
+    /// The label content for a group row.
+    @ViewBuilder
+    private func groupRowLabel(_ group: VaultListGroup, _ count: Int) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text(group.name)
+                .styleGuide(.body)
+                .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
+                .accessibilityIdentifier("GroupNameLabel")
+
+            if let subTitle = store.state.item.subtitle, !subTitle.isEmpty {
+                Text(subTitle)
+                    .styleGuide(.subheadline)
+                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
+                    .lineLimit(1)
+                    .accessibilityIdentifier("GroupSubTitleLabel")
+            }
+        }
+        .accessibilityElement(children: .combine)
+
+        Spacer()
+
+        if let accessoryIcon = store.state.item.accessoryIcon {
+            Image(decorative: accessoryIcon)
+                .imageStyle(.rowIcon)
+                .accessibilityHidden(true)
+        } else {
+            Text("\(count)")
+                .styleGuide(.body)
+                .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
+                .accessibilityIdentifier("GroupCountLabel")
+        }
+    }
+
+    /// The label content for a row showing the totp code, excluding the copy button.
+    @ViewBuilder
+    private func totpRowLabel(
         _ name: String,
         _ model: VaultListTOTP,
     ) -> some View {
@@ -172,15 +201,6 @@ struct VaultListItemRowView: View {
             Text(model.totpCode.displayCode)
                 .styleGuide(.bodyMonospaced, weight: .regular, monoSpacedDigit: true)
                 .foregroundColor(SharedAsset.Colors.textPrimary.swiftUIColor)
-            if store.state.showTotpCopyButton {
-                Button {
-                    store.send(.copyTOTPCode(model.totpCode.code))
-                } label: {
-                    SharedAsset.Icons.copy24.swiftUIImage
-                }
-                .foregroundColor(SharedAsset.Colors.iconPrimary.swiftUIColor)
-                .accessibilityLabel(Localizations.copyTotp)
-            }
         }
     }
 }

--- a/ViewInspectorTestHelpers/InspectableView.swift
+++ b/ViewInspectorTestHelpers/InspectableView.swift
@@ -177,6 +177,20 @@ public extension InspectableView {
         }
     }
 
+    /// Attempts to locate an async button with the provided accessibility identifier.
+    ///
+    /// - Parameter accessibilityIdentifier: The accessibility identifier to use while searching for a button.
+    /// - Returns: A button, if one can be located.
+    /// - Throws: Throws an error if a view was unable to be located.
+    ///
+    func find(
+        asyncButtonWithAccessibilityIdentifier accessibilityIdentifier: String,
+    ) throws -> InspectableView<AsyncButtonType> {
+        try find(AsyncButtonType.self) { view in
+            try view.accessibilityIdentifier() == accessibilityIdentifier
+        }
+    }
+
     /// Attempts to locate a bitwarden menu field with the provided title.
     ///
     /// - Parameters:


### PR DESCRIPTION
## 🎟️ Tracking

- [PM-42026](https://bitwarden.atlassian.net/browse/PM-42026) - Overflow menu is not announced and can't be accessed

## 📔 Objective

Stacked on top of #3012. Fixes the vault list row's overflow ("more options") menu being unreachable to VoiceOver, mirroring the identical fix shipped for Bank Account in #2985 (commit `7e137f3eb`).

The button was nested inside another Button at every call site (the row itself is the label of an outer Button used to open the item). SwiftUI always flattens a Button's whole label subtree into a single VoiceOver element, so the nested button's own accessibility label and activation were swallowed by the outer button — a simpler fix exposing "More options" as a custom rotor action would only make it reachable via the actions rotor, not as its own swipeable, independently selectable stop.

Instead, moves "open item" tap handling inside `VaultListItemRowView` itself, behind a new `.pressed` effect, so the primary open action and the secondary options/copy buttons become siblings instead of nested buttons — mirroring the pattern already used by `SendListItemRowView`. All 4 call sites (`VaultListView`, `VaultGroupView`, `VaultItemSelectionView`, `VaultAutofillListView`) drop their outer `Button` wrapper and forward `.pressed` through the `mapEffect` closure they already use for `.morePressed`. `itemPressed` moves from a `VaultListAction`/`VaultGroupAction` to a `VaultListEffect`/`VaultGroupEffect` to route through the same mechanism. Because a real `Button`/`AsyncButton` is preserved (just relocated), there's no loss of native press-highlight feedback.

Since this reworks the shared `VaultListItemRowView`, it benefits every cipher type, not just Drivers License.

Local review (`code-review-local`) flagged two non-blocking items, both also present unchanged in the identical Bank Account implementation (#2985) — left as-is here to stay consistent with that PR rather than diverge:
- `VaultAutofillListView`'s `mapEffect` now completes an autofill request on `.morePressed` instead of being a no-op; currently unreachable since `CipherOptionsButton` is always hidden when `isFromExtension: true`.
- `VaultListItemRowView`'s row-level `accessibilityIdentifier` moved from the outer combined element to a `.contain` container; the tap target is now identified via `"VaultListItemRowButton"` instead.

## 📸 Screenshots

N/A — behavior matches the already-reviewed Bank Account implementation in #2985; VoiceOver announcements should be confirmed on-device.


[PM-42026]: https://bitwarden.atlassian.net/browse/PM-42026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ