### PR TITLE
[PM-43234] fix: Hide Edit option for non-compliant Sends in the send list menu

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView+ViewInspectorTests.swift
@@ -1,0 +1,81 @@
+// swiftlint:disable:this file_name
+import BitwardenKit
+import BitwardenKitMocks
+import BitwardenResources
+@preconcurrency import BitwardenSdk
+import ViewInspector
+import XCTest
+
+@testable import BitwardenShared
+
+// MARK: - SendListItemRowViewTests
+
+class SendListItemRowViewTests: BitwardenTestCase {
+    // MARK: Properties
+
+    var processor: MockProcessor<SendListItemRowState, SendListItemRowAction, SendListItemRowEffect>!
+    var subject: SendListItemRowView!
+
+    // MARK: Setup & Teardown
+
+    override func setUp() {
+        super.setUp()
+
+        processor = MockProcessor(
+            state: SendListItemRowState(
+                item: SendListItem(id: "1", itemType: .send(.fixture(id: "1"))),
+                hasDivider: false,
+            ),
+        )
+        subject = SendListItemRowView(store: Store(processor: processor))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+
+        processor = nil
+        subject = nil
+    }
+
+    // MARK: Tests
+
+    /// The options menu doesn't show an Edit option for a Send that's individually
+    /// non-compliant (`sendView.disabled`), even when Sends aren't disabled org-wide.
+    @MainActor
+    func test_optionsMenu_disabledSend_hidesEdit() throws {
+        processor.state.item = SendListItem(id: "1", itemType: .send(.fixture(id: "1", disabled: true)))
+
+        let menu = try subject.inspect().find(ViewType.Menu.self) { view in
+            try view.accessibilityIdentifier() == "SendOptionsButton"
+        }
+        XCTAssertThrowsError(try menu.find(button: Localizations.edit))
+    }
+
+    /// The options menu shows an Edit option for a compliant Send, and tapping it dispatches
+    /// the `.editPressed` action.
+    @MainActor
+    func test_optionsMenu_enabledSend_editTapped() throws {
+        let sendView = SendView.fixture(id: "1", disabled: false)
+        processor.state.item = SendListItem(id: "1", itemType: .send(sendView))
+
+        let menu = try subject.inspect().find(ViewType.Menu.self) { view in
+            try view.accessibilityIdentifier() == "SendOptionsButton"
+        }
+        let button = try menu.find(button: Localizations.edit)
+        try button.tap()
+        XCTAssertEqual(processor.dispatchedActions.last, .editPressed(sendView))
+    }
+
+    /// The options menu doesn't show an Edit option when Sends are disabled org-wide, even for
+    /// a Send that isn't itself individually non-compliant.
+    @MainActor
+    func test_optionsMenu_sendsDisabledByPolicy_hidesEdit() throws {
+        processor.state.isSendDisabled = true
+        processor.state.item = SendListItem(id: "1", itemType: .send(.fixture(id: "1", disabled: false)))
+
+        let menu = try subject.inspect().find(ViewType.Menu.self) { view in
+            try view.accessibilityIdentifier() == "SendOptionsButton"
+        }
+        XCTAssertThrowsError(try menu.find(button: Localizations.edit))
+    }
+}

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -169,8 +169,10 @@ struct SendListItemRowView: View {
                     Button(Localizations.view) {
                         store.send(.viewSend(sendView))
                     }
-                    Button(Localizations.edit) {
-                        store.send(.editPressed(sendView))
+                    if !sendView.disabled {
+                        Button(Localizations.edit) {
+                            store.send(.editPressed(sendView))
+                        }
                     }
                     if sendView.hasPassword {
                         AsyncButton(Localizations.removePassword) {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-43234](https://bitwarden.atlassian.net/browse/PM-43234)

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- The Send List's "..." item-options menu only suppressed Edit when Sends were disabled org-wide (`SendPolicyOptions.isSendDisabled`), but never checked the per-item `sendView.disabled` flag that marks an individual Send as non-compliant — the same flag already used to hide the Edit FAB on the View Send screen.
- Closes the remaining gap: a non-compliant Send could still be edited via the row's "..." menu even though the FAB path was already blocked.
- Gated the Edit button in `SendListItemRowView.optionsMenu(for:)` on `!sendView.disabled`. No other menu items (View/Copy/Share/RemovePassword/Delete) or the global `isSendDisabled` behavior changed.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/fc595936-9122-45b6-85d0-a22506a7896a" /> | <video src="https://github.com/user-attachments/assets/6a56cb48-9b87-49b7-9176-783f18619bd9" /> | 








[PM-43234]: https://bitwarden.atlassian.net/browse/PM-43234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ