### PR TITLE
[PM-43340] [PM-43372] fix: Hide Remove Password, Copy Link, and Share Link options for non-compliant Sends in the send list menu

### DIFF
--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView+ViewInspectorTests.swift
@@ -39,12 +39,15 @@ class SendListItemRowViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// The options menu doesn't show Edit, Copy Link, or Share Link options for a Send that's
-    /// individually non-compliant (`sendView.disabled`), even when Sends aren't disabled
-    /// org-wide.
+    /// The options menu doesn't show Edit, Copy Link, Share Link, or Remove Password options for
+    /// a Send that's individually non-compliant (`sendView.disabled`), even when Sends aren't
+    /// disabled org-wide.
     @MainActor
-    func test_optionsMenu_disabledSend_hidesEditCopyAndShareLink() throws {
-        processor.state.item = SendListItem(id: "1", itemType: .send(.fixture(id: "1", disabled: true)))
+    func test_optionsMenu_disabledSend_hidesEditCopyShareLinkAndRemovePassword() throws {
+        processor.state.item = SendListItem(
+            id: "1",
+            itemType: .send(.fixture(id: "1", hasPassword: true, disabled: true)),
+        )
 
         let menu = try subject.inspect().find(ViewType.Menu.self) { view in
             try view.accessibilityIdentifier() == "SendOptionsButton"
@@ -52,13 +55,14 @@ class SendListItemRowViewTests: BitwardenTestCase {
         XCTAssertThrowsError(try menu.find(button: Localizations.edit))
         XCTAssertThrowsError(try menu.find(button: Localizations.copyLink))
         XCTAssertThrowsError(try menu.find(button: Localizations.shareLink))
+        XCTAssertThrowsError(try menu.find(button: Localizations.removePassword))
     }
 
-    /// The options menu shows Edit, Copy Link, and Share Link options for a compliant Send, and
-    /// tapping each dispatches the corresponding action/effect.
+    /// The options menu shows Edit, Copy Link, Share Link, and Remove Password options for a
+    /// compliant Send, and tapping each dispatches the corresponding action/effect.
     @MainActor
-    func test_optionsMenu_enabledSend_showsEditCopyAndShareLinkAndTapped() async throws {
-        let sendView = SendView.fixture(id: "1", disabled: false)
+    func test_optionsMenu_enabledSend_showsEditCopyShareLinkAndRemovePasswordAndTapped() async throws {
+        let sendView = SendView.fixture(id: "1", hasPassword: true, disabled: false)
         processor.state.item = SendListItem(id: "1", itemType: .send(sendView))
 
         let menu = try subject.inspect().find(ViewType.Menu.self) { view in
@@ -73,17 +77,25 @@ class SendListItemRowViewTests: BitwardenTestCase {
         try await shareButton.tap()
         XCTAssertEqual(processor.effects.last, .shareLinkPressed(sendView))
 
+        let removePasswordButton = try subject.inspect().find(asyncButton: Localizations.removePassword)
+        try await removePasswordButton.tap()
+        XCTAssertEqual(processor.effects.last, .removePassword(sendView))
+
         let editButton = try menu.find(button: Localizations.edit)
         try editButton.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .editPressed(sendView))
     }
 
-    /// The options menu doesn't show Edit, Copy Link, or Share Link options when Sends are
-    /// disabled org-wide, even for a Send that isn't itself individually non-compliant.
+    /// The options menu doesn't show Edit, Copy Link, Share Link, or Remove Password options
+    /// when Sends are disabled org-wide, even for a Send that isn't itself individually
+    /// non-compliant.
     @MainActor
-    func test_optionsMenu_sendsDisabledByPolicy_hidesEditCopyAndShareLink() throws {
+    func test_optionsMenu_sendsDisabledByPolicy_hidesEditCopyShareLinkAndRemovePassword() throws {
         processor.state.isSendDisabled = true
-        processor.state.item = SendListItem(id: "1", itemType: .send(.fixture(id: "1", disabled: false)))
+        processor.state.item = SendListItem(
+            id: "1",
+            itemType: .send(.fixture(id: "1", hasPassword: true, disabled: false)),
+        )
 
         let menu = try subject.inspect().find(ViewType.Menu.self) { view in
             try view.accessibilityIdentifier() == "SendOptionsButton"
@@ -91,5 +103,6 @@ class SendListItemRowViewTests: BitwardenTestCase {
         XCTAssertThrowsError(try menu.find(button: Localizations.edit))
         XCTAssertThrowsError(try menu.find(button: Localizations.copyLink))
         XCTAssertThrowsError(try menu.find(button: Localizations.shareLink))
+        XCTAssertThrowsError(try menu.find(button: Localizations.removePassword))
     }
 }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView+ViewInspectorTests.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView+ViewInspectorTests.swift
@@ -39,37 +39,49 @@ class SendListItemRowViewTests: BitwardenTestCase {
 
     // MARK: Tests
 
-    /// The options menu doesn't show an Edit option for a Send that's individually
-    /// non-compliant (`sendView.disabled`), even when Sends aren't disabled org-wide.
+    /// The options menu doesn't show Edit, Copy Link, or Share Link options for a Send that's
+    /// individually non-compliant (`sendView.disabled`), even when Sends aren't disabled
+    /// org-wide.
     @MainActor
-    func test_optionsMenu_disabledSend_hidesEdit() throws {
+    func test_optionsMenu_disabledSend_hidesEditCopyAndShareLink() throws {
         processor.state.item = SendListItem(id: "1", itemType: .send(.fixture(id: "1", disabled: true)))
 
         let menu = try subject.inspect().find(ViewType.Menu.self) { view in
             try view.accessibilityIdentifier() == "SendOptionsButton"
         }
         XCTAssertThrowsError(try menu.find(button: Localizations.edit))
+        XCTAssertThrowsError(try menu.find(button: Localizations.copyLink))
+        XCTAssertThrowsError(try menu.find(button: Localizations.shareLink))
     }
 
-    /// The options menu shows an Edit option for a compliant Send, and tapping it dispatches
-    /// the `.editPressed` action.
+    /// The options menu shows Edit, Copy Link, and Share Link options for a compliant Send, and
+    /// tapping each dispatches the corresponding action/effect.
     @MainActor
-    func test_optionsMenu_enabledSend_editTapped() throws {
+    func test_optionsMenu_enabledSend_showsEditCopyAndShareLinkAndTapped() async throws {
         let sendView = SendView.fixture(id: "1", disabled: false)
         processor.state.item = SendListItem(id: "1", itemType: .send(sendView))
 
         let menu = try subject.inspect().find(ViewType.Menu.self) { view in
             try view.accessibilityIdentifier() == "SendOptionsButton"
         }
-        let button = try menu.find(button: Localizations.edit)
-        try button.tap()
+
+        let copyButton = try subject.inspect().find(asyncButton: Localizations.copyLink)
+        try await copyButton.tap()
+        XCTAssertEqual(processor.effects.last, .copyLinkPressed(sendView))
+
+        let shareButton = try subject.inspect().find(asyncButton: Localizations.shareLink)
+        try await shareButton.tap()
+        XCTAssertEqual(processor.effects.last, .shareLinkPressed(sendView))
+
+        let editButton = try menu.find(button: Localizations.edit)
+        try editButton.tap()
         XCTAssertEqual(processor.dispatchedActions.last, .editPressed(sendView))
     }
 
-    /// The options menu doesn't show an Edit option when Sends are disabled org-wide, even for
-    /// a Send that isn't itself individually non-compliant.
+    /// The options menu doesn't show Edit, Copy Link, or Share Link options when Sends are
+    /// disabled org-wide, even for a Send that isn't itself individually non-compliant.
     @MainActor
-    func test_optionsMenu_sendsDisabledByPolicy_hidesEdit() throws {
+    func test_optionsMenu_sendsDisabledByPolicy_hidesEditCopyAndShareLink() throws {
         processor.state.isSendDisabled = true
         processor.state.item = SendListItem(id: "1", itemType: .send(.fixture(id: "1", disabled: false)))
 
@@ -77,5 +89,7 @@ class SendListItemRowViewTests: BitwardenTestCase {
             try view.accessibilityIdentifier() == "SendOptionsButton"
         }
         XCTAssertThrowsError(try menu.find(button: Localizations.edit))
+        XCTAssertThrowsError(try menu.find(button: Localizations.copyLink))
+        XCTAssertThrowsError(try menu.find(button: Localizations.shareLink))
     }
 }

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -175,10 +175,10 @@ struct SendListItemRowView: View {
                         Button(Localizations.edit) {
                             store.send(.editPressed(sendView))
                         }
-                    }
-                    if sendView.hasPassword {
-                        AsyncButton(Localizations.removePassword) {
-                            await store.perform(.removePassword(sendView))
+                        if sendView.hasPassword {
+                            AsyncButton(Localizations.removePassword) {
+                                await store.perform(.removePassword(sendView))
+                            }
                         }
                     }
 

--- a/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
+++ b/BitwardenShared/UI/Tools/Send/Send/SendList/SendListItemRowView.swift
@@ -157,12 +157,14 @@ struct SendListItemRowView: View {
     private func optionsMenu(for sendView: SendView) -> some View {
         Menu {
             if !store.state.isSendDisabled {
-                AsyncButton(Localizations.copyLink) {
-                    await store.perform(.copyLinkPressed(sendView))
-                }
-                .accessibilityIdentifier("Copy")
-                AsyncButton(Localizations.shareLink) {
-                    await store.perform(.shareLinkPressed(sendView))
+                if !sendView.disabled {
+                    AsyncButton(Localizations.copyLink) {
+                        await store.perform(.copyLinkPressed(sendView))
+                    }
+                    .accessibilityIdentifier("Copy")
+                    AsyncButton(Localizations.shareLink) {
+                        await store.perform(.shareLinkPressed(sendView))
+                    }
                 }
 
                 Section("") {


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-43340](https://bitwarden.atlassian.net/browse/PM-43340) - Remove Copy and Share Link Buttons From Item Options For Non-Compliant Sends
[PM-43372](https://bitwarden.atlassian.net/browse/PM-43372) - Remove "Remove Password" When Viewing Item Options

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

Hides the "Remove password", "Copy link", and "Share link" buttons from the Send item options menu if the Send is disabled.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/c16d7c2e-6fad-4250-a553-f2dd4ba4266f" /> | <video src="https://github.com/user-attachments/assets/6e532f9f-756f-43c1-beeb-ed703803ab03" /> | 








[PM-43340]: https://bitwarden.atlassian.net/browse/PM-43340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-43372]: https://bitwarden.atlassian.net/browse/PM-43372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ