### PR TITLE
[PM-43223] [PM-43220] fix: Update "Who can view" and "Deletion date" menu footer text

### DIFF
--- a/BitwardenResources/Localizations/en.lproj/Localizable.strings
+++ b/BitwardenResources/Localizations/en.lproj/Localizable.strings
@@ -1092,6 +1092,7 @@
 "AnyoneWithTheLink" = "Anyone with the link";
 "AnyoneWithThisLinkCanViewThisSend" = "Anyone with this link can view this Send.";
 "AfterSharingThisSendLinkDescriptionLong" = "After sharing this Send link, individuals will need to verify their email with a code to view this Send.";
+"IndividualsWillNeedToEnterThisPasswordDescriptionLong" = "Individuals will need to enter this password to view this Send";
 "SpecificPeople" = "Specific people";
 "WhoCanView" = "Who can view";
 "SharingWithSpecificPeopleIsPremiumFeatureDescriptionLong" = "Sharing with specific people is a Premium feature. Your current plan does not include access to this feature.";

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -215,6 +215,18 @@ struct AddEditSendItemState: Equatable, Sendable {
     var shouldShowHideEmailPolicyBanner: Bool {
         isSendHideEmailDisabled && !isSendControlsPolicyEnabled
     }
+
+    /// The footer text to display below the "who can view" menu.
+    var whoCanViewFooter: String? {
+        switch accessType {
+        case .anyoneWithLink:
+            Localizations.anyoneWithThisLinkCanViewThisSend
+        case .specificPeople:
+            Localizations.afterSharingThisSendLinkDescriptionLong
+        case .anyoneWithPassword:
+            nil
+        }
+    }
 }
 
 extension AddEditSendItemState {

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemState.swift
@@ -224,7 +224,7 @@ struct AddEditSendItemState: Equatable, Sendable {
         case .specificPeople:
             Localizations.afterSharingThisSendLinkDescriptionLong
         case .anyoneWithPassword:
-            nil
+            Localizations.individualsWillNeedToEnterThisPasswordDescriptionLong
         }
     }
 }

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -553,7 +553,8 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
         XCTAssertEqual(subject.whoCanViewFooter, Localizations.afterSharingThisSendLinkDescriptionLong)
     }
 
-    /// `whoCanViewFooter` is `nil` when the access type is "Anyone with the password".
+    /// `whoCanViewFooter` returns the "individuals will need to enter this password" description
+    /// when the access type is "Anyone with the password".
     func test_whoCanViewFooter_anyoneWithPassword() {
         let subject = AddEditSendItemState(accessType: .anyoneWithPassword)
         XCTAssertEqual(subject.whoCanViewFooter, Localizations.individualsWillNeedToEnterThisPasswordDescriptionLong)

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -556,6 +556,6 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
     /// `whoCanViewFooter` is `nil` when the access type is "Anyone with the password".
     func test_whoCanViewFooter_anyoneWithPassword() {
         let subject = AddEditSendItemState(accessType: .anyoneWithPassword)
-        XCTAssertNil(subject.whoCanViewFooter)
+        XCTAssertEqual(subject.whoCanViewFooter, Localizations.individualsWillNeedToEnterThisPasswordDescriptionLong)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemStateTests.swift
@@ -1,3 +1,4 @@
+import BitwardenResources
 import BitwardenSdk
 import XCTest
 
@@ -534,5 +535,27 @@ class AddEditSendItemStateTests: BitwardenTestCase { // swiftlint:disable:this t
             sendPolicyOptions: SendPolicyOptions(isHideEmailDisabled: true),
         )
         XCTAssertFalse(subject.shouldShowHideEmailPolicyBanner)
+    }
+
+    // MARK: whoCanViewFooter
+
+    /// `whoCanViewFooter` returns the "anyone with this link" description when the access type is
+    /// "Anyone with the link".
+    func test_whoCanViewFooter_anyoneWithLink() {
+        let subject = AddEditSendItemState(accessType: .anyoneWithLink)
+        XCTAssertEqual(subject.whoCanViewFooter, Localizations.anyoneWithThisLinkCanViewThisSend)
+    }
+
+    /// `whoCanViewFooter` returns the "specific people" description when the access type is
+    /// "Specific people".
+    func test_whoCanViewFooter_specificPeople() {
+        let subject = AddEditSendItemState(accessType: .specificPeople)
+        XCTAssertEqual(subject.whoCanViewFooter, Localizations.afterSharingThisSendLinkDescriptionLong)
+    }
+
+    /// `whoCanViewFooter` is `nil` when the access type is "Anyone with the password".
+    func test_whoCanViewFooter_anyoneWithPassword() {
+        let subject = AddEditSendItemState(accessType: .anyoneWithPassword)
+        XCTAssertNil(subject.whoCanViewFooter)
     }
 } // swiftlint:disable:this file_length

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -187,6 +187,9 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
         ContentBlock(dividerLeadingPadding: 16) {
             BitwardenMenuField(
                 title: Localizations.deletionDate,
+                footer: store.state.isDeletionDateEnforcedByPolicy
+                    ? Localizations.thisDateIsEnforcedByYourOrganization
+                    : Localizations.deletionDateInfo,
                 accessibilityIdentifier: "SendDeletionOptionsPicker",
                 options: store.state.availableDeletionDateTypes,
                 selection: store.binding(
@@ -195,14 +198,6 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
                 ),
             )
             .disabled(store.state.isDeletionDateEnforcedByPolicy)
-
-            Text(store.state.isDeletionDateEnforcedByPolicy
-                ? Localizations.thisDateIsEnforcedByYourOrganization
-                : Localizations.deletionDateInfo)
-                .styleGuide(.footnote)
-                .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
         }
     }
 
@@ -328,11 +323,12 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
 
     /// The "Who can view" section for access type selection.
     @ViewBuilder private var whoCanView: some View {
-        ContentBlock(dividerLeadingPadding: 16) {
+        ContentBlock(dividerLeadingPadding: 0) {
             // When the access type is enforced by policy, the menu shows the enforced selection but
             // is disabled so the user can't change it.
             BitwardenMenuField(
                 title: Localizations.whoCanView,
+                footer: store.state.whoCanViewFooter,
                 accessibilityIdentifier: "SendAccessTypePicker",
                 options: SendAccessType.allCases,
                 selection: store.binding(
@@ -351,21 +347,9 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
     @ViewBuilder private var whoCanViewContent: some View {
         switch store.state.accessType {
         case .anyoneWithLink:
-            Text(Localizations.anyoneWithThisLinkCanViewThisSend)
-                .styleGuide(.footnote)
-                .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                .padding(.horizontal, 16)
-                .padding(.vertical, 12)
+            EmptyView()
         case .specificPeople:
-            VStack(alignment: .leading, spacing: 0) {
-                Text(Localizations.afterSharingThisSendLinkDescriptionLong)
-                    .styleGuide(.footnote)
-                    .foregroundColor(SharedAsset.Colors.textSecondary.swiftUIColor)
-                    .padding(.horizontal, 16)
-                    .padding(.vertical, 12)
-
-                recipientEmailsList
-            }
+            recipientEmailsList
         case .anyoneWithPassword:
             BitwardenTextField(
                 title: Localizations.password,

--- a/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
+++ b/BitwardenShared/UI/Tools/Send/SendItem/AddEditSendItem/AddEditSendItemView.swift
@@ -388,9 +388,6 @@ struct AddEditSendItemView: View { // swiftlint:disable:this type_body_length
     /// The list of recipient emails for "Specific people" access type.
     @ViewBuilder private var recipientEmailsList: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Divider()
-                .padding(.leading, 16)
-
             ForEach(store.state.recipientEmails.indices, id: \.self) { index in
                 BitwardenTextField(
                     title: Localizations.email,


### PR DESCRIPTION
## 🎟️ Tracking

<!-- Paste the link to the Jira or GitHub issue or otherwise describe / point to where this change is coming from. -->

[PM-43223](https://bitwarden.atlassian.net/browse/PM-43223) - Supporting text for "Who can view" option is not greyed out when policy is enforced.
[PM-43220](https://bitwarden.atlassian.net/browse/PM-43220) - Add Supporting Text to "Anyone with a password set by you" Who can view option for sends

## 📔 Objective

<!-- Describe what the purpose of this PR is, for example what bug you're fixing or new feature you're adding. -->

- Updates the disabled state of the "Who can view" and "Deletion date" menu footer text. When the menu was disabled, the footer text background didn't change with the menu itself to indicate that it was disabled. The footer text was implemented as a separate text view. This was moved into the Menu itself so that it could style the footer text when the menu is disabled.
- Adds the "Individuals will need to enter this password to view this Send" footer text to the "Who can view" menu when "Anyone with a password set by you" is selected.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->

| Before | After |
|--------|--------|
| <img width="568" height="1084" alt="Screenshot 2026-09-11 at 12 00 44 PM" src="https://github.com/user-attachments/assets/467e2dbb-efc0-4610-ada5-3093deea6c21" /> | <img width="568" height="1084" alt="Screenshot 2026-09-11 at 11 45 50 AM" src="https://github.com/user-attachments/assets/c0bd2dfa-0034-45ff-a6be-80ebd11ccaf0" />   | 


[PM-43223]: https://bitwarden.atlassian.net/browse/PM-43223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PM-43220]: https://bitwarden.atlassian.net/browse/PM-43220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ