### PR TITLE
[PM-32153] feat: Split master password authentication/unlock data in register-finish request

### DIFF
--- a/BitwardenShared/Core/Auth/Models/Request/RegisterFinishRequestModel.swift
+++ b/BitwardenShared/Core/Auth/Models/Request/RegisterFinishRequestModel.swift
@@ -14,81 +14,26 @@ struct RegisterFinishRequestModel: Equatable {
     /// The token to verify the email address
     let emailVerificationToken: String
 
-    /// The type of kdf for this request.
-    var kdf: KdfType?
-
-    /// The number of kdf iterations performed in this request.
-    var kdfIterations: Int?
-
-    /// The kdf memory allocated for the computed password hash.
-    var kdfMemory: Int?
-
-    /// The number of threads upon which the kdf iterations are performed.
-    var kdfParallelism: Int?
-
-    /// The master password hash used to authenticate a user.
-    let masterPasswordHash: String
+    /// The user's master password authentication data.
+    let masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel
 
     /// The master password hint.
     let masterPasswordHint: String?
 
+    /// The user's master password unlock data.
+    let masterPasswordUnlock: MasterPasswordUnlockDataRequestModel
+
     /// The user's name.
-    let name: String?
+    let name: String? = nil
 
     /// The organization's user ID.
-    let organizationUserId: String?
+    let organizationUserId: String? = nil
 
     /// The token used when making this request.
-    let token: String?
-
-    /// The user symmetric key used for this request.
-    let userSymmetricKey: String?
+    let token: String? = nil
 
     /// The user asymmetric keys used for this request.
     let userAsymmetricKeys: KeysRequestModel?
-
-    // MARK: Initialization
-
-    /// Initializes a `RegisterFinishRequestModel`.
-    ///
-    /// - Parameters:
-    ///   - email: The user's email address.
-    ///   - kdfConfig: A model for configuring KDF options.
-    ///   - masterPasswordHash: The master password hash used to authenticate a user.
-    ///   - masterPasswordHint: The master password hint.
-    ///   - name: The user's name.
-    ///   - organizationUserId: The organization's user ID.
-    ///   - token: The token used when making this request.
-    ///   - userSymmetricKey: The key used for this request.
-    ///   - userAsymmetricKeys: The keys used for this request.
-    ///
-    init(
-        email: String,
-        emailVerificationToken: String,
-        kdfConfig: KdfConfig,
-        masterPasswordHash: String,
-        masterPasswordHint: String?,
-        name: String? = nil,
-        organizationUserId: String? = nil,
-        token: String? = nil,
-        userSymmetricKey: String? = nil,
-        userAsymmetricKeys: KeysRequestModel? = nil,
-    ) {
-        self.email = email
-        self.emailVerificationToken = emailVerificationToken
-        kdf = kdfConfig.kdf
-        kdfIterations = kdfConfig.kdfIterations
-        kdfMemory = kdfConfig.kdfMemory
-        kdfParallelism = kdfConfig.kdfParallelism
-        kdfMemory = kdfConfig.kdfMemory
-        self.masterPasswordHash = masterPasswordHash
-        self.masterPasswordHint = masterPasswordHint
-        self.name = name
-        self.organizationUserId = organizationUserId
-        self.token = token
-        self.userSymmetricKey = userSymmetricKey
-        self.userAsymmetricKeys = userAsymmetricKeys
-    }
 }
 
 // MARK: JSONRequestBody

--- a/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/AccountAPIServiceTests.swift
@@ -143,10 +143,17 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
                 body: RegisterFinishRequestModel(
                     email: "example@email.com",
                     emailVerificationToken: "thisisanawesometoken",
-                    kdfConfig: KdfConfig(),
-                    masterPasswordHash: "1a2b3c",
+                    masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                        kdf: KdfConfig(),
+                        masterPasswordAuthenticationHash: "1a2b3c",
+                        salt: "example@email.com",
+                    ),
                     masterPasswordHint: "hint",
-                    userSymmetricKey: "key",
+                    masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                        kdf: KdfConfig(),
+                        masterKeyWrappedUserKey: "key",
+                        salt: "example@email.com",
+                    ),
                     userAsymmetricKeys: KeysRequestModel(encryptedPrivateKey: "private"),
                 ),
             )
@@ -163,10 +170,17 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
                 body: RegisterFinishRequestModel(
                     email: "example@email.com",
                     emailVerificationToken: "thisisanawesometoken",
-                    kdfConfig: KdfConfig(),
-                    masterPasswordHash: "1a2b3c",
+                    masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                        kdf: KdfConfig(),
+                        masterPasswordAuthenticationHash: "1a2b3c",
+                        salt: "example@email.com",
+                    ),
                     masterPasswordHint: "hint",
-                    userSymmetricKey: "key",
+                    masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                        kdf: KdfConfig(),
+                        masterKeyWrappedUserKey: "key",
+                        salt: "example@email.com",
+                    ),
                     userAsymmetricKeys: KeysRequestModel(encryptedPrivateKey: "private"),
                 ),
             )
@@ -182,10 +196,17 @@ class AccountAPIServiceTests: BitwardenTestCase { // swiftlint:disable:this type
             body: RegisterFinishRequestModel(
                 email: "example@email.com",
                 emailVerificationToken: "thisisanawesometoken",
-                kdfConfig: KdfConfig(),
-                masterPasswordHash: "1a2b3c",
+                masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterPasswordAuthenticationHash: "1a2b3c",
+                    salt: "example@email.com",
+                ),
                 masterPasswordHint: "hint",
-                userSymmetricKey: "key",
+                masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterKeyWrappedUserKey: "key",
+                    salt: "example@email.com",
+                ),
                 userAsymmetricKeys: KeysRequestModel(encryptedPrivateKey: "private"),
             ),
         )

--- a/BitwardenShared/Core/Auth/Services/API/Account/Requests/RegisterFinishRequestTests.swift
+++ b/BitwardenShared/Core/Auth/Services/API/Account/Requests/RegisterFinishRequestTests.swift
@@ -21,10 +21,17 @@ class RegisterFinishRequestTests: BitwardenTestCase {
             body: RegisterFinishRequestModel(
                 email: "example@email.com",
                 emailVerificationToken: "thisisanawesometoken",
-                kdfConfig: KdfConfig(),
-                masterPasswordHash: "1a2b3c",
+                masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterPasswordAuthenticationHash: "1a2b3c",
+                    salt: "example@email.com",
+                ),
                 masterPasswordHint: "hint",
-                userSymmetricKey: "key",
+                masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                    kdf: KdfConfig(),
+                    masterKeyWrappedUserKey: "key",
+                    salt: "example@email.com",
+                ),
                 userAsymmetricKeys: KeysRequestModel(encryptedPrivateKey: "private"),
             ),
         )

--- a/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
+++ b/BitwardenShared/UI/Auth/CompleteRegistration/CompleteRegistrationProcessor.swift
@@ -6,6 +6,8 @@ import Combine
 import Foundation
 import OSLog
 
+// swiftlint:disable file_length
+
 // MARK: - MasterPasswordUpdateDelegate
 
 /// A delegate protocol for handling master password updates during registration completion.
@@ -43,7 +45,7 @@ enum CompleteRegistrationError: Error {
 
 /// The processor used to manage state and handle actions for the complete registration screen.
 ///
-class CompleteRegistrationProcessor: StateProcessor<
+class CompleteRegistrationProcessor: StateProcessor<// swiftlint:disable:this type_body_length
     CompleteRegistrationState,
     CompleteRegistrationAction,
     CompleteRegistrationEffect,
@@ -204,10 +206,17 @@ class CompleteRegistrationProcessor: StateProcessor<
                 body: RegisterFinishRequestModel(
                     email: state.userEmail,
                     emailVerificationToken: state.emailVerificationToken,
-                    kdfConfig: kdfConfig,
-                    masterPasswordHash: hashedPassword,
+                    masterPasswordAuthentication: MasterPasswordAuthenticationDataRequestModel(
+                        kdf: kdfConfig,
+                        masterPasswordAuthenticationHash: hashedPassword,
+                        salt: state.userEmail,
+                    ),
                     masterPasswordHint: state.passwordHintText,
-                    userSymmetricKey: keys.encryptedUserKey,
+                    masterPasswordUnlock: MasterPasswordUnlockDataRequestModel(
+                        kdf: kdfConfig,
+                        masterKeyWrappedUserKey: keys.encryptedUserKey,
+                        salt: state.userEmail,
+                    ),
                     userAsymmetricKeys: KeysRequestModel(
                         encryptedPrivateKey: keys.keys.private,
                         publicKey: keys.keys.public,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-32153](https://bitwarden.atlassian.net/browse/PM-32153)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Migrates the iOS register-finish request (`POST /accounts/register/finish`, V1 legacy registration path) to the `masterPasswordAuthentication` / `masterPasswordUnlock` nested request shape the server now expects, replacing the flat `masterPasswordHash`, `userSymmetricKey`, `kdf`, `kdfIterations`, `kdfMemory`, and `kdfParallelism` fields.
- Reuses the existing `MasterPasswordAuthenticationDataRequestModel` / `MasterPasswordUnlockDataRequestModel` types (already used by `UpdateKdfRequestModel`) — no new shared types introduced.


[PM-32153]: https://bitwarden.atlassian.net/browse/PM-32153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ