### PR TITLE
[PM-37884] fix: Show the scan card button when editing a card

### DIFF
--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditCardItem/CardItemState.swift
@@ -56,6 +56,21 @@ extension CardItemState {
             number: cardNumber.nilIfEmpty,
         )
     }
+
+    /// Returns a copy of the state with the card scanner's state copied over from another state.
+    ///
+    /// The card scanner's state is driven by the feature flag and the UI rather than by the cipher,
+    /// so it needs to be carried over whenever the state is rebuilt from an updated cipher.
+    ///
+    /// - Parameter other: The state to copy the card scanner's state from.
+    /// - Returns: A copy of the state with the card scanner's state applied.
+    ///
+    func preservingCardScannerState(from other: CardItemState) -> CardItemState {
+        var state = self
+        state.cardScannerEnabled = other.cardScannerEnabled
+        state.isCardScannerPresented = other.isCardScannerPresented
+        return state
+    }
 }
 
 // MARK: AddEditCardItemState

--- a/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/AddEditItem/AddEditItemProcessorTests.swift
@@ -1924,6 +1924,30 @@ class AddEditItemProcessorTests: BitwardenTestCase {
         try XCTAssertEqual(XCTUnwrap(subject.state as? CipherItemState), updatedState)
     }
 
+    /// `perform(_:)` with `.streamCipherDetails` preserves the card scanner's state when an update
+    /// to the cipher occurs, so the scan card button remains visible while editing a card.
+    @MainActor
+    func test_perform_streamCipherDetails_cardScannerState() async throws {
+        subject.state = try XCTUnwrap(
+            CipherItemState(existing: .fixture(card: .fixture(), id: "1", type: .card), hasPremium: false),
+        )
+        subject.state.cardItemState.cardScannerEnabled = true
+        subject.state.cardItemState.isCardScannerPresented = true
+
+        let task = Task {
+            await subject.perform(.streamCipherDetails)
+        }
+        defer { task.cancel() }
+
+        vaultRepository.cipherDetailsSubject.send(
+            .fixture(card: .fixture(), id: "1", name: "Updated name", type: .card),
+        )
+        try await waitForAsync { self.subject.state.name == "Updated name" }
+
+        XCTAssertTrue(subject.state.cardItemState.cardScannerEnabled)
+        XCTAssertTrue(subject.state.cardItemState.isCardScannerPresented)
+    }
+
     /// `perform(_:)` with `.streamCipherDetails` logs an error if getting updates for the cipher fails.
     @MainActor
     func test_perform_streamCipherDetails_error() async throws {

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemState.swift
@@ -481,7 +481,7 @@ struct CipherItemState: Equatable { // swiftlint:disable:this type_body_length
         }
 
         bankAccountItemState = cipherView.bankAccountItemState()
-        cardItemState = cipherView.cardItemState()
+        cardItemState = cipherView.cardItemState().preservingCardScannerState(from: cardItemState)
         driversLicenseItemState = cipherView.driversLicenseItemState()
         collectionIds = cipherView.collectionIds
         customFieldsState = AddEditCustomFieldsState(cipherType: type, customFields: cipherView.customFields)

--- a/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
+++ b/BitwardenShared/UI/Vault/VaultItem/CipherItemStateTests.swift
@@ -843,6 +843,21 @@ class CipherItemStateTests: BitwardenTestCase { // swiftlint:disable:this type_b
         XCTAssertEqual(subject, expected)
     }
 
+    /// `update(from:)` preserves the card scanner's state, which isn't derived from the `CipherView`.
+    func test_updateFromCipherView_cardScannerState() throws {
+        var subject = try XCTUnwrap(
+            CipherItemState(existing: .fixture(card: .fixture(), type: .card), hasPremium: true),
+        )
+        subject.cardItemState.cardScannerEnabled = true
+        subject.cardItemState.isCardScannerPresented = true
+
+        subject.update(from: .fixture(card: .fixture(number: "1111222233334444"), name: "Card", type: .card))
+
+        XCTAssertEqual(subject.cardItemState.cardNumber, "1111222233334444")
+        XCTAssertTrue(subject.cardItemState.cardScannerEnabled)
+        XCTAssertTrue(subject.cardItemState.isCardScannerPresented)
+    }
+
     /// `update(from:)` updates the state from an updated identity `CipherView`.
     func test_updateFromCipherView_identity() {
         var subject = CipherItemState(existing: .fixture(type: .identity), hasPremium: true)


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->
https://bitwarden.atlassian.net/browse/PM-37884

## 📔 Objective
<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

The "Scan card" button never showed up when editing an existing card, only when adding a new one.

- The edit screen listens for cipher updates, and every update rebuilt the card state straight from the cipher
- That rebuild threw away `cardScannerEnabled`, which the feature flag had just set, so the button disappeared before anyone could see it
- Adding a card was fine because that flow has no cipher to stream yet
- The card state now carries the scanner values over when it's rebuilt, so the button sticks around (and an incoming sync no longer closes the scanner sheet mid-scan)
- Added tests on both `CipherItemState` and `AddEditItemProcessor` that fail without the fix

## 📸 Screenshots 

| Before | After |
|--------|--------|
| <img width="365" src="https://github.com/user-attachments/assets/f3043bdc-7a49-474f-8044-7f351bedfc5b" /> | <img width="365" src="https://github.com/user-attachments/assets/a4828265-7ca3-43f5-a20e-cceeb3f204ef" /> |
